### PR TITLE
feat(core): implement core definitions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::cluster::ClusterSpec;
-use crate::errors::CliError;
+use crate::errors::{self, CliError};
 use crate::prepared_suite::PreparedSuiteArtifact;
 use crate::schema::RunStatus;
 
@@ -66,7 +66,16 @@ impl RunLayout {
     /// # Errors
     /// Returns IO error on failure.
     pub fn ensure_dirs(&self) -> std::io::Result<()> {
-        todo!()
+        for dir in [
+            self.run_dir(),
+            self.artifacts_dir(),
+            self.commands_dir(),
+            self.manifests_dir(),
+            self.state_dir(),
+        ] {
+            std::fs::create_dir_all(dir)?;
+        }
+        Ok(())
     }
 
     /// Build from a run directory path.
@@ -124,9 +133,22 @@ pub struct CommandEnv {
 }
 
 impl CommandEnv {
+    /// Convert to a map of environment variable names to values.
     #[must_use]
     pub fn to_env_dict(&self) -> HashMap<String, String> {
-        todo!()
+        let mut map = HashMap::with_capacity(9);
+        map.insert("PROFILE".into(), self.profile.clone());
+        map.insert("REPO_ROOT".into(), self.repo_root.clone());
+        map.insert("RUN_DIR".into(), self.run_dir.clone());
+        map.insert("RUN_ID".into(), self.run_id.clone());
+        map.insert("RUN_ROOT".into(), self.run_root.clone());
+        map.insert("SUITE_DIR".into(), self.suite_dir.clone());
+        map.insert("SUITE_ID".into(), self.suite_id.clone());
+        map.insert("SUITE_PATH".into(), self.suite_path.clone());
+        if let Some(ref kc) = self.kubeconfig {
+            map.insert("KUBECONFIG".into(), kc.clone());
+        }
+        map
     }
 }
 
@@ -200,23 +222,514 @@ pub struct RunContext {
     pub preflight: Option<PreflightArtifact>,
 }
 
+fn read_json_file<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, CliError> {
+    let content = std::fs::read_to_string(path).map_err(|_| {
+        errors::cli_err(
+            &errors::MISSING_FILE,
+            &[("path", &path.display().to_string())],
+        )
+    })?;
+    serde_json::from_str(&content).map_err(|e| CliError {
+        code: "KSRCLI010".into(),
+        message: format!("invalid JSON in {}: {e}", path.display()),
+        exit_code: 5,
+        hint: None,
+        details: None,
+    })
+}
+
 impl RunContext {
     /// Load from a run directory.
     ///
     /// # Errors
-    /// Returns `CliError` if required files are missing.
-    pub fn from_run_dir(_run_dir: &Path) -> Result<Self, CliError> {
-        todo!()
+    /// Returns `CliError` if required files are missing or invalid.
+    pub fn from_run_dir(run_dir: &Path) -> Result<Self, CliError> {
+        let layout = RunLayout::from_run_dir(run_dir);
+        let metadata: RunMetadata = read_json_file(&layout.metadata_path())?;
+        let status: RunStatus = read_json_file(&layout.status_path())?;
+
+        let prepared_suite = if layout.prepared_suite_path().exists() {
+            read_json_file(&layout.prepared_suite_path()).ok()
+        } else {
+            None
+        };
+
+        let preflight_path = layout.artifacts_dir().join("preflight.json");
+        let preflight = if preflight_path.exists() {
+            read_json_file(&preflight_path).ok()
+        } else {
+            None
+        };
+
+        Ok(Self {
+            layout,
+            metadata,
+            status: Some(status),
+            cluster: None,
+            prepared_suite,
+            preflight,
+        })
     }
 
     /// Load from the current session context.
     ///
+    /// No active session tracking in the Rust implementation yet.
+    ///
     /// # Errors
     /// Returns `CliError` on failure.
     pub fn from_current() -> Result<Option<Self>, CliError> {
-        todo!()
+        Ok(None)
     }
 }
 
+/// Extract group ID strings from a `serde_json::Value` array.
+///
+/// Each element can be a plain string or an object with a `group_id` field.
+#[must_use]
+pub fn extract_group_ids(values: &[serde_json::Value]) -> Vec<String> {
+    values
+        .iter()
+        .filter_map(|v| match v {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Object(map) => map
+                .get("group_id")
+                .and_then(serde_json::Value::as_str)
+                .map(String::from),
+            _ => None,
+        })
+        .collect()
+}
+
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+    use crate::schema::RunCounts;
+
+    fn sample_layout() -> RunLayout {
+        RunLayout {
+            run_root: "/tmp/runs".into(),
+            run_id: "run-1".into(),
+        }
+    }
+
+    fn sample_metadata() -> RunMetadata {
+        RunMetadata {
+            run_id: "run-1".into(),
+            suite_id: "suite-a".into(),
+            suite_path: "/suites/suite-a/suite.md".into(),
+            suite_dir: "/suites/suite-a".into(),
+            profile: "single-zone".into(),
+            repo_root: "/repo".into(),
+            keep_clusters: false,
+            created_at: "2026-03-14T00:00:00Z".into(),
+            user_stories: vec![],
+            required_dependencies: vec![],
+        }
+    }
+
+    // -- RunLayout path tests --
+
+    #[test]
+    fn run_layout_run_dir() {
+        let layout = sample_layout();
+        assert_eq!(layout.run_dir(), PathBuf::from("/tmp/runs/run-1"));
+    }
+
+    #[test]
+    fn run_layout_artifacts_dir() {
+        let layout = sample_layout();
+        assert_eq!(
+            layout.artifacts_dir(),
+            PathBuf::from("/tmp/runs/run-1/artifacts")
+        );
+    }
+
+    #[test]
+    fn run_layout_commands_dir() {
+        let layout = sample_layout();
+        assert_eq!(
+            layout.commands_dir(),
+            PathBuf::from("/tmp/runs/run-1/commands")
+        );
+    }
+
+    #[test]
+    fn run_layout_state_dir() {
+        let layout = sample_layout();
+        assert_eq!(layout.state_dir(), PathBuf::from("/tmp/runs/run-1/state"));
+    }
+
+    #[test]
+    fn run_layout_manifests_dir() {
+        let layout = sample_layout();
+        assert_eq!(
+            layout.manifests_dir(),
+            PathBuf::from("/tmp/runs/run-1/manifests")
+        );
+    }
+
+    #[test]
+    fn run_layout_metadata_path() {
+        let layout = sample_layout();
+        assert_eq!(
+            layout.metadata_path(),
+            PathBuf::from("/tmp/runs/run-1/run-metadata.json")
+        );
+    }
+
+    #[test]
+    fn run_layout_status_path() {
+        let layout = sample_layout();
+        assert_eq!(
+            layout.status_path(),
+            PathBuf::from("/tmp/runs/run-1/run-status.json")
+        );
+    }
+
+    #[test]
+    fn run_layout_report_path() {
+        let layout = sample_layout();
+        assert_eq!(
+            layout.report_path(),
+            PathBuf::from("/tmp/runs/run-1/run-report.md")
+        );
+    }
+
+    #[test]
+    fn run_layout_prepared_suite_path() {
+        let layout = sample_layout();
+        assert_eq!(
+            layout.prepared_suite_path(),
+            PathBuf::from("/tmp/runs/run-1/prepared-suite.json")
+        );
+    }
+
+    #[test]
+    fn run_layout_from_run_dir() {
+        let layout = RunLayout::from_run_dir(Path::new("/tmp/runs/run-42"));
+        assert_eq!(layout.run_root, "/tmp/runs");
+        assert_eq!(layout.run_id, "run-42");
+        assert_eq!(layout.run_dir(), PathBuf::from("/tmp/runs/run-42"));
+    }
+
+    #[test]
+    fn run_layout_ensure_dirs_creates_subdirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let layout = RunLayout {
+            run_root: tmp.path().to_string_lossy().to_string(),
+            run_id: "test-run".into(),
+        };
+        layout.ensure_dirs().unwrap();
+        assert!(layout.run_dir().is_dir());
+        assert!(layout.artifacts_dir().is_dir());
+        assert!(layout.commands_dir().is_dir());
+        assert!(layout.manifests_dir().is_dir());
+        assert!(layout.state_dir().is_dir());
+    }
+
+    #[test]
+    fn run_layout_ensure_dirs_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let layout = RunLayout {
+            run_root: tmp.path().to_string_lossy().to_string(),
+            run_id: "test-run".into(),
+        };
+        layout.ensure_dirs().unwrap();
+        layout.ensure_dirs().unwrap();
+        assert!(layout.run_dir().is_dir());
+    }
+
+    #[test]
+    fn run_layout_serialization_roundtrip() {
+        let layout = sample_layout();
+        let json = serde_json::to_string(&layout).unwrap();
+        let back: RunLayout = serde_json::from_str(&json).unwrap();
+        assert_eq!(layout, back);
+    }
+
+    // -- CommandEnv tests --
+
+    #[test]
+    fn command_env_to_env_dict_without_kubeconfig() {
+        let env = CommandEnv {
+            profile: "single-zone".into(),
+            repo_root: "/repo".into(),
+            run_dir: "/runs/r1".into(),
+            run_id: "r1".into(),
+            run_root: "/runs".into(),
+            suite_dir: "/suites/s".into(),
+            suite_id: "s".into(),
+            suite_path: "/suites/s/suite.md".into(),
+            kubeconfig: None,
+        };
+        let dict = env.to_env_dict();
+        assert_eq!(dict.get("PROFILE").unwrap(), "single-zone");
+        assert_eq!(dict.get("REPO_ROOT").unwrap(), "/repo");
+        assert_eq!(dict.get("RUN_DIR").unwrap(), "/runs/r1");
+        assert_eq!(dict.get("RUN_ID").unwrap(), "r1");
+        assert_eq!(dict.get("RUN_ROOT").unwrap(), "/runs");
+        assert_eq!(dict.get("SUITE_DIR").unwrap(), "/suites/s");
+        assert_eq!(dict.get("SUITE_ID").unwrap(), "s");
+        assert_eq!(dict.get("SUITE_PATH").unwrap(), "/suites/s/suite.md");
+        assert!(!dict.contains_key("KUBECONFIG"));
+        assert_eq!(dict.len(), 8);
+    }
+
+    #[test]
+    fn command_env_to_env_dict_with_kubeconfig() {
+        let env = CommandEnv {
+            profile: "p".into(),
+            repo_root: "/r".into(),
+            run_dir: "/d".into(),
+            run_id: "i".into(),
+            run_root: "/rr".into(),
+            suite_dir: "/sd".into(),
+            suite_id: "si".into(),
+            suite_path: "/sp".into(),
+            kubeconfig: Some("/kube/config".into()),
+        };
+        let dict = env.to_env_dict();
+        assert_eq!(dict.get("KUBECONFIG").unwrap(), "/kube/config");
+        assert_eq!(dict.len(), 9);
+    }
+
+    // -- RunMetadata tests --
+
+    #[test]
+    fn run_metadata_serialization_roundtrip() {
+        let meta = sample_metadata();
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: RunMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, back);
+    }
+
+    #[test]
+    fn run_metadata_defaults_for_optional_fields() {
+        let json = r#"{
+            "run_id": "r1",
+            "suite_id": "s1",
+            "suite_path": "/p",
+            "suite_dir": "/d",
+            "profile": "single-zone",
+            "repo_root": "/repo",
+            "created_at": "now"
+        }"#;
+        let meta: RunMetadata = serde_json::from_str(json).unwrap();
+        assert!(!meta.keep_clusters);
+        assert!(meta.user_stories.is_empty());
+        assert!(meta.required_dependencies.is_empty());
+    }
+
+    // -- RunStatus deserialization tests (ported from test_schema.py:251-309) --
+
+    #[test]
+    fn load_run_status_from_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("run-status.json");
+        let data = serde_json::json!({
+            "run_id": "t",
+            "suite_id": "s",
+            "profile": "single-zone",
+            "started_at": "now",
+            "completed_at": null,
+            "executed_groups": [],
+            "skipped_groups": [],
+            "overall_verdict": "pending",
+            "last_state_capture": null,
+            "notes": []
+        });
+        std::fs::write(&path, serde_json::to_string(&data).unwrap()).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let status: RunStatus = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(status.last_state_capture, None);
+        assert_eq!(status.counts, RunCounts::default());
+        assert_eq!(status.last_completed_group, None);
+        assert_eq!(status.next_planned_group, None);
+    }
+
+    #[test]
+    fn load_run_status_accepts_structured_group_entries() {
+        let data = serde_json::json!({
+            "run_id": "t",
+            "suite_id": "s",
+            "profile": "single-zone",
+            "started_at": "now",
+            "completed_at": null,
+            "counts": {"passed": 1, "failed": 0, "skipped": 0},
+            "executed_groups": [
+                {
+                    "group_id": "g02",
+                    "verdict": "pass",
+                    "completed_at": "2026-03-14T07:57:19Z"
+                }
+            ],
+            "skipped_groups": [],
+            "last_completed_group": "g02",
+            "overall_verdict": "pending",
+            "last_state_capture": "state/after-g02.json",
+            "last_updated_utc": "2026-03-14T07:57:19Z",
+            "next_planned_group": "g03",
+            "notes": []
+        });
+
+        let status: RunStatus = serde_json::from_value(data).unwrap();
+
+        assert_eq!(
+            status.counts,
+            RunCounts {
+                passed: 1,
+                failed: 0,
+                skipped: 0
+            }
+        );
+        let group_ids = extract_group_ids(&status.executed_groups);
+        assert_eq!(group_ids, vec!["g02"]);
+        assert_eq!(status.last_completed_group.as_deref(), Some("g02"));
+        assert_eq!(status.next_planned_group.as_deref(), Some("g03"));
+    }
+
+    // -- extract_group_ids tests --
+
+    #[test]
+    fn extract_group_ids_from_strings() {
+        let vals = vec![
+            serde_json::Value::String("g01".into()),
+            serde_json::Value::String("g02".into()),
+        ];
+        assert_eq!(extract_group_ids(&vals), vec!["g01", "g02"]);
+    }
+
+    #[test]
+    fn extract_group_ids_from_objects() {
+        let vals = vec![serde_json::json!({"group_id": "g03", "verdict": "pass"})];
+        assert_eq!(extract_group_ids(&vals), vec!["g03"]);
+    }
+
+    #[test]
+    fn extract_group_ids_mixed() {
+        let vals = vec![
+            serde_json::Value::String("g01".into()),
+            serde_json::json!({"group_id": "g02"}),
+        ];
+        assert_eq!(extract_group_ids(&vals), vec!["g01", "g02"]);
+    }
+
+    #[test]
+    fn extract_group_ids_skips_invalid() {
+        let vals = vec![
+            serde_json::json!(42),
+            serde_json::json!({"no_group_id": true}),
+        ];
+        assert!(extract_group_ids(&vals).is_empty());
+    }
+
+    // -- RunContext from_run_dir test --
+
+    #[test]
+    fn run_context_from_run_dir_loads_metadata_and_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let run_dir = tmp.path().join("run-1");
+        let layout = RunLayout::from_run_dir(&run_dir);
+        layout.ensure_dirs().unwrap();
+
+        let metadata = sample_metadata();
+        let meta_json = serde_json::to_string_pretty(&metadata).unwrap();
+        std::fs::write(layout.metadata_path(), &meta_json).unwrap();
+
+        let status_data = serde_json::json!({
+            "run_id": "run-1",
+            "suite_id": "suite-a",
+            "profile": "single-zone",
+            "started_at": "2026-03-14T00:00:00Z",
+            "overall_verdict": "pending",
+            "notes": []
+        });
+        std::fs::write(
+            layout.status_path(),
+            serde_json::to_string_pretty(&status_data).unwrap(),
+        )
+        .unwrap();
+
+        let ctx = RunContext::from_run_dir(&run_dir).unwrap();
+        assert_eq!(ctx.layout.run_id, "run-1");
+        assert_eq!(ctx.metadata.suite_id, "suite-a");
+        assert_eq!(ctx.metadata.profile, "single-zone");
+        let status = ctx.status.unwrap();
+        assert_eq!(status.overall_verdict, "pending");
+        assert_eq!(status.run_id, "run-1");
+        assert!(ctx.cluster.is_none());
+        assert!(ctx.prepared_suite.is_none());
+        assert!(ctx.preflight.is_none());
+    }
+
+    #[test]
+    fn run_context_from_run_dir_fails_on_missing_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let run_dir = tmp.path().join("run-missing");
+        std::fs::create_dir_all(&run_dir).unwrap();
+
+        let result = RunContext::from_run_dir(&run_dir);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, "KSRCLI014");
+    }
+
+    #[test]
+    fn run_context_from_current_returns_none() {
+        let result = RunContext::from_current().unwrap();
+        assert!(result.is_none());
+    }
+
+    // -- CurrentRunRecord tests --
+
+    #[test]
+    fn current_run_record_serialization_roundtrip() {
+        let record = CurrentRunRecord {
+            layout: sample_layout(),
+            profile: Some("single-zone".into()),
+            repo_root: Some("/repo".into()),
+            suite_dir: Some("/suites/s".into()),
+            suite_id: Some("s".into()),
+            suite_path: Some("/suites/s/suite.md".into()),
+            cluster: None,
+            keep_clusters: false,
+            user_stories: vec![],
+            required_dependencies: vec![],
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        let back: CurrentRunRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.layout, record.layout);
+        assert_eq!(back.profile, record.profile);
+        assert_eq!(back.repo_root, record.repo_root);
+    }
+
+    // -- ArtifactSnapshot tests --
+
+    #[test]
+    fn artifact_snapshot_serialization() {
+        let snap = ArtifactSnapshot {
+            kind: "markdown".into(),
+            exists: true,
+            row_count: Some(5),
+            files: vec!["a.txt".into(), "b.txt".into()],
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        let back: ArtifactSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(snap, back);
+    }
+
+    // -- PreflightArtifact tests --
+
+    #[test]
+    fn preflight_artifact_deserialization_with_defaults() {
+        let data = serde_json::json!({"checked_at": "2026-03-14T00:00:00Z"});
+        let pf: PreflightArtifact = serde_json::from_value(data).unwrap();
+        assert_eq!(pf.checked_at, "2026-03-14T00:00:00Z");
+        assert!(pf.prepared_suite_path.is_none());
+        assert!(pf.repo_root.is_none());
+        assert_eq!(pf.tools, serde_json::Value::Null);
+        assert_eq!(pf.nodes, serde_json::Value::Null);
+    }
+}

--- a/src/core_defs.rs
+++ b/src/core_defs.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
-use crate::errors::CliError;
+use sha2::{Digest, Sha256};
+
+use crate::errors::{self, COMMAND_FAILED, CliError};
 
 /// Build information resolved from the repo.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,7 +16,7 @@ impl BuildInfo {
     #[must_use]
     pub fn env(&self) -> HashMap<String, String> {
         let mut m = HashMap::new();
-        m.insert("BUILD_INFO_VERSION".to_string(), self.version.clone());
+        m.insert("BUILD_INFO_VERSION".into(), self.version.clone());
         m
     }
 }
@@ -33,7 +36,7 @@ pub fn utc_now() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
-/// XDG data root (XDG_DATA_HOME or ~/.local/share).
+/// XDG data root (`XDG_DATA_HOME` or `~/.local/share`).
 #[must_use]
 pub fn data_root() -> PathBuf {
     if let Ok(xdg) = std::env::var("XDG_DATA_HOME")
@@ -44,34 +47,99 @@ pub fn data_root() -> PathBuf {
     dirs_home().join(".local").join("share")
 }
 
-/// Harness data root: data_root/kuma.
+/// Harness data root: `data_root/kuma`.
 #[must_use]
 pub fn harness_data_root() -> PathBuf {
     data_root().join("kuma")
 }
 
-/// Suite root: harness_data_root/suites.
+/// Suite root: `harness_data_root/suites`.
 #[must_use]
 pub fn suite_root() -> PathBuf {
     harness_data_root().join("suites")
 }
 
+/// Read an env var, returning `None` if empty or an unexpanded shell variable.
+fn context_scope_value(name: &str) -> Option<String> {
+    let value = std::env::var(name).unwrap_or_default();
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.starts_with("${") && trimmed.ends_with('}') {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Compute a hex digest prefix from a scope string.
+fn scope_digest(scope: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(scope.as_bytes());
+    let hash = hasher.finalize();
+    hex_encode_prefix(&hash, 8)
+}
+
+/// Encode the first `n` bytes of a hash as lowercase hex (producing `2*n` chars).
+fn hex_encode_prefix(bytes: &[u8], n: usize) -> String {
+    bytes
+        .iter()
+        .take(n)
+        .fold(String::with_capacity(n * 2), |mut acc, b| {
+            use std::fmt::Write;
+            let _ = write!(acc, "{b:02x}");
+            acc
+        })
+}
+
 /// Compute a context scope key from environment (session > project > cwd).
 #[must_use]
 pub fn session_scope_key() -> String {
-    todo!()
+    if let Some(session_id) = context_scope_value("CLAUDE_SESSION_ID") {
+        let scope = format!("session:{session_id}");
+        return format!("session-{}", scope_digest(&scope));
+    }
+    if let Some(project_dir) = context_scope_value("CLAUDE_PROJECT_DIR") {
+        let resolved = PathBuf::from(project_dir)
+            .canonicalize()
+            .unwrap_or_else(|_| PathBuf::from(""));
+        let scope = format!("project:{}", resolved.display());
+        return format!("project-{}", scope_digest(&scope));
+    }
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let resolved = cwd.canonicalize().unwrap_or(cwd);
+    let scope = format!("cwd:{}", resolved.display());
+    format!("cwd-{}", scope_digest(&scope))
 }
 
 /// Session context directory.
 #[must_use]
 pub fn session_context_dir() -> PathBuf {
-    todo!()
+    harness_data_root()
+        .join("contexts")
+        .join(session_scope_key())
+}
+
+/// Path to the current run context JSON file.
+#[must_use]
+pub fn current_run_context_path() -> PathBuf {
+    session_context_dir().join("current-run.json")
 }
 
 /// Project context directory (hashed from project path).
 #[must_use]
-pub fn project_context_dir(_project_dir: &Path) -> PathBuf {
-    todo!()
+pub fn project_context_dir(project_dir: &Path) -> PathBuf {
+    let resolved = project_dir
+        .canonicalize()
+        .unwrap_or_else(|_| project_dir.to_path_buf());
+    let scope = resolved.to_string_lossy();
+    let mut hasher = Sha256::new();
+    hasher.update(scope.as_bytes());
+    let hash = hasher.finalize();
+    let digest = hex_encode_prefix(&hash, 8);
+    harness_data_root()
+        .join("projects")
+        .join(format!("project-{digest}"))
 }
 
 /// Merge current env with extra key-value pairs.
@@ -88,14 +156,65 @@ pub fn merge_env(extra: Option<&HashMap<String, String>>) -> HashMap<String, Str
 ///
 /// # Errors
 /// Returns `CliError` on command failure.
-pub fn resolve_build_info(_repo: &Path) -> Result<BuildInfo, CliError> {
-    todo!()
+pub fn resolve_build_info(repo: &Path) -> Result<BuildInfo, CliError> {
+    let version_script = repo.join("tools").join("releases").join("version.sh");
+    if version_script.exists()
+        && let Ok(output) = Command::new(&version_script).current_dir(repo).output()
+        && output.status.success()
+    {
+        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !version.is_empty() {
+            return Ok(BuildInfo { version });
+        }
+    }
+
+    let dirty_output = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .current_dir(repo)
+        .output()
+        .map_err(|e| CliError {
+            code: COMMAND_FAILED.code.to_string(),
+            message: format!("command failed: git status: {e}"),
+            exit_code: COMMAND_FAILED.exit_code,
+            hint: None,
+            details: None,
+        })?;
+
+    let dirty = String::from_utf8_lossy(&dirty_output.stdout)
+        .trim()
+        .to_string();
+
+    if !dirty.is_empty() {
+        return Ok(BuildInfo {
+            version: "0.0.0-preview.vlocal-build".into(),
+        });
+    }
+
+    let sha_output = Command::new("git")
+        .args(["rev-parse", "--short=10", "HEAD"])
+        .current_dir(repo)
+        .output()
+        .map_err(|e| CliError {
+            code: COMMAND_FAILED.code.to_string(),
+            message: format!("command failed: git rev-parse: {e}"),
+            exit_code: COMMAND_FAILED.exit_code,
+            hint: None,
+            details: None,
+        })?;
+
+    let short_sha = String::from_utf8_lossy(&sha_output.stdout)
+        .trim()
+        .to_string();
+
+    Ok(BuildInfo {
+        version: format!("0.0.0-preview.v{short_sha}"),
+    })
 }
 
 /// Render an error for display to stderr.
 #[must_use]
 pub fn render_error(error: &CliError) -> String {
-    crate::errors::render_error(error)
+    errors::render_error(error)
 }
 
 fn dirs_home() -> PathBuf {
@@ -105,4 +224,122 @@ fn dirs_home() -> PathBuf {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utc_now_ends_with_z() {
+        let now = utc_now();
+        assert!(now.ends_with('Z'), "expected Z suffix, got: {now}");
+        assert!(!now.contains('+'), "expected no +, got: {now}");
+    }
+
+    #[test]
+    fn cli_error_has_all_fields() {
+        let err = CliError {
+            code: "CODE1".into(),
+            message: "msg".into(),
+            exit_code: 3,
+            hint: Some("try this".into()),
+            details: Some("more".into()),
+        };
+        assert_eq!(err.code, "CODE1");
+        assert_eq!(err.message, "msg");
+        assert_eq!(err.exit_code, 3);
+        assert_eq!(err.hint.as_deref(), Some("try this"));
+        assert_eq!(err.details.as_deref(), Some("more"));
+    }
+
+    #[test]
+    fn render_error_includes_hint_and_details() {
+        let err = CliError {
+            code: "X".into(),
+            message: "bad".into(),
+            exit_code: 1,
+            hint: Some("fix it".into()),
+            details: Some("stack".into()),
+        };
+        let rendered = render_error(&err);
+        assert!(
+            rendered.contains("ERROR [X] bad"),
+            "missing header: {rendered}"
+        );
+        assert!(
+            rendered.contains("Hint: fix it"),
+            "missing hint: {rendered}"
+        );
+        assert!(rendered.contains("stack"), "missing details: {rendered}");
+    }
+
+    #[test]
+    fn build_info_env() {
+        let info = BuildInfo {
+            version: "1.2.3".into(),
+        };
+        let env = info.env();
+        assert_eq!(env.len(), 1);
+        assert_eq!(env.get("BUILD_INFO_VERSION").unwrap(), "1.2.3");
+    }
+
+    /// # Safety helper - wraps unsafe env manipulation for tests.
+    unsafe fn with_env_var(name: &str, value: &str, f: impl FnOnce()) {
+        let saved = std::env::var(name).ok();
+        unsafe { std::env::set_var(name, value) };
+        f();
+        match saved {
+            Some(v) => unsafe { std::env::set_var(name, v) },
+            None => unsafe { std::env::remove_var(name) },
+        }
+    }
+
+    // All env-dependent tests are combined into one test to avoid races
+    // from parallel test execution mutating the same env var.
+    #[test]
+    fn session_scope_and_context_path() {
+        unsafe {
+            with_env_var("CLAUDE_SESSION_ID", "combined-scope-test", || {
+                // session_scope_key uses session prefix
+                let key = session_scope_key();
+                assert!(
+                    key.starts_with("session-"),
+                    "expected session- prefix: {key}"
+                );
+                assert_eq!(
+                    key.len(),
+                    "session-".len() + 16,
+                    "digest should be 16 hex chars"
+                );
+
+                // deterministic: calling twice gives same result
+                let key2 = session_scope_key();
+                assert_eq!(key, key2);
+
+                // current_run_context_path is under session context dir
+                let path = current_run_context_path();
+                assert!(
+                    path.ends_with("current-run.json"),
+                    "expected current-run.json suffix: {path:?}"
+                );
+                let parent_name = path
+                    .parent()
+                    .and_then(|p| p.file_name())
+                    .unwrap()
+                    .to_string_lossy();
+                assert!(
+                    parent_name.starts_with("session-"),
+                    "expected session- prefix: {parent_name}"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn resolve_build_info_in_current_repo() {
+        // This repo has a git history, so resolve_build_info should return something
+        let repo = std::env::current_dir().unwrap();
+        let info = resolve_build_info(&repo);
+        assert!(info.is_ok(), "expected Ok, got: {info:?}");
+        let info = info.unwrap();
+        assert!(!info.version.is_empty(), "version should not be empty");
+    }
+}


### PR DESCRIPTION
## Motivation

The context module had stub implementations (todo!() bodies) for core functions needed by the run lifecycle: directory creation, environment variable mapping, and loading run context from disk.

## Implementation information

- `RunLayout::ensure_dirs()` - creates run subdirectories (artifacts, commands, manifests, state)
- `CommandEnv::to_env_dict()` - maps fields to environment variable names
- `RunContext::from_run_dir()` - loads metadata and status from disk
- `RunContext::from_current()` - returns None (session tracking not yet available)
- `extract_group_ids()` helper for parsing structured group entries from RunStatus
- 29 tests ported from Python test suite