### PR TITLE
feat(daemon): plan remote tls acme

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -36,8 +36,6 @@ pub mod ordering;
 pub mod protocol;
 pub mod remote;
 pub mod remote_acme;
-#[cfg(test)]
-mod remote_acme_tests;
 pub mod service;
 pub mod snapshot;
 pub mod state;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -35,6 +35,9 @@ pub mod launchd;
 pub mod ordering;
 pub mod protocol;
 pub mod remote;
+pub mod remote_acme;
+#[cfg(test)]
+mod remote_acme_tests;
 pub mod service;
 pub mod snapshot;
 pub mod state;

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -1,0 +1,320 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use sha2::{Digest, Sha256};
+
+use super::protocol::http_paths;
+use super::remote::{
+    RemoteAcmeChallenge, RemoteDaemonConfigError, RemoteDaemonServeConfig, RemoteDnsProvider,
+    validate_remote_serve_config,
+};
+
+const HTTPS_ALPN_PROTOCOLS: &[&[u8]] = &[b"h2", b"http/1.1"];
+const TLS_ALPN_CHALLENGE_PROTOCOLS: &[&[u8]] = &[b"acme-tls/1"];
+const NO_CHALLENGE_ALPN_PROTOCOLS: &[&[u8]] = &[];
+const HTTP01_PREFIX: &str = "/.well-known/acme-challenge/";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteAcmeRuntimeError {
+    InvalidConfig(RemoteDaemonConfigError),
+    MissingPersistedAcmeState,
+    MissingCertificate,
+}
+
+impl fmt::Display for RemoteAcmeRuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidConfig(error) => write!(f, "{error}"),
+            Self::MissingPersistedAcmeState => {
+                write!(f, "remote daemon requires persisted ACME state")
+            }
+            Self::MissingCertificate => {
+                write!(f, "remote daemon requires a persisted TLS certificate")
+            }
+        }
+    }
+}
+
+impl Error for RemoteAcmeRuntimeError {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RemoteAcmeRuntimeState {
+    acme_account_id: Option<String>,
+    certificate: Option<RemoteCertificateBundle>,
+}
+
+impl RemoteAcmeRuntimeState {
+    #[must_use]
+    pub fn with_account_and_certificate(
+        account_id: impl Into<String>,
+        certificate: RemoteCertificateBundle,
+    ) -> Self {
+        Self {
+            acme_account_id: Some(account_id.into()),
+            certificate: Some(certificate),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteAcmeRuntimePlan {
+    domain: String,
+    https_port: u16,
+    challenge: RemoteAcmeChallenge,
+    certificate: RemoteCertificateBundle,
+}
+
+impl RemoteAcmeRuntimePlan {
+    #[must_use]
+    pub fn public_https_origin(&self) -> String {
+        if self.https_port == 443 {
+            format!("https://{}", self.domain)
+        } else {
+            format!("https://{}:{}", self.domain, self.https_port)
+        }
+    }
+
+    #[must_use]
+    pub fn public_wss_url(&self) -> String {
+        let host = if self.https_port == 443 {
+            self.domain.clone()
+        } else {
+            format!("{}:{}", self.domain, self.https_port)
+        };
+        format!("wss://{host}{}", http_paths::WS)
+    }
+
+    #[must_use]
+    pub const fn uses_rustls_https(&self) -> bool {
+        true
+    }
+
+    #[must_use]
+    pub const fn https_alpn_protocols(&self) -> &'static [&'static [u8]] {
+        HTTPS_ALPN_PROTOCOLS
+    }
+
+    #[must_use]
+    pub const fn challenge_alpn_protocols(&self) -> &'static [&'static [u8]] {
+        match self.challenge {
+            RemoteAcmeChallenge::TlsAlpn => TLS_ALPN_CHALLENGE_PROTOCOLS,
+            RemoteAcmeChallenge::Http | RemoteAcmeChallenge::Dns => NO_CHALLENGE_ALPN_PROTOCOLS,
+        }
+    }
+
+    #[must_use]
+    pub const fn certificate(&self) -> &RemoteCertificateBundle {
+        &self.certificate
+    }
+}
+
+/// Build the remote daemon TLS/ACME runtime plan.
+///
+/// # Errors
+/// Returns [`RemoteAcmeRuntimeError`] when the static config is invalid or
+/// persisted ACME account/certificate state is missing.
+pub fn build_remote_acme_runtime_plan(
+    config: &RemoteDaemonServeConfig,
+    state: &RemoteAcmeRuntimeState,
+) -> Result<RemoteAcmeRuntimePlan, RemoteAcmeRuntimeError> {
+    validate_remote_serve_config(config).map_err(RemoteAcmeRuntimeError::InvalidConfig)?;
+    if state
+        .acme_account_id
+        .as_deref()
+        .unwrap_or_default()
+        .is_empty()
+    {
+        return Err(RemoteAcmeRuntimeError::MissingPersistedAcmeState);
+    }
+    let certificate = state
+        .certificate
+        .clone()
+        .ok_or(RemoteAcmeRuntimeError::MissingCertificate)?;
+
+    Ok(RemoteAcmeRuntimePlan {
+        domain: config.domain.trim().to_string(),
+        https_port: config.https_port,
+        challenge: config.acme_challenge,
+        certificate,
+    })
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AcmeHttp01ChallengeStore {
+    authorizations: BTreeMap<String, String>,
+}
+
+impl AcmeHttp01ChallengeStore {
+    #[must_use]
+    pub fn from_pairs<const N: usize>(pairs: [(&str, &str); N]) -> Self {
+        Self {
+            authorizations: pairs
+                .into_iter()
+                .map(|(token, authorization)| (token.to_string(), authorization.to_string()))
+                .collect(),
+        }
+    }
+
+    #[must_use]
+    pub fn response_for_path(&self, path: &str) -> Option<&str> {
+        let token = path.strip_prefix(HTTP01_PREFIX)?;
+        if token.is_empty() || token.contains('/') || token.contains("..") {
+            return None;
+        }
+        self.authorizations.get(token).map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dns01ProviderAction {
+    provider: RemoteDnsProvider,
+    fqdn: String,
+    digest: String,
+}
+
+impl Dns01ProviderAction {
+    #[must_use]
+    pub fn for_provider(
+        provider: RemoteDnsProvider,
+        fqdn: impl Into<String>,
+        digest: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider,
+            fqdn: fqdn.into(),
+            digest: digest.into(),
+        }
+    }
+
+    #[must_use]
+    pub const fn required_secret_names(&self) -> &'static [&'static str] {
+        match self.provider {
+            RemoteDnsProvider::Cloudflare => &["CLOUDFLARE_API_TOKEN"],
+            RemoteDnsProvider::Route53 => &["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+            RemoteDnsProvider::Exec => &["HARNESS_REMOTE_ACME_DNS_EXEC"],
+        }
+    }
+
+    #[must_use]
+    pub fn command_preview(&self) -> String {
+        match self.provider {
+            RemoteDnsProvider::Cloudflare => {
+                format!("cloudflare TXT {} {}", self.fqdn, self.digest)
+            }
+            RemoteDnsProvider::Route53 => format!("route53 TXT {} {}", self.fqdn, self.digest),
+            RemoteDnsProvider::Exec => {
+                format!(
+                    "$HARNESS_REMOTE_ACME_DNS_EXEC present {} {}",
+                    self.fqdn, self.digest
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteCertificateBundle {
+    certificate_pem: String,
+    private_key_pem: String,
+    fingerprint: String,
+}
+
+impl RemoteCertificateBundle {
+    #[cfg(test)]
+    #[must_use]
+    pub fn new_for_tests(certificate_pem: &str, private_key_pem: &str) -> Self {
+        Self::new(certificate_pem, private_key_pem)
+    }
+
+    #[must_use]
+    pub fn new(certificate_pem: &str, private_key_pem: &str) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(certificate_pem.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(private_key_pem.as_bytes());
+        let fingerprint = hex::encode(hasher.finalize());
+        Self {
+            certificate_pem: certificate_pem.to_string(),
+            private_key_pem: private_key_pem.to_string(),
+            fingerprint,
+        }
+    }
+
+    #[must_use]
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteCertificateSlot {
+    bundle: RemoteCertificateBundle,
+    generation: u64,
+}
+
+impl RemoteCertificateSlot {
+    #[must_use]
+    pub const fn new(bundle: RemoteCertificateBundle) -> Self {
+        Self {
+            bundle,
+            generation: 1,
+        }
+    }
+
+    #[must_use]
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn reload(&mut self, bundle: RemoteCertificateBundle) -> bool {
+        if self.bundle.fingerprint() == bundle.fingerprint() {
+            return false;
+        }
+        self.bundle = bundle;
+        self.generation += 1;
+        true
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteRenewalOutcome {
+    Succeeded,
+    Failed { report: String },
+}
+
+impl RemoteRenewalOutcome {
+    #[must_use]
+    pub fn failure(detail: &str) -> Self {
+        Self::Failed {
+            report: format!("renewal failed: {}", redact_secret_detail(detail)),
+        }
+    }
+
+    #[must_use]
+    pub const fn is_failure(&self) -> bool {
+        matches!(self, Self::Failed { .. })
+    }
+
+    #[must_use]
+    pub fn report(&self) -> &str {
+        match self {
+            Self::Succeeded => "renewal succeeded",
+            Self::Failed { report } => report,
+        }
+    }
+}
+
+fn redact_secret_detail(detail: &str) -> String {
+    detail
+        .split_whitespace()
+        .map(|part| {
+            if part.starts_with("secret=") || part.starts_with("token=") {
+                "<redacted>".to_string()
+            } else {
+                part.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -322,15 +322,37 @@ impl RemoteRenewalOutcome {
 }
 
 fn redact_secret_detail(detail: &str) -> String {
-    detail
-        .split_whitespace()
-        .map(|part| {
-            if part.starts_with("secret=") || part.starts_with("token=") {
-                "<redacted>".to_string()
-            } else {
-                part.to_string()
+    let mut redacted = String::with_capacity(detail.len());
+    let mut offset = 0;
+
+    while offset < detail.len() {
+        let rest = &detail[offset..];
+        if let Some(key) = ["secret=", "token="]
+            .into_iter()
+            .find(|key| rest.starts_with(key))
+        {
+            redacted.push_str(key);
+            redacted.push_str("<redacted>");
+            offset += key.len();
+            while let Some(value_char) = detail[offset..].chars().next() {
+                if is_secret_value_terminator(value_char) {
+                    break;
+                }
+                offset += value_char.len_utf8();
             }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+        } else if let Some(plain_char) = rest.chars().next() {
+            redacted.push(plain_char);
+            offset += plain_char.len_utf8();
+        }
+    }
+
+    redacted
+}
+
+fn is_secret_value_terminator(value_char: char) -> bool {
+    value_char.is_whitespace()
+        || matches!(
+            value_char,
+            '&' | ';' | ',' | ')' | ']' | '}' | '"' | '\''
+        )
 }

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -10,6 +10,10 @@ use super::remote::{
     validate_remote_serve_config,
 };
 
+#[cfg(test)]
+#[path = "remote_acme_tests.rs"]
+mod tests;
+
 const HTTPS_ALPN_PROTOCOLS: &[&[u8]] = &[b"h2", b"http/1.1"];
 const TLS_ALPN_CHALLENGE_PROTOCOLS: &[&[u8]] = &[b"acme-tls/1"];
 const NO_CHALLENGE_ALPN_PROTOCOLS: &[&[u8]] = &[];

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -139,6 +139,9 @@ pub fn build_remote_acme_runtime_plan(
         .certificate
         .clone()
         .ok_or(RemoteAcmeRuntimeError::MissingCertificate)?;
+    if !certificate.has_material() {
+        return Err(RemoteAcmeRuntimeError::MissingCertificate);
+    }
 
     Ok(RemoteAcmeRuntimePlan {
         domain: config.domain.trim().to_string(),
@@ -252,6 +255,11 @@ impl RemoteCertificateBundle {
     #[must_use]
     pub fn fingerprint(&self) -> &str {
         &self.fingerprint
+    }
+
+    #[must_use]
+    pub fn has_material(&self) -> bool {
+        !self.certificate_pem.trim().is_empty() && !self.private_key_pem.trim().is_empty()
     }
 }
 

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -36,7 +36,14 @@ impl fmt::Display for RemoteAcmeRuntimeError {
     }
 }
 
-impl Error for RemoteAcmeRuntimeError {}
+impl Error for RemoteAcmeRuntimeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidConfig(error) => Some(error),
+            Self::MissingPersistedAcmeState | Self::MissingCertificate => None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RemoteAcmeRuntimeState {
@@ -123,6 +130,7 @@ pub fn build_remote_acme_runtime_plan(
         .acme_account_id
         .as_deref()
         .unwrap_or_default()
+        .trim()
         .is_empty()
     {
         return Err(RemoteAcmeRuntimeError::MissingPersistedAcmeState);

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -53,6 +53,14 @@ pub struct RemoteAcmeRuntimeState {
 
 impl RemoteAcmeRuntimeState {
     #[must_use]
+    pub fn with_account(account_id: impl Into<String>) -> Self {
+        Self {
+            acme_account_id: Some(account_id.into()),
+            certificate: None,
+        }
+    }
+
+    #[must_use]
     pub fn with_account_and_certificate(
         account_id: impl Into<String>,
         certificate: RemoteCertificateBundle,

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -40,6 +40,15 @@ fn remote_tls_acme_plan_rejects_blank_persisted_account_id() {
 }
 
 #[test]
+fn remote_tls_acme_plan_reports_missing_certificate_after_account_state_loads() {
+    let state = RemoteAcmeRuntimeState::with_account("acct-1");
+    let error = build_remote_acme_runtime_plan(&tls_alpn_config(), &state)
+        .expect_err("account-only ACME state should fail on missing certificate");
+
+    assert!(error.to_string().contains("persisted TLS certificate"));
+}
+
+#[test]
 fn remote_tls_acme_plan_rejects_blank_persisted_certificate_material() {
     let state = RemoteAcmeRuntimeState::with_account_and_certificate(
         "acct-1",

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -1,0 +1,128 @@
+use super::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
+use super::remote_acme::{
+    AcmeHttp01ChallengeStore, Dns01ProviderAction, RemoteAcmeRuntimeState, RemoteCertificateBundle,
+    RemoteCertificateSlot, RemoteRenewalOutcome, build_remote_acme_runtime_plan,
+};
+
+fn tls_alpn_config() -> RemoteDaemonServeConfig {
+    RemoteDaemonServeConfig {
+        domain: "daemon.example.com".to_string(),
+        host: "0.0.0.0".to_string(),
+        https_port: 443,
+        http_port: 80,
+        acme_email: "ops@example.com".to_string(),
+        acme_challenge: RemoteAcmeChallenge::TlsAlpn,
+        acme_dns_provider: None,
+    }
+}
+
+#[test]
+fn remote_tls_acme_plan_requires_persisted_state() {
+    let error =
+        build_remote_acme_runtime_plan(&tls_alpn_config(), &RemoteAcmeRuntimeState::default())
+            .expect_err("remote mode should fail closed without persisted ACME state");
+
+    assert!(error.to_string().contains("persisted ACME state"));
+}
+
+#[test]
+fn remote_tls_acme_plan_uses_rustls_https_and_wss_urls() {
+    let state = RemoteAcmeRuntimeState::with_account_and_certificate(
+        "acct-1",
+        RemoteCertificateBundle::new_for_tests("cert-a", "key-a"),
+    );
+    let plan = build_remote_acme_runtime_plan(&tls_alpn_config(), &state)
+        .expect("persisted ACME state should allow planning");
+
+    assert_eq!(plan.public_https_origin(), "https://daemon.example.com");
+    assert_eq!(plan.public_wss_url(), "wss://daemon.example.com/v1/ws");
+    assert!(plan.uses_rustls_https());
+    assert_eq!(
+        plan.https_alpn_protocols(),
+        &[b"h2".as_slice(), b"http/1.1".as_slice()]
+    );
+}
+
+#[test]
+fn remote_tls_alpn_challenge_adds_acme_alpn_protocol() {
+    let state = RemoteAcmeRuntimeState::with_account_and_certificate(
+        "acct-1",
+        RemoteCertificateBundle::new_for_tests("cert-a", "key-a"),
+    );
+    let plan = build_remote_acme_runtime_plan(&tls_alpn_config(), &state)
+        .expect("tls-alpn config should plan");
+
+    assert_eq!(plan.challenge_alpn_protocols(), &[b"acme-tls/1".as_slice()]);
+}
+
+#[test]
+fn remote_http01_challenge_routes_only_well_known_tokens() {
+    let store = AcmeHttp01ChallengeStore::from_pairs([("token-1", "token-1.key-auth")]);
+
+    assert_eq!(
+        store.response_for_path("/.well-known/acme-challenge/token-1"),
+        Some("token-1.key-auth")
+    );
+    assert_eq!(
+        store.response_for_path("/.well-known/acme-challenge/../token-1"),
+        None
+    );
+    assert_eq!(store.response_for_path("/v1/config"), None);
+}
+
+#[test]
+fn remote_dns01_providers_report_required_operations() {
+    let cloudflare = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Cloudflare,
+        "_acme-challenge.daemon.example.com",
+        "digest",
+    );
+    let route53 = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Route53,
+        "_acme-challenge.daemon.example.com",
+        "digest",
+    );
+    let exec = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Exec,
+        "_acme-challenge.daemon.example.com",
+        "digest",
+    );
+
+    assert_eq!(
+        cloudflare.required_secret_names(),
+        &["CLOUDFLARE_API_TOKEN"]
+    );
+    assert_eq!(
+        route53.required_secret_names(),
+        &["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+    );
+    assert_eq!(
+        exec.required_secret_names(),
+        &["HARNESS_REMOTE_ACME_DNS_EXEC"]
+    );
+    assert!(
+        exec.command_preview()
+            .contains("_acme-challenge.daemon.example.com")
+    );
+}
+
+#[test]
+fn remote_certificate_reload_tracks_generation_and_noops_unchanged_bundle() {
+    let mut slot =
+        RemoteCertificateSlot::new(RemoteCertificateBundle::new_for_tests("cert-a", "key-a"));
+
+    assert_eq!(slot.generation(), 1);
+    assert!(!slot.reload(RemoteCertificateBundle::new_for_tests("cert-a", "key-a")));
+    assert_eq!(slot.generation(), 1);
+    assert!(slot.reload(RemoteCertificateBundle::new_for_tests("cert-b", "key-b")));
+    assert_eq!(slot.generation(), 2);
+}
+
+#[test]
+fn remote_renewal_failure_status_is_reported_without_secret_detail() {
+    let outcome = RemoteRenewalOutcome::failure("dns token secret=super-secret-token failed");
+
+    assert!(outcome.is_failure());
+    assert!(outcome.report().contains("dns token"));
+    assert!(!outcome.report().contains("super-secret-token"));
+}

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use super::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
 use super::remote_acme::{
     AcmeHttp01ChallengeStore, Dns01ProviderAction, RemoteAcmeRuntimeState, RemoteCertificateBundle,
@@ -23,6 +25,33 @@ fn remote_tls_acme_plan_requires_persisted_state() {
             .expect_err("remote mode should fail closed without persisted ACME state");
 
     assert!(error.to_string().contains("persisted ACME state"));
+}
+
+#[test]
+fn remote_tls_acme_plan_rejects_blank_persisted_account_id() {
+    let state = RemoteAcmeRuntimeState::with_account_and_certificate(
+        "   ",
+        RemoteCertificateBundle::new_for_tests("cert-a", "key-a"),
+    );
+    let error = build_remote_acme_runtime_plan(&tls_alpn_config(), &state)
+        .expect_err("blank ACME account id should fail closed");
+
+    assert!(error.to_string().contains("persisted ACME state"));
+}
+
+#[test]
+fn remote_tls_acme_plan_exposes_invalid_config_error_source() {
+    let mut config = tls_alpn_config();
+    config.domain.clear();
+    let error = build_remote_acme_runtime_plan(&config, &RemoteAcmeRuntimeState::default())
+        .expect_err("invalid config should fail before state checks");
+
+    assert!(
+        error
+            .source()
+            .is_some_and(|source| source.to_string().contains("domain is required")),
+        "expected invalid config source, got: {error:?}"
+    );
 }
 
 #[test]

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -167,3 +167,14 @@ fn remote_renewal_failure_status_is_reported_without_secret_detail() {
     assert!(outcome.report().contains("dns token"));
     assert!(!outcome.report().contains("super-secret-token"));
 }
+
+#[test]
+fn remote_renewal_failure_redacts_embedded_secret_values() {
+    let outcome = RemoteRenewalOutcome::failure(
+        "dns https://issuer.example/renew?token=url-secret-token&retry=1 error=secret=nested-secret",
+    );
+
+    assert!(outcome.report().contains("retry=1"));
+    assert!(!outcome.report().contains("url-secret-token"));
+    assert!(!outcome.report().contains("nested-secret"));
+}

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -1,10 +1,10 @@
 use std::error::Error;
 
-use super::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
-use super::remote_acme::{
+use super::{
     AcmeHttp01ChallengeStore, Dns01ProviderAction, RemoteAcmeRuntimeState, RemoteCertificateBundle,
     RemoteCertificateSlot, RemoteRenewalOutcome, build_remote_acme_runtime_plan,
 };
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
 
 fn tls_alpn_config() -> RemoteDaemonServeConfig {
     RemoteDaemonServeConfig {

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -40,6 +40,18 @@ fn remote_tls_acme_plan_rejects_blank_persisted_account_id() {
 }
 
 #[test]
+fn remote_tls_acme_plan_rejects_blank_persisted_certificate_material() {
+    let state = RemoteAcmeRuntimeState::with_account_and_certificate(
+        "acct-1",
+        RemoteCertificateBundle::new_for_tests("   ", "\n\t"),
+    );
+    let error = build_remote_acme_runtime_plan(&tls_alpn_config(), &state)
+        .expect_err("blank TLS certificate material should fail closed");
+
+    assert!(error.to_string().contains("persisted TLS certificate"));
+}
+
+#[test]
 fn remote_tls_acme_plan_exposes_invalid_config_error_source() {
     let mut config = tls_alpn_config();
     config.domain.clear();


### PR DESCRIPTION
## Motivation

Phase 1 locked the remote daemon CLI and authorization contract. The next slice needs a reviewed TLS/ACME runtime contract before listener and persistence code starts depending on it.

## Implementation

- Add a remote TLS/ACME planning module that fails closed without persisted ACME state and certificate material.
- Capture HTTPS/WSS public URL derivation, rustls ALPN decisions, TLS-ALPN challenge selection, HTTP-01 token routing, DNS-01 provider requirements, cert reload generations, and redacted renewal failures.
- Add focused TDD coverage for the remote TLS/ACME contract and keep Phase 1 remote contract tests passing.

Proofs:
- `mise run cargo:local -- test remote_acme`
- `mise run cargo:local -- test remote`
- `mise run cargo:local -- clippy -p harness --lib`
