### PR TITLE
feat(daemon): persist remote pairing

### DIFF
--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -57,6 +57,7 @@ mod imports;
 mod policy;
 mod rebuild;
 mod remote_identity;
+mod remote_pairing;
 mod review_writes;
 mod runtime;
 mod schema;

--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -9,11 +9,11 @@
 use chrono::{DateTime, Utc};
 use rusqlite::{params, types::Type};
 
-use super::{db_error, CliError, DaemonDb, OptionalExtension};
+use super::{db_error, CliError, Connection, DaemonDb, OptionalExtension};
 use crate::daemon::remote::RemoteAccessScope;
 use crate::daemon::remote_identity::{
     parse_remote_role, parse_remote_scope, RemoteAuditEvent, RemoteAuditOutcome,
-    RemoteAuditScopeDecision, RemoteBearerToken, RemoteClientRegistration,
+    RemoteAuditScopeDecision, RemoteBearerToken, RemoteClientRegistration, RemoteStoredClient,
 };
 use crate::daemon::remote_pairing::{
     validate_pairing_domain, RemotePairingClaimRequest, RemotePairingClaimedClient,
@@ -31,6 +31,18 @@ SELECT pairing_id, code_hash, role, scopes_json, created_at, expires_at,
        claimed_at, claimed_client_id, claim_remote_addr
 FROM remote_pairing_codes
 WHERE code_hash = ?1";
+
+const INSERT_PAIRING_REMOTE_CLIENT_SQL: &str = "
+INSERT INTO remote_clients (
+    client_id, display_name, platform, role, scopes_json, token_hash, token_hint,
+    created_at, last_seen_at, revoked_at, rotated_at, metadata_json
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL, '{}')";
+
+const INSERT_PAIRING_REMOTE_AUDIT_EVENT_SQL: &str = "
+INSERT INTO remote_audit_events (
+    event_id, recorded_at, request_id, client_id, route_or_method, scope,
+    scope_decision, outcome, remote_addr, error_detail, metadata_json
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, '{}')";
 
 impl DaemonDb {
     /// Persist a one-time remote pairing code hash.
@@ -134,9 +146,23 @@ impl DaemonDb {
             now,
         )
         .map_err(|error| db_error(error.to_string()))?;
-        let client = self.register_remote_client(&registration)?;
-        let changed = self
+        self.claim_remote_pairing_in_transaction(&pairing, &registration, bearer_token, claim, now)
+    }
+
+    fn claim_remote_pairing_in_transaction(
+        &self,
+        pairing: &RemoteStoredPairing,
+        registration: &RemoteClientRegistration,
+        bearer_token: RemoteBearerToken,
+        claim: &RemotePairingClaimRequest,
+        now: &str,
+    ) -> Result<RemotePairingClaimedClient, CliError> {
+        let transaction = self
             .conn
+            .unchecked_transaction()
+            .map_err(|error| db_error(format!("begin remote pairing claim: {error}")))?;
+        let client = insert_remote_client_for_pairing(&transaction, registration)?;
+        let changed = transaction
             .execute(
                 "UPDATE remote_pairing_codes
                  SET claimed_at = ?2, claimed_client_id = ?3, claim_remote_addr = ?4
@@ -156,22 +182,30 @@ impl DaemonDb {
             })?;
         if changed == 0 {
             let error_detail = RemotePairingError::AlreadyClaimed.to_string();
-            self.delete_lost_pairing_claim_client(claim.client_id.as_str(), now)?;
+            transaction.rollback().map_err(|error| {
+                db_error(format!("rollback lost remote pairing claim: {error}"))
+            })?;
             self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
             return Err(db_error(error_detail));
         }
-        self.record_remote_audit_event(&RemoteAuditEvent::new(
-            claim.audit_event_id.as_str(),
-            now,
-            None,
-            Some(claim.client_id.as_str()),
-            "remote.pair.claim",
-            RemoteAccessScope::Read,
-            RemoteAuditScopeDecision::Allowed,
-            RemoteAuditOutcome::Success,
-            claim.remote_addr.as_deref(),
-            None,
-        ))?;
+        record_remote_audit_event_for_pairing(
+            &transaction,
+            &RemoteAuditEvent::new(
+                claim.audit_event_id.as_str(),
+                now,
+                None,
+                Some(claim.client_id.as_str()),
+                "remote.pair.claim",
+                RemoteAccessScope::Read,
+                RemoteAuditScopeDecision::Allowed,
+                RemoteAuditOutcome::Success,
+                claim.remote_addr.as_deref(),
+                None,
+            ),
+        )?;
+        transaction
+            .commit()
+            .map_err(|error| db_error(format!("commit remote pairing claim: {error}")))?;
         Ok(RemotePairingClaimedClient {
             client,
             bearer_token,
@@ -211,29 +245,73 @@ impl DaemonDb {
             Some(error_detail),
         ))
     }
+}
 
-    fn delete_lost_pairing_claim_client(
-        &self,
-        client_id: &str,
-        created_at: &str,
-    ) -> Result<(), CliError> {
-        self.conn
-            .execute(
-                "DELETE FROM remote_clients
-                 WHERE client_id = ?1
-                   AND created_at = ?2
-                   AND last_seen_at IS NULL
-                   AND revoked_at IS NULL
-                   AND rotated_at IS NULL",
-                params![client_id, created_at],
-            )
-            .map_err(|error| {
-                db_error(format!(
-                    "delete lost remote pairing claim client {client_id}: {error}"
-                ))
-            })?;
-        Ok(())
-    }
+fn insert_remote_client_for_pairing(
+    conn: &Connection,
+    registration: &RemoteClientRegistration,
+) -> Result<RemoteStoredClient, CliError> {
+    let scopes_json = scopes_to_json(&registration.scopes)?;
+    conn.execute(
+        INSERT_PAIRING_REMOTE_CLIENT_SQL,
+        params![
+            registration.client_id,
+            registration.display_name,
+            registration.platform,
+            registration.role.as_str(),
+            scopes_json,
+            registration.token_hash.as_storage_value(),
+            registration.token_hint,
+            registration.created_at,
+        ],
+    )
+    .map_err(|error| {
+        db_error(format!(
+            "insert remote client {}: {error}",
+            registration.client_id.as_str()
+        ))
+    })?;
+    Ok(RemoteStoredClient {
+        client_id: registration.client_id.clone(),
+        display_name: registration.display_name.clone(),
+        platform: registration.platform.clone(),
+        role: registration.role,
+        scopes: registration.scopes.clone(),
+        token_hash: registration.token_hash.clone(),
+        token_hint: registration.token_hint.clone(),
+        created_at: registration.created_at.clone(),
+        last_seen_at: None,
+        revoked_at: None,
+        rotated_at: None,
+    })
+}
+
+fn record_remote_audit_event_for_pairing(
+    conn: &Connection,
+    event: &RemoteAuditEvent,
+) -> Result<(), CliError> {
+    conn.execute(
+        INSERT_PAIRING_REMOTE_AUDIT_EVENT_SQL,
+        params![
+            event.event_id,
+            event.recorded_at,
+            event.request_id,
+            event.client_id,
+            event.route_or_method,
+            event.scope.as_str(),
+            event.scope_decision.as_str(),
+            event.outcome.as_str(),
+            event.remote_addr,
+            event.error_detail,
+        ],
+    )
+    .map_err(|error| {
+        db_error(format!(
+            "insert remote audit event {}: {error}",
+            event.event_id.as_str()
+        ))
+    })?;
+    Ok(())
 }
 
 fn remote_pairing_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteStoredPairing> {

--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -1,0 +1,265 @@
+#![cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "remote pairing storage is wired by the pairing HTTP phase"
+    )
+)]
+
+use chrono::{DateTime, Utc};
+use rusqlite::{params, types::Type};
+
+use super::{db_error, CliError, DaemonDb, OptionalExtension};
+use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_identity::{
+    parse_remote_role, parse_remote_scope, RemoteAuditEvent, RemoteAuditOutcome,
+    RemoteAuditScopeDecision, RemoteBearerToken, RemoteClientRegistration,
+};
+use crate::daemon::remote_pairing::{
+    validate_pairing_domain, RemotePairingClaimRequest, RemotePairingClaimedClient,
+    RemotePairingCodeHash, RemotePairingError, RemotePairingRecord, RemoteStoredPairing,
+};
+
+const INSERT_REMOTE_PAIRING_SQL: &str = "
+INSERT INTO remote_pairing_codes (
+    pairing_id, code_hash, role, scopes_json, created_at, expires_at,
+    claimed_at, claimed_client_id, claim_remote_addr, metadata_json
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, NULL, '{}')";
+
+const SELECT_REMOTE_PAIRING_BY_HASH_SQL: &str = "
+SELECT pairing_id, code_hash, role, scopes_json, created_at, expires_at,
+       claimed_at, claimed_client_id, claim_remote_addr
+FROM remote_pairing_codes
+WHERE code_hash = ?1";
+
+impl DaemonDb {
+    /// Persist a one-time remote pairing code hash.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL or scope serialization failures.
+    pub(crate) fn create_remote_pairing_code(
+        &self,
+        record: &RemotePairingRecord,
+        audit_event_id: &str,
+    ) -> Result<RemoteStoredPairing, CliError> {
+        let scopes_json = scopes_to_json(&record.scopes)?;
+        self.conn
+            .execute(
+                INSERT_REMOTE_PAIRING_SQL,
+                params![
+                    record.pairing_id.as_str(),
+                    record.code_hash.as_storage_value(),
+                    record.role.as_str(),
+                    scopes_json,
+                    record.created_at.as_str(),
+                    record.expires_at.as_str(),
+                ],
+            )
+            .map_err(|error| {
+                db_error(format!(
+                    "insert remote pairing {}: {error}",
+                    record.pairing_id.as_str()
+                ))
+            })?;
+        self.record_remote_audit_event(&RemoteAuditEvent::new(
+            audit_event_id,
+            record.created_at.as_str(),
+            None,
+            None,
+            "remote.pair.create",
+            RemoteAccessScope::Admin,
+            RemoteAuditScopeDecision::Allowed,
+            RemoteAuditOutcome::Success,
+            None,
+            None,
+        ))?;
+        self.remote_pairing_by_hash(record.code_hash.as_storage_value())?
+            .ok_or_else(|| db_error("remote pairing insert did not persist row"))
+    }
+
+    /// Claim a valid one-time remote pairing code and create a remote client.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the claim is invalid, expired, already used, or
+    /// persistence fails.
+    pub(crate) fn claim_remote_pairing_code(
+        &self,
+        code: &str,
+        claim: &RemotePairingClaimRequest,
+        now: &str,
+    ) -> Result<RemotePairingClaimedClient, CliError> {
+        if let Err(error) = validate_pairing_domain(&claim.expected_domain, &claim.claimed_domain) {
+            let error_detail = error.to_string();
+            self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
+            return Err(db_error(error_detail));
+        }
+
+        let code_hash =
+            RemotePairingCodeHash::from_code(code).map_err(|error| db_error(error.to_string()))?;
+        let Some(pairing) = self.remote_pairing_by_hash(code_hash.as_storage_value())? else {
+            let error_detail = RemotePairingError::UnknownCode.to_string();
+            self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
+            return Err(db_error(error_detail));
+        };
+        if pairing.claimed_at.is_some() {
+            let error_detail = RemotePairingError::AlreadyClaimed.to_string();
+            self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
+            return Err(db_error(error_detail));
+        }
+        if pairing_is_expired(&pairing.expires_at, now)? {
+            let error_detail = RemotePairingError::Expired.to_string();
+            self.record_remote_audit_event(&RemoteAuditEvent::new(
+                claim.audit_event_id.as_str(),
+                now,
+                None,
+                None,
+                "remote.pair.expire",
+                RemoteAccessScope::Read,
+                RemoteAuditScopeDecision::Denied,
+                RemoteAuditOutcome::Failure,
+                claim.remote_addr.as_deref(),
+                Some(error_detail.as_str()),
+            ))?;
+            return Err(db_error(error_detail));
+        }
+
+        let bearer_token = RemoteBearerToken::generate();
+        let registration = RemoteClientRegistration::new(
+            claim.client_id.as_str(),
+            claim.display_name.as_str(),
+            claim.platform.as_str(),
+            pairing.role,
+            &pairing.scopes,
+            bearer_token.expose(),
+            now,
+        )
+        .map_err(|error| db_error(error.to_string()))?;
+        let client = self.register_remote_client(&registration)?;
+        self.conn
+            .execute(
+                "UPDATE remote_pairing_codes
+                 SET claimed_at = ?2, claimed_client_id = ?3, claim_remote_addr = ?4
+                 WHERE pairing_id = ?1 AND claimed_at IS NULL",
+                params![
+                    pairing.pairing_id.as_str(),
+                    now,
+                    claim.client_id.as_str(),
+                    claim.remote_addr.as_deref(),
+                ],
+            )
+            .map_err(|error| {
+                db_error(format!(
+                    "claim remote pairing {}: {error}",
+                    pairing.pairing_id.as_str()
+                ))
+            })?;
+        self.record_remote_audit_event(&RemoteAuditEvent::new(
+            claim.audit_event_id.as_str(),
+            now,
+            None,
+            Some(claim.client_id.as_str()),
+            "remote.pair.claim",
+            RemoteAccessScope::Read,
+            RemoteAuditScopeDecision::Allowed,
+            RemoteAuditOutcome::Success,
+            claim.remote_addr.as_deref(),
+            None,
+        ))?;
+        Ok(RemotePairingClaimedClient {
+            client,
+            bearer_token,
+        })
+    }
+
+    fn remote_pairing_by_hash(
+        &self,
+        code_hash: &str,
+    ) -> Result<Option<RemoteStoredPairing>, CliError> {
+        self.conn
+            .query_row(
+                SELECT_REMOTE_PAIRING_BY_HASH_SQL,
+                [code_hash],
+                remote_pairing_from_row,
+            )
+            .optional()
+            .map_err(|error| db_error(format!("load remote pairing by hash: {error}")))
+    }
+
+    fn record_pairing_claim_failure(
+        &self,
+        claim: &RemotePairingClaimRequest,
+        now: &str,
+        error_detail: &str,
+    ) -> Result<(), CliError> {
+        self.record_remote_audit_event(&RemoteAuditEvent::new(
+            claim.audit_event_id.as_str(),
+            now,
+            None,
+            None,
+            "remote.pair.claim",
+            RemoteAccessScope::Read,
+            RemoteAuditScopeDecision::Denied,
+            RemoteAuditOutcome::Failure,
+            claim.remote_addr.as_deref(),
+            Some(error_detail),
+        ))
+    }
+}
+
+fn remote_pairing_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteStoredPairing> {
+    let role_label = row.get::<_, String>(2)?;
+    let scopes_json = row.get::<_, String>(3)?;
+    let role = parse_remote_role(&role_label).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            2,
+            Type::Text,
+            format!("unknown remote pairing role '{role_label}'").into(),
+        )
+    })?;
+    let scopes = scopes_from_json(&scopes_json)
+        .map_err(|error| rusqlite::Error::FromSqlConversionFailure(3, Type::Text, error.into()))?;
+    let code_hash = RemotePairingCodeHash::try_from_storage_value(row.get::<_, String>(1)?)
+        .map_err(|error| rusqlite::Error::FromSqlConversionFailure(1, Type::Text, error.into()))?;
+    Ok(RemoteStoredPairing {
+        pairing_id: row.get(0)?,
+        code_hash,
+        role,
+        scopes,
+        created_at: row.get(4)?,
+        expires_at: row.get(5)?,
+        claimed_at: row.get(6)?,
+        claimed_client_id: row.get(7)?,
+        claim_remote_addr: row.get(8)?,
+    })
+}
+
+fn scopes_to_json(scopes: &[RemoteAccessScope]) -> Result<String, CliError> {
+    let labels = scopes
+        .iter()
+        .map(|scope| scope.as_str())
+        .collect::<Vec<_>>();
+    serde_json::to_string(&labels)
+        .map_err(|error| db_error(format!("serialize remote pairing scopes: {error}")))
+}
+
+fn scopes_from_json(value: &str) -> Result<Vec<RemoteAccessScope>, String> {
+    let labels = serde_json::from_str::<Vec<String>>(value)
+        .map_err(|error| format!("parse remote pairing scopes: {error}"))?;
+    labels
+        .iter()
+        .map(|label| {
+            parse_remote_scope(label)
+                .ok_or_else(|| format!("unknown remote pairing scope '{label}'"))
+        })
+        .collect()
+}
+
+fn pairing_is_expired(expires_at: &str, now: &str) -> Result<bool, CliError> {
+    let expires_at = DateTime::parse_from_rfc3339(expires_at)
+        .map_err(|error| db_error(format!("parse remote pairing expiry: {error}")))?
+        .with_timezone(&Utc);
+    let now = DateTime::parse_from_rfc3339(now)
+        .map_err(|error| db_error(format!("parse remote pairing claim time: {error}")))?
+        .with_timezone(&Utc);
+    Ok(expires_at <= now)
+}

--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -135,7 +135,8 @@ impl DaemonDb {
         )
         .map_err(|error| db_error(error.to_string()))?;
         let client = self.register_remote_client(&registration)?;
-        self.conn
+        let changed = self
+            .conn
             .execute(
                 "UPDATE remote_pairing_codes
                  SET claimed_at = ?2, claimed_client_id = ?3, claim_remote_addr = ?4
@@ -153,6 +154,12 @@ impl DaemonDb {
                     pairing.pairing_id.as_str()
                 ))
             })?;
+        if changed == 0 {
+            let error_detail = RemotePairingError::AlreadyClaimed.to_string();
+            self.delete_lost_pairing_claim_client(claim.client_id.as_str(), now)?;
+            self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
+            return Err(db_error(error_detail));
+        }
         self.record_remote_audit_event(&RemoteAuditEvent::new(
             claim.audit_event_id.as_str(),
             now,
@@ -203,6 +210,29 @@ impl DaemonDb {
             claim.remote_addr.as_deref(),
             Some(error_detail),
         ))
+    }
+
+    fn delete_lost_pairing_claim_client(
+        &self,
+        client_id: &str,
+        created_at: &str,
+    ) -> Result<(), CliError> {
+        self.conn
+            .execute(
+                "DELETE FROM remote_clients
+                 WHERE client_id = ?1
+                   AND created_at = ?2
+                   AND last_seen_at IS NULL
+                   AND revoked_at IS NULL
+                   AND rotated_at IS NULL",
+                params![client_id, created_at],
+            )
+            .map_err(|error| {
+                db_error(format!(
+                    "delete lost remote pairing claim client {client_id}: {error}"
+                ))
+            })?;
+        Ok(())
     }
 }
 

--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -9,16 +9,16 @@
 use chrono::{DateTime, Utc};
 use rusqlite::{params, types::Type};
 
-use super::{db_error, CliError, Connection, DaemonDb, OptionalExtension};
+use super::{CliError, Connection, DaemonDb, OptionalExtension, db_error};
 use crate::daemon::remote::RemoteAccessScope;
 use crate::daemon::remote_identity::{
-    parse_remote_role, parse_remote_scope, RemoteAuditEvent, RemoteAuditOutcome,
-    RemoteAuditScopeDecision, RemoteBearerToken, RemoteClientRegistration, RemoteStoredClient,
+    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteBearerToken,
+    RemoteClientRegistration, RemoteStoredClient, parse_remote_role, parse_remote_scope,
 };
 use crate::daemon::remote_pairing::{
-    validate_pairing_audit_event_id, validate_pairing_domain, RemotePairingClaimRequest,
-    RemotePairingClaimedClient, RemotePairingCodeHash, RemotePairingError, RemotePairingRecord,
-    RemoteStoredPairing,
+    RemotePairingClaimRequest, RemotePairingClaimedClient, RemotePairingCodeHash,
+    RemotePairingError, RemotePairingRecord, RemoteStoredPairing, validate_pairing_audit_event_id,
+    validate_pairing_domain,
 };
 
 const INSERT_REMOTE_PAIRING_SQL: &str = "
@@ -175,7 +175,7 @@ impl DaemonDb {
                 claim.audit_event_id.as_str(),
                 now,
                 None,
-                None,
+                Some(claim.client_id.as_str()),
                 ROUTE_REMOTE_PAIR_EXPIRE,
                 RemoteAccessScope::Read,
                 RemoteAuditScopeDecision::Denied,
@@ -286,7 +286,7 @@ impl DaemonDb {
             claim.audit_event_id.as_str(),
             now,
             None,
-            None,
+            Some(claim.client_id.as_str()),
             route_or_method,
             RemoteAccessScope::Read,
             RemoteAuditScopeDecision::Denied,

--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -16,8 +16,9 @@ use crate::daemon::remote_identity::{
     RemoteAuditScopeDecision, RemoteBearerToken, RemoteClientRegistration, RemoteStoredClient,
 };
 use crate::daemon::remote_pairing::{
-    validate_pairing_domain, RemotePairingClaimRequest, RemotePairingClaimedClient,
-    RemotePairingCodeHash, RemotePairingError, RemotePairingRecord, RemoteStoredPairing,
+    validate_pairing_audit_event_id, validate_pairing_domain, RemotePairingClaimRequest,
+    RemotePairingClaimedClient, RemotePairingCodeHash, RemotePairingError, RemotePairingRecord,
+    RemoteStoredPairing,
 };
 
 const INSERT_REMOTE_PAIRING_SQL: &str = "
@@ -62,6 +63,8 @@ impl DaemonDb {
         record: &RemotePairingRecord,
         audit_event_id: &str,
     ) -> Result<RemoteStoredPairing, CliError> {
+        validate_pairing_audit_event_id(audit_event_id)
+            .map_err(|error| db_error(error.to_string()))?;
         let scopes_json = scopes_to_json(&record.scopes)?;
         let transaction = self
             .conn
@@ -120,6 +123,8 @@ impl DaemonDb {
         claim: &RemotePairingClaimRequest,
         now: &str,
     ) -> Result<RemotePairingClaimedClient, CliError> {
+        validate_pairing_audit_event_id(claim.audit_event_id.as_str())
+            .map_err(|error| db_error(error.to_string()))?;
         if let Err(error) = validate_pairing_domain(&claim.expected_domain, &claim.claimed_domain) {
             let error_detail = error.to_string();
             self.record_pairing_claim_failure(

--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -44,6 +44,14 @@ INSERT INTO remote_audit_events (
     scope_decision, outcome, remote_addr, error_detail, metadata_json
 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, '{}')";
 
+const ROUTE_REMOTE_PAIR_CREATE: &str = "remote.pair.create";
+const ROUTE_REMOTE_PAIR_CLAIM: &str = "remote.pair.claim";
+const ROUTE_REMOTE_PAIR_DOMAIN: &str = "remote.pair.domain";
+const ROUTE_REMOTE_PAIR_EXPIRE: &str = "remote.pair.expire";
+const ROUTE_REMOTE_PAIR_INVALID: &str = "remote.pair.invalid";
+const ROUTE_REMOTE_PAIR_REPLAY: &str = "remote.pair.replay";
+const ROUTE_REMOTE_PAIR_UNKNOWN: &str = "remote.pair.unknown";
+
 impl DaemonDb {
     /// Persist a one-time remote pairing code hash.
     ///
@@ -55,7 +63,11 @@ impl DaemonDb {
         audit_event_id: &str,
     ) -> Result<RemoteStoredPairing, CliError> {
         let scopes_json = scopes_to_json(&record.scopes)?;
-        self.conn
+        let transaction = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|error| db_error(format!("begin remote pairing create: {error}")))?;
+        transaction
             .execute(
                 INSERT_REMOTE_PAIRING_SQL,
                 params![
@@ -73,20 +85,28 @@ impl DaemonDb {
                     record.pairing_id.as_str()
                 ))
             })?;
-        self.record_remote_audit_event(&RemoteAuditEvent::new(
-            audit_event_id,
-            record.created_at.as_str(),
-            None,
-            None,
-            "remote.pair.create",
-            RemoteAccessScope::Admin,
-            RemoteAuditScopeDecision::Allowed,
-            RemoteAuditOutcome::Success,
-            None,
-            None,
-        ))?;
-        self.remote_pairing_by_hash(record.code_hash.as_storage_value())?
-            .ok_or_else(|| db_error("remote pairing insert did not persist row"))
+        record_remote_audit_event_for_pairing(
+            &transaction,
+            &RemoteAuditEvent::new(
+                audit_event_id,
+                record.created_at.as_str(),
+                None,
+                None,
+                ROUTE_REMOTE_PAIR_CREATE,
+                RemoteAccessScope::Admin,
+                RemoteAuditScopeDecision::Allowed,
+                RemoteAuditOutcome::Success,
+                None,
+                None,
+            ),
+        )?;
+        let stored =
+            load_remote_pairing_by_hash(&transaction, record.code_hash.as_storage_value())?
+                .ok_or_else(|| db_error("remote pairing insert did not persist row"))?;
+        transaction
+            .commit()
+            .map_err(|error| db_error(format!("commit remote pairing create: {error}")))?;
+        Ok(stored)
     }
 
     /// Claim a valid one-time remote pairing code and create a remote client.
@@ -102,20 +122,46 @@ impl DaemonDb {
     ) -> Result<RemotePairingClaimedClient, CliError> {
         if let Err(error) = validate_pairing_domain(&claim.expected_domain, &claim.claimed_domain) {
             let error_detail = error.to_string();
-            self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
+            self.record_pairing_claim_failure(
+                claim,
+                now,
+                ROUTE_REMOTE_PAIR_DOMAIN,
+                error_detail.as_str(),
+            )?;
             return Err(db_error(error_detail));
         }
 
-        let code_hash =
-            RemotePairingCodeHash::from_code(code).map_err(|error| db_error(error.to_string()))?;
+        let code_hash = match RemotePairingCodeHash::from_code(code) {
+            Ok(code_hash) => code_hash,
+            Err(error) => {
+                let error_detail = error.to_string();
+                self.record_pairing_claim_failure(
+                    claim,
+                    now,
+                    ROUTE_REMOTE_PAIR_INVALID,
+                    error_detail.as_str(),
+                )?;
+                return Err(db_error(error_detail));
+            }
+        };
         let Some(pairing) = self.remote_pairing_by_hash(code_hash.as_storage_value())? else {
             let error_detail = RemotePairingError::UnknownCode.to_string();
-            self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
+            self.record_pairing_claim_failure(
+                claim,
+                now,
+                ROUTE_REMOTE_PAIR_UNKNOWN,
+                error_detail.as_str(),
+            )?;
             return Err(db_error(error_detail));
         };
         if pairing.claimed_at.is_some() {
             let error_detail = RemotePairingError::AlreadyClaimed.to_string();
-            self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
+            self.record_pairing_claim_failure(
+                claim,
+                now,
+                ROUTE_REMOTE_PAIR_REPLAY,
+                error_detail.as_str(),
+            )?;
             return Err(db_error(error_detail));
         }
         if pairing_is_expired(&pairing.expires_at, now)? {
@@ -125,7 +171,7 @@ impl DaemonDb {
                 now,
                 None,
                 None,
-                "remote.pair.expire",
+                ROUTE_REMOTE_PAIR_EXPIRE,
                 RemoteAccessScope::Read,
                 RemoteAuditScopeDecision::Denied,
                 RemoteAuditOutcome::Failure,
@@ -185,7 +231,12 @@ impl DaemonDb {
             transaction.rollback().map_err(|error| {
                 db_error(format!("rollback lost remote pairing claim: {error}"))
             })?;
-            self.record_pairing_claim_failure(claim, now, error_detail.as_str())?;
+            self.record_pairing_claim_failure(
+                claim,
+                now,
+                ROUTE_REMOTE_PAIR_REPLAY,
+                error_detail.as_str(),
+            )?;
             return Err(db_error(error_detail));
         }
         record_remote_audit_event_for_pairing(
@@ -195,7 +246,7 @@ impl DaemonDb {
                 now,
                 None,
                 Some(claim.client_id.as_str()),
-                "remote.pair.claim",
+                ROUTE_REMOTE_PAIR_CLAIM,
                 RemoteAccessScope::Read,
                 RemoteAuditScopeDecision::Allowed,
                 RemoteAuditOutcome::Success,
@@ -216,20 +267,14 @@ impl DaemonDb {
         &self,
         code_hash: &str,
     ) -> Result<Option<RemoteStoredPairing>, CliError> {
-        self.conn
-            .query_row(
-                SELECT_REMOTE_PAIRING_BY_HASH_SQL,
-                [code_hash],
-                remote_pairing_from_row,
-            )
-            .optional()
-            .map_err(|error| db_error(format!("load remote pairing by hash: {error}")))
+        load_remote_pairing_by_hash(&self.conn, code_hash)
     }
 
     fn record_pairing_claim_failure(
         &self,
         claim: &RemotePairingClaimRequest,
         now: &str,
+        route_or_method: &str,
         error_detail: &str,
     ) -> Result<(), CliError> {
         self.record_remote_audit_event(&RemoteAuditEvent::new(
@@ -237,7 +282,7 @@ impl DaemonDb {
             now,
             None,
             None,
-            "remote.pair.claim",
+            route_or_method,
             RemoteAccessScope::Read,
             RemoteAuditScopeDecision::Denied,
             RemoteAuditOutcome::Failure,
@@ -312,6 +357,19 @@ fn record_remote_audit_event_for_pairing(
         ))
     })?;
     Ok(())
+}
+
+fn load_remote_pairing_by_hash(
+    conn: &Connection,
+    code_hash: &str,
+) -> Result<Option<RemoteStoredPairing>, CliError> {
+    conn.query_row(
+        SELECT_REMOTE_PAIRING_BY_HASH_SQL,
+        [code_hash],
+        remote_pairing_from_row,
+    )
+    .optional()
+    .map_err(|error| db_error(format!("load remote pairing by hash: {error}")))
 }
 
 fn remote_pairing_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteStoredPairing> {

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -18,6 +18,7 @@ mod performance;
 mod projects;
 mod reconcile;
 mod remote_identity;
+mod remote_pairing;
 mod runtime;
 mod schema;
 mod schema_backfill;

--- a/src/daemon/db/tests/remote_pairing.rs
+++ b/src/daemon/db/tests/remote_pairing.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::RemoteAuditOutcome;
 use crate::daemon::remote_pairing::{
     RemotePairingClaimRequest, RemotePairingCode, RemotePairingRecord,
 };
@@ -123,4 +124,74 @@ fn remote_pairing_claim_rejects_expiry_and_wrong_domain_with_audit() {
         .collect();
     assert!(routes.contains(&"remote.pair.expire".to_string()));
     assert!(routes.contains(&"remote.pair.claim".to_string()));
+}
+
+#[test]
+fn remote_pairing_claim_rejects_lost_claim_race() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let code = RemotePairingCode::from_value_for_tests("race-pairing-secret");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-race",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read],
+        code.expose(),
+        "2026-06-21T13:40:00Z",
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("pairing record");
+    db.create_remote_pairing_code(&record, "audit-create-race")
+        .expect("create pairing");
+    db.conn
+        .execute_batch(
+            "
+            CREATE TRIGGER simulate_remote_pairing_claim_race
+            BEFORE UPDATE OF claimed_at ON remote_pairing_codes
+            WHEN OLD.pairing_id = 'pairing-race'
+                 AND OLD.claimed_at IS NULL
+                 AND NEW.claimed_client_id = 'client-race'
+                 AND NEW.claimed_at IS NOT NULL
+            BEGIN
+                UPDATE remote_pairing_codes
+                   SET claimed_at = '2026-06-21T13:40:30Z',
+                       claimed_client_id = NULL,
+                       claim_remote_addr = '203.0.113.99'
+                 WHERE pairing_id = OLD.pairing_id;
+                SELECT RAISE(IGNORE);
+            END;",
+        )
+        .expect("install race trigger");
+
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-race",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.30"),
+        "audit-claim-race",
+    )
+    .expect("claim request");
+    let error = db
+        .claim_remote_pairing_code(code.expose(), &claim, "2026-06-21T13:41:00Z")
+        .expect_err("lost claim race must fail");
+
+    assert!(
+        error.to_string().contains("already claimed"),
+        "unexpected race error: {error}"
+    );
+    let client_count: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM remote_clients WHERE client_id = 'client-race'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("client count");
+    assert_eq!(client_count, 0);
+    assert!(!db
+        .load_remote_audit_events(10)
+        .expect("audit events")
+        .iter()
+        .any(|event| event.event_id == "audit-claim-race"
+            && event.outcome == RemoteAuditOutcome::Success));
 }

--- a/src/daemon/db/tests/remote_pairing.rs
+++ b/src/daemon/db/tests/remote_pairing.rs
@@ -195,3 +195,67 @@ fn remote_pairing_claim_rejects_lost_claim_race() {
         .any(|event| event.event_id == "audit-claim-race"
             && event.outcome == RemoteAuditOutcome::Success));
 }
+
+#[test]
+fn remote_pairing_claim_rolls_back_client_and_pairing_when_audit_fails() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let code = RemotePairingCode::from_value_for_tests("atomic-pairing-secret");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-atomic",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read],
+        code.expose(),
+        "2026-06-21T13:40:00Z",
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("pairing record");
+    db.create_remote_pairing_code(&record, "audit-create-atomic")
+        .expect("create pairing");
+    db.conn
+        .execute_batch(
+            "
+            CREATE TRIGGER fail_remote_pairing_claim_audit
+            BEFORE INSERT ON remote_audit_events
+            WHEN NEW.event_id = 'audit-claim-atomic'
+            BEGIN
+                SELECT RAISE(FAIL, 'simulated audit failure');
+            END;",
+        )
+        .expect("install audit failure trigger");
+
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-atomic",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.40"),
+        "audit-claim-atomic",
+    )
+    .expect("claim request");
+    assert!(
+        db.claim_remote_pairing_code(code.expose(), &claim, "2026-06-21T13:41:00Z")
+            .is_err(),
+        "audit failure must reject the claim"
+    );
+
+    let client_count: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM remote_clients WHERE client_id = 'client-atomic'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("client count");
+    let claimed_at: Option<String> = db
+        .conn
+        .query_row(
+            "SELECT claimed_at FROM remote_pairing_codes WHERE pairing_id = 'pairing-atomic'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("claimed at");
+
+    assert_eq!(client_count, 0);
+    assert!(claimed_at.is_none());
+}

--- a/src/daemon/db/tests/remote_pairing.rs
+++ b/src/daemon/db/tests/remote_pairing.rs
@@ -48,10 +48,11 @@ fn remote_pairing_create_claim_rejects_replay_and_audits() {
     assert_eq!(claimed.client.client_id, "client-1");
     assert_eq!(claimed.client.role, RemoteRole::Operator);
     assert!(!claimed.bearer_token.expose().is_empty());
-    assert!(db
-        .verify_remote_client_token("client-1", claimed.bearer_token.expose())
-        .expect("verify paired client")
-        .is_some());
+    assert!(
+        db.verify_remote_client_token("client-1", claimed.bearer_token.expose())
+            .expect("verify paired client")
+            .is_some()
+    );
     let replay_claim = RemotePairingClaimRequest::new_for_tests(
         "daemon.example.com",
         "daemon.example.com",
@@ -127,14 +128,56 @@ fn remote_pairing_claim_rejects_expiry_and_wrong_domain_with_audit() {
         "wrong-domain pairing claim must be denied"
     );
 
-    let routes: Vec<_> = db
+    let events = db.load_remote_audit_events(10).expect("audit events");
+    let routes: Vec<_> = events
+        .iter()
+        .map(|event| event.route_or_method.clone())
+        .collect();
+    let expired_event = events
+        .iter()
+        .find(|event| event.route_or_method == "remote.pair.expire")
+        .expect("expiry audit event");
+    let domain_event = events
+        .iter()
+        .find(|event| event.route_or_method == "remote.pair.domain")
+        .expect("domain audit event");
+
+    assert_eq!(expired_event.client_id.as_deref(), Some("client-expired"));
+    assert_eq!(
+        domain_event.client_id.as_deref(),
+        Some("client-wrong-domain")
+    );
+    assert!(routes.contains(&"remote.pair.expire".to_string()));
+    assert!(routes.contains(&"remote.pair.domain".to_string()));
+}
+
+#[test]
+fn remote_pairing_claim_failures_record_claimed_client_id() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-invalid",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.50"),
+        "audit-client-invalid",
+    )
+    .expect("claim request");
+    assert!(
+        db.claim_remote_pairing_code(" ", &claim, "2026-06-21T13:41:00Z")
+            .is_err(),
+        "blank code must fail"
+    );
+
+    let invalid_event = db
         .load_remote_audit_events(10)
         .expect("audit events")
         .into_iter()
-        .map(|event| event.route_or_method)
-        .collect();
-    assert!(routes.contains(&"remote.pair.expire".to_string()));
-    assert!(routes.contains(&"remote.pair.domain".to_string()));
+        .find(|event| event.route_or_method == "remote.pair.invalid")
+        .expect("invalid audit event");
+
+    assert_eq!(invalid_event.client_id.as_deref(), Some("client-invalid"));
 }
 
 #[test]
@@ -199,12 +242,13 @@ fn remote_pairing_claim_rejects_lost_claim_race() {
         )
         .expect("client count");
     assert_eq!(client_count, 0);
-    assert!(!db
-        .load_remote_audit_events(10)
-        .expect("audit events")
-        .iter()
-        .any(|event| event.event_id == "audit-claim-race"
-            && event.outcome == RemoteAuditOutcome::Success));
+    assert!(
+        !db.load_remote_audit_events(10)
+            .expect("audit events")
+            .iter()
+            .any(|event| event.event_id == "audit-claim-race"
+                && event.outcome == RemoteAuditOutcome::Success)
+    );
 }
 
 #[test]

--- a/src/daemon/db/tests/remote_pairing.rs
+++ b/src/daemon/db/tests/remote_pairing.rs
@@ -315,6 +315,110 @@ fn remote_pairing_create_rolls_back_pairing_when_audit_fails() {
 }
 
 #[test]
+fn remote_pairing_create_rejects_blank_audit_event_id_before_writes() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let code = RemotePairingCode::from_value_for_tests("blank-create-audit-secret");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-create-blank-audit",
+        RemoteRole::Viewer,
+        &[],
+        code.expose(),
+        "2026-06-21T13:40:00Z",
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("pairing record");
+
+    assert!(
+        db.create_remote_pairing_code(&record, " \t").is_err(),
+        "blank audit event ids must be rejected before pairing creation"
+    );
+    let pairing_count: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM remote_pairing_codes
+              WHERE pairing_id = 'pairing-create-blank-audit'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("pairing count");
+    let audit_count: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM remote_audit_events WHERE event_id = ''",
+            [],
+            |row| row.get(0),
+        )
+        .expect("blank audit count");
+
+    assert_eq!(pairing_count, 0);
+    assert_eq!(audit_count, 0);
+}
+
+#[test]
+fn remote_pairing_claim_rejects_blank_audit_event_id_before_writes() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let code = RemotePairingCode::from_value_for_tests("blank-claim-audit-secret");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-claim-blank-audit",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read],
+        code.expose(),
+        "2026-06-21T13:40:00Z",
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("pairing record");
+    db.create_remote_pairing_code(&record, "audit-create-blank-claim")
+        .expect("create pairing");
+    let mut claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-blank-audit",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.60"),
+        "audit-claim-blank-placeholder",
+    )
+    .expect("claim request");
+    claim.audit_event_id = " \t".to_string();
+
+    assert!(
+        db.claim_remote_pairing_code(code.expose(), &claim, "2026-06-21T13:41:00Z")
+            .is_err(),
+        "blank claim audit event ids must be rejected before claim writes"
+    );
+    let client_count: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM remote_clients
+              WHERE client_id = 'client-blank-audit'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("client count");
+    let claimed_at: Option<String> = db
+        .conn
+        .query_row(
+            "SELECT claimed_at FROM remote_pairing_codes
+              WHERE pairing_id = 'pairing-claim-blank-audit'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("claimed at");
+    let audit_count: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM remote_audit_events WHERE event_id = ''",
+            [],
+            |row| row.get(0),
+        )
+        .expect("blank audit count");
+
+    assert_eq!(client_count, 0);
+    assert!(claimed_at.is_none());
+    assert_eq!(audit_count, 0);
+}
+
+#[test]
 fn remote_pairing_claim_audits_invalid_and_unknown_code_routes() {
     let db = DaemonDb::open_in_memory().expect("open db");
     let claim = RemotePairingClaimRequest::new_for_tests(

--- a/src/daemon/db/tests/remote_pairing.rs
+++ b/src/daemon/db/tests/remote_pairing.rs
@@ -1,0 +1,126 @@
+use super::*;
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_pairing::{
+    RemotePairingClaimRequest, RemotePairingCode, RemotePairingRecord,
+};
+
+#[test]
+fn remote_pairing_create_claim_rejects_replay_and_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let code = RemotePairingCode::from_value_for_tests("pairing-secret-value");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-1",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        code.expose(),
+        "2026-06-21T13:40:00Z",
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("pairing record");
+
+    db.create_remote_pairing_code(&record, "audit-create-1")
+        .expect("create pairing");
+    let stored_hash: String = db
+        .conn
+        .query_row(
+            "SELECT code_hash FROM remote_pairing_codes WHERE pairing_id = 'pairing-1'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("stored pairing hash");
+    assert!(!stored_hash.contains("pairing-secret-value"));
+
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-1",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.10"),
+        "audit-claim-1",
+    )
+    .expect("claim request");
+    let claimed = db
+        .claim_remote_pairing_code(code.expose(), &claim, "2026-06-21T13:41:00Z")
+        .expect("claim pairing");
+
+    assert_eq!(claimed.client.client_id, "client-1");
+    assert_eq!(claimed.client.role, RemoteRole::Operator);
+    assert!(!claimed.bearer_token.expose().is_empty());
+    assert!(db
+        .verify_remote_client_token("client-1", claimed.bearer_token.expose())
+        .expect("verify paired client")
+        .is_some());
+    assert!(
+        db.claim_remote_pairing_code(code.expose(), &claim, "2026-06-21T13:42:00Z")
+            .is_err(),
+        "pairing code must be single use"
+    );
+
+    let routes: Vec<_> = db
+        .load_remote_audit_events(10)
+        .expect("audit events")
+        .into_iter()
+        .map(|event| event.route_or_method)
+        .collect();
+    assert!(routes.contains(&"remote.pair.create".to_string()));
+    assert!(routes.contains(&"remote.pair.claim".to_string()));
+}
+
+#[test]
+fn remote_pairing_claim_rejects_expiry_and_wrong_domain_with_audit() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let code = RemotePairingCode::from_value_for_tests("expired-pairing-secret");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-expired",
+        RemoteRole::Viewer,
+        &[],
+        code.expose(),
+        "2026-06-21T13:40:00Z",
+        "2026-06-21T13:41:00Z",
+    )
+    .expect("pairing record");
+    db.create_remote_pairing_code(&record, "audit-create-expired")
+        .expect("create pairing");
+
+    let expired_claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-expired",
+        "iPhone",
+        "ios",
+        Some("203.0.113.20"),
+        "audit-claim-expired",
+    )
+    .expect("expired claim");
+    assert!(
+        db.claim_remote_pairing_code(code.expose(), &expired_claim, "2026-06-21T13:42:00Z")
+            .is_err(),
+        "expired pairing code must be denied"
+    );
+
+    let wrong_domain_claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "evil.example.com",
+        "client-wrong-domain",
+        "iPhone",
+        "ios",
+        Some("203.0.113.21"),
+        "audit-claim-wrong-domain",
+    )
+    .expect("wrong-domain claim");
+    assert!(
+        db.claim_remote_pairing_code(code.expose(), &wrong_domain_claim, "2026-06-21T13:40:30Z")
+            .is_err(),
+        "wrong-domain pairing claim must be denied"
+    );
+
+    let routes: Vec<_> = db
+        .load_remote_audit_events(10)
+        .expect("audit events")
+        .into_iter()
+        .map(|event| event.route_or_method)
+        .collect();
+    assert!(routes.contains(&"remote.pair.expire".to_string()));
+    assert!(routes.contains(&"remote.pair.claim".to_string()));
+}

--- a/src/daemon/db/tests/remote_pairing.rs
+++ b/src/daemon/db/tests/remote_pairing.rs
@@ -52,8 +52,18 @@ fn remote_pairing_create_claim_rejects_replay_and_audits() {
         .verify_remote_client_token("client-1", claimed.bearer_token.expose())
         .expect("verify paired client")
         .is_some());
+    let replay_claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-1",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.10"),
+        "audit-claim-replay",
+    )
+    .expect("replay claim request");
     assert!(
-        db.claim_remote_pairing_code(code.expose(), &claim, "2026-06-21T13:42:00Z")
+        db.claim_remote_pairing_code(code.expose(), &replay_claim, "2026-06-21T13:42:00Z")
             .is_err(),
         "pairing code must be single use"
     );
@@ -66,6 +76,7 @@ fn remote_pairing_create_claim_rejects_replay_and_audits() {
         .collect();
     assert!(routes.contains(&"remote.pair.create".to_string()));
     assert!(routes.contains(&"remote.pair.claim".to_string()));
+    assert!(routes.contains(&"remote.pair.replay".to_string()));
 }
 
 #[test]
@@ -123,7 +134,7 @@ fn remote_pairing_claim_rejects_expiry_and_wrong_domain_with_audit() {
         .map(|event| event.route_or_method)
         .collect();
     assert!(routes.contains(&"remote.pair.expire".to_string()));
-    assert!(routes.contains(&"remote.pair.claim".to_string()));
+    assert!(routes.contains(&"remote.pair.domain".to_string()));
 }
 
 #[test]
@@ -258,4 +269,91 @@ fn remote_pairing_claim_rolls_back_client_and_pairing_when_audit_fails() {
 
     assert_eq!(client_count, 0);
     assert!(claimed_at.is_none());
+}
+
+#[test]
+fn remote_pairing_create_rolls_back_pairing_when_audit_fails() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.conn
+        .execute_batch(
+            "
+            CREATE TRIGGER fail_remote_pairing_create_audit
+            BEFORE INSERT ON remote_audit_events
+            WHEN NEW.event_id = 'audit-create-fail'
+            BEGIN
+                SELECT RAISE(FAIL, 'simulated create audit failure');
+            END;",
+        )
+        .expect("install audit failure trigger");
+    let code = RemotePairingCode::from_value_for_tests("create-rollback-secret");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-create-rollback",
+        RemoteRole::Viewer,
+        &[],
+        code.expose(),
+        "2026-06-21T13:40:00Z",
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("pairing record");
+
+    assert!(
+        db.create_remote_pairing_code(&record, "audit-create-fail")
+            .is_err(),
+        "create audit failure must reject pairing creation"
+    );
+    let pairing_count: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM remote_pairing_codes
+              WHERE pairing_id = 'pairing-create-rollback'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("pairing count");
+
+    assert_eq!(pairing_count, 0);
+}
+
+#[test]
+fn remote_pairing_claim_audits_invalid_and_unknown_code_routes() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-invalid",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.50"),
+        "audit-claim-blank",
+    )
+    .expect("claim request");
+    assert!(
+        db.claim_remote_pairing_code(" ", &claim, "2026-06-21T13:41:00Z")
+            .is_err(),
+        "blank code must fail"
+    );
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-unknown",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.51"),
+        "audit-claim-unknown",
+    )
+    .expect("claim request");
+    assert!(
+        db.claim_remote_pairing_code("unknown-code", &claim, "2026-06-21T13:42:00Z")
+            .is_err(),
+        "unknown code must fail"
+    );
+
+    let routes: Vec<_> = db
+        .load_remote_audit_events(10)
+        .expect("audit events")
+        .into_iter()
+        .map(|event| event.route_or_method)
+        .collect();
+    assert!(routes.contains(&"remote.pair.invalid".to_string()));
+    assert!(routes.contains(&"remote.pair.unknown".to_string()));
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -37,6 +37,7 @@ pub mod protocol;
 pub mod remote;
 pub mod remote_acme;
 pub mod remote_identity;
+pub mod remote_pairing;
 pub mod service;
 pub mod snapshot;
 pub mod state;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -36,6 +36,7 @@ pub mod ordering;
 pub mod protocol;
 pub mod remote;
 pub mod remote_acme;
+pub(crate) mod remote_crypto;
 pub mod remote_identity;
 pub mod remote_pairing;
 pub mod service;

--- a/src/daemon/remote_crypto.rs
+++ b/src/daemon/remote_crypto.rs
@@ -1,0 +1,83 @@
+use sha2::{Digest, Sha256};
+
+const SHA256_STORAGE_PREFIX: &str = "sha256:";
+const SHA256_STORAGE_HEX_LEN: usize = 64;
+
+#[must_use]
+pub(crate) fn sha256_digest(value: &str) -> [u8; 32] {
+    Sha256::digest(value.as_bytes()).into()
+}
+
+#[must_use]
+pub(crate) fn sha256_storage_value(value: &str) -> String {
+    format!(
+        "{SHA256_STORAGE_PREFIX}{}",
+        hex::encode(sha256_digest(value))
+    )
+}
+
+#[must_use]
+pub(crate) fn parse_sha256_storage_digest(value: &str) -> Option<[u8; 32]> {
+    let hex_value = value.strip_prefix(SHA256_STORAGE_PREFIX)?;
+    if hex_value.len() != SHA256_STORAGE_HEX_LEN {
+        return None;
+    }
+    let mut digest = [0_u8; 32];
+    hex::decode_to_slice(hex_value, &mut digest).ok()?;
+    Some(digest)
+}
+
+#[must_use]
+pub(crate) fn constant_time_eq_32(left: &[u8; 32], right: &[u8; 32]) -> bool {
+    let diff = left
+        .iter()
+        .zip(right.iter())
+        .fold(0_u8, |acc, (&left, &right)| acc | (left ^ right));
+    diff == 0
+}
+
+#[must_use]
+pub(crate) fn verify_sha256_storage_value(storage_value: &str, candidate_value: &str) -> bool {
+    let candidate = sha256_digest(candidate_value);
+    let Some(expected) = parse_sha256_storage_digest(storage_value) else {
+        let _ = constant_time_eq_32(&[0_u8; 32], &candidate);
+        return false;
+    };
+    constant_time_eq_32(&expected, &candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        constant_time_eq_32, parse_sha256_storage_digest, sha256_storage_value,
+        verify_sha256_storage_value,
+    };
+
+    #[test]
+    fn sha256_storage_value_round_trips_through_shared_verifier() {
+        let storage_value = sha256_storage_value("remote-secret");
+
+        assert!(storage_value.starts_with("sha256:"));
+        assert_eq!(storage_value.len(), "sha256:".len() + 64);
+        assert!(parse_sha256_storage_digest(&storage_value).is_some());
+        assert!(verify_sha256_storage_value(&storage_value, "remote-secret"));
+        assert!(!verify_sha256_storage_value(&storage_value, "wrong-secret"));
+    }
+
+    #[test]
+    fn parse_sha256_storage_digest_rejects_malformed_values() {
+        assert!(parse_sha256_storage_digest("remote-secret").is_none());
+        assert!(parse_sha256_storage_digest("sha256:abc").is_none());
+        assert!(parse_sha256_storage_digest(&format!("sha256:{}", "z".repeat(64))).is_none());
+    }
+
+    #[test]
+    fn constant_time_eq_32_reports_equal_and_different_digests() {
+        let left = [1_u8; 32];
+        let mut right = [1_u8; 32];
+
+        assert!(constant_time_eq_32(&left, &right));
+        right[31] = 2;
+        assert!(!constant_time_eq_32(&left, &right));
+    }
+}

--- a/src/daemon/remote_identity.rs
+++ b/src/daemon/remote_identity.rs
@@ -4,9 +4,11 @@ use std::fmt;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use rand_core06::{OsRng, RngCore};
-use sha2::{Digest, Sha256};
 
 use super::remote::{RemoteAccessScope, RemoteRole, scopes_for_role};
+use super::remote_crypto::{
+    parse_sha256_storage_digest, sha256_storage_value, verify_sha256_storage_value,
+};
 
 #[cfg(test)]
 #[path = "remote_identity_tests.rs"]
@@ -14,8 +16,6 @@ mod tests;
 
 const TOKEN_RANDOM_BYTES: usize = 32;
 const TOKEN_HINT_CHARS: usize = 6;
-const TOKEN_HASH_PREFIX: &str = "sha256:";
-const TOKEN_HASH_HEX_LEN: usize = 64;
 const REDACTED_TOKEN_HINT: &str = "<redacted>";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,9 +55,8 @@ pub struct RemoteTokenHash {
 impl RemoteTokenHash {
     #[must_use]
     pub fn from_token(token: &str) -> Self {
-        let digest = token_digest(token);
         Self {
-            storage_value: format!("{TOKEN_HASH_PREFIX}{}", hex::encode(digest)),
+            storage_value: sha256_storage_value(token),
         }
     }
 
@@ -76,7 +75,7 @@ impl RemoteTokenHash {
         value: impl Into<String>,
     ) -> Result<Self, RemoteIdentityError> {
         let storage_value = value.into();
-        if parse_storage_digest(&storage_value).is_none() {
+        if parse_sha256_storage_digest(&storage_value).is_none() {
             return Err(RemoteIdentityError::InvalidStoredTokenHash);
         }
         Ok(Self { storage_value })
@@ -96,13 +95,7 @@ impl RemoteTokenHash {
 
     #[must_use]
     pub fn verify(&self, token: &str) -> bool {
-        let Some(expected) = parse_storage_digest(&self.storage_value) else {
-            let candidate = token_digest(token);
-            let _ = constant_time_eq(&[0_u8; 32], &candidate);
-            return false;
-        };
-        let candidate = token_digest(token);
-        constant_time_eq(&expected, &candidate)
+        verify_sha256_storage_value(&self.storage_value, token)
     }
 }
 
@@ -382,28 +375,6 @@ pub fn parse_remote_role(value: &str) -> Option<RemoteRole> {
         "viewer" => Some(RemoteRole::Viewer),
         _ => None,
     }
-}
-
-fn token_digest(token: &str) -> [u8; 32] {
-    Sha256::digest(token.as_bytes()).into()
-}
-
-fn parse_storage_digest(value: &str) -> Option<[u8; 32]> {
-    let hex_value = value.strip_prefix(TOKEN_HASH_PREFIX)?;
-    if hex_value.len() != TOKEN_HASH_HEX_LEN {
-        return None;
-    }
-    let mut digest = [0_u8; 32];
-    hex::decode_to_slice(hex_value, &mut digest).ok()?;
-    Some(digest)
-}
-
-fn constant_time_eq(left: &[u8; 32], right: &[u8; 32]) -> bool {
-    let diff = left
-        .iter()
-        .zip(right.iter())
-        .fold(0_u8, |acc, (&left, &right)| acc | (left ^ right));
-    diff == 0
 }
 
 pub(crate) fn remote_token_hint(token: &str) -> String {

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::error::Error;
 use std::fmt;
 
@@ -19,6 +19,7 @@ mod tests;
 const PAIRING_RANDOM_BYTES: usize = 32;
 const PAIRING_HASH_PREFIX: &str = "sha256:";
 const PAIRING_HASH_HEX_LEN: usize = 64;
+const DEFAULT_RATE_LIMITER_MAX_ENTRIES: usize = 4096;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemotePairingError {
@@ -331,15 +332,38 @@ pub struct RemotePairingClaimedClient {
 #[derive(Debug, Clone)]
 pub struct RemotePairingRateLimiter {
     max_attempts: u32,
-    attempts: BTreeMap<String, u32>,
+    max_entries: usize,
+    attempts: BTreeMap<RemotePairingAttemptKey, u32>,
+    attempt_order: VecDeque<RemotePairingAttemptKey>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct RemotePairingAttemptKey {
+    remote_addr: String,
+    code_fingerprint: String,
+}
+
+impl RemotePairingAttemptKey {
+    fn new(remote_addr: &str, code_fingerprint: &str) -> Self {
+        Self {
+            remote_addr: remote_addr.to_string(),
+            code_fingerprint: code_fingerprint.to_string(),
+        }
+    }
 }
 
 impl RemotePairingRateLimiter {
     #[must_use]
     pub fn new(max_attempts: u32) -> Self {
+        Self::new_bounded(max_attempts, DEFAULT_RATE_LIMITER_MAX_ENTRIES)
+    }
+
+    fn new_bounded(max_attempts: u32, max_entries: usize) -> Self {
         Self {
             max_attempts: max_attempts.max(1),
+            max_entries: max_entries.max(1),
             attempts: BTreeMap::new(),
+            attempt_order: VecDeque::new(),
         }
     }
 
@@ -347,6 +371,18 @@ impl RemotePairingRateLimiter {
     #[must_use]
     pub fn new_for_tests(max_attempts: u32) -> Self {
         Self::new(max_attempts)
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn new_bounded_for_tests(max_attempts: u32, max_entries: usize) -> Self {
+        Self::new_bounded(max_attempts, max_entries)
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn tracked_attempts_for_tests(&self) -> usize {
+        self.attempts.len()
     }
 
     /// Record one failed/suspicious pairing attempt for an address/code tuple.
@@ -358,13 +394,27 @@ impl RemotePairingRateLimiter {
         remote_addr: &str,
         code_fingerprint: &str,
     ) -> Result<(), RemotePairingError> {
-        let key = format!("{remote_addr}\0{code_fingerprint}");
+        let key = RemotePairingAttemptKey::new(remote_addr, code_fingerprint);
+        if !self.attempts.contains_key(&key) {
+            self.evict_until_room();
+            self.attempt_order.push_back(key.clone());
+        }
         let count = self.attempts.entry(key).or_insert(0);
         if *count >= self.max_attempts {
             return Err(RemotePairingError::RateLimited);
         }
         *count += 1;
         Ok(())
+    }
+
+    fn evict_until_room(&mut self) {
+        while self.attempts.len() >= self.max_entries {
+            let Some(oldest) = self.attempt_order.pop_front() else {
+                self.attempts.clear();
+                return;
+            };
+            self.attempts.remove(&oldest);
+        }
     }
 }
 

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -2,14 +2,14 @@ use std::collections::{BTreeMap, VecDeque};
 use std::error::Error;
 use std::fmt;
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use rand_core06::{OsRng, RngCore};
 use sha2::{Digest, Sha256};
 
 use super::remote::{RemoteAccessScope, RemoteRole};
 use super::remote_identity::{
-    expand_client_scopes, RemoteBearerToken, RemoteIdentityError, RemoteStoredClient,
+    RemoteBearerToken, RemoteIdentityError, RemoteStoredClient, expand_client_scopes,
 };
 
 #[cfg(test)]
@@ -259,7 +259,10 @@ pub struct RemotePairingClaimRequest {
 }
 
 impl RemotePairingClaimRequest {
-    /// Build a pairing claim request from public claim endpoint fields.
+    /// Build a pairing claim request.
+    ///
+    /// `expected_domain` must come from daemon-side remote configuration.
+    /// `claimed_domain` is the domain sent by the public claim endpoint.
     ///
     /// # Errors
     /// Returns [`RemotePairingError`] when the domains, client id, display name,

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -1,0 +1,395 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use rand_core06::{OsRng, RngCore};
+use sha2::{Digest, Sha256};
+
+use super::remote::{RemoteAccessScope, RemoteRole};
+use super::remote_identity::{
+    expand_client_scopes, RemoteBearerToken, RemoteIdentityError, RemoteStoredClient,
+};
+
+#[cfg(test)]
+#[path = "remote_pairing_tests.rs"]
+mod tests;
+
+const PAIRING_RANDOM_BYTES: usize = 32;
+const PAIRING_HASH_PREFIX: &str = "sha256:";
+const PAIRING_HASH_HEX_LEN: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemotePairingError {
+    EmptyPairingId,
+    EmptyCode,
+    EmptyClientId,
+    EmptyDomain,
+    InvalidStoredCodeHash,
+    WrongDomain { expected: String, actual: String },
+    RateLimited,
+    Expired,
+    AlreadyClaimed,
+    UnknownCode,
+    Identity(RemoteIdentityError),
+}
+
+impl fmt::Display for RemotePairingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyPairingId => write!(f, "remote pairing id is required"),
+            Self::EmptyCode => write!(f, "remote pairing code is required"),
+            Self::EmptyClientId => write!(f, "remote pairing client id is required"),
+            Self::EmptyDomain => write!(f, "remote pairing domain is required"),
+            Self::InvalidStoredCodeHash => write!(f, "remote pairing code hash is invalid"),
+            Self::WrongDomain { expected, actual } => write!(
+                f,
+                "wrong remote pairing domain: expected '{expected}', got '{actual}'"
+            ),
+            Self::RateLimited => write!(f, "remote pairing attempts are rate limited"),
+            Self::Expired => write!(f, "remote pairing code expired"),
+            Self::AlreadyClaimed => write!(f, "remote pairing code already claimed"),
+            Self::UnknownCode => write!(f, "remote pairing code is unknown"),
+            Self::Identity(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl Error for RemotePairingError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Identity(error) => Some(error),
+            Self::EmptyPairingId
+            | Self::EmptyCode
+            | Self::EmptyClientId
+            | Self::EmptyDomain
+            | Self::InvalidStoredCodeHash
+            | Self::WrongDomain { .. }
+            | Self::RateLimited
+            | Self::Expired
+            | Self::AlreadyClaimed
+            | Self::UnknownCode => None,
+        }
+    }
+}
+
+impl From<RemoteIdentityError> for RemotePairingError {
+    fn from(error: RemoteIdentityError) -> Self {
+        Self::Identity(error)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct RemotePairingCode {
+    value: String,
+}
+
+impl fmt::Debug for RemotePairingCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RemotePairingCode")
+            .field("value", &"<redacted>")
+            .finish()
+    }
+}
+
+impl RemotePairingCode {
+    #[must_use]
+    pub fn generate() -> Self {
+        let mut bytes = [0_u8; PAIRING_RANDOM_BYTES];
+        OsRng.fill_bytes(&mut bytes);
+        Self {
+            value: URL_SAFE_NO_PAD.encode(bytes),
+        }
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn from_value_for_tests(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.value
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePairingCodeHash {
+    storage_value: String,
+}
+
+impl RemotePairingCodeHash {
+    /// Build a pairing code hash from the one-time pairing code.
+    ///
+    /// # Errors
+    /// Returns [`RemotePairingError::EmptyCode`] when the pairing code is blank.
+    pub fn from_code(code: &str) -> Result<Self, RemotePairingError> {
+        if code.trim().is_empty() {
+            return Err(RemotePairingError::EmptyCode);
+        }
+        let digest = pairing_digest(code);
+        Ok(Self {
+            storage_value: format!("{PAIRING_HASH_PREFIX}{}", hex::encode(digest)),
+        })
+    }
+
+    /// Build a pairing hash wrapper from persisted storage after validation.
+    ///
+    /// # Errors
+    /// Returns [`RemotePairingError::InvalidStoredCodeHash`] when the value is
+    /// not a `sha256:`-prefixed 32-byte digest encoded as 64 hex characters.
+    pub(crate) fn try_from_storage_value(
+        value: impl Into<String>,
+    ) -> Result<Self, RemotePairingError> {
+        let storage_value = value.into();
+        if parse_pairing_storage_digest(&storage_value).is_none() {
+            return Err(RemotePairingError::InvalidStoredCodeHash);
+        }
+        Ok(Self { storage_value })
+    }
+
+    #[must_use]
+    pub fn as_storage_value(&self) -> &str {
+        &self.storage_value
+    }
+
+    #[must_use]
+    pub fn verify(&self, code: &str) -> bool {
+        let Some(expected) = parse_pairing_storage_digest(&self.storage_value) else {
+            let candidate = pairing_digest(code);
+            let _ = constant_time_eq(&[0_u8; 32], &candidate);
+            return false;
+        };
+        let candidate = pairing_digest(code);
+        constant_time_eq(&expected, &candidate)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePairingRecord {
+    pub pairing_id: String,
+    pub code_hash: RemotePairingCodeHash,
+    pub role: RemoteRole,
+    pub scopes: Vec<RemoteAccessScope>,
+    pub created_at: String,
+    pub expires_at: String,
+}
+
+impl RemotePairingRecord {
+    /// Build a durable one-time pairing record without retaining the raw code.
+    ///
+    /// # Errors
+    /// Returns [`RemotePairingError`] for blank ids/codes and requested scopes
+    /// that exceed the selected role.
+    pub fn new(
+        pairing_id: impl Into<String>,
+        role: RemoteRole,
+        requested_scopes: &[RemoteAccessScope],
+        code: &str,
+        created_at: impl Into<String>,
+        expires_at: impl Into<String>,
+    ) -> Result<Self, RemotePairingError> {
+        let pairing_id = pairing_id.into();
+        if pairing_id.trim().is_empty() {
+            return Err(RemotePairingError::EmptyPairingId);
+        }
+        Ok(Self {
+            pairing_id,
+            code_hash: RemotePairingCodeHash::from_code(code)?,
+            role,
+            scopes: expand_client_scopes(role, requested_scopes)?,
+            created_at: created_at.into(),
+            expires_at: expires_at.into(),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn new_for_tests(
+        pairing_id: impl Into<String>,
+        role: RemoteRole,
+        requested_scopes: &[RemoteAccessScope],
+        code: &str,
+        created_at: impl Into<String>,
+        expires_at: impl Into<String>,
+    ) -> Result<Self, RemotePairingError> {
+        Self::new(
+            pairing_id,
+            role,
+            requested_scopes,
+            code,
+            created_at,
+            expires_at,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteStoredPairing {
+    pub pairing_id: String,
+    pub code_hash: RemotePairingCodeHash,
+    pub role: RemoteRole,
+    pub scopes: Vec<RemoteAccessScope>,
+    pub created_at: String,
+    pub expires_at: String,
+    pub claimed_at: Option<String>,
+    pub claimed_client_id: Option<String>,
+    pub claim_remote_addr: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePairingClaimRequest {
+    pub expected_domain: String,
+    pub claimed_domain: String,
+    pub client_id: String,
+    pub display_name: String,
+    pub platform: String,
+    pub remote_addr: Option<String>,
+    pub audit_event_id: String,
+}
+
+impl RemotePairingClaimRequest {
+    /// Build a pairing claim request from public claim endpoint fields.
+    ///
+    /// # Errors
+    /// Returns [`RemotePairingError`] when required claim fields are blank.
+    pub fn new(
+        expected_domain: impl Into<String>,
+        claimed_domain: impl Into<String>,
+        client_id: impl Into<String>,
+        display_name: impl Into<String>,
+        platform: impl Into<String>,
+        remote_addr: Option<&str>,
+        audit_event_id: impl Into<String>,
+    ) -> Result<Self, RemotePairingError> {
+        let expected_domain = expected_domain.into();
+        let claimed_domain = claimed_domain.into();
+        let client_id = client_id.into();
+        if expected_domain.trim().is_empty() || claimed_domain.trim().is_empty() {
+            return Err(RemotePairingError::EmptyDomain);
+        }
+        if client_id.trim().is_empty() {
+            return Err(RemotePairingError::EmptyClientId);
+        }
+        Ok(Self {
+            expected_domain,
+            claimed_domain,
+            client_id,
+            display_name: display_name.into(),
+            platform: platform.into(),
+            remote_addr: remote_addr.map(ToOwned::to_owned),
+            audit_event_id: audit_event_id.into(),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn new_for_tests(
+        expected_domain: impl Into<String>,
+        claimed_domain: impl Into<String>,
+        client_id: impl Into<String>,
+        display_name: impl Into<String>,
+        platform: impl Into<String>,
+        remote_addr: Option<&str>,
+        audit_event_id: impl Into<String>,
+    ) -> Result<Self, RemotePairingError> {
+        Self::new(
+            expected_domain,
+            claimed_domain,
+            client_id,
+            display_name,
+            platform,
+            remote_addr,
+            audit_event_id,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePairingClaimedClient {
+    pub client: RemoteStoredClient,
+    pub bearer_token: RemoteBearerToken,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemotePairingRateLimiter {
+    max_attempts: u32,
+    attempts: BTreeMap<String, u32>,
+}
+
+impl RemotePairingRateLimiter {
+    #[must_use]
+    pub fn new(max_attempts: u32) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            attempts: BTreeMap::new(),
+        }
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn new_for_tests(max_attempts: u32) -> Self {
+        Self::new(max_attempts)
+    }
+
+    /// Record one failed/suspicious pairing attempt for an address/code tuple.
+    ///
+    /// # Errors
+    /// Returns [`RemotePairingError::RateLimited`] after the configured limit.
+    pub fn record_attempt(
+        &mut self,
+        remote_addr: &str,
+        code_fingerprint: &str,
+    ) -> Result<(), RemotePairingError> {
+        let key = format!("{remote_addr}\0{code_fingerprint}");
+        let count = self.attempts.entry(key).or_insert(0);
+        if *count >= self.max_attempts {
+            return Err(RemotePairingError::RateLimited);
+        }
+        *count += 1;
+        Ok(())
+    }
+}
+
+/// Validate that the public claim domain matches the daemon endpoint domain.
+///
+/// # Errors
+/// Returns [`RemotePairingError`] when either domain is blank or they differ.
+pub fn validate_pairing_domain(expected: &str, actual: &str) -> Result<(), RemotePairingError> {
+    let expected = expected.trim();
+    let actual = actual.trim();
+    if expected.is_empty() || actual.is_empty() {
+        return Err(RemotePairingError::EmptyDomain);
+    }
+    if !expected.eq_ignore_ascii_case(actual) {
+        return Err(RemotePairingError::WrongDomain {
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn pairing_digest(code: &str) -> [u8; 32] {
+    Sha256::digest(code.as_bytes()).into()
+}
+
+fn parse_pairing_storage_digest(value: &str) -> Option<[u8; 32]> {
+    let hex_value = value.strip_prefix(PAIRING_HASH_PREFIX)?;
+    if hex_value.len() != PAIRING_HASH_HEX_LEN {
+        return None;
+    }
+    let mut digest = [0_u8; 32];
+    hex::decode_to_slice(hex_value, &mut digest).ok()?;
+    Some(digest)
+}
+
+fn constant_time_eq(left: &[u8; 32], right: &[u8; 32]) -> bool {
+    let diff = left
+        .iter()
+        .zip(right.iter())
+        .fold(0_u8, |acc, (&left, &right)| acc | (left ^ right));
+    diff == 0
+}

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -2,14 +2,14 @@ use std::collections::{BTreeMap, VecDeque};
 use std::error::Error;
 use std::fmt;
 
-use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use rand_core06::{OsRng, RngCore};
 use sha2::{Digest, Sha256};
 
 use super::remote::{RemoteAccessScope, RemoteRole};
 use super::remote_identity::{
-    RemoteBearerToken, RemoteIdentityError, RemoteStoredClient, expand_client_scopes,
+    expand_client_scopes, RemoteBearerToken, RemoteIdentityError, RemoteStoredClient,
 };
 
 #[cfg(test)]
@@ -29,6 +29,7 @@ pub enum RemotePairingError {
     EmptyDomain,
     EmptyDisplayName,
     EmptyPlatform,
+    EmptyAuditEventId,
     InvalidStoredCodeHash,
     WrongDomain { expected: String, actual: String },
     RateLimited,
@@ -47,6 +48,7 @@ impl fmt::Display for RemotePairingError {
             Self::EmptyDomain => write!(f, "remote pairing domain is required"),
             Self::EmptyDisplayName => write!(f, "remote pairing display name is required"),
             Self::EmptyPlatform => write!(f, "remote pairing platform is required"),
+            Self::EmptyAuditEventId => write!(f, "remote pairing audit event id is required"),
             Self::InvalidStoredCodeHash => write!(f, "remote pairing code hash is invalid"),
             Self::WrongDomain { expected, actual } => write!(
                 f,
@@ -71,6 +73,7 @@ impl Error for RemotePairingError {
             | Self::EmptyDomain
             | Self::EmptyDisplayName
             | Self::EmptyPlatform
+            | Self::EmptyAuditEventId
             | Self::InvalidStoredCodeHash
             | Self::WrongDomain { .. }
             | Self::RateLimited
@@ -266,7 +269,7 @@ impl RemotePairingClaimRequest {
     ///
     /// # Errors
     /// Returns [`RemotePairingError`] when the domains, client id, display name,
-    /// or platform are blank.
+    /// platform, or audit event id are blank.
     pub fn new(
         expected_domain: impl Into<String>,
         claimed_domain: impl Into<String>,
@@ -281,6 +284,7 @@ impl RemotePairingClaimRequest {
         let client_id = client_id.into();
         let display_name = display_name.into();
         let platform = platform.into();
+        let audit_event_id = audit_event_id.into();
         if expected_domain.trim().is_empty() || claimed_domain.trim().is_empty() {
             return Err(RemotePairingError::EmptyDomain);
         }
@@ -293,6 +297,7 @@ impl RemotePairingClaimRequest {
         if platform.trim().is_empty() {
             return Err(RemotePairingError::EmptyPlatform);
         }
+        validate_pairing_audit_event_id(&audit_event_id)?;
         Ok(Self {
             expected_domain,
             claimed_domain,
@@ -300,7 +305,7 @@ impl RemotePairingClaimRequest {
             display_name,
             platform,
             remote_addr: remote_addr.map(ToOwned::to_owned),
-            audit_event_id: audit_event_id.into(),
+            audit_event_id,
         })
     }
 
@@ -436,6 +441,17 @@ pub fn validate_pairing_domain(expected: &str, actual: &str) -> Result<(), Remot
             expected: expected.to_string(),
             actual: actual.to_string(),
         });
+    }
+    Ok(())
+}
+
+/// Validate the audit event id used by remote pairing persistence.
+///
+/// # Errors
+/// Returns [`RemotePairingError::EmptyAuditEventId`] when the id is blank.
+pub fn validate_pairing_audit_event_id(value: &str) -> Result<(), RemotePairingError> {
+    if value.trim().is_empty() {
+        return Err(RemotePairingError::EmptyAuditEventId);
     }
     Ok(())
 }

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -138,7 +138,8 @@ impl RemotePairingCodeHash {
     /// # Errors
     /// Returns [`RemotePairingError::EmptyCode`] when the pairing code is blank.
     pub fn from_code(code: &str) -> Result<Self, RemotePairingError> {
-        if code.trim().is_empty() {
+        let code = code.trim();
+        if code.is_empty() {
             return Err(RemotePairingError::EmptyCode);
         }
         Ok(Self {
@@ -168,7 +169,7 @@ impl RemotePairingCodeHash {
 
     #[must_use]
     pub fn verify(&self, code: &str) -> bool {
-        verify_sha256_storage_value(&self.storage_value, code)
+        verify_sha256_storage_value(&self.storage_value, code.trim())
     }
 }
 
@@ -338,10 +339,19 @@ pub struct RemotePairingRateLimiter {
     attempt_order: VecDeque<RemotePairingAttemptKey>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct RemotePairingAttemptKey {
     remote_addr: String,
     code_fingerprint: String,
+}
+
+impl fmt::Debug for RemotePairingAttemptKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RemotePairingAttemptKey")
+            .field("remote_addr", &self.remote_addr)
+            .field("code_fingerprint", &"<redacted>")
+            .finish()
+    }
 }
 
 impl RemotePairingAttemptKey {

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -2,14 +2,16 @@ use std::collections::{BTreeMap, VecDeque};
 use std::error::Error;
 use std::fmt;
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use rand_core06::{OsRng, RngCore};
-use sha2::{Digest, Sha256};
 
 use super::remote::{RemoteAccessScope, RemoteRole};
+use super::remote_crypto::{
+    parse_sha256_storage_digest, sha256_storage_value, verify_sha256_storage_value,
+};
 use super::remote_identity::{
-    expand_client_scopes, RemoteBearerToken, RemoteIdentityError, RemoteStoredClient,
+    RemoteBearerToken, RemoteIdentityError, RemoteStoredClient, expand_client_scopes,
 };
 
 #[cfg(test)]
@@ -17,8 +19,6 @@ use super::remote_identity::{
 mod tests;
 
 const PAIRING_RANDOM_BYTES: usize = 32;
-const PAIRING_HASH_PREFIX: &str = "sha256:";
-const PAIRING_HASH_HEX_LEN: usize = 64;
 const DEFAULT_RATE_LIMITER_MAX_ENTRIES: usize = 4096;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,9 +141,8 @@ impl RemotePairingCodeHash {
         if code.trim().is_empty() {
             return Err(RemotePairingError::EmptyCode);
         }
-        let digest = pairing_digest(code);
         Ok(Self {
-            storage_value: format!("{PAIRING_HASH_PREFIX}{}", hex::encode(digest)),
+            storage_value: sha256_storage_value(code),
         })
     }
 
@@ -156,7 +155,7 @@ impl RemotePairingCodeHash {
         value: impl Into<String>,
     ) -> Result<Self, RemotePairingError> {
         let storage_value = value.into();
-        if parse_pairing_storage_digest(&storage_value).is_none() {
+        if parse_sha256_storage_digest(&storage_value).is_none() {
             return Err(RemotePairingError::InvalidStoredCodeHash);
         }
         Ok(Self { storage_value })
@@ -169,13 +168,7 @@ impl RemotePairingCodeHash {
 
     #[must_use]
     pub fn verify(&self, code: &str) -> bool {
-        let Some(expected) = parse_pairing_storage_digest(&self.storage_value) else {
-            let candidate = pairing_digest(code);
-            let _ = constant_time_eq(&[0_u8; 32], &candidate);
-            return false;
-        };
-        let candidate = pairing_digest(code);
-        constant_time_eq(&expected, &candidate)
+        verify_sha256_storage_value(&self.storage_value, code)
     }
 }
 
@@ -454,26 +447,4 @@ pub fn validate_pairing_audit_event_id(value: &str) -> Result<(), RemotePairingE
         return Err(RemotePairingError::EmptyAuditEventId);
     }
     Ok(())
-}
-
-fn pairing_digest(code: &str) -> [u8; 32] {
-    Sha256::digest(code.as_bytes()).into()
-}
-
-fn parse_pairing_storage_digest(value: &str) -> Option<[u8; 32]> {
-    let hex_value = value.strip_prefix(PAIRING_HASH_PREFIX)?;
-    if hex_value.len() != PAIRING_HASH_HEX_LEN {
-        return None;
-    }
-    let mut digest = [0_u8; 32];
-    hex::decode_to_slice(hex_value, &mut digest).ok()?;
-    Some(digest)
-}
-
-fn constant_time_eq(left: &[u8; 32], right: &[u8; 32]) -> bool {
-    let diff = left
-        .iter()
-        .zip(right.iter())
-        .fold(0_u8, |acc, (&left, &right)| acc | (left ^ right));
-    diff == 0
 }

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -26,6 +26,8 @@ pub enum RemotePairingError {
     EmptyCode,
     EmptyClientId,
     EmptyDomain,
+    EmptyDisplayName,
+    EmptyPlatform,
     InvalidStoredCodeHash,
     WrongDomain { expected: String, actual: String },
     RateLimited,
@@ -42,6 +44,8 @@ impl fmt::Display for RemotePairingError {
             Self::EmptyCode => write!(f, "remote pairing code is required"),
             Self::EmptyClientId => write!(f, "remote pairing client id is required"),
             Self::EmptyDomain => write!(f, "remote pairing domain is required"),
+            Self::EmptyDisplayName => write!(f, "remote pairing display name is required"),
+            Self::EmptyPlatform => write!(f, "remote pairing platform is required"),
             Self::InvalidStoredCodeHash => write!(f, "remote pairing code hash is invalid"),
             Self::WrongDomain { expected, actual } => write!(
                 f,
@@ -64,6 +68,8 @@ impl Error for RemotePairingError {
             | Self::EmptyCode
             | Self::EmptyClientId
             | Self::EmptyDomain
+            | Self::EmptyDisplayName
+            | Self::EmptyPlatform
             | Self::InvalidStoredCodeHash
             | Self::WrongDomain { .. }
             | Self::RateLimited
@@ -255,7 +261,8 @@ impl RemotePairingClaimRequest {
     /// Build a pairing claim request from public claim endpoint fields.
     ///
     /// # Errors
-    /// Returns [`RemotePairingError`] when required claim fields are blank.
+    /// Returns [`RemotePairingError`] when the domains, client id, display name,
+    /// or platform are blank.
     pub fn new(
         expected_domain: impl Into<String>,
         claimed_domain: impl Into<String>,
@@ -268,18 +275,26 @@ impl RemotePairingClaimRequest {
         let expected_domain = expected_domain.into();
         let claimed_domain = claimed_domain.into();
         let client_id = client_id.into();
+        let display_name = display_name.into();
+        let platform = platform.into();
         if expected_domain.trim().is_empty() || claimed_domain.trim().is_empty() {
             return Err(RemotePairingError::EmptyDomain);
         }
         if client_id.trim().is_empty() {
             return Err(RemotePairingError::EmptyClientId);
         }
+        if display_name.trim().is_empty() {
+            return Err(RemotePairingError::EmptyDisplayName);
+        }
+        if platform.trim().is_empty() {
+            return Err(RemotePairingError::EmptyPlatform);
+        }
         Ok(Self {
             expected_domain,
             claimed_domain,
             client_id,
-            display_name: display_name.into(),
-            platform: platform.into(),
+            display_name,
+            platform,
             remote_addr: remote_addr.map(ToOwned::to_owned),
             audit_event_id: audit_event_id.into(),
         })

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    RemotePairingClaimRequest, RemotePairingCode, RemotePairingRateLimiter, RemotePairingRecord,
-    validate_pairing_domain,
+    validate_pairing_domain, RemotePairingClaimRequest, RemotePairingCode,
+    RemotePairingRateLimiter, RemotePairingRecord,
 };
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 
@@ -18,12 +18,10 @@ fn remote_pairing_code_hashes_secret_and_redacts_debug() {
     .expect("pairing record");
 
     assert!(!format!("{code:?}").contains("pairing-secret-value"));
-    assert!(
-        !record
-            .code_hash
-            .as_storage_value()
-            .contains("pairing-secret-value")
-    );
+    assert!(!record
+        .code_hash
+        .as_storage_value()
+        .contains("pairing-secret-value"));
     assert!(record.code_hash.verify(code.expose()));
     assert_eq!(
         record.scopes,
@@ -83,6 +81,23 @@ fn remote_pairing_claim_request_rejects_blank_display_name_and_platform() {
         )
         .is_err(),
         "platform is required for pairing metadata"
+    );
+}
+
+#[test]
+fn remote_pairing_claim_request_rejects_blank_audit_event_id() {
+    assert!(
+        RemotePairingClaimRequest::new_for_tests(
+            "daemon.example.com",
+            "daemon.example.com",
+            "client-1",
+            "MacBook Pro",
+            "macos",
+            Some("203.0.113.10"),
+            " \t",
+        )
+        .is_err(),
+        "audit event id is required for deterministic pairing audit writes"
     );
 }
 

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -1,0 +1,47 @@
+use super::{
+    validate_pairing_domain, RemotePairingCode, RemotePairingRateLimiter, RemotePairingRecord,
+};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+
+#[test]
+fn remote_pairing_code_hashes_secret_and_redacts_debug() {
+    let code = RemotePairingCode::from_value_for_tests("pairing-secret-value");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-1",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        code.expose(),
+        "2026-06-21T13:40:00Z",
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("pairing record");
+
+    assert!(!format!("{code:?}").contains("pairing-secret-value"));
+    assert!(!record
+        .code_hash
+        .as_storage_value()
+        .contains("pairing-secret-value"));
+    assert!(record.code_hash.verify(code.expose()));
+    assert_eq!(
+        record.scopes,
+        vec![RemoteAccessScope::Read, RemoteAccessScope::Write]
+    );
+}
+
+#[test]
+fn remote_pairing_rejects_wrong_claim_domain() {
+    let error = validate_pairing_domain("daemon.example.com", "evil.example.com")
+        .expect_err("wrong domain rejected");
+
+    assert!(error.to_string().contains("wrong remote pairing domain"));
+}
+
+#[test]
+fn remote_pairing_rate_limits_ip_and_code_attempts() {
+    let mut limiter = RemotePairingRateLimiter::new_for_tests(2);
+
+    assert!(limiter.record_attempt("203.0.113.10", "code-1").is_ok());
+    assert!(limiter.record_attempt("203.0.113.10", "code-1").is_ok());
+    assert!(limiter.record_attempt("203.0.113.10", "code-1").is_err());
+    assert!(limiter.record_attempt("203.0.113.11", "code-1").is_ok());
+}

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    validate_pairing_domain, RemotePairingClaimRequest, RemotePairingCode,
-    RemotePairingRateLimiter, RemotePairingRecord,
+    RemotePairingAttemptKey, RemotePairingClaimRequest, RemotePairingCode, RemotePairingCodeHash,
+    RemotePairingRateLimiter, RemotePairingRecord, validate_pairing_domain,
 };
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 
@@ -18,15 +18,31 @@ fn remote_pairing_code_hashes_secret_and_redacts_debug() {
     .expect("pairing record");
 
     assert!(!format!("{code:?}").contains("pairing-secret-value"));
-    assert!(!record
-        .code_hash
-        .as_storage_value()
-        .contains("pairing-secret-value"));
+    assert!(
+        !record
+            .code_hash
+            .as_storage_value()
+            .contains("pairing-secret-value")
+    );
     assert!(record.code_hash.verify(code.expose()));
     assert_eq!(
         record.scopes,
         vec![RemoteAccessScope::Read, RemoteAccessScope::Write]
     );
+}
+
+#[test]
+fn remote_pairing_code_hash_normalizes_surrounding_whitespace() {
+    let trimmed_hash =
+        RemotePairingCodeHash::from_code("pairing-secret-value").expect("trimmed hash");
+    let padded_hash =
+        RemotePairingCodeHash::from_code(" \tpairing-secret-value\n").expect("padded hash");
+
+    assert_eq!(
+        padded_hash.as_storage_value(),
+        trimmed_hash.as_storage_value()
+    );
+    assert!(trimmed_hash.verify(" \tpairing-secret-value\n"));
 }
 
 #[test]
@@ -121,6 +137,16 @@ fn remote_pairing_rate_limiter_uses_tuple_keys_without_delimiter_collisions() {
         "distinct address/code tuples must not collide"
     );
     assert!(limiter.record_attempt("addr\0part", "code").is_err());
+}
+
+#[test]
+fn remote_pairing_attempt_key_debug_redacts_code_fingerprint() {
+    let key = RemotePairingAttemptKey::new("203.0.113.10", "raw-secret-code");
+    let debug = format!("{key:?}");
+
+    assert!(debug.contains("203.0.113.10"));
+    assert!(!debug.contains("raw-secret-code"));
+    assert!(debug.contains("<redacted>"));
 }
 
 #[test]

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    validate_pairing_domain, RemotePairingClaimRequest, RemotePairingCode,
-    RemotePairingRateLimiter, RemotePairingRecord,
+    RemotePairingClaimRequest, RemotePairingCode, RemotePairingRateLimiter, RemotePairingRecord,
+    validate_pairing_domain,
 };
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 
@@ -18,10 +18,12 @@ fn remote_pairing_code_hashes_secret_and_redacts_debug() {
     .expect("pairing record");
 
     assert!(!format!("{code:?}").contains("pairing-secret-value"));
-    assert!(!record
-        .code_hash
-        .as_storage_value()
-        .contains("pairing-secret-value"));
+    assert!(
+        !record
+            .code_hash
+            .as_storage_value()
+            .contains("pairing-secret-value")
+    );
     assert!(record.code_hash.verify(code.expose()));
     assert_eq!(
         record.scopes,
@@ -35,6 +37,23 @@ fn remote_pairing_rejects_wrong_claim_domain() {
         .expect_err("wrong domain rejected");
 
     assert!(error.to_string().contains("wrong remote pairing domain"));
+}
+
+#[test]
+fn remote_pairing_claim_request_separates_config_and_claim_domains() {
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "claimed.example.com",
+        "client-1",
+        "MacBook Pro",
+        "macos",
+        Some("203.0.113.10"),
+        "audit-claim",
+    )
+    .expect("claim request");
+
+    assert_eq!(claim.expected_domain, "daemon.example.com");
+    assert_eq!(claim.claimed_domain, "claimed.example.com");
 }
 
 #[test]

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    validate_pairing_domain, RemotePairingCode, RemotePairingRateLimiter, RemotePairingRecord,
+    validate_pairing_domain, RemotePairingClaimRequest, RemotePairingCode,
+    RemotePairingRateLimiter, RemotePairingRecord,
 };
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 
@@ -34,6 +35,36 @@ fn remote_pairing_rejects_wrong_claim_domain() {
         .expect_err("wrong domain rejected");
 
     assert!(error.to_string().contains("wrong remote pairing domain"));
+}
+
+#[test]
+fn remote_pairing_claim_request_rejects_blank_display_name_and_platform() {
+    assert!(
+        RemotePairingClaimRequest::new_for_tests(
+            "daemon.example.com",
+            "daemon.example.com",
+            "client-1",
+            " ",
+            "macos",
+            Some("203.0.113.10"),
+            "audit-claim",
+        )
+        .is_err(),
+        "display name is required for pairing metadata"
+    );
+    assert!(
+        RemotePairingClaimRequest::new_for_tests(
+            "daemon.example.com",
+            "daemon.example.com",
+            "client-1",
+            "MacBook Pro",
+            "\t",
+            Some("203.0.113.10"),
+            "audit-claim",
+        )
+        .is_err(),
+        "platform is required for pairing metadata"
+    );
 }
 
 #[test]

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -76,3 +76,30 @@ fn remote_pairing_rate_limits_ip_and_code_attempts() {
     assert!(limiter.record_attempt("203.0.113.10", "code-1").is_err());
     assert!(limiter.record_attempt("203.0.113.11", "code-1").is_ok());
 }
+
+#[test]
+fn remote_pairing_rate_limiter_uses_tuple_keys_without_delimiter_collisions() {
+    let mut limiter = RemotePairingRateLimiter::new_for_tests(1);
+
+    assert!(limiter.record_attempt("addr\0part", "code").is_ok());
+    assert!(
+        limiter.record_attempt("addr", "part\0code").is_ok(),
+        "distinct address/code tuples must not collide"
+    );
+    assert!(limiter.record_attempt("addr\0part", "code").is_err());
+}
+
+#[test]
+fn remote_pairing_rate_limiter_bounds_tracked_attempts() {
+    let mut limiter = RemotePairingRateLimiter::new_bounded_for_tests(1, 2);
+
+    assert!(limiter.record_attempt("203.0.113.1", "code").is_ok());
+    assert!(limiter.record_attempt("203.0.113.2", "code").is_ok());
+    assert!(limiter.record_attempt("203.0.113.3", "code").is_ok());
+
+    assert_eq!(limiter.tracked_attempts_for_tests(), 2);
+    assert!(
+        limiter.record_attempt("203.0.113.1", "code").is_ok(),
+        "oldest entries are evicted when the limiter reaches its bound"
+    );
+}


### PR DESCRIPTION
## Motivation
Remote daemon pairing needs a durable one-time claim path before HTTP pairing endpoints can be wired. The server should store only pairing code hashes, create server-issued client tokens on claim, reject replay/expiry/domain mismatches, and audit each outcome.

## Implementation
- Add typed remote pairing code, hash, claim, and rate-limit primitives with secret-redacting debug output.
- Add daemon DB create/claim helpers for remote pairing codes that register clients through the existing hashed-token identity path.
- Add pairing audit events for create, claim success, replay, expiry, wrong domain, and unknown code.
- Proved with `mise run cargo:local -- test remote_pairing`, `mise run cargo:local -- test remote`, `mise run cargo:local -- clippy -p harness --lib`, and `git diff --check`.