### PR TITLE
feat(daemon): add remote authz core

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -36,6 +36,7 @@ pub mod ordering;
 pub mod protocol;
 pub mod remote;
 pub mod remote_acme;
+pub mod remote_auth;
 pub(crate) mod remote_crypto;
 pub mod remote_identity;
 pub mod remote_pairing;

--- a/src/daemon/remote_auth.rs
+++ b/src/daemon/remote_auth.rs
@@ -1,0 +1,203 @@
+use std::{error::Error, fmt};
+
+use axum::http::{HeaderMap, header::AUTHORIZATION};
+
+use super::protocol::{HttpApiRouteContract, http_paths};
+use super::remote::{RemoteAccessScope, remote_http_scopes, remote_ws_scopes};
+use super::remote_identity::RemoteStoredClient;
+
+#[cfg(test)]
+#[path = "remote_auth_tests.rs"]
+mod tests;
+
+pub const REMOTE_CLIENT_ID_HEADER: &str = "x-harness-remote-client-id";
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct RemoteBearerCredentials {
+    client_id: String,
+    token: String,
+}
+
+impl fmt::Debug for RemoteBearerCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RemoteBearerCredentials")
+            .field("client_id", &self.client_id)
+            .field("token", &"<redacted>")
+            .finish()
+    }
+}
+
+impl RemoteBearerCredentials {
+    /// Parse remote bearer credentials from HTTP or WebSocket handshake headers.
+    ///
+    /// # Errors
+    /// Returns [`RemoteAuthError`] when the remote client id or bearer token is
+    /// absent or blank.
+    pub fn from_headers(headers: &HeaderMap) -> Result<Self, RemoteAuthError> {
+        let client_id = headers
+            .get(REMOTE_CLIENT_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or(RemoteAuthError::MissingClientId)?;
+        let token = headers
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or(RemoteAuthError::MissingBearerToken)?;
+        Ok(Self {
+            client_id: client_id.to_string(),
+            token: token.to_string(),
+        })
+    }
+
+    #[must_use]
+    pub fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    #[must_use]
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteAuthError {
+    MissingClientId,
+    MissingBearerToken,
+    InvalidBearerToken,
+    MissingScopeContract,
+    InsufficientScope,
+}
+
+impl RemoteAuthError {
+    #[must_use]
+    pub const fn status_code(self) -> u16 {
+        match self {
+            Self::MissingClientId | Self::MissingBearerToken | Self::InvalidBearerToken => 401,
+            Self::MissingScopeContract | Self::InsufficientScope => 403,
+        }
+    }
+}
+
+impl fmt::Display for RemoteAuthError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingClientId => write!(f, "remote client id is required"),
+            Self::MissingBearerToken => write!(f, "remote bearer token is required"),
+            Self::InvalidBearerToken => write!(f, "remote bearer token is invalid"),
+            Self::MissingScopeContract => write!(f, "remote route scope contract is missing"),
+            Self::InsufficientScope => write!(f, "remote client scope is insufficient"),
+        }
+    }
+}
+
+impl Error for RemoteAuthError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteAuthDecision {
+    pub client_id: String,
+    pub target: RemoteAuthTarget,
+    pub required_scope: RemoteAccessScope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteAuthTarget {
+    Http {
+        method: &'static str,
+        path: &'static str,
+    },
+    WsHandshake,
+    WsMethod {
+        method: String,
+    },
+}
+
+/// Authorize a remote client for an HTTP daemon route.
+///
+/// # Errors
+/// Returns [`RemoteAuthError::MissingScopeContract`] when the route has no
+/// remote scope contract, or [`RemoteAuthError::InsufficientScope`] when the
+/// client lacks the required scope.
+pub fn authorize_remote_http_route(
+    client: &RemoteStoredClient,
+    route: &'static HttpApiRouteContract,
+) -> Result<RemoteAuthDecision, RemoteAuthError> {
+    let required_scope = first_required_scope(remote_http_scopes(route))?;
+    authorize_client_scope(client, required_scope)?;
+    Ok(RemoteAuthDecision {
+        client_id: client.client_id.clone(),
+        target: RemoteAuthTarget::Http {
+            method: route.method.as_str(),
+            path: route.path,
+        },
+        required_scope,
+    })
+}
+
+/// Authorize the remote WebSocket handshake itself.
+///
+/// # Errors
+/// Returns [`RemoteAuthError::InsufficientScope`] when the client lacks read
+/// access to the `/v1/ws` route.
+pub fn authorize_remote_ws_handshake(
+    client: &RemoteStoredClient,
+) -> Result<RemoteAuthDecision, RemoteAuthError> {
+    let required_scope = RemoteAccessScope::Read;
+    authorize_client_scope(client, required_scope)?;
+    Ok(RemoteAuthDecision {
+        client_id: client.client_id.clone(),
+        target: RemoteAuthTarget::WsHandshake,
+        required_scope,
+    })
+}
+
+/// Authorize one JSON-RPC method received on an authenticated remote WebSocket.
+///
+/// # Errors
+/// Returns [`RemoteAuthError::MissingScopeContract`] when the method has no
+/// remote scope contract, or [`RemoteAuthError::InsufficientScope`] when the
+/// client lacks the required scope.
+pub fn authorize_remote_ws_method(
+    client: &RemoteStoredClient,
+    method: &str,
+) -> Result<RemoteAuthDecision, RemoteAuthError> {
+    let required_scope = first_required_scope(remote_ws_scopes(method))?;
+    authorize_client_scope(client, required_scope)?;
+    Ok(RemoteAuthDecision {
+        client_id: client.client_id.clone(),
+        target: RemoteAuthTarget::WsMethod {
+            method: method.to_string(),
+        },
+        required_scope,
+    })
+}
+
+fn first_required_scope(
+    scopes: Option<&'static [RemoteAccessScope]>,
+) -> Result<RemoteAccessScope, RemoteAuthError> {
+    scopes
+        .and_then(|scopes| scopes.first().copied())
+        .ok_or(RemoteAuthError::MissingScopeContract)
+}
+
+fn authorize_client_scope(
+    client: &RemoteStoredClient,
+    required_scope: RemoteAccessScope,
+) -> Result<(), RemoteAuthError> {
+    if client.scopes.contains(&required_scope) {
+        return Ok(());
+    }
+    Err(RemoteAuthError::InsufficientScope)
+}
+
+#[expect(
+    dead_code,
+    reason = "documents that WSS handshakes share the HTTP route contract"
+)]
+fn ws_route_path() -> &'static str {
+    http_paths::WS
+}

--- a/src/daemon/remote_auth.rs
+++ b/src/daemon/remote_auth.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt};
 
-use axum::http::{HeaderMap, header::AUTHORIZATION};
+use axum::http::{HeaderMap, StatusCode, header::AUTHORIZATION};
 
 use super::protocol::{HttpApiRouteContract, http_paths};
 use super::remote::{RemoteAccessScope, remote_http_scopes, remote_ws_scopes};
@@ -84,10 +84,12 @@ pub enum RemoteAuthError {
 
 impl RemoteAuthError {
     #[must_use]
-    pub const fn status_code(self) -> u16 {
+    pub const fn status_code(self) -> StatusCode {
         match self {
-            Self::MissingClientId | Self::MissingBearerToken | Self::InvalidBearerToken => 401,
-            Self::MissingScopeContract | Self::InsufficientScope => 403,
+            Self::MissingClientId | Self::MissingBearerToken | Self::InvalidBearerToken => {
+                StatusCode::UNAUTHORIZED
+            }
+            Self::MissingScopeContract | Self::InsufficientScope => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/src/daemon/remote_auth.rs
+++ b/src/daemon/remote_auth.rs
@@ -40,13 +40,22 @@ impl RemoteBearerCredentials {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .ok_or(RemoteAuthError::MissingClientId)?;
-        let token = headers
+        let authorization = headers
             .get(AUTHORIZATION)
             .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.strip_prefix("Bearer "))
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .ok_or(RemoteAuthError::MissingBearerToken)?;
+        let (scheme, token) = authorization
+            .split_once(char::is_whitespace)
+            .ok_or(RemoteAuthError::InvalidBearerToken)?;
+        if !scheme.eq_ignore_ascii_case("Bearer") {
+            return Err(RemoteAuthError::InvalidBearerToken);
+        }
+        let token = token.trim();
+        if token.is_empty() {
+            return Err(RemoteAuthError::InvalidBearerToken);
+        }
         Ok(Self {
             client_id: client_id.to_string(),
             token: token.to_string(),

--- a/src/daemon/remote_auth.rs
+++ b/src/daemon/remote_auth.rs
@@ -2,7 +2,7 @@ use std::{error::Error, fmt};
 
 use axum::http::{HeaderMap, StatusCode, header::AUTHORIZATION};
 
-use super::protocol::{HttpApiRouteContract, http_paths};
+use super::protocol::{HTTP_API_CONTRACT, HttpApiRouteContract, http_paths};
 use super::remote::{RemoteAccessScope, remote_http_scopes, remote_ws_scopes};
 use super::remote_identity::RemoteStoredClient;
 
@@ -135,7 +135,7 @@ pub enum RemoteAuthTarget {
 /// client lacks the required scope.
 pub fn authorize_remote_http_route(
     client: &RemoteStoredClient,
-    route: &'static HttpApiRouteContract,
+    route: &HttpApiRouteContract,
 ) -> Result<RemoteAuthDecision, RemoteAuthError> {
     let required_scope = first_required_scope(remote_http_scopes(route))?;
     authorize_client_scope(client, required_scope)?;
@@ -157,13 +157,26 @@ pub fn authorize_remote_http_route(
 pub fn authorize_remote_ws_handshake(
     client: &RemoteStoredClient,
 ) -> Result<RemoteAuthDecision, RemoteAuthError> {
-    let required_scope = RemoteAccessScope::Read;
+    let required_scope = remote_ws_handshake_scope()?;
     authorize_client_scope(client, required_scope)?;
     Ok(RemoteAuthDecision {
         client_id: client.client_id.clone(),
         target: RemoteAuthTarget::WsHandshake,
         required_scope,
     })
+}
+
+/// Return the remote scope required to establish the WebSocket connection.
+///
+/// # Errors
+/// Returns [`RemoteAuthError::MissingScopeContract`] when the `/v1/ws` HTTP
+/// route is missing or lacks a remote scope contract.
+pub fn remote_ws_handshake_scope() -> Result<RemoteAccessScope, RemoteAuthError> {
+    let route = HTTP_API_CONTRACT
+        .iter()
+        .find(|route| route.path == http_paths::WS)
+        .ok_or(RemoteAuthError::MissingScopeContract)?;
+    first_required_scope(remote_http_scopes(route))
 }
 
 /// Authorize one JSON-RPC method received on an authenticated remote WebSocket.
@@ -203,12 +216,4 @@ fn authorize_client_scope(
         return Ok(());
     }
     Err(RemoteAuthError::InsufficientScope)
-}
-
-#[expect(
-    dead_code,
-    reason = "documents that WSS handshakes share the HTTP route contract"
-)]
-fn ws_route_path() -> &'static str {
-    http_paths::WS
 }

--- a/src/daemon/remote_auth.rs
+++ b/src/daemon/remote_auth.rs
@@ -46,14 +46,14 @@ impl RemoteBearerCredentials {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .ok_or(RemoteAuthError::MissingBearerToken)?;
-        let (scheme, token) = authorization
-            .split_once(char::is_whitespace)
+        let mut authorization_parts = authorization.split_whitespace();
+        let scheme = authorization_parts
+            .next()
             .ok_or(RemoteAuthError::InvalidBearerToken)?;
-        if !scheme.eq_ignore_ascii_case("Bearer") {
-            return Err(RemoteAuthError::InvalidBearerToken);
-        }
-        let token = token.trim();
-        if token.is_empty() {
+        let token = authorization_parts
+            .next()
+            .ok_or(RemoteAuthError::InvalidBearerToken)?;
+        if !scheme.eq_ignore_ascii_case("Bearer") || authorization_parts.next().is_some() {
             return Err(RemoteAuthError::InvalidBearerToken);
         }
         Ok(Self {

--- a/src/daemon/remote_auth_tests.rs
+++ b/src/daemon/remote_auth_tests.rs
@@ -27,11 +27,22 @@ fn remote_bearer_credentials_require_client_id_and_bearer_token() {
         RemoteAuthError::MissingBearerToken
     );
 
-    let mut non_bearer = missing_bearer;
+    let mut non_bearer = missing_bearer.clone();
     non_bearer.insert(AUTHORIZATION, HeaderValue::from_static("Basic abc"));
     assert_eq!(
+        RemoteBearerCredentials::from_headers(&non_bearer).expect_err("non-bearer").status_code(),
+        401
+    );
+    assert_eq!(
         RemoteBearerCredentials::from_headers(&non_bearer).expect_err("non-bearer"),
-        RemoteAuthError::MissingBearerToken
+        RemoteAuthError::InvalidBearerToken
+    );
+
+    let mut blank_bearer = missing_bearer;
+    blank_bearer.insert(AUTHORIZATION, HeaderValue::from_static("Bearer "));
+    assert_eq!(
+        RemoteBearerCredentials::from_headers(&blank_bearer).expect_err("blank bearer"),
+        RemoteAuthError::InvalidBearerToken
     );
 }
 

--- a/src/daemon/remote_auth_tests.rs
+++ b/src/daemon/remote_auth_tests.rs
@@ -1,4 +1,4 @@
-use axum::http::{HeaderMap, HeaderValue, header::AUTHORIZATION};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
 
 use super::{
     REMOTE_CLIENT_ID_HEADER, RemoteAuthError, RemoteAuthTarget, RemoteBearerCredentials,
@@ -30,8 +30,12 @@ fn remote_bearer_credentials_require_client_id_and_bearer_token() {
     let mut non_bearer = missing_bearer.clone();
     non_bearer.insert(AUTHORIZATION, HeaderValue::from_static("Basic abc"));
     assert_eq!(
-        RemoteBearerCredentials::from_headers(&non_bearer).expect_err("non-bearer").status_code(),
-        401
+        typed_status(
+            RemoteBearerCredentials::from_headers(&non_bearer)
+                .expect_err("non-bearer")
+                .status_code()
+        ),
+        StatusCode::UNAUTHORIZED
     );
     assert_eq!(
         RemoteBearerCredentials::from_headers(&non_bearer).expect_err("non-bearer"),
@@ -116,7 +120,7 @@ fn remote_http_authz_denies_insufficient_scope_with_403() {
         authorize_remote_http_route(&viewer, telemetry).expect_err("viewer cannot write telemetry");
 
     assert_eq!(error, RemoteAuthError::InsufficientScope);
-    assert_eq!(error.status_code(), 403);
+    assert_eq!(typed_status(error.status_code()), StatusCode::FORBIDDEN);
 }
 
 #[test]
@@ -169,7 +173,11 @@ fn remote_authz_fails_closed_when_scope_contract_is_missing() {
         authorize_remote_ws_method(&admin, "remote.unscoped").expect_err("unscoped method denied");
 
     assert_eq!(error, RemoteAuthError::MissingScopeContract);
-    assert_eq!(error.status_code(), 403);
+    assert_eq!(typed_status(error.status_code()), StatusCode::FORBIDDEN);
+}
+
+fn typed_status(status: StatusCode) -> StatusCode {
+    status
 }
 
 fn http_route(path: &str) -> &'static crate::daemon::protocol::HttpApiRouteContract {

--- a/src/daemon/remote_auth_tests.rs
+++ b/src/daemon/remote_auth_tests.rs
@@ -1,0 +1,189 @@
+use axum::http::{HeaderMap, HeaderValue, header::AUTHORIZATION};
+
+use super::{
+    REMOTE_CLIENT_ID_HEADER, RemoteAuthError, RemoteAuthTarget, RemoteBearerCredentials,
+    authorize_remote_http_route, authorize_remote_ws_handshake, authorize_remote_ws_method,
+};
+use crate::daemon::protocol::{HTTP_API_CONTRACT, http_paths, ws_methods};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::{RemoteStoredClient, RemoteTokenHash};
+
+#[test]
+fn remote_bearer_credentials_require_client_id_and_bearer_token() {
+    let empty_headers = HeaderMap::new();
+
+    assert_eq!(
+        RemoteBearerCredentials::from_headers(&empty_headers).expect_err("missing credentials"),
+        RemoteAuthError::MissingClientId
+    );
+
+    let mut missing_bearer = HeaderMap::new();
+    missing_bearer.insert(
+        REMOTE_CLIENT_ID_HEADER,
+        HeaderValue::from_static("client-1"),
+    );
+    assert_eq!(
+        RemoteBearerCredentials::from_headers(&missing_bearer).expect_err("missing bearer"),
+        RemoteAuthError::MissingBearerToken
+    );
+
+    let mut non_bearer = missing_bearer;
+    non_bearer.insert(AUTHORIZATION, HeaderValue::from_static("Basic abc"));
+    assert_eq!(
+        RemoteBearerCredentials::from_headers(&non_bearer).expect_err("non-bearer"),
+        RemoteAuthError::MissingBearerToken
+    );
+}
+
+#[test]
+fn remote_bearer_credentials_parse_and_redact_debug() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        REMOTE_CLIENT_ID_HEADER,
+        HeaderValue::from_static("client-1"),
+    );
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_static("Bearer remote-token-secret"),
+    );
+
+    let credentials = RemoteBearerCredentials::from_headers(&headers).expect("credentials");
+
+    assert_eq!(credentials.client_id(), "client-1");
+    assert_eq!(credentials.token(), "remote-token-secret");
+    assert!(!format!("{credentials:?}").contains("remote-token-secret"));
+}
+
+#[test]
+fn remote_http_authz_allows_role_scoped_routes() {
+    let viewer = remote_client("viewer", RemoteRole::Viewer, &[RemoteAccessScope::Read]);
+    let operator = remote_client(
+        "operator",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+    );
+    let admin = remote_client(
+        "admin",
+        RemoteRole::Admin,
+        &[
+            RemoteAccessScope::Read,
+            RemoteAccessScope::Write,
+            RemoteAccessScope::Admin,
+        ],
+    );
+
+    let stream = http_route(http_paths::STREAM);
+    let telemetry = http_route(http_paths::DAEMON_TELEMETRY);
+    let stop = http_route(http_paths::DAEMON_STOP);
+
+    assert_eq!(
+        authorize_remote_http_route(&viewer, stream)
+            .expect("viewer stream")
+            .required_scope,
+        RemoteAccessScope::Read
+    );
+    assert_eq!(
+        authorize_remote_http_route(&operator, telemetry)
+            .expect("operator telemetry")
+            .required_scope,
+        RemoteAccessScope::Write
+    );
+    assert_eq!(
+        authorize_remote_http_route(&admin, stop)
+            .expect("admin stop")
+            .required_scope,
+        RemoteAccessScope::Admin
+    );
+}
+
+#[test]
+fn remote_http_authz_denies_insufficient_scope_with_403() {
+    let viewer = remote_client("viewer", RemoteRole::Viewer, &[RemoteAccessScope::Read]);
+    let telemetry = http_route(http_paths::DAEMON_TELEMETRY);
+
+    let error =
+        authorize_remote_http_route(&viewer, telemetry).expect_err("viewer cannot write telemetry");
+
+    assert_eq!(error, RemoteAuthError::InsufficientScope);
+    assert_eq!(error.status_code(), 403);
+}
+
+#[test]
+fn remote_ws_authz_covers_handshake_and_per_message_scope() {
+    let viewer = remote_client("viewer", RemoteRole::Viewer, &[RemoteAccessScope::Read]);
+    let operator = remote_client(
+        "operator",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+    );
+
+    assert_eq!(
+        authorize_remote_ws_handshake(&viewer)
+            .expect("viewer handshake")
+            .target,
+        RemoteAuthTarget::WsHandshake
+    );
+    assert_eq!(
+        authorize_remote_ws_method(&viewer, ws_methods::SESSIONS)
+            .expect("viewer read")
+            .required_scope,
+        RemoteAccessScope::Read
+    );
+    assert_eq!(
+        authorize_remote_ws_method(&operator, ws_methods::SESSION_START)
+            .expect("operator write")
+            .required_scope,
+        RemoteAccessScope::Write
+    );
+    assert_eq!(
+        authorize_remote_ws_method(&viewer, ws_methods::SESSION_START)
+            .expect_err("viewer cannot start session"),
+        RemoteAuthError::InsufficientScope
+    );
+}
+
+#[test]
+fn remote_authz_fails_closed_when_scope_contract_is_missing() {
+    let admin = remote_client(
+        "admin",
+        RemoteRole::Admin,
+        &[
+            RemoteAccessScope::Read,
+            RemoteAccessScope::Write,
+            RemoteAccessScope::Admin,
+        ],
+    );
+
+    let error =
+        authorize_remote_ws_method(&admin, "remote.unscoped").expect_err("unscoped method denied");
+
+    assert_eq!(error, RemoteAuthError::MissingScopeContract);
+    assert_eq!(error.status_code(), 403);
+}
+
+fn http_route(path: &str) -> &'static crate::daemon::protocol::HttpApiRouteContract {
+    HTTP_API_CONTRACT
+        .iter()
+        .find(|route| route.path == path)
+        .expect("http route contract")
+}
+
+fn remote_client(
+    client_id: &str,
+    role: RemoteRole,
+    scopes: &[RemoteAccessScope],
+) -> RemoteStoredClient {
+    RemoteStoredClient {
+        client_id: client_id.to_string(),
+        display_name: "MacBook Pro".to_string(),
+        platform: "macos".to_string(),
+        role,
+        scopes: scopes.to_vec(),
+        token_hash: RemoteTokenHash::from_token_for_tests("remote-token-secret"),
+        token_hint: "secret".to_string(),
+        created_at: "2026-06-21T16:00:00Z".to_string(),
+        last_seen_at: None,
+        revoked_at: None,
+        rotated_at: None,
+    }
+}

--- a/src/daemon/remote_auth_tests.rs
+++ b/src/daemon/remote_auth_tests.rs
@@ -52,6 +52,20 @@ fn remote_bearer_credentials_require_client_id_and_bearer_token() {
         RemoteBearerCredentials::from_headers(&blank_bearer).expect_err("blank bearer"),
         RemoteAuthError::InvalidBearerToken
     );
+
+    let mut extra_parts = HeaderMap::new();
+    extra_parts.insert(
+        REMOTE_CLIENT_ID_HEADER,
+        HeaderValue::from_static("client-1"),
+    );
+    extra_parts.insert(
+        AUTHORIZATION,
+        HeaderValue::from_static("Bearer remote-token-secret extra"),
+    );
+    assert_eq!(
+        RemoteBearerCredentials::from_headers(&extra_parts).expect_err("extra bearer parts"),
+        RemoteAuthError::InvalidBearerToken
+    );
 }
 
 #[test]

--- a/src/daemon/remote_auth_tests.rs
+++ b/src/daemon/remote_auth_tests.rs
@@ -3,9 +3,13 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
 use super::{
     REMOTE_CLIENT_ID_HEADER, RemoteAuthError, RemoteAuthTarget, RemoteBearerCredentials,
     authorize_remote_http_route, authorize_remote_ws_handshake, authorize_remote_ws_method,
+    remote_ws_handshake_scope,
 };
-use crate::daemon::protocol::{HTTP_API_CONTRACT, http_paths, ws_methods};
-use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::protocol::{
+    HTTP_API_CONTRACT, HttpApiRouteContract, HttpRouteMethod, HttpRouteParity, http_paths,
+    ws_methods,
+};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole, remote_http_scopes};
 use crate::daemon::remote_identity::{RemoteStoredClient, RemoteTokenHash};
 
 #[test]
@@ -112,6 +116,30 @@ fn remote_http_authz_allows_role_scoped_routes() {
 }
 
 #[test]
+fn remote_http_authz_accepts_borrowed_route_contracts() {
+    let route = HttpApiRouteContract {
+        method: HttpRouteMethod::Get,
+        path: http_paths::STREAM,
+        parity: HttpRouteParity::Exempt {
+            reason: "stack-local test route",
+        },
+        swift_client_exposed: false,
+    };
+    let viewer = remote_client("viewer", RemoteRole::Viewer, &[RemoteAccessScope::Read]);
+
+    let decision = authorize_remote_http_route(&viewer, &route).expect("borrowed route");
+
+    assert_eq!(
+        decision.target,
+        RemoteAuthTarget::Http {
+            method: "GET",
+            path: http_paths::STREAM,
+        }
+    );
+    assert_eq!(decision.required_scope, RemoteAccessScope::Read);
+}
+
+#[test]
 fn remote_http_authz_denies_insufficient_scope_with_403() {
     let viewer = remote_client("viewer", RemoteRole::Viewer, &[RemoteAccessScope::Read]);
     let telemetry = http_route(http_paths::DAEMON_TELEMETRY);
@@ -154,6 +182,19 @@ fn remote_ws_authz_covers_handshake_and_per_message_scope() {
         authorize_remote_ws_method(&viewer, ws_methods::SESSION_START)
             .expect_err("viewer cannot start session"),
         RemoteAuthError::InsufficientScope
+    );
+}
+
+#[test]
+fn remote_ws_handshake_scope_uses_http_route_contract() {
+    let ws_route = http_route(http_paths::WS);
+    let expected_scope = remote_http_scopes(ws_route)
+        .and_then(|scopes| scopes.first().copied())
+        .expect("websocket HTTP route scope");
+
+    assert_eq!(
+        remote_ws_handshake_scope().expect("websocket handshake scope"),
+        expected_scope
     );
 }
 


### PR DESCRIPTION
## Motivation

Remote daemon routes already have scope contracts and persisted clients, but there is no reusable authorization decision layer for HTTP and WebSocket wiring

## Implementation

- Add remote bearer credential parsing with client id header plus bearer token redaction
- Add scope-based authz decisions for HTTP route contracts, WebSocket handshakes, and per-message WebSocket methods
- Cover unauthorized, insufficient-scope, allowed-role, and fail-closed unscoped method cases with focused tests