### PR TITLE
feat(daemon): enforce remote http authz

### DIFF
--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -13,6 +13,8 @@ use crate::daemon::remote_identity::RemoteStoredClient;
 
 use super::DaemonHttpState;
 
+const REMOTE_AUTH_STORE_UNAVAILABLE_MESSAGE: &str = "remote authentication store is unavailable";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DaemonHttpAuthMode {
     #[default]
@@ -93,9 +95,14 @@ fn require_local_auth(headers: &HeaderMap, state: &DaemonHttpState) -> Result<()
 }
 
 fn http_route_contract(method: &Method, route_path: &str) -> Option<&'static HttpApiRouteContract> {
+    let method = if *method == Method::HEAD {
+        Method::GET.as_str()
+    } else {
+        method.as_str()
+    };
     HTTP_API_CONTRACT
         .iter()
-        .find(|route| route.method.as_str() == method.as_str() && route.path == route_path)
+        .find(|route| route.method.as_str() == method && route.path == route_path)
 }
 
 fn verify_remote_client(
@@ -108,13 +115,11 @@ fn verify_remote_client(
         .db
         .get()
         .ok_or_else(|| Box::new(remote_store_unavailable_response()))?;
-    let db = db.lock().map_err(|error| {
-        Box::new(remote_service_error_response(format!(
-            "remote client store lock poisoned: {error}"
-        )))
-    })?;
+    let db = db
+        .lock()
+        .map_err(|_| Box::new(remote_store_unavailable_response()))?;
     db.verify_remote_client_token(credentials.client_id(), credentials.token())
-        .map_err(|error| Box::new(remote_service_error_response(error.to_string())))?
+        .map_err(|_| Box::new(remote_store_unavailable_response()))?
         .ok_or_else(|| {
             Box::new(remote_auth_error_response(
                 RemoteAuthError::InvalidBearerToken,
@@ -149,16 +154,12 @@ fn remote_auth_error_response(error: RemoteAuthError) -> Response {
 }
 
 fn remote_store_unavailable_response() -> Response {
-    remote_service_error_response("remote client store is unavailable")
-}
-
-fn remote_service_error_response(message: impl Into<String>) -> Response {
     (
         StatusCode::SERVICE_UNAVAILABLE,
         Json(serde_json::json!({
             "error": {
                 "code": "REMOTE_AUTH_STORE",
-                "message": message.into(),
+                "message": REMOTE_AUTH_STORE_UNAVAILABLE_MESSAGE,
             }
         })),
     )

--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -15,6 +15,10 @@ use super::DaemonHttpState;
 
 const REMOTE_AUTH_STORE_UNAVAILABLE_MESSAGE: &str = "remote authentication store is unavailable";
 
+tokio::task_local! {
+    static REMOTE_HTTP_CLIENT: RemoteStoredClient;
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DaemonHttpAuthMode {
     #[default]
@@ -38,10 +42,17 @@ pub(crate) fn require_auth(
 ) -> Result<(), Box<Response>> {
     match state.auth_mode {
         DaemonHttpAuthMode::Local => require_local_auth(headers, state),
-        DaemonHttpAuthMode::Remote => verify_remote_client(headers, state).map(|_| ()),
+        DaemonHttpAuthMode::Remote => {
+            if has_scoped_remote_client() {
+                Ok(())
+            } else {
+                verify_remote_client(headers, state).map(|_| ())
+            }
+        }
     }
 }
 
+#[cfg(test)]
 pub(crate) fn authorize_http_route(
     headers: &HeaderMap,
     state: &DaemonHttpState,
@@ -50,10 +61,7 @@ pub(crate) fn authorize_http_route(
     match state.auth_mode {
         DaemonHttpAuthMode::Local => require_local_auth(headers, state),
         DaemonHttpAuthMode::Remote => {
-            let client = verify_remote_client(headers, state)?;
-            authorize_remote_http_route(&client, route)
-                .map(|_| ())
-                .map_err(|error| Box::new(remote_auth_error_response(error)))
+            verify_and_authorize_http_route(headers, state, route).map(|_| ())
         }
     }
 }
@@ -76,10 +84,10 @@ pub(crate) async fn authorize_remote_http_request(
     let Some(route) = http_route_contract(request.method(), route_path) else {
         return remote_auth_error_response(RemoteAuthError::MissingScopeContract);
     };
-    if let Err(response) = authorize_http_route(request.headers(), &state, route) {
-        return *response;
+    match verify_and_authorize_http_route(request.headers(), &state, route) {
+        Ok(client) => REMOTE_HTTP_CLIENT.scope(client, next.run(request)).await,
+        Err(response) => *response,
     }
-    next.run(request).await
 }
 
 fn require_local_auth(headers: &HeaderMap, state: &DaemonHttpState) -> Result<(), Box<Response>> {
@@ -125,6 +133,21 @@ fn verify_remote_client(
                 RemoteAuthError::InvalidBearerToken,
             ))
         })
+}
+
+fn verify_and_authorize_http_route(
+    headers: &HeaderMap,
+    state: &DaemonHttpState,
+    route: &HttpApiRouteContract,
+) -> Result<RemoteStoredClient, Box<Response>> {
+    let client = verify_remote_client(headers, state)?;
+    authorize_remote_http_route(&client, route)
+        .map(|_| client)
+        .map_err(|error| Box::new(remote_auth_error_response(error)))
+}
+
+fn has_scoped_remote_client() -> bool {
+    REMOTE_HTTP_CLIENT.try_with(|_| ()).is_ok()
 }
 
 fn local_auth_response() -> Response {

--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -1,10 +1,24 @@
 use axum::Json;
-use axum::http::{HeaderMap, StatusCode, header::AUTHORIZATION};
+use axum::body::Body;
+use axum::extract::{MatchedPath, State};
+use axum::http::{HeaderMap, Method, Request, StatusCode, header::AUTHORIZATION};
+use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 
-use crate::daemon::protocol::ControlPlaneActorRequest;
+use crate::daemon::protocol::{ControlPlaneActorRequest, HTTP_API_CONTRACT, HttpApiRouteContract};
+use crate::daemon::remote_auth::{
+    RemoteAuthError, RemoteBearerCredentials, authorize_remote_http_route,
+};
+use crate::daemon::remote_identity::RemoteStoredClient;
 
 use super::DaemonHttpState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DaemonHttpAuthMode {
+    #[default]
+    Local,
+    Remote,
+}
 
 pub(super) fn authorize_control_request<T: ControlPlaneActorRequest>(
     headers: &HeaderMap,
@@ -20,6 +34,50 @@ pub(crate) fn require_auth(
     headers: &HeaderMap,
     state: &DaemonHttpState,
 ) -> Result<(), Box<Response>> {
+    match state.auth_mode {
+        DaemonHttpAuthMode::Local => require_local_auth(headers, state),
+        DaemonHttpAuthMode::Remote => verify_remote_client(headers, state).map(|_| ()),
+    }
+}
+
+pub(crate) fn authorize_http_route(
+    headers: &HeaderMap,
+    state: &DaemonHttpState,
+    route: &HttpApiRouteContract,
+) -> Result<(), Box<Response>> {
+    match state.auth_mode {
+        DaemonHttpAuthMode::Local => require_local_auth(headers, state),
+        DaemonHttpAuthMode::Remote => {
+            let client = verify_remote_client(headers, state)?;
+            authorize_remote_http_route(&client, route)
+                .map(|_| ())
+                .map_err(|error| Box::new(remote_auth_error_response(error)))
+        }
+    }
+}
+
+pub(crate) async fn authorize_remote_http_request(
+    State(state): State<DaemonHttpState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    if state.auth_mode == DaemonHttpAuthMode::Local {
+        return next.run(request).await;
+    }
+    let route_path = request.extensions().get::<MatchedPath>().map_or_else(
+        || request.uri().path().to_string(),
+        |matched| matched.as_str().to_string(),
+    );
+    let Some(route) = http_route_contract(request.method(), &route_path) else {
+        return remote_auth_error_response(RemoteAuthError::MissingScopeContract);
+    };
+    if let Err(response) = authorize_http_route(request.headers(), &state, route) {
+        return *response;
+    }
+    next.run(request).await
+}
+
+fn require_local_auth(headers: &HeaderMap, state: &DaemonHttpState) -> Result<(), Box<Response>> {
     let provided = headers
         .get(AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
@@ -28,16 +86,78 @@ pub(crate) fn require_auth(
     if provided == Some(state.token.as_str()) {
         return Ok(());
     }
-    Err(Box::new(
-        (
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({
-                "error": {
-                    "code": "DAEMON_AUTH",
-                    "message": "missing or invalid daemon bearer token",
-                }
-            })),
-        )
-            .into_response(),
-    ))
+    Err(Box::new(local_auth_response()))
+}
+
+fn http_route_contract(method: &Method, route_path: &str) -> Option<&'static HttpApiRouteContract> {
+    HTTP_API_CONTRACT
+        .iter()
+        .find(|route| route.method.as_str() == method.as_str() && route.path == route_path)
+}
+
+fn verify_remote_client(
+    headers: &HeaderMap,
+    state: &DaemonHttpState,
+) -> Result<RemoteStoredClient, Box<Response>> {
+    let credentials = RemoteBearerCredentials::from_headers(headers)
+        .map_err(|error| Box::new(remote_auth_error_response(error)))?;
+    let db = state
+        .db
+        .get()
+        .ok_or_else(|| Box::new(remote_store_unavailable_response()))?;
+    let db = db.lock().map_err(|error| {
+        Box::new(remote_service_error_response(format!(
+            "remote client store lock poisoned: {error}"
+        )))
+    })?;
+    db.verify_remote_client_token(credentials.client_id(), credentials.token())
+        .map_err(|error| Box::new(remote_service_error_response(error.to_string())))?
+        .ok_or_else(|| {
+            Box::new(remote_auth_error_response(
+                RemoteAuthError::InvalidBearerToken,
+            ))
+        })
+}
+
+fn local_auth_response() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({
+            "error": {
+                "code": "DAEMON_AUTH",
+                "message": "missing or invalid daemon bearer token",
+            }
+        })),
+    )
+        .into_response()
+}
+
+fn remote_auth_error_response(error: RemoteAuthError) -> Response {
+    (
+        error.status_code(),
+        Json(serde_json::json!({
+            "error": {
+                "code": "REMOTE_AUTH",
+                "message": error.to_string(),
+            }
+        })),
+    )
+        .into_response()
+}
+
+fn remote_store_unavailable_response() -> Response {
+    remote_service_error_response("remote client store is unavailable")
+}
+
+fn remote_service_error_response(message: impl Into<String>) -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": {
+                "code": "REMOTE_AUTH_STORE",
+                "message": message.into(),
+            }
+        })),
+    )
+        .into_response()
 }

--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -64,11 +64,14 @@ pub(crate) async fn authorize_remote_http_request(
     if state.auth_mode == DaemonHttpAuthMode::Local {
         return next.run(request).await;
     }
-    let route_path = request.extensions().get::<MatchedPath>().map_or_else(
-        || request.uri().path().to_string(),
-        |matched| matched.as_str().to_string(),
-    );
-    let Some(route) = http_route_contract(request.method(), &route_path) else {
+    let Some(route_path) = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(MatchedPath::as_str)
+    else {
+        return next.run(request).await;
+    };
+    let Some(route) = http_route_contract(request.method(), route_path) else {
         return remote_auth_error_response(RemoteAuthError::MissingScopeContract);
     };
     if let Err(response) = authorize_http_route(request.headers(), &state, route) {

--- a/src/daemon/http/managed_agents.rs
+++ b/src/daemon/http/managed_agents.rs
@@ -223,6 +223,7 @@ mod tests {
         .expect("manifest");
         DaemonHttpState {
             token: "token".into(),
+            auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
             sender: sender.clone(),
             prepared_sender: broadcast::channel(8).0,
             manifest,

--- a/src/daemon/http/managed_agents/acp_inspect.rs
+++ b/src/daemon/http/managed_agents/acp_inspect.rs
@@ -72,6 +72,7 @@ mod tests {
         .expect("manifest");
         DaemonHttpState {
             token: "token".into(),
+            auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
             sender: sender.clone(),
             prepared_sender: broadcast::channel(8).0,
             manifest,

--- a/src/daemon/http/managed_agents/acp_transcript.rs
+++ b/src/daemon/http/managed_agents/acp_transcript.rs
@@ -82,6 +82,7 @@ mod tests {
         .expect("manifest");
         DaemonHttpState {
             token: "token".into(),
+            auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
             sender: sender.clone(),
             prepared_sender: broadcast::channel(8).0,
             manifest,

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -349,7 +349,7 @@ pub async fn serve(
         })
 }
 
-fn daemon_http_router(state: DaemonHttpState) -> Router {
+fn daemon_http_router(state: DaemonHttpState) -> Router<()> {
     Router::new()
         .merge(core::core_routes())
         .merge(sessions::session_routes())

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -57,6 +57,7 @@ mod tasks;
 mod tests;
 mod voice;
 
+pub use auth::DaemonHttpAuthMode;
 pub(crate) use auth::require_auth;
 pub(crate) use managed_agents::{
     acp_inspect_response, acp_transcript_response, ensure_acp_agent, ensure_acp_enabled,
@@ -161,6 +162,7 @@ pub(crate) fn connect_async_db_for_tests(path: &std::path::Path) -> Arc<AsyncDae
 #[derive(Clone)]
 pub struct DaemonHttpState {
     pub token: String,
+    pub auth_mode: DaemonHttpAuthMode,
     pub sender: broadcast::Sender<StreamEvent>,
     /// Fan-out channel carrying events serialized once into a shared
     /// [`PreparedBroadcast`]. Connection relays and SSE streams subscribe here
@@ -326,7 +328,7 @@ pub async fn serve(
         }
     });
 
-    let app = daemon_http_router().with_state(state);
+    let app = daemon_http_router(state);
 
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
@@ -347,7 +349,7 @@ pub async fn serve(
         })
 }
 
-fn daemon_http_router() -> Router<DaemonHttpState> {
+fn daemon_http_router(state: DaemonHttpState) -> Router {
     Router::new()
         .merge(core::core_routes())
         .merge(sessions::session_routes())
@@ -360,7 +362,12 @@ fn daemon_http_router() -> Router<DaemonHttpState> {
         .merge(openrouter_models::openrouter_model_routes())
         .merge(signals::signal_routes())
         .merge(voice::voice_routes())
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::authorize_remote_http_request,
+        ))
         .layer(middleware::from_fn(trace_http_request))
+        .with_state(state)
 }
 
 async fn trace_http_request(request: Request<Body>, next: Next) -> Response {

--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -32,6 +32,7 @@ mod async_reads;
 mod async_signal_mutations;
 mod async_stream;
 mod decode_failure_telemetry;
+mod remote_authz;
 mod reviews_policy_writes;
 mod session_archive_tests;
 mod shutdown;

--- a/src/daemon/http/tests/async_mutations.rs
+++ b/src/daemon/http/tests/async_mutations.rs
@@ -53,6 +53,7 @@ pub(super) async fn test_http_state_with_empty_async_db(
 
     DaemonHttpState {
         token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
         sender: sender.clone(),
         prepared_sender: broadcast::channel(8).0,
         manifest,

--- a/src/daemon/http/tests/async_reads.rs
+++ b/src/daemon/http/tests/async_reads.rs
@@ -58,6 +58,7 @@ async fn build_async_http_state(seed_timeline: bool) -> DaemonHttpState {
 
     DaemonHttpState {
         token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
         sender: sender.clone(),
         prepared_sender: broadcast::channel(8).0,
         manifest,

--- a/src/daemon/http/tests/remote_authz.rs
+++ b/src/daemon/http/tests/remote_authz.rs
@@ -1,4 +1,7 @@
+use std::thread;
+
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
+use rusqlite::Connection;
 use serde_json::json;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
@@ -182,6 +185,79 @@ async fn remote_http_authz_preserves_not_found_for_unmatched_routes() {
     let _ = server.await;
 }
 
+#[tokio::test]
+async fn remote_http_authz_treats_head_as_get_scope() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+    let (base_url, server) = serve_http(state).await;
+
+    let response = reqwest::Client::new()
+        .head(format!("{base_url}{}", http_paths::HEALTH))
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .send()
+        .await
+        .expect("send health head request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn remote_http_authz_redacts_poisoned_store_errors() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let db_slot = state.db.clone();
+    let _ = thread::spawn(move || {
+        let _guard = db_slot.get().expect("db slot").lock().expect("db lock");
+        panic!("poison remote client store");
+    })
+    .join();
+
+    let response = authorize_http_route(
+        &remote_headers("viewer"),
+        &state,
+        http_route(http_paths::STREAM),
+    )
+    .expect_err("poisoned store rejected");
+    assert_redacted_store_error(*response).await;
+}
+
+#[tokio::test]
+async fn remote_http_authz_redacts_token_verification_store_errors() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+    let db_path = state.db_path.as_ref().expect("db path");
+    Connection::open(db_path)
+        .expect("open db")
+        .execute(
+            "UPDATE remote_clients SET token_hash = 'not-a-valid-token-hash' WHERE client_id = 'viewer'",
+            [],
+        )
+        .expect("corrupt token hash");
+
+    let response = authorize_http_route(
+        &remote_headers("viewer"),
+        &state,
+        http_route(http_paths::STREAM),
+    )
+    .expect_err("store error rejected");
+    assert_redacted_store_error(*response).await;
+}
+
 fn register_remote_client(
     state: &crate::daemon::http::DaemonHttpState,
     client_id: &str,
@@ -238,4 +314,14 @@ fn http_route(path: &str) -> &'static HttpApiRouteContract {
         .iter()
         .find(|route| route.path == path)
         .expect("http route contract")
+}
+
+async fn assert_redacted_store_error(response: axum::response::Response) {
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(body["error"]["code"], "REMOTE_AUTH_STORE");
+    assert_eq!(
+        body["error"]["message"],
+        "remote authentication store is unavailable"
+    );
 }

--- a/src/daemon/http/tests/remote_authz.rs
+++ b/src/daemon/http/tests/remote_authz.rs
@@ -1,6 +1,8 @@
 use std::thread;
 
+use axum::extract::State;
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
+use axum::{Router, middleware, routing::get};
 use rusqlite::Connection;
 use serde_json::json;
 use tokio::net::TcpListener;
@@ -169,6 +171,41 @@ async fn remote_http_authz_router_enforces_route_scope_before_handler() {
 }
 
 #[tokio::test]
+async fn remote_http_authz_reuses_middleware_client_for_handler_auth() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+    let app = Router::new()
+        .route(
+            http_paths::HEALTH,
+            get(poison_store_then_require_handler_auth),
+        )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            super::super::auth::authorize_remote_http_request,
+        ))
+        .with_state(state);
+    let (base_url, server) = serve_router(app).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{base_url}{}", http_paths::HEALTH))
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .send()
+        .await
+        .expect("send health request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
 async fn remote_http_authz_preserves_not_found_for_unmatched_routes() {
     let mut state = test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
@@ -299,6 +336,10 @@ fn remote_token(client_id: &str) -> String {
 
 async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {
     let app = super::super::daemon_http_router(state);
+    serve_router(app).await
+}
+
+async fn serve_router(app: Router) -> (String, JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");
@@ -307,6 +348,22 @@ async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, Joi
         axum::serve(listener, app).await.expect("serve router");
     });
     (format!("http://{addr}"), server)
+}
+
+async fn poison_store_then_require_handler_auth(
+    State(state): State<crate::daemon::http::DaemonHttpState>,
+    headers: HeaderMap,
+) -> StatusCode {
+    let db_slot = state.db.clone();
+    let _ = thread::spawn(move || {
+        let _guard = db_slot.get().expect("db slot").lock().expect("db lock");
+        panic!("poison remote client store");
+    })
+    .join();
+    match require_auth(&headers, &state) {
+        Ok(()) => StatusCode::OK,
+        Err(response) => response.status(),
+    }
 }
 
 fn http_route(path: &str) -> &'static HttpApiRouteContract {

--- a/src/daemon/http/tests/remote_authz.rs
+++ b/src/daemon/http/tests/remote_authz.rs
@@ -1,0 +1,224 @@
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+use crate::daemon::http::auth::{DaemonHttpAuthMode, authorize_http_route, require_auth};
+use crate::daemon::protocol::{HTTP_API_CONTRACT, HttpApiRouteContract, http_paths};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_auth::REMOTE_CLIENT_ID_HEADER;
+use crate::daemon::remote_identity::RemoteClientRegistration;
+
+use super::{response_json, test_http_state_with_db};
+
+#[tokio::test]
+async fn remote_http_authz_denies_missing_credentials_with_401() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+
+    let response = authorize_http_route(&HeaderMap::new(), &state, http_route(http_paths::STREAM))
+        .expect_err("missing remote credentials");
+
+    let (status, body) = response_json(*response).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"]["code"], "REMOTE_AUTH");
+}
+
+#[tokio::test]
+async fn remote_http_authz_denies_insufficient_scope_with_403() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+
+    let response = authorize_http_route(
+        &remote_headers("viewer"),
+        &state,
+        http_route(http_paths::DAEMON_TELEMETRY),
+    )
+    .expect_err("viewer cannot write telemetry");
+
+    let (status, body) = response_json(*response).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["error"]["code"], "REMOTE_AUTH");
+}
+
+#[test]
+fn remote_http_authz_allows_role_scoped_routes() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+    register_remote_client(
+        &state,
+        "operator",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+    );
+    register_remote_client(
+        &state,
+        "admin",
+        RemoteRole::Admin,
+        &[
+            RemoteAccessScope::Read,
+            RemoteAccessScope::Write,
+            RemoteAccessScope::Admin,
+        ],
+    );
+
+    authorize_http_route(
+        &remote_headers("viewer"),
+        &state,
+        http_route(http_paths::STREAM),
+    )
+    .expect("viewer stream");
+    authorize_http_route(
+        &remote_headers("operator"),
+        &state,
+        http_route(http_paths::DAEMON_TELEMETRY),
+    )
+    .expect("operator telemetry");
+    authorize_http_route(
+        &remote_headers("admin"),
+        &state,
+        http_route(http_paths::DAEMON_STOP),
+    )
+    .expect("admin stop");
+}
+
+#[test]
+fn remote_http_authz_rejects_revoked_clients() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+    {
+        let db = state.db.get().expect("db slot").lock().expect("db lock");
+        db.revoke_remote_client("viewer", "2026-06-21T17:00:00Z")
+            .expect("revoke viewer");
+    }
+
+    let response = authorize_http_route(
+        &remote_headers("viewer"),
+        &state,
+        http_route(http_paths::STREAM),
+    )
+    .expect_err("revoked client rejected");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn remote_http_authz_handler_auth_accepts_valid_remote_client_without_local_token() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+
+    require_auth(&remote_headers("viewer"), &state)
+        .expect("remote client accepted by handler auth");
+}
+
+#[tokio::test]
+async fn remote_http_authz_router_enforces_route_scope_before_handler() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+    let (base_url, server) = serve_http(state).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}{}", http_paths::DAEMON_TELEMETRY))
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .json(&json!({
+            "kind": "decode_failure",
+            "source": "remote-test",
+            "message": "should not reach handler"
+        }))
+        .send()
+        .await
+        .expect("send telemetry request");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    server.abort();
+    let _ = server.await;
+}
+
+fn register_remote_client(
+    state: &crate::daemon::http::DaemonHttpState,
+    client_id: &str,
+    role: RemoteRole,
+    scopes: &[RemoteAccessScope],
+) {
+    let registration = RemoteClientRegistration::new_for_tests(
+        client_id,
+        "MacBook Pro",
+        "macos",
+        role,
+        scopes,
+        &remote_token(client_id),
+        "2026-06-21T16:00:00Z",
+    )
+    .expect("remote registration");
+    let db = state.db.get().expect("db slot").lock().expect("db lock");
+    db.register_remote_client(&registration)
+        .expect("register remote client");
+}
+
+fn remote_headers(client_id: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        REMOTE_CLIENT_ID_HEADER,
+        HeaderValue::from_str(client_id).expect("client id header"),
+    );
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {}", remote_token(client_id)))
+            .expect("authorization header"),
+    );
+    headers
+}
+
+fn remote_token(client_id: &str) -> String {
+    format!("remote-token-secret-{client_id}")
+}
+
+async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {
+    let app = super::super::daemon_http_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve router");
+    });
+    (format!("http://{addr}"), server)
+}
+
+fn http_route(path: &str) -> &'static HttpApiRouteContract {
+    HTTP_API_CONTRACT
+        .iter()
+        .find(|route| route.path == path)
+        .expect("http route contract")
+}

--- a/src/daemon/http/tests/remote_authz.rs
+++ b/src/daemon/http/tests/remote_authz.rs
@@ -165,6 +165,23 @@ async fn remote_http_authz_router_enforces_route_scope_before_handler() {
     let _ = server.await;
 }
 
+#[tokio::test]
+async fn remote_http_authz_preserves_not_found_for_unmatched_routes() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let (base_url, server) = serve_http(state).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{base_url}/v1/not-a-real-route"))
+        .send()
+        .await
+        .expect("send unmatched request");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    server.abort();
+    let _ = server.await;
+}
+
 fn register_remote_client(
     state: &crate::daemon::http::DaemonHttpState,
     client_id: &str,

--- a/src/daemon/http/tests/support.rs
+++ b/src/daemon/http/tests/support.rs
@@ -79,6 +79,7 @@ pub(in crate::daemon::http) fn test_http_state_with_db() -> DaemonHttpState {
     .expect("deserialize daemon manifest");
     DaemonHttpState {
         token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
         sender: sender.clone(),
         prepared_sender: broadcast::channel(8).0,
         manifest,
@@ -129,6 +130,7 @@ pub(in crate::daemon::http) fn test_http_state_with_sync_db_only(
     .expect("deserialize daemon manifest");
     DaemonHttpState {
         token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
         sender: sender.clone(),
         prepared_sender: broadcast::channel(8).0,
         manifest,

--- a/src/daemon/http/tests/task_board_crud.rs
+++ b/src/daemon/http/tests/task_board_crud.rs
@@ -206,7 +206,7 @@ async fn run_flow() {
 }
 
 async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {
-    let app = super::super::daemon_http_router().with_state(state);
+    let app = super::super::daemon_http_router(state);
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");

--- a/src/daemon/http/tests/task_board_parity.rs
+++ b/src/daemon/http/tests/task_board_parity.rs
@@ -150,7 +150,7 @@ async fn run_task_board_transport_parity() {
 }
 
 async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {
-    let app = super::super::daemon_http_router().with_state(state);
+    let app = super::super::daemon_http_router(state);
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");

--- a/src/daemon/http/tests/task_board_route_parity_support.rs
+++ b/src/daemon/http/tests/task_board_route_parity_support.rs
@@ -18,7 +18,7 @@ use crate::task_board::{TaskBoardItem, TaskBoardStatus, TaskBoardStore, default_
 pub(super) async fn serve_http(
     state: crate::daemon::http::DaemonHttpState,
 ) -> (String, JoinHandle<()>) {
-    let app = super::super::daemon_http_router().with_state(state);
+    let app = super::super::daemon_http_router(state);
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");

--- a/src/daemon/http/tests/task_board_support.rs
+++ b/src/daemon/http/tests/task_board_support.rs
@@ -78,7 +78,7 @@ pub(super) async fn join_leader(
 pub(super) async fn serve_http(
     state: crate::daemon::http::DaemonHttpState,
 ) -> (String, JoinHandle<()>) {
-    let app = super::super::daemon_http_router().with_state(state);
+    let app = super::super::daemon_http_router(state);
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");

--- a/src/daemon/service/mod.rs
+++ b/src/daemon/service/mod.rs
@@ -34,7 +34,7 @@ use super::agent_tui::AgentTuiManagerHandle;
 use super::bridge;
 use super::codex_controller::CodexControllerHandle;
 use super::codex_transport::{self, CodexTransportKind};
-use super::http::{self, DaemonHttpState};
+use super::http::{self, DaemonHttpAuthMode, DaemonHttpState};
 use super::index::{self, ResolvedSession};
 use super::launchd::{self, LaunchAgentStatus};
 #[cfg(test)]
@@ -148,6 +148,7 @@ pub struct DaemonStatusReport {
 pub struct DaemonServeConfig {
     pub host: String,
     pub port: u16,
+    pub auth_mode: DaemonHttpAuthMode,
     pub poll_interval: Duration,
     pub observe_interval: Duration,
     /// Whether the daemon is running inside the macOS App Sandbox.
@@ -167,6 +168,7 @@ impl Default for DaemonServeConfig {
         Self {
             host: "127.0.0.1".into(),
             port: 0,
+            auth_mode: DaemonHttpAuthMode::Local,
             poll_interval: Duration::from_secs(2),
             observe_interval: Duration::from_secs(5),
             sandboxed: false,

--- a/src/daemon/service/serve/mod.rs
+++ b/src/daemon/service/serve/mod.rs
@@ -104,6 +104,7 @@ pub async fn serve(config: DaemonServeConfig) -> Result<(), CliError> {
     let _bridge_watcher = bridge::spawn_manifest_watcher();
     let app_state = DaemonHttpState {
         token,
+        auth_mode: http::DaemonHttpAuthMode::Local,
         sender,
         prepared_sender,
         manifest,

--- a/src/daemon/service/serve/mod.rs
+++ b/src/daemon/service/serve/mod.rs
@@ -104,7 +104,7 @@ pub async fn serve(config: DaemonServeConfig) -> Result<(), CliError> {
     let _bridge_watcher = bridge::spawn_manifest_watcher();
     let app_state = DaemonHttpState {
         token,
-        auth_mode: http::DaemonHttpAuthMode::Local,
+        auth_mode: http_auth_mode(&config),
         sender,
         prepared_sender,
         manifest,
@@ -135,6 +135,10 @@ pub async fn serve(config: DaemonServeConfig) -> Result<(), CliError> {
         (Err(error), _, _) | (Ok(()), Err(error), _) | (Ok(()), Ok(()), Err(error)) => Err(error),
         (Ok(()), Ok(()), Ok(())) => Ok(()),
     }
+}
+
+pub(crate) const fn http_auth_mode(config: &DaemonServeConfig) -> http::DaemonHttpAuthMode {
+    config.auth_mode
 }
 
 pub(crate) fn validate_serve_config(config: &DaemonServeConfig) -> Result<(), CliError> {

--- a/src/daemon/service/tests/background_import.rs
+++ b/src/daemon/service/tests/background_import.rs
@@ -22,6 +22,7 @@ fn serve_helpers_round_trip_smoke_covers_public_surface() {
         super::super::serve::validate_serve_config(&DaemonServeConfig {
             host: "127.0.0.1".into(),
             port: 0,
+            auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
             poll_interval: Duration::from_secs(2),
             observe_interval: Duration::from_secs(5),
             sandboxed: false,

--- a/src/daemon/service/tests/config.rs
+++ b/src/daemon/service/tests/config.rs
@@ -10,6 +10,22 @@ fn daemon_serve_config_default_is_unsandboxed() {
     let config = DaemonServeConfig::default();
     assert!(!config.sandboxed);
     assert_eq!(config.codex_transport, CodexTransportKind::Stdio);
+    assert_eq!(
+        config.auth_mode,
+        crate::daemon::http::DaemonHttpAuthMode::Local
+    );
+}
+
+#[test]
+fn daemon_serve_config_can_select_remote_http_auth_mode() {
+    let config = DaemonServeConfig {
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Remote,
+        ..DaemonServeConfig::default()
+    };
+    assert_eq!(
+        super::super::serve::http_auth_mode(&config),
+        crate::daemon::http::DaemonHttpAuthMode::Remote
+    );
 }
 
 fn with_isolated_transport_env<F: FnOnce()>(ws_url: Option<&str>, f: F) {

--- a/src/daemon/task_board_managed_agents.rs
+++ b/src/daemon/task_board_managed_agents.rs
@@ -296,6 +296,7 @@ mod tests {
         .expect("deserialize daemon manifest");
         DaemonHttpState {
             token: "token".into(),
+            auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
             sender: sender.clone(),
             prepared_sender: broadcast::channel(8).0,
             manifest,

--- a/src/daemon/transport/commands.rs
+++ b/src/daemon/transport/commands.rs
@@ -182,6 +182,7 @@ impl DaemonServeArgs {
         DaemonServeConfig {
             host: self.host.clone(),
             port: self.port,
+            auth_mode: super::super::http::DaemonHttpAuthMode::Local,
             poll_interval: Duration::from_secs(self.refresh_seconds.max(1)),
             observe_interval: Duration::from_secs(self.observe_seconds.max(1)),
             sandboxed,
@@ -277,6 +278,7 @@ impl DaemonDevArgs {
             serve_config: DaemonServeConfig {
                 host: self.host.clone(),
                 port: self.port,
+                auth_mode: super::super::http::DaemonHttpAuthMode::Local,
                 poll_interval: Duration::from_secs(2),
                 observe_interval: Duration::from_secs(5),
                 sandboxed: false,

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -3,10 +3,12 @@ use std::{num::NonZeroU64, str::FromStr};
 use clap::{Args, Subcommand, ValueEnum};
 
 use crate::app::command_context::{AppContext, Execute};
+use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::remote::{
-    RemoteAccessScope, RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider,
-    RemoteRole, validate_remote_serve_config,
+    RemoteAccessScope, RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider, RemoteRole,
+    validate_remote_serve_config,
 };
+use crate::daemon::service::DaemonServeConfig;
 use crate::errors::{CliError, CliErrorKind};
 
 #[derive(Debug, Clone, Subcommand)]
@@ -41,7 +43,7 @@ pub enum DaemonRemoteCommand {
 impl Execute for DaemonRemoteCommand {
     fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
         if let Self::Serve(args) = self {
-            args.contract_config()?;
+            args.daemon_serve_config()?;
         }
         Err(CliErrorKind::workflow_parse(
             "remote daemon execution is reserved for the next implementation phase",
@@ -93,6 +95,20 @@ impl DaemonRemoteServeArgs {
         validate_remote_serve_config(&config)
             .map_err(|error| CliError::from(CliErrorKind::workflow_parse(error.to_string())))?;
         Ok(config)
+    }
+
+    /// Build the daemon service config for remote serve execution.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the remote TLS or ACME contract is invalid.
+    pub fn daemon_serve_config(&self) -> Result<DaemonServeConfig, CliError> {
+        let remote_config = self.contract_config()?;
+        Ok(DaemonServeConfig {
+            host: remote_config.host,
+            port: remote_config.https_port,
+            auth_mode: DaemonHttpAuthMode::Remote,
+            ..DaemonServeConfig::default()
+        })
     }
 }
 

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -43,7 +43,7 @@ pub enum DaemonRemoteCommand {
 impl Execute for DaemonRemoteCommand {
     fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
         if let Self::Serve(args) = self {
-            args.daemon_serve_config()?;
+            args.remote_auth_scaffold_config()?;
         }
         Err(CliErrorKind::workflow_parse(
             "remote daemon execution is reserved for the next implementation phase",
@@ -97,11 +97,16 @@ impl DaemonRemoteServeArgs {
         Ok(config)
     }
 
-    /// Build the daemon service config for remote serve execution.
+    /// Build the remote-auth scaffold config for the future remote serve path.
+    ///
+    /// This selects [`DaemonHttpAuthMode::Remote`] and preserves the public
+    /// remote bind host from the remote contract. It is not passed to the
+    /// current local [`crate::daemon::service::serve`] path, whose validation
+    /// intentionally remains loopback-only.
     ///
     /// # Errors
     /// Returns [`CliError`] when the remote TLS or ACME contract is invalid.
-    pub fn daemon_serve_config(&self) -> Result<DaemonServeConfig, CliError> {
+    pub fn remote_auth_scaffold_config(&self) -> Result<DaemonServeConfig, CliError> {
         let remote_config = self.contract_config()?;
         Ok(DaemonServeConfig {
             host: remote_config.host,

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -51,8 +51,8 @@ fn daemon_remote_serve_args_select_remote_http_auth_mode() {
 
     let serve_config = parsed
         .args
-        .daemon_serve_config()
-        .expect("remote serve config");
+        .remote_auth_scaffold_config()
+        .expect("remote auth scaffold config");
     assert_eq!(serve_config.host, "0.0.0.0");
     assert_eq!(serve_config.port, 443);
     assert_eq!(

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -1,8 +1,6 @@
 use clap::Parser;
 
-use super::super::{
-    DaemonRemoteCommand, DaemonRemotePairCommand, DaemonRemoteServeArgs,
-};
+use super::super::{DaemonRemoteCommand, DaemonRemotePairCommand, DaemonRemoteServeArgs};
 
 #[derive(Debug, Parser)]
 struct DaemonRemoteServeArgsTestHarness {
@@ -38,6 +36,29 @@ fn daemon_remote_serve_args_default_tls_alpn_config_is_valid() {
         .args
         .contract_config()
         .expect("default remote serve inputs should satisfy the contract");
+}
+
+#[test]
+fn daemon_remote_serve_args_select_remote_http_auth_mode() {
+    let parsed = DaemonRemoteServeArgsTestHarness::try_parse_from([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ])
+    .unwrap();
+
+    let serve_config = parsed
+        .args
+        .daemon_serve_config()
+        .expect("remote serve config");
+    assert_eq!(serve_config.host, "0.0.0.0");
+    assert_eq!(serve_config.port, 443);
+    assert_eq!(
+        serve_config.auth_mode,
+        crate::daemon::http::DaemonHttpAuthMode::Remote
+    );
 }
 
 #[test]
@@ -264,11 +285,7 @@ fn daemon_remote_pair_create_rejects_unknown_scope() {
 fn daemon_remote_pair_create_rejects_invalid_ttl() {
     assert!(
         DaemonRemoteCommandTestHarness::try_parse_from([
-            "test",
-            "pair",
-            "create",
-            "--ttl",
-            "tomorrow",
+            "test", "pair", "create", "--ttl", "tomorrow",
         ])
         .is_err()
     );
@@ -276,14 +293,9 @@ fn daemon_remote_pair_create_rejects_invalid_ttl() {
 
 #[test]
 fn daemon_remote_pair_create_reports_zero_ttl() {
-    let error = DaemonRemoteCommandTestHarness::try_parse_from([
-        "test",
-        "pair",
-        "create",
-        "--ttl",
-        "0m",
-    ])
-    .expect_err("zero ttl should be rejected");
+    let error =
+        DaemonRemoteCommandTestHarness::try_parse_from(["test", "pair", "create", "--ttl", "0m"])
+            .expect_err("zero ttl should be rejected");
     assert!(
         error.to_string().contains("greater than zero"),
         "unexpected error: {error}"

--- a/src/daemon/websocket/test_support.rs
+++ b/src/daemon/websocket/test_support.rs
@@ -112,6 +112,7 @@ pub(super) async fn test_http_state_with_async_db_timeline() -> DaemonHttpState 
 
     DaemonHttpState {
         token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
         sender: sender.clone(),
         prepared_sender: broadcast::channel(8).0,
         manifest: sample_manifest("18.2.3", "2026-04-04T00:00:00Z"),
@@ -187,6 +188,7 @@ fn build_test_http_state(version: &str, started_at: &str, install_db: bool) -> D
 
     DaemonHttpState {
         token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
         sender,
         prepared_sender: broadcast::channel(8).0,
         manifest: sample_manifest(version, started_at),

--- a/src/daemon/websocket/tests.rs
+++ b/src/daemon/websocket/tests.rs
@@ -61,6 +61,7 @@ pub(super) async fn test_websocket_state_with_empty_async_db(db_path: &Path) -> 
 
     DaemonHttpState {
         token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
         sender: sender.clone(),
         prepared_sender: broadcast::channel(8).0,
         manifest,
@@ -120,6 +121,7 @@ pub(super) fn test_websocket_state_with_sync_db_only(db_path: &Path) -> DaemonHt
 
     DaemonHttpState {
         token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
         sender: sender.clone(),
         prepared_sender: broadcast::channel(8).0,
         manifest,

--- a/tests/integration/daemon_perf.rs
+++ b/tests/integration/daemon_perf.rs
@@ -95,6 +95,7 @@ async fn start_test_daemon(db: Option<DaemonDb>) -> TestDaemon {
     );
     let state = DaemonHttpState {
         token: token.clone(),
+        auth_mode: harness::daemon::http::DaemonHttpAuthMode::Local,
         sender: sender.clone(),
         manifest,
         daemon_epoch: harness::workspace::utc_now(),


### PR DESCRIPTION
## Motivation
Remote clients can now be paired and authorized by scope, but the HTTP router still only understood the local file-token path. Remote mode needs a first live enforcement point that verifies persisted clients and route scopes without changing local serve/dev behavior.

## Implementation
- Add a local/remote auth mode to daemon HTTP state, defaulting existing constructors and local serve to file-token auth.
- Add remote client verification against the persisted remote client store and route-scope authorization for HTTP requests.
- Install a remote-only router middleware so insufficient-scope requests are rejected before handlers run.
- Cover missing credentials, revoked clients, insufficient scope, allowed role/scope paths, handler auth, and real-router enforcement with focused tests.

Validation:
- MISE_TRUSTED_CONFIG_PATHS=/Users/Shared/codex-home/worktrees/99db/harness/.mise.toml mise run cargo:local -- test remote_http_authz
- MISE_TRUSTED_CONFIG_PATHS=/Users/Shared/codex-home/worktrees/99db/harness/.mise.toml mise run cargo:local -- test get_health_requires_auth
- MISE_TRUSTED_CONFIG_PATHS=/Users/Shared/codex-home/worktrees/99db/harness/.mise.toml mise run cargo:local -- clippy -p harness --lib
- rustfmt --edition 2024 --check <touched Rust files>
- git diff --check

Semver: evaluated, no version bump requested for this internal remote-daemon slice.