### PR TITLE
feat(daemon): enforce remote websocket authz

### DIFF
--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -43,10 +43,26 @@ pub(crate) fn require_auth(
     match state.auth_mode {
         DaemonHttpAuthMode::Local => require_local_auth(headers, state),
         DaemonHttpAuthMode::Remote => {
-            if has_scoped_remote_client() {
+            if scoped_remote_client().is_some() {
                 Ok(())
             } else {
                 verify_remote_client(headers, state).map(|_| ())
+            }
+        }
+    }
+}
+
+pub(crate) fn websocket_remote_client(
+    headers: &HeaderMap,
+    state: &DaemonHttpState,
+) -> Result<Option<RemoteStoredClient>, Box<Response>> {
+    match state.auth_mode {
+        DaemonHttpAuthMode::Local => require_local_auth(headers, state).map(|()| None),
+        DaemonHttpAuthMode::Remote => {
+            if let Some(client) = scoped_remote_client() {
+                Ok(Some(client))
+            } else {
+                verify_remote_client(headers, state).map(Some)
             }
         }
     }
@@ -146,8 +162,8 @@ fn verify_and_authorize_http_route(
         .map_err(|error| Box::new(remote_auth_error_response(error)))
 }
 
-fn has_scoped_remote_client() -> bool {
-    REMOTE_HTTP_CLIENT.try_with(|_| ()).is_ok()
+fn scoped_remote_client() -> Option<RemoteStoredClient> {
+    REMOTE_HTTP_CLIENT.try_with(Clone::clone).ok()
 }
 
 fn local_auth_response() -> Response {

--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -43,7 +43,7 @@ pub(crate) fn require_auth(
     match state.auth_mode {
         DaemonHttpAuthMode::Local => require_local_auth(headers, state),
         DaemonHttpAuthMode::Remote => {
-            if scoped_remote_client().is_some() {
+            if has_scoped_remote_client() {
                 Ok(())
             } else {
                 verify_remote_client(headers, state).map(|_| ())
@@ -164,6 +164,10 @@ fn verify_and_authorize_http_route(
 
 fn scoped_remote_client() -> Option<RemoteStoredClient> {
     REMOTE_HTTP_CLIENT.try_with(Clone::clone).ok()
+}
+
+fn has_scoped_remote_client() -> bool {
+    REMOTE_HTTP_CLIENT.try_with(|_| ()).is_ok()
 }
 
 fn local_auth_response() -> Response {

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -58,7 +58,7 @@ mod tests;
 mod voice;
 
 pub use auth::DaemonHttpAuthMode;
-pub(crate) use auth::require_auth;
+pub(crate) use auth::websocket_remote_client;
 pub(crate) use managed_agents::{
     acp_inspect_response, acp_transcript_response, ensure_acp_agent, ensure_acp_enabled,
     ensure_codex_agent, ensure_terminal_agent_async, managed_agent_list_response_async,

--- a/src/daemon/http/tests/remote_authz.rs
+++ b/src/daemon/http/tests/remote_authz.rs
@@ -8,6 +8,7 @@ use rusqlite::Connection;
 use serde_json::json;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
+use tokio::time::{Duration, timeout};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message};
@@ -417,25 +418,29 @@ where
         + Stream<Item = Result<Message, WebSocketError>>
         + Unpin,
 {
-    socket
-        .send(Message::Text(
-            json!({ "id": id, "method": method, "params": {} })
-                .to_string()
-                .into(),
-        ))
-        .await
-        .expect("send websocket request");
-    while let Some(frame) = socket.next().await {
-        let frame = frame.expect("read websocket frame");
-        let Message::Text(text) = frame else {
-            continue;
-        };
-        let value = serde_json::from_str::<serde_json::Value>(&text).expect("websocket json");
-        if value["id"].as_str() == Some(id) {
-            return value;
+    timeout(Duration::from_secs(5), async {
+        socket
+            .send(Message::Text(
+                json!({ "id": id, "method": method, "params": {} })
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .expect("send websocket request");
+        while let Some(frame) = socket.next().await {
+            let frame = frame.expect("read websocket frame");
+            let Message::Text(text) = frame else {
+                continue;
+            };
+            let value = serde_json::from_str::<serde_json::Value>(&text).expect("websocket json");
+            if value["id"].as_str() == Some(id) {
+                return value;
+            }
         }
-    }
-    panic!("missing websocket response for {id}");
+        panic!("missing websocket response for {id}");
+    })
+    .await
+    .expect("timed out waiting for websocket response")
 }
 
 async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {

--- a/src/daemon/http/tests/remote_authz.rs
+++ b/src/daemon/http/tests/remote_authz.rs
@@ -1,15 +1,19 @@
 use std::thread;
 
 use axum::extract::State;
-use axum::http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
+use axum::http::{HeaderMap, HeaderValue, Request, StatusCode, header::AUTHORIZATION};
 use axum::{Router, middleware, routing::get};
+use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use rusqlite::Connection;
 use serde_json::json;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message};
 
 use crate::daemon::http::auth::{DaemonHttpAuthMode, authorize_http_route, require_auth};
-use crate::daemon::protocol::{HTTP_API_CONTRACT, HttpApiRouteContract, http_paths};
+use crate::daemon::protocol::{HTTP_API_CONTRACT, HttpApiRouteContract, http_paths, ws_methods};
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 use crate::daemon::remote_auth::REMOTE_CLIENT_ID_HEADER;
 use crate::daemon::remote_identity::RemoteClientRegistration;
@@ -248,6 +252,55 @@ async fn remote_http_authz_treats_head_as_get_scope() {
 }
 
 #[tokio::test]
+async fn remote_ws_handshake_denies_missing_credentials_with_401() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let (base_url, server) = serve_http(state).await;
+
+    let status = match connect_async(ws_url(&base_url)).await {
+        Ok(_) => panic!("missing remote credentials connected"),
+        Err(WebSocketError::Http(response)) => response.status(),
+        Err(error) => panic!("unexpected websocket error: {error}"),
+    };
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn remote_ws_connection_enforces_persisted_client_scope() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_remote_client(
+        &state,
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    );
+    let (base_url, server) = serve_http(state).await;
+    let request = remote_ws_request(&base_url, "viewer");
+    let (mut socket, _) = connect_async(request).await.expect("connect websocket");
+
+    let ping = ws_rpc(&mut socket, "req-ping", ws_methods::PING).await;
+    assert_eq!(ping["error"], serde_json::Value::Null);
+    assert_eq!(ping["result"]["pong"], true);
+
+    let denied = ws_rpc(&mut socket, "req-write", ws_methods::SESSION_START).await;
+    assert_eq!(denied["result"], serde_json::Value::Null);
+    assert_eq!(denied["error"]["code"], "REMOTE_AUTH");
+    assert_eq!(
+        denied["error"]["message"],
+        "remote client scope is insufficient"
+    );
+    assert_eq!(denied["error"]["status_code"], 403);
+
+    let _ = socket.close(None).await;
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
 async fn remote_http_authz_redacts_poisoned_store_errors() {
     let mut state = test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
@@ -332,6 +385,57 @@ fn remote_headers(client_id: &str) -> HeaderMap {
 
 fn remote_token(client_id: &str) -> String {
     format!("remote-token-secret-{client_id}")
+}
+
+fn ws_url(base_url: &str) -> String {
+    format!(
+        "{}{}",
+        base_url.replacen("http://", "ws://", 1),
+        http_paths::WS
+    )
+}
+
+fn remote_ws_request(base_url: &str, client_id: &str) -> Request<()> {
+    let mut request = ws_url(base_url)
+        .into_client_request()
+        .expect("websocket request");
+    request.headers_mut().insert(
+        REMOTE_CLIENT_ID_HEADER,
+        HeaderValue::from_str(client_id).expect("client id header"),
+    );
+    request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {}", remote_token(client_id)))
+            .expect("authorization header"),
+    );
+    request
+}
+
+async fn ws_rpc<S>(socket: &mut S, id: &str, method: &str) -> serde_json::Value
+where
+    S: Sink<Message, Error = WebSocketError>
+        + Stream<Item = Result<Message, WebSocketError>>
+        + Unpin,
+{
+    socket
+        .send(Message::Text(
+            json!({ "id": id, "method": method, "params": {} })
+                .to_string()
+                .into(),
+        ))
+        .await
+        .expect("send websocket request");
+    while let Some(frame) = socket.next().await {
+        let frame = frame.expect("read websocket frame");
+        let Message::Text(text) = frame else {
+            continue;
+        };
+        let value = serde_json::from_str::<serde_json::Value>(&text).expect("websocket json");
+        if value["id"].as_str() == Some(id) {
+            return value;
+        }
+    }
+    panic!("missing websocket response for {id}");
 }
 
 async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {

--- a/src/daemon/websocket/connection.rs
+++ b/src/daemon/websocket/connection.rs
@@ -18,6 +18,7 @@ use tracing::{debug, info, warn};
 use crate::daemon::http::{self, DaemonHttpState};
 #[cfg(test)]
 use crate::daemon::protocol::StreamEvent;
+use crate::daemon::remote_identity::RemoteStoredClient;
 use crate::telemetry::{apply_parent_context_from_headers, current_trace_id, with_active_baggage};
 
 use super::config::build_config_push_frame;
@@ -27,6 +28,7 @@ use super::relay::relay_broadcast;
 pub(crate) struct ConnectionState {
     pub(crate) global_subscription: bool,
     pub(crate) session_subscriptions: HashSet<String>,
+    remote_client: Option<RemoteStoredClient>,
     /// Highest broadcast `seq` this connection has relayed. On a `Lagged`
     /// overflow the relay replays the buffer from here before falling back to a
     /// full recovery snapshot.
@@ -34,12 +36,27 @@ pub(crate) struct ConnectionState {
 }
 
 impl ConnectionState {
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
+        Self::new_with_remote_client(None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_remote(remote_client: RemoteStoredClient) -> Self {
+        Self::new_with_remote_client(Some(remote_client))
+    }
+
+    fn new_with_remote_client(remote_client: Option<RemoteStoredClient>) -> Self {
         Self {
             global_subscription: false,
             session_subscriptions: HashSet::new(),
+            remote_client,
             last_relayed_seq: 0,
         }
+    }
+
+    pub(crate) fn remote_client(&self) -> Option<&RemoteStoredClient> {
+        self.remote_client.as_ref()
     }
 
     #[cfg(test)]
@@ -208,14 +225,18 @@ pub async fn ws_upgrade_handler(
     metadata.record_on_span(&connection_span);
     let baggage = apply_parent_context_from_headers(&connection_span, &headers);
     record_trace_id_on_span(&connection_span);
-    if let Err(response) = http::require_auth(&headers, &state) {
-        record_rejected_connection(&connection_span, &client_label);
-        return *response;
-    }
+    let remote_client = match http::websocket_remote_client(&headers, &state) {
+        Ok(client) => client,
+        Err(response) => {
+            record_rejected_connection(&connection_span, &client_label);
+            return *response;
+        }
+    };
     ws.on_upgrade(move |socket| async move {
         with_active_baggage(
             baggage,
-            handle_connection(socket, state, client_label).instrument(connection_span.clone()),
+            handle_connection(socket, state, client_label, remote_client)
+                .instrument(connection_span.clone()),
         )
         .await;
     })
@@ -263,10 +284,17 @@ fn websocket_connection_span(request_id: &str) -> tracing::Span {
     clippy::cognitive_complexity,
     reason = "tracing macro expansion; tokio-rs/tracing#553"
 )]
-async fn handle_connection(socket: WebSocket, state: DaemonHttpState, client_label: String) {
+async fn handle_connection(
+    socket: WebSocket,
+    state: DaemonHttpState,
+    client_label: String,
+    remote_client: Option<RemoteStoredClient>,
+) {
     tracing::info!(client = %client_label, "websocket connection opened");
     let (mut sender, mut receiver) = socket.split();
-    let connection = Arc::new(Mutex::new(ConnectionState::new()));
+    let connection = Arc::new(Mutex::new(ConnectionState::new_with_remote_client(
+        remote_client,
+    )));
 
     let (priority_tx, mut priority_rx) = mpsc::channel::<Message>(64);
     let (bulk_tx, mut bulk_rx) = mpsc::channel::<Message>(256);

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -1,7 +1,12 @@
 use super::connection::ConnectionState;
-use super::frames::{error_response, serialize_error_response_frames, serialize_response_frames};
-use crate::daemon::http::DaemonHttpState;
-use crate::daemon::protocol::{WsRequest, WsResponse};
+use super::frames::{
+    error_response, error_response_with_payload, serialize_error_response_frames,
+    serialize_response_frames,
+};
+use crate::daemon::http::{DaemonHttpAuthMode, DaemonHttpState};
+use crate::daemon::protocol::{WsErrorPayload, WsRequest, WsResponse, ws_methods};
+use crate::daemon::remote_auth::{RemoteAuthError, authorize_remote_ws_method};
+use crate::daemon::remote_identity::RemoteStoredClient;
 use crate::telemetry::{
     TelemetryBaggage, apply_parent_context_from_text_map, current_trace_id, with_active_baggage,
 };
@@ -114,6 +119,9 @@ async fn dispatch_inner(
     state: &DaemonHttpState,
     connection: &Arc<Mutex<ConnectionState>>,
 ) -> WsResponse {
+    if let Some(response) = authorize_remote_ws_request(request, state, connection) {
+        return response;
+    }
     if let Some(response) = routing::dispatch_known_method(request, state, connection).await {
         return response;
     }
@@ -121,6 +129,51 @@ async fn dispatch_inner(
         &request.id,
         "UNKNOWN_METHOD",
         &format!("unknown method: {}", request.method),
+    )
+}
+
+fn authorize_remote_ws_request(
+    request: &WsRequest,
+    state: &DaemonHttpState,
+    connection: &Arc<Mutex<ConnectionState>>,
+) -> Option<WsResponse> {
+    if state.auth_mode == DaemonHttpAuthMode::Local || !is_declared_ws_method(&request.method) {
+        return None;
+    }
+    let Some(client) = remote_client_for_connection(connection) else {
+        return Some(remote_ws_auth_error_response(
+            &request.id,
+            RemoteAuthError::MissingClientId,
+        ));
+    };
+    authorize_remote_ws_method(&client, &request.method)
+        .err()
+        .map(|error| remote_ws_auth_error_response(&request.id, error))
+}
+
+fn is_declared_ws_method(method: &str) -> bool {
+    ws_methods::ALL.contains(&method)
+}
+
+fn remote_client_for_connection(
+    connection: &Arc<Mutex<ConnectionState>>,
+) -> Option<RemoteStoredClient> {
+    connection
+        .lock()
+        .ok()
+        .and_then(|connection| connection.remote_client().cloned())
+}
+
+fn remote_ws_auth_error_response(request_id: &str, error: RemoteAuthError) -> WsResponse {
+    error_response_with_payload(
+        request_id,
+        WsErrorPayload {
+            code: "REMOTE_AUTH".to_string(),
+            message: error.to_string(),
+            details: Vec::new(),
+            status_code: Some(error.status_code().as_u16()),
+            data: None,
+        },
     )
 }
 

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -160,8 +160,9 @@ fn remote_client_for_connection(
 ) -> Option<RemoteStoredClient> {
     connection
         .lock()
-        .ok()
-        .and_then(|connection| connection.remote_client().cloned())
+        .expect("connection lock")
+        .remote_client()
+        .cloned()
 }
 
 fn remote_ws_auth_error_response(request_id: &str, error: RemoteAuthError) -> WsResponse {

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -5,6 +5,7 @@ use crate::daemon::protocol::ws_methods;
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 use crate::daemon::remote_identity::{RemoteStoredClient, RemoteTokenHash};
 use std::sync::{Arc, Mutex};
+use std::thread;
 
 #[test]
 fn websocket_activity_logging_uses_debug_level() {
@@ -93,6 +94,22 @@ async fn remote_ws_dispatch_preserves_unknown_method_errors() {
     assert_eq!(error.code, "UNKNOWN_METHOD");
     assert!(error.message.contains("remote.unscoped"));
     assert_eq!(error.status_code, None);
+}
+
+#[test]
+#[should_panic(expected = "connection lock")]
+fn remote_ws_dispatch_panics_on_poisoned_connection_lock() {
+    let connection = Arc::new(Mutex::new(ConnectionState::new()));
+    let poisoned_connection = Arc::clone(&connection);
+    let _ = thread::spawn(move || {
+        let _guard = poisoned_connection
+            .lock()
+            .expect("poison test connection lock");
+        panic!("poison websocket connection state");
+    })
+    .join();
+
+    let _ = remote_client_for_connection(&connection);
 }
 
 fn ws_request(id: &str, method: &str) -> WsRequest {

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -1,5 +1,10 @@
 use super::*;
+use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::protocol::WsRequest;
+use crate::daemon::protocol::ws_methods;
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::{RemoteStoredClient, RemoteTokenHash};
+use std::sync::{Arc, Mutex};
 
 #[test]
 fn websocket_activity_logging_uses_debug_level() {
@@ -12,4 +17,109 @@ fn ws_request_deserialization() {
     let request: WsRequest = serde_json::from_str(json).expect("deserialize");
     assert_eq!(request.id, "abc-123");
     assert_eq!(request.method, "health");
+}
+
+#[tokio::test]
+async fn remote_ws_dispatch_allows_viewer_read_method() {
+    let mut state = super::super::test_support::test_ws_state();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    ))));
+    let request = ws_request("req-read", ws_methods::PING);
+
+    let response = dispatch(&request, &state, &connection).await;
+
+    assert!(response.error.is_none());
+    assert_eq!(response.result.expect("ping result")["pong"], true);
+}
+
+#[tokio::test]
+async fn remote_ws_dispatch_denies_viewer_write_method() {
+    let mut state = super::super::test_support::test_ws_state();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    ))));
+    let request = ws_request("req-write", ws_methods::SESSION_START);
+
+    let response = dispatch(&request, &state, &connection).await;
+    let error = response.error.expect("remote auth error");
+
+    assert_eq!(error.code, "REMOTE_AUTH");
+    assert_eq!(error.message, "remote client scope is insufficient");
+    assert_eq!(error.status_code, Some(403));
+    assert!(response.result.is_none());
+}
+
+#[tokio::test]
+async fn remote_ws_dispatch_denies_known_method_without_remote_client() {
+    let mut state = super::super::test_support::test_ws_state();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let connection = Arc::new(Mutex::new(ConnectionState::new()));
+    let request = ws_request("req-missing-client", ws_methods::PING);
+
+    let response = dispatch(&request, &state, &connection).await;
+    let error = response.error.expect("remote auth error");
+
+    assert_eq!(error.code, "REMOTE_AUTH");
+    assert_eq!(error.message, "remote client id is required");
+    assert_eq!(error.status_code, Some(401));
+    assert!(response.result.is_none());
+}
+
+#[tokio::test]
+async fn remote_ws_dispatch_preserves_unknown_method_errors() {
+    let mut state = super::super::test_support::test_ws_state();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
+        "admin",
+        RemoteRole::Admin,
+        &[
+            RemoteAccessScope::Read,
+            RemoteAccessScope::Write,
+            RemoteAccessScope::Admin,
+        ],
+    ))));
+    let request = ws_request("req-unknown", "remote.unscoped");
+
+    let response = dispatch(&request, &state, &connection).await;
+    let error = response.error.expect("unknown method error");
+
+    assert_eq!(error.code, "UNKNOWN_METHOD");
+    assert!(error.message.contains("remote.unscoped"));
+    assert_eq!(error.status_code, None);
+}
+
+fn ws_request(id: &str, method: &str) -> WsRequest {
+    WsRequest {
+        id: id.to_string(),
+        method: method.to_string(),
+        params: serde_json::json!({}),
+        trace_context: None,
+    }
+}
+
+fn remote_client(
+    client_id: &str,
+    role: RemoteRole,
+    scopes: &[RemoteAccessScope],
+) -> RemoteStoredClient {
+    RemoteStoredClient {
+        client_id: client_id.to_string(),
+        display_name: "MacBook Pro".to_string(),
+        platform: "macos".to_string(),
+        role,
+        scopes: scopes.to_vec(),
+        token_hash: RemoteTokenHash::from_token_for_tests("remote-token-secret"),
+        token_hint: "secret".to_string(),
+        created_at: "2026-06-21T18:30:00Z".to_string(),
+        last_seen_at: None,
+        revoked_at: None,
+        rotated_at: None,
+    }
 }


### PR DESCRIPTION
## Motivation
Remote WebSocket connections need the same fail-closed remote authorization as HTTP routes. The upgrade has to authenticate the paired client, and each declared JSON-RPC method has to enforce its role scope after the socket is established.

## Implementation
- Carry the verified remote client from the WebSocket upgrade into connection state.
- Enforce remote scopes for declared WebSocket methods before dispatch, with 401/403 error payloads.
- Cover missing credentials, persisted-client scope checks, allowed read methods, denied write methods, and static scope-contract coverage.