### PR TITLE
feat(daemon): persist remote pair create

### DIFF
--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -247,10 +247,8 @@ pub(crate) struct DaemonRemotePairCreateResponse {
 }
 
 fn open_remote_daemon_db() -> Result<DaemonDb, CliError> {
-    let daemon_root = state::daemon_root();
-    fs_err::create_dir_all(&daemon_root)
-        .map_err(|error| CliErrorKind::workflow_io(format!("create daemon root: {error}")))?;
-    DaemonDb::open(&daemon_root.join("harness.db"))
+    state::ensure_daemon_dirs()?;
+    DaemonDb::open(&state::daemon_root().join("harness.db"))
 }
 
 fn expires_at_from_ttl(created_at: &str, ttl_seconds: u64) -> Result<String, CliError> {

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -1,15 +1,24 @@
 use std::{num::NonZeroU64, str::FromStr};
 
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
+use uuid::Uuid;
 
 use crate::app::command_context::{AppContext, Execute};
+use crate::daemon::db::DaemonDb;
 use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::remote::{
-    RemoteAccessScope, RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider, RemoteRole,
-    validate_remote_serve_config,
+    validate_remote_serve_config, RemoteAccessScope, RemoteAcmeChallenge, RemoteDaemonServeConfig,
+    RemoteDnsProvider, RemoteRole,
 };
+use crate::daemon::remote_pairing::{RemotePairingCode, RemotePairingRecord};
 use crate::daemon::service::DaemonServeConfig;
+use crate::daemon::state;
 use crate::errors::{CliError, CliErrorKind};
+use crate::workspace::utc_now;
+
+use super::control::{adopt_daemon_root_for_transport_command, print_json};
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum DaemonRemoteCommand {
@@ -41,15 +50,28 @@ pub enum DaemonRemoteCommand {
 }
 
 impl Execute for DaemonRemoteCommand {
-    fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
-        if let Self::Serve(args) = self {
-            args.remote_auth_scaffold_config()?;
+    fn execute(&self, context: &AppContext) -> Result<i32, CliError> {
+        match self {
+            Self::Pair { command } => command.execute(context),
+            Self::Serve(args) => {
+                args.remote_auth_scaffold_config()?;
+                Err(remote_execution_reserved_error())
+            }
+            Self::Clients { .. }
+            | Self::Acme { .. }
+            | Self::Doctor
+            | Self::InstallSystemd(_)
+            | Self::UninstallSystemd(_)
+            | Self::Status(_) => Err(remote_execution_reserved_error()),
         }
-        Err(CliErrorKind::workflow_parse(
-            "remote daemon execution is reserved for the next implementation phase",
-        )
-        .into())
     }
+}
+
+fn remote_execution_reserved_error() -> CliError {
+    CliErrorKind::workflow_parse(
+        "remote daemon execution is reserved for the next implementation phase",
+    )
+    .into()
 }
 
 #[derive(Debug, Clone, Args)]
@@ -123,6 +145,14 @@ pub enum DaemonRemotePairCommand {
     Create(DaemonRemotePairCreateArgs),
 }
 
+impl Execute for DaemonRemotePairCommand {
+    fn execute(&self, context: &AppContext) -> Result<i32, CliError> {
+        match self {
+            Self::Create(args) => args.execute(context),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct DaemonRemotePairCreateArgs {
     /// Role granted to the paired client.
@@ -134,6 +164,105 @@ pub struct DaemonRemotePairCreateArgs {
     /// Pairing code time-to-live.
     #[arg(long, default_value = "10m")]
     pub ttl: DaemonRemotePairTtl,
+}
+
+impl Execute for DaemonRemotePairCreateArgs {
+    fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
+        adopt_daemon_root_for_transport_command("daemon-remote-pair-create");
+        let db = open_remote_daemon_db()?;
+        let code = RemotePairingCode::generate();
+        let pairing_id = format!("pairing-{}", Uuid::new_v4());
+        let audit_event_id = format!("remote-pair-create-{}", Uuid::new_v4());
+        let created_at = utc_now();
+        let response = self.create_pairing_with(
+            &db,
+            pairing_id.as_str(),
+            audit_event_id.as_str(),
+            &code,
+            created_at.as_str(),
+        )?;
+        print_json(&response)?;
+        Ok(0)
+    }
+}
+
+impl DaemonRemotePairCreateArgs {
+    /// Create a durable pairing record and return the one-time operator
+    /// response containing the raw code.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when scope expansion, expiry calculation, or
+    /// persistence fails.
+    pub(crate) fn create_pairing_with(
+        &self,
+        db: &DaemonDb,
+        pairing_id: &str,
+        audit_event_id: &str,
+        code: &RemotePairingCode,
+        created_at: &str,
+    ) -> Result<DaemonRemotePairCreateResponse, CliError> {
+        let role = RemoteRole::from(self.role);
+        let requested_scopes = self
+            .scopes
+            .iter()
+            .copied()
+            .map(RemoteAccessScope::from)
+            .collect::<Vec<_>>();
+        let expires_at = expires_at_from_ttl(created_at, self.ttl.as_secs())?;
+        let record = RemotePairingRecord::new(
+            pairing_id,
+            role,
+            &requested_scopes,
+            code.expose(),
+            created_at,
+            expires_at.as_str(),
+        )
+        .map_err(|error| CliErrorKind::workflow_parse(error.to_string()))?;
+        let stored = db.create_remote_pairing_code(&record, audit_event_id)?;
+        Ok(DaemonRemotePairCreateResponse {
+            pairing_id: stored.pairing_id,
+            code: code.expose().to_string(),
+            role: stored.role.as_str().to_string(),
+            scopes: stored
+                .scopes
+                .iter()
+                .map(|scope| scope.as_str().to_string())
+                .collect(),
+            created_at: stored.created_at,
+            expires_at: stored.expires_at,
+            ttl_seconds: self.ttl.as_secs(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemotePairCreateResponse {
+    pub pairing_id: String,
+    pub code: String,
+    pub role: String,
+    pub scopes: Vec<String>,
+    pub created_at: String,
+    pub expires_at: String,
+    pub ttl_seconds: u64,
+}
+
+fn open_remote_daemon_db() -> Result<DaemonDb, CliError> {
+    let daemon_root = state::daemon_root();
+    fs_err::create_dir_all(&daemon_root)
+        .map_err(|error| CliErrorKind::workflow_io(format!("create daemon root: {error}")))?;
+    DaemonDb::open(&daemon_root.join("harness.db"))
+}
+
+fn expires_at_from_ttl(created_at: &str, ttl_seconds: u64) -> Result<String, CliError> {
+    let created_at = DateTime::parse_from_rfc3339(created_at)
+        .map_err(|error| CliErrorKind::workflow_parse(format!("parse pairing time: {error}")))?
+        .with_timezone(&Utc);
+    let ttl_seconds = i64::try_from(ttl_seconds)
+        .map_err(|_| CliErrorKind::workflow_parse("pairing ttl value is too large"))?;
+    let expires_at = created_at
+        .checked_add_signed(ChronoDuration::seconds(ttl_seconds))
+        .ok_or_else(|| CliErrorKind::workflow_parse("pairing ttl value is too large"))?;
+    Ok(expires_at.format("%Y-%m-%dT%H:%M:%SZ").to_string())
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -1,4 +1,10 @@
 use clap::Parser;
+use fs2::FileExt as _;
+
+use crate::app::command_context::{AppContext, Execute};
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote_pairing::RemotePairingCode;
+use crate::daemon::state;
 
 use super::super::{DaemonRemoteCommand, DaemonRemotePairCommand, DaemonRemoteServeArgs};
 
@@ -269,26 +275,22 @@ fn daemon_remote_pair_create_accepts_fixed_scope_values() {
 
 #[test]
 fn daemon_remote_pair_create_rejects_unknown_scope() {
-    assert!(
-        DaemonRemoteCommandTestHarness::try_parse_from([
-            "test",
-            "pair",
-            "create",
-            "--scopes",
-            "read,root",
-        ])
-        .is_err()
-    );
+    assert!(DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "pair",
+        "create",
+        "--scopes",
+        "read,root",
+    ])
+    .is_err());
 }
 
 #[test]
 fn daemon_remote_pair_create_rejects_invalid_ttl() {
-    assert!(
-        DaemonRemoteCommandTestHarness::try_parse_from([
-            "test", "pair", "create", "--ttl", "tomorrow",
-        ])
-        .is_err()
-    );
+    assert!(DaemonRemoteCommandTestHarness::try_parse_from([
+        "test", "pair", "create", "--ttl", "tomorrow",
+    ])
+    .is_err());
 }
 
 #[test]
@@ -321,4 +323,105 @@ fn daemon_remote_pair_create_reports_ttl_overflow_as_too_large() {
         !message.contains("greater than zero"),
         "overflow should not report zero ttl, got: {message}"
     );
+}
+
+#[test]
+fn daemon_remote_pair_create_builds_persisted_record_and_response() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test", "pair", "create", "--role", "operator", "--scopes", "read", "--ttl", "2m",
+    ])
+    .unwrap()
+    .command;
+    let DaemonRemoteCommand::Pair {
+        command: DaemonRemotePairCommand::Create(args),
+    } = parsed
+    else {
+        panic!("expected pair create");
+    };
+
+    let code = RemotePairingCode::from_value_for_tests("manual-code-value");
+    let response = args
+        .create_pairing_with(
+            &db,
+            "pairing-test",
+            "audit-pairing-test",
+            &code,
+            "2026-06-21T13:40:00Z",
+        )
+        .expect("create pairing response");
+
+    assert_eq!(response.pairing_id, "pairing-test");
+    assert_eq!(response.code, "manual-code-value");
+    assert_eq!(response.role, "operator");
+    assert_eq!(response.scopes, vec!["read"]);
+    assert_eq!(response.ttl_seconds, 120);
+    assert_eq!(response.created_at, "2026-06-21T13:40:00Z");
+    assert_eq!(response.expires_at, "2026-06-21T13:42:00Z");
+
+    let stored: (String, String) = db
+        .connection()
+        .query_row(
+            "SELECT pairing_id, code_hash FROM remote_pairing_codes",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("stored pairing");
+    assert_eq!(stored.0, "pairing-test");
+    assert_ne!(stored.1, "manual-code-value");
+    assert!(stored.1.starts_with("sha256:"));
+
+    let audit_routes: Vec<_> = db
+        .load_remote_audit_events(10)
+        .expect("load audit events")
+        .into_iter()
+        .map(|event| event.route_or_method)
+        .collect();
+    assert_eq!(audit_routes, vec!["remote.pair.create"]);
+}
+
+#[test]
+fn daemon_remote_pair_create_execute_persists_pairing_in_daemon_db() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let daemon_root = temp.path().join("daemon-root");
+    std::fs::create_dir_all(&daemon_root).expect("daemon root");
+    let _root = state::ScopedDaemonRootOverride::set(Some(daemon_root.clone()));
+    let lock_path = daemon_root.join(state::DAEMON_LOCK_FILE);
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)
+        .expect("open lock");
+    lock.try_lock_exclusive().expect("hold daemon lock");
+
+    let command = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test", "pair", "create", "--role", "viewer", "--ttl", "30s",
+    ])
+    .unwrap()
+    .command;
+
+    let exit = command.execute(&AppContext).expect("execute pair create");
+    assert_eq!(exit, 0);
+
+    let db = DaemonDb::open(&daemon_root.join("harness.db")).expect("open daemon db");
+    let stored_count: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM remote_pairing_codes", [], |row| {
+            row.get(0)
+        })
+        .expect("stored pairing count");
+    assert_eq!(stored_count, 1);
+
+    let (role, scopes_json, code_hash): (String, String, String) = db
+        .connection()
+        .query_row(
+            "SELECT role, scopes_json, code_hash FROM remote_pairing_codes",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("stored pairing row");
+    assert_eq!(role, "viewer");
+    assert_eq!(scopes_json, "[\"read\"]");
+    assert!(code_hash.starts_with("sha256:"));
 }

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use fs2::FileExt as _;
+use harness_testkit::with_isolated_harness_env;
 
 use crate::app::command_context::{AppContext, Execute};
 use crate::daemon::db::DaemonDb;
@@ -383,45 +383,39 @@ fn daemon_remote_pair_create_builds_persisted_record_and_response() {
 #[test]
 fn daemon_remote_pair_create_execute_persists_pairing_in_daemon_db() {
     let temp = tempfile::tempdir().expect("temp dir");
-    let daemon_root = temp.path().join("daemon-root");
-    std::fs::create_dir_all(&daemon_root).expect("daemon root");
-    let _root = state::ScopedDaemonRootOverride::set(Some(daemon_root.clone()));
-    let lock_path = daemon_root.join(state::DAEMON_LOCK_FILE);
-    let lock = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(lock_path)
-        .expect("open lock");
-    lock.try_lock_exclusive().expect("hold daemon lock");
+    with_isolated_harness_env(temp.path(), || {
+        state::ensure_daemon_dirs().expect("daemon dirs");
+        let daemon_root = state::daemon_root();
+        let _lock = state::acquire_singleton_lock().expect("hold daemon lock");
 
-    let command = DaemonRemoteCommandTestHarness::try_parse_from([
-        "test", "pair", "create", "--role", "viewer", "--ttl", "30s",
-    ])
-    .unwrap()
-    .command;
+        let command = DaemonRemoteCommandTestHarness::try_parse_from([
+            "test", "pair", "create", "--role", "viewer", "--ttl", "30s",
+        ])
+        .unwrap()
+        .command;
 
-    let exit = command.execute(&AppContext).expect("execute pair create");
-    assert_eq!(exit, 0);
+        let exit = command.execute(&AppContext).expect("execute pair create");
+        assert_eq!(exit, 0);
 
-    let db = DaemonDb::open(&daemon_root.join("harness.db")).expect("open daemon db");
-    let stored_count: i64 = db
-        .connection()
-        .query_row("SELECT COUNT(*) FROM remote_pairing_codes", [], |row| {
-            row.get(0)
-        })
-        .expect("stored pairing count");
-    assert_eq!(stored_count, 1);
+        let db = DaemonDb::open(&daemon_root.join("harness.db")).expect("open daemon db");
+        let stored_count: i64 = db
+            .connection()
+            .query_row("SELECT COUNT(*) FROM remote_pairing_codes", [], |row| {
+                row.get(0)
+            })
+            .expect("stored pairing count");
+        assert_eq!(stored_count, 1);
 
-    let (role, scopes_json, code_hash): (String, String, String) = db
-        .connection()
-        .query_row(
-            "SELECT role, scopes_json, code_hash FROM remote_pairing_codes",
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .expect("stored pairing row");
-    assert_eq!(role, "viewer");
-    assert_eq!(scopes_json, "[\"read\"]");
-    assert!(code_hash.starts_with("sha256:"));
+        let (role, scopes_json, code_hash): (String, String, String) = db
+            .connection()
+            .query_row(
+                "SELECT role, scopes_json, code_hash FROM remote_pairing_codes",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("stored pairing row");
+        assert_eq!(role, "viewer");
+        assert_eq!(scopes_json, "[\"read\"]");
+        assert!(code_hash.starts_with("sha256:"));
+    });
 }


### PR DESCRIPTION
## Motivation
Remote pairing was parsed by the CLI, but every remote daemon command still fell through to the placeholder execution error. The next remote-daemon phase needs a real operator command that creates one-time pairing material in the daemon store before the HTTP claim endpoint is wired.

## Implementation
- Route `harness daemon remote pair create` through real execution while leaving unimplemented remote commands fail-closed.
- Generate a one-time pairing code, persist only its hash with role-expanded scopes, and write the existing `remote.pair.create` audit event.
- Return the raw code only in the command JSON response with pairing id, role, scopes, creation time, expiry, and TTL.
- Added red-first transport tests for persisted DB state, audit output, scope expansion, and command dispatch.
- Validation: `mise run cargo:local -- test daemon_remote_pair_create --lib`, `mise run cargo:local -- test remote_pairing --lib`, `mise run cargo:local -- test remote_cli --lib`, touched-file `rustfmt --check`, and `git diff --check`. `mise run harness:check` reached `check:scripts` but failed in unrelated Harness Monitor `test_interrupt_cleanup_exits_zero_and_clears_manifest`, which left a manifest behind outside this daemon remote CLI path.