### PR TITLE
feat(daemon): manage remote clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,7 +3385,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror 2.0.18",
 ]
 
@@ -3592,10 +3592,10 @@ dependencies = [
  "nix 0.31.3",
  "notify",
  "noyalib",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry_sdk",
  "pathdiff",
  "pgp",
  "portable-pty",
@@ -3604,7 +3604,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "rusqlite",
  "rustls",
  "sea-query",
@@ -4435,7 +4435,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",
@@ -5130,19 +5130,6 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -5156,11 +5143,11 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -5168,61 +5155,47 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.31.0",
- "reqwest 0.12.28",
+ "opentelemetry",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
  "tonic-prost",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.4",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5234,7 +5207,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
@@ -5903,7 +5876,7 @@ dependencies = [
  "object 0.39.1",
  "once_cell",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "serde_json",
  "smallvec",
  "spin 0.12.0",
@@ -6173,38 +6146,6 @@ name = "replace_with"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "reqwest"
@@ -7865,6 +7806,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7962,12 +7914,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,11 @@ pgp = { version = "0.19.0", default-features = false }
 rand_core06 = { package = "rand_core", version = "0.6.4", features = ["std"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json"] }
-opentelemetry = { version = "0.31.0", default-features = false, features = ["trace", "metrics", "logs"] }
+opentelemetry = { version = "0.32.0", default-features = false, features = ["trace", "metrics", "logs"] }
 opentelemetry_sdk = { version = "0.32.0", default-features = false, features = ["trace", "metrics", "logs", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["trace", "metrics", "logs", "grpc-tonic", "http-proto", "reqwest-client"] }
-tracing-opentelemetry = { version = "0.32.1", default-features = false }
-opentelemetry-appender-tracing = "0.31.0"
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["trace", "metrics", "logs", "grpc-tonic", "http-proto", "reqwest-client"] }
+tracing-opentelemetry = { version = "0.33.0", default-features = false }
+opentelemetry-appender-tracing = "0.32.0"
 tonic = { version = "0.14.1", default-features = false }
 pyroscope = { version = "2.0.0", features = ["backend-pprof-rs"] }
 fs2 = "0.4.3"

--- a/src/daemon/db/remote_identity.rs
+++ b/src/daemon/db/remote_identity.rs
@@ -8,12 +8,12 @@
 
 use rusqlite::{params, types::Type};
 
-use super::{CliError, DaemonDb, OptionalExtension, db_error};
+use super::{db_error, CliError, DaemonDb, OptionalExtension};
 use crate::daemon::remote::RemoteAccessScope;
 use crate::daemon::remote_identity::{
-    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteClientRegistration,
-    RemoteStoredAuditEvent, RemoteStoredClient, RemoteTokenHash, parse_remote_role,
-    parse_remote_scope, remote_token_hint,
+    parse_remote_role, parse_remote_scope, remote_token_hint, RemoteAuditEvent, RemoteAuditOutcome,
+    RemoteAuditScopeDecision, RemoteClientRegistration, RemoteStoredAuditEvent, RemoteStoredClient,
+    RemoteTokenHash,
 };
 
 const INSERT_REMOTE_CLIENT_SQL: &str = "
@@ -27,6 +27,12 @@ SELECT client_id, display_name, platform, role, scopes_json, token_hash, token_h
        created_at, last_seen_at, revoked_at, rotated_at
 FROM remote_clients
 WHERE client_id = ?1";
+
+const SELECT_REMOTE_CLIENTS_SQL: &str = "
+SELECT client_id, display_name, platform, role, scopes_json, token_hash, token_hint,
+       created_at, last_seen_at, revoked_at, rotated_at
+FROM remote_clients
+ORDER BY created_at ASC, client_id ASC";
 
 const INSERT_REMOTE_AUDIT_EVENT_SQL: &str = "
 INSERT INTO remote_audit_events (
@@ -66,6 +72,22 @@ impl DaemonDb {
             })?;
         self.remote_client(&registration.client_id)?
             .ok_or_else(|| db_error("remote client insert did not persist row"))
+    }
+
+    /// Load paired remote clients in stable creation order.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL or row parsing failures.
+    pub(crate) fn list_remote_clients(&self) -> Result<Vec<RemoteStoredClient>, CliError> {
+        let mut statement = self
+            .conn
+            .prepare(SELECT_REMOTE_CLIENTS_SQL)
+            .map_err(|error| db_error(format!("prepare remote clients list: {error}")))?;
+        let rows = statement
+            .query_map([], remote_client_from_row)
+            .map_err(|error| db_error(format!("query remote clients: {error}")))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|error| db_error(format!("read remote client row: {error}")))
     }
 
     /// Verify a non-revoked remote client's bearer token.
@@ -220,10 +242,8 @@ fn remote_client_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteSto
     })?;
     let scopes = scopes_from_json(&scopes_json)
         .map_err(|error| rusqlite::Error::FromSqlConversionFailure(4, Type::Text, error.into()))?;
-    let token_hash =
-        RemoteTokenHash::try_from_storage_value(row.get::<_, String>(5)?).map_err(|error| {
-            rusqlite::Error::FromSqlConversionFailure(5, Type::Text, error.into())
-        })?;
+    let token_hash = RemoteTokenHash::try_from_storage_value(row.get::<_, String>(5)?)
+        .map_err(|error| rusqlite::Error::FromSqlConversionFailure(5, Type::Text, error.into()))?;
     Ok(RemoteStoredClient {
         client_id: row.get(0)?,
         display_name: row.get(1)?,

--- a/src/daemon/transport/mod.rs
+++ b/src/daemon/transport/mod.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod control;
 mod remote;
+mod remote_clients;
 #[cfg(test)]
 mod tests;
 

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -9,12 +9,8 @@ use crate::app::command_context::{AppContext, Execute};
 use crate::daemon::db::DaemonDb;
 use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::remote::{
-    validate_remote_serve_config, RemoteAccessScope, RemoteAcmeChallenge, RemoteDaemonServeConfig,
-    RemoteDnsProvider, RemoteRole,
-};
-use crate::daemon::remote_identity::{
-    remote_token_hint, RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision,
-    RemoteBearerToken, RemoteStoredClient,
+    RemoteAccessScope, RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider, RemoteRole,
+    validate_remote_serve_config,
 };
 use crate::daemon::remote_pairing::{RemotePairingCode, RemotePairingRecord};
 use crate::daemon::service::DaemonServeConfig;
@@ -250,7 +246,7 @@ pub(crate) struct DaemonRemotePairCreateResponse {
     pub ttl_seconds: u64,
 }
 
-fn open_remote_daemon_db() -> Result<DaemonDb, CliError> {
+pub(super) fn open_remote_daemon_db() -> Result<DaemonDb, CliError> {
     state::ensure_daemon_dirs()?;
     DaemonDb::open(&state::daemon_root().join("harness.db"))
 }
@@ -277,260 +273,11 @@ pub enum DaemonRemoteClientsCommand {
     Rotate(DaemonRemoteClientIdArgs),
 }
 
-impl Execute for DaemonRemoteClientsCommand {
-    fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
-        adopt_daemon_root_for_transport_command("daemon-remote-clients");
-        let db = open_remote_daemon_db()?;
-        let now = utc_now();
-        let audit_event_id = format!("remote-clients-{}-{}", self.action_label(), Uuid::new_v4());
-        match self {
-            Self::List => {
-                let response =
-                    self.list_clients_with(&db, audit_event_id.as_str(), now.as_str())?;
-                print_json(&response)?;
-            }
-            Self::Revoke(args) => {
-                let response =
-                    args.revoke_client_with(&db, audit_event_id.as_str(), now.as_str())?;
-                print_json(&response)?;
-            }
-            Self::Rotate(args) => {
-                let token = RemoteBearerToken::generate();
-                let response = args.rotate_client_with(
-                    &db,
-                    token.expose(),
-                    audit_event_id.as_str(),
-                    now.as_str(),
-                )?;
-                print_json(&response)?;
-            }
-        }
-        Ok(0)
-    }
-}
-
-impl DaemonRemoteClientsCommand {
-    /// List paired remote clients without exposing token hashes or raw tokens.
-    ///
-    /// # Errors
-    /// Returns [`CliError`] when database reads or audit writes fail.
-    pub(crate) fn list_clients_with(
-        &self,
-        db: &DaemonDb,
-        audit_event_id: &str,
-        now: &str,
-    ) -> Result<DaemonRemoteClientsListResponse, CliError> {
-        let Self::List = self else {
-            return Err(CliErrorKind::workflow_parse("remote clients command must be list").into());
-        };
-        let clients = db
-            .list_remote_clients()?
-            .iter()
-            .map(DaemonRemoteClientSummary::from_stored_client)
-            .collect();
-        record_remote_clients_audit(
-            db,
-            audit_event_id,
-            now,
-            None,
-            "remote.clients.list",
-            RemoteAuditOutcome::Success,
-            None,
-        )?;
-        Ok(DaemonRemoteClientsListResponse { clients })
-    }
-
-    #[must_use]
-    const fn action_label(&self) -> &'static str {
-        match self {
-            Self::List => "list",
-            Self::Revoke(_) => "revoke",
-            Self::Rotate(_) => "rotate",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Args)]
 pub struct DaemonRemoteClientIdArgs {
     /// Remote client identifier.
     #[arg(long)]
     pub client_id: String,
-}
-
-impl DaemonRemoteClientIdArgs {
-    /// Revoke a paired remote client.
-    ///
-    /// # Errors
-    /// Returns [`CliError`] when the client is unknown, already revoked, or
-    /// persistence/audit fails.
-    pub(crate) fn revoke_client_with(
-        &self,
-        db: &DaemonDb,
-        audit_event_id: &str,
-        revoked_at: &str,
-    ) -> Result<DaemonRemoteClientRevokeResponse, CliError> {
-        let client_id = self.trimmed_client_id()?;
-        let changed = db.revoke_remote_client(client_id, revoked_at)?;
-        if !changed {
-            record_remote_clients_audit(
-                db,
-                audit_event_id,
-                revoked_at,
-                Some(client_id),
-                "remote.clients.revoke",
-                RemoteAuditOutcome::Failure,
-                Some("remote client not found or already revoked"),
-            )?;
-            return Err(CliErrorKind::workflow_parse(format!(
-                "remote client '{client_id}' not found or already revoked"
-            ))
-            .into());
-        }
-        record_remote_clients_audit(
-            db,
-            audit_event_id,
-            revoked_at,
-            Some(client_id),
-            "remote.clients.revoke",
-            RemoteAuditOutcome::Success,
-            None,
-        )?;
-        Ok(DaemonRemoteClientRevokeResponse {
-            client_id: client_id.to_string(),
-            revoked_at: revoked_at.to_string(),
-        })
-    }
-
-    /// Rotate a paired remote client's bearer token.
-    ///
-    /// # Errors
-    /// Returns [`CliError`] when the client is unknown, revoked, the new token
-    /// is invalid, or persistence/audit fails.
-    pub(crate) fn rotate_client_with(
-        &self,
-        db: &DaemonDb,
-        token: &str,
-        audit_event_id: &str,
-        rotated_at: &str,
-    ) -> Result<DaemonRemoteClientRotateResponse, CliError> {
-        let client_id = self.trimmed_client_id()?;
-        let changed = db.rotate_remote_client_token(client_id, token, rotated_at)?;
-        if !changed {
-            record_remote_clients_audit(
-                db,
-                audit_event_id,
-                rotated_at,
-                Some(client_id),
-                "remote.clients.rotate",
-                RemoteAuditOutcome::Failure,
-                Some("remote client not found or revoked"),
-            )?;
-            return Err(CliErrorKind::workflow_parse(format!(
-                "remote client '{client_id}' not found or revoked"
-            ))
-            .into());
-        }
-        record_remote_clients_audit(
-            db,
-            audit_event_id,
-            rotated_at,
-            Some(client_id),
-            "remote.clients.rotate",
-            RemoteAuditOutcome::Success,
-            None,
-        )?;
-        Ok(DaemonRemoteClientRotateResponse {
-            client_id: client_id.to_string(),
-            token: token.to_string(),
-            token_hint: remote_token_hint(token),
-            rotated_at: rotated_at.to_string(),
-        })
-    }
-
-    fn trimmed_client_id(&self) -> Result<&str, CliError> {
-        let client_id = self.client_id.trim();
-        if client_id.is_empty() {
-            return Err(CliErrorKind::workflow_parse("remote client id is required").into());
-        }
-        Ok(client_id)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct DaemonRemoteClientsListResponse {
-    pub clients: Vec<DaemonRemoteClientSummary>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct DaemonRemoteClientSummary {
-    pub client_id: String,
-    pub display_name: String,
-    pub platform: String,
-    pub role: String,
-    pub scopes: Vec<String>,
-    pub token_hint: String,
-    pub created_at: String,
-    pub last_seen_at: Option<String>,
-    pub revoked_at: Option<String>,
-    pub rotated_at: Option<String>,
-}
-
-impl DaemonRemoteClientSummary {
-    fn from_stored_client(client: &RemoteStoredClient) -> Self {
-        Self {
-            client_id: client.client_id.clone(),
-            display_name: client.display_name.clone(),
-            platform: client.platform.clone(),
-            role: client.role.as_str().to_string(),
-            scopes: client
-                .scopes
-                .iter()
-                .map(|scope| scope.as_str().to_string())
-                .collect(),
-            token_hint: client.token_hint.clone(),
-            created_at: client.created_at.clone(),
-            last_seen_at: client.last_seen_at.clone(),
-            revoked_at: client.revoked_at.clone(),
-            rotated_at: client.rotated_at.clone(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct DaemonRemoteClientRevokeResponse {
-    pub client_id: String,
-    pub revoked_at: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct DaemonRemoteClientRotateResponse {
-    pub client_id: String,
-    pub token: String,
-    pub token_hint: String,
-    pub rotated_at: String,
-}
-
-fn record_remote_clients_audit(
-    db: &DaemonDb,
-    event_id: &str,
-    recorded_at: &str,
-    client_id: Option<&str>,
-    route_or_method: &str,
-    outcome: RemoteAuditOutcome,
-    error_detail: Option<&str>,
-) -> Result<(), CliError> {
-    db.record_remote_audit_event(&RemoteAuditEvent::new(
-        event_id,
-        recorded_at,
-        None,
-        client_id,
-        route_or_method,
-        RemoteAccessScope::Admin,
-        RemoteAuditScopeDecision::Allowed,
-        outcome,
-        None,
-        error_detail,
-    ))
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -12,6 +12,10 @@ use crate::daemon::remote::{
     validate_remote_serve_config, RemoteAccessScope, RemoteAcmeChallenge, RemoteDaemonServeConfig,
     RemoteDnsProvider, RemoteRole,
 };
+use crate::daemon::remote_identity::{
+    remote_token_hint, RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision,
+    RemoteBearerToken, RemoteStoredClient,
+};
 use crate::daemon::remote_pairing::{RemotePairingCode, RemotePairingRecord};
 use crate::daemon::service::DaemonServeConfig;
 use crate::daemon::state;
@@ -53,12 +57,12 @@ impl Execute for DaemonRemoteCommand {
     fn execute(&self, context: &AppContext) -> Result<i32, CliError> {
         match self {
             Self::Pair { command } => command.execute(context),
+            Self::Clients { command } => command.execute(context),
             Self::Serve(args) => {
                 args.remote_auth_scaffold_config()?;
                 Err(remote_execution_reserved_error())
             }
-            Self::Clients { .. }
-            | Self::Acme { .. }
+            Self::Acme { .. }
             | Self::Doctor
             | Self::InstallSystemd(_)
             | Self::UninstallSystemd(_)
@@ -273,11 +277,260 @@ pub enum DaemonRemoteClientsCommand {
     Rotate(DaemonRemoteClientIdArgs),
 }
 
+impl Execute for DaemonRemoteClientsCommand {
+    fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
+        adopt_daemon_root_for_transport_command("daemon-remote-clients");
+        let db = open_remote_daemon_db()?;
+        let now = utc_now();
+        let audit_event_id = format!("remote-clients-{}-{}", self.action_label(), Uuid::new_v4());
+        match self {
+            Self::List => {
+                let response =
+                    self.list_clients_with(&db, audit_event_id.as_str(), now.as_str())?;
+                print_json(&response)?;
+            }
+            Self::Revoke(args) => {
+                let response =
+                    args.revoke_client_with(&db, audit_event_id.as_str(), now.as_str())?;
+                print_json(&response)?;
+            }
+            Self::Rotate(args) => {
+                let token = RemoteBearerToken::generate();
+                let response = args.rotate_client_with(
+                    &db,
+                    token.expose(),
+                    audit_event_id.as_str(),
+                    now.as_str(),
+                )?;
+                print_json(&response)?;
+            }
+        }
+        Ok(0)
+    }
+}
+
+impl DaemonRemoteClientsCommand {
+    /// List paired remote clients without exposing token hashes or raw tokens.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when database reads or audit writes fail.
+    pub(crate) fn list_clients_with(
+        &self,
+        db: &DaemonDb,
+        audit_event_id: &str,
+        now: &str,
+    ) -> Result<DaemonRemoteClientsListResponse, CliError> {
+        let Self::List = self else {
+            return Err(CliErrorKind::workflow_parse("remote clients command must be list").into());
+        };
+        let clients = db
+            .list_remote_clients()?
+            .iter()
+            .map(DaemonRemoteClientSummary::from_stored_client)
+            .collect();
+        record_remote_clients_audit(
+            db,
+            audit_event_id,
+            now,
+            None,
+            "remote.clients.list",
+            RemoteAuditOutcome::Success,
+            None,
+        )?;
+        Ok(DaemonRemoteClientsListResponse { clients })
+    }
+
+    #[must_use]
+    const fn action_label(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Revoke(_) => "revoke",
+            Self::Rotate(_) => "rotate",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct DaemonRemoteClientIdArgs {
     /// Remote client identifier.
     #[arg(long)]
     pub client_id: String,
+}
+
+impl DaemonRemoteClientIdArgs {
+    /// Revoke a paired remote client.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the client is unknown, already revoked, or
+    /// persistence/audit fails.
+    pub(crate) fn revoke_client_with(
+        &self,
+        db: &DaemonDb,
+        audit_event_id: &str,
+        revoked_at: &str,
+    ) -> Result<DaemonRemoteClientRevokeResponse, CliError> {
+        let client_id = self.trimmed_client_id()?;
+        let changed = db.revoke_remote_client(client_id, revoked_at)?;
+        if !changed {
+            record_remote_clients_audit(
+                db,
+                audit_event_id,
+                revoked_at,
+                Some(client_id),
+                "remote.clients.revoke",
+                RemoteAuditOutcome::Failure,
+                Some("remote client not found or already revoked"),
+            )?;
+            return Err(CliErrorKind::workflow_parse(format!(
+                "remote client '{client_id}' not found or already revoked"
+            ))
+            .into());
+        }
+        record_remote_clients_audit(
+            db,
+            audit_event_id,
+            revoked_at,
+            Some(client_id),
+            "remote.clients.revoke",
+            RemoteAuditOutcome::Success,
+            None,
+        )?;
+        Ok(DaemonRemoteClientRevokeResponse {
+            client_id: client_id.to_string(),
+            revoked_at: revoked_at.to_string(),
+        })
+    }
+
+    /// Rotate a paired remote client's bearer token.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the client is unknown, revoked, the new token
+    /// is invalid, or persistence/audit fails.
+    pub(crate) fn rotate_client_with(
+        &self,
+        db: &DaemonDb,
+        token: &str,
+        audit_event_id: &str,
+        rotated_at: &str,
+    ) -> Result<DaemonRemoteClientRotateResponse, CliError> {
+        let client_id = self.trimmed_client_id()?;
+        let changed = db.rotate_remote_client_token(client_id, token, rotated_at)?;
+        if !changed {
+            record_remote_clients_audit(
+                db,
+                audit_event_id,
+                rotated_at,
+                Some(client_id),
+                "remote.clients.rotate",
+                RemoteAuditOutcome::Failure,
+                Some("remote client not found or revoked"),
+            )?;
+            return Err(CliErrorKind::workflow_parse(format!(
+                "remote client '{client_id}' not found or revoked"
+            ))
+            .into());
+        }
+        record_remote_clients_audit(
+            db,
+            audit_event_id,
+            rotated_at,
+            Some(client_id),
+            "remote.clients.rotate",
+            RemoteAuditOutcome::Success,
+            None,
+        )?;
+        Ok(DaemonRemoteClientRotateResponse {
+            client_id: client_id.to_string(),
+            token: token.to_string(),
+            token_hint: remote_token_hint(token),
+            rotated_at: rotated_at.to_string(),
+        })
+    }
+
+    fn trimmed_client_id(&self) -> Result<&str, CliError> {
+        let client_id = self.client_id.trim();
+        if client_id.is_empty() {
+            return Err(CliErrorKind::workflow_parse("remote client id is required").into());
+        }
+        Ok(client_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteClientsListResponse {
+    pub clients: Vec<DaemonRemoteClientSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteClientSummary {
+    pub client_id: String,
+    pub display_name: String,
+    pub platform: String,
+    pub role: String,
+    pub scopes: Vec<String>,
+    pub token_hint: String,
+    pub created_at: String,
+    pub last_seen_at: Option<String>,
+    pub revoked_at: Option<String>,
+    pub rotated_at: Option<String>,
+}
+
+impl DaemonRemoteClientSummary {
+    fn from_stored_client(client: &RemoteStoredClient) -> Self {
+        Self {
+            client_id: client.client_id.clone(),
+            display_name: client.display_name.clone(),
+            platform: client.platform.clone(),
+            role: client.role.as_str().to_string(),
+            scopes: client
+                .scopes
+                .iter()
+                .map(|scope| scope.as_str().to_string())
+                .collect(),
+            token_hint: client.token_hint.clone(),
+            created_at: client.created_at.clone(),
+            last_seen_at: client.last_seen_at.clone(),
+            revoked_at: client.revoked_at.clone(),
+            rotated_at: client.rotated_at.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteClientRevokeResponse {
+    pub client_id: String,
+    pub revoked_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteClientRotateResponse {
+    pub client_id: String,
+    pub token: String,
+    pub token_hint: String,
+    pub rotated_at: String,
+}
+
+fn record_remote_clients_audit(
+    db: &DaemonDb,
+    event_id: &str,
+    recorded_at: &str,
+    client_id: Option<&str>,
+    route_or_method: &str,
+    outcome: RemoteAuditOutcome,
+    error_detail: Option<&str>,
+) -> Result<(), CliError> {
+    db.record_remote_audit_event(&RemoteAuditEvent::new(
+        event_id,
+        recorded_at,
+        None,
+        client_id,
+        route_or_method,
+        RemoteAccessScope::Admin,
+        RemoteAuditScopeDecision::Allowed,
+        outcome,
+        None,
+        error_detail,
+    ))
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/src/daemon/transport/remote_clients.rs
+++ b/src/daemon/transport/remote_clients.rs
@@ -1,0 +1,264 @@
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::app::command_context::{AppContext, Execute};
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_identity::{
+    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteBearerToken,
+    RemoteStoredClient, remote_token_hint,
+};
+use crate::errors::{CliError, CliErrorKind};
+use crate::workspace::utc_now;
+
+use super::control::{adopt_daemon_root_for_transport_command, print_json};
+use super::remote::{DaemonRemoteClientIdArgs, DaemonRemoteClientsCommand, open_remote_daemon_db};
+
+impl Execute for DaemonRemoteClientsCommand {
+    fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
+        adopt_daemon_root_for_transport_command("daemon-remote-clients");
+        let db = open_remote_daemon_db()?;
+        let now = utc_now();
+        let audit_event_id = format!("remote-clients-{}-{}", self.action_label(), Uuid::new_v4());
+        match self {
+            Self::List => {
+                let response =
+                    self.list_clients_with(&db, audit_event_id.as_str(), now.as_str())?;
+                print_json(&response)?;
+            }
+            Self::Revoke(args) => {
+                let response =
+                    args.revoke_client_with(&db, audit_event_id.as_str(), now.as_str())?;
+                print_json(&response)?;
+            }
+            Self::Rotate(args) => {
+                let token = RemoteBearerToken::generate();
+                let response = args.rotate_client_with(
+                    &db,
+                    token.expose(),
+                    audit_event_id.as_str(),
+                    now.as_str(),
+                )?;
+                print_json(&response)?;
+            }
+        }
+        Ok(0)
+    }
+}
+
+impl DaemonRemoteClientsCommand {
+    /// List paired remote clients without exposing token hashes or raw tokens.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when database reads or audit writes fail.
+    pub(crate) fn list_clients_with(
+        &self,
+        db: &DaemonDb,
+        audit_event_id: &str,
+        now: &str,
+    ) -> Result<DaemonRemoteClientsListResponse, CliError> {
+        let Self::List = self else {
+            return Err(CliErrorKind::workflow_parse("remote clients command must be list").into());
+        };
+        let clients = db
+            .list_remote_clients()?
+            .iter()
+            .map(DaemonRemoteClientSummary::from_stored_client)
+            .collect();
+        record_remote_clients_audit(
+            db,
+            audit_event_id,
+            now,
+            None,
+            "remote.clients.list",
+            RemoteAuditOutcome::Success,
+            None,
+        )?;
+        Ok(DaemonRemoteClientsListResponse { clients })
+    }
+
+    #[must_use]
+    const fn action_label(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Revoke(_) => "revoke",
+            Self::Rotate(_) => "rotate",
+        }
+    }
+}
+
+impl DaemonRemoteClientIdArgs {
+    /// Revoke a paired remote client.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the client is unknown, already revoked, or
+    /// persistence/audit fails.
+    pub(crate) fn revoke_client_with(
+        &self,
+        db: &DaemonDb,
+        audit_event_id: &str,
+        revoked_at: &str,
+    ) -> Result<DaemonRemoteClientRevokeResponse, CliError> {
+        let client_id = self.trimmed_client_id()?;
+        let changed = db.revoke_remote_client(client_id, revoked_at)?;
+        if !changed {
+            record_remote_clients_audit(
+                db,
+                audit_event_id,
+                revoked_at,
+                Some(client_id),
+                "remote.clients.revoke",
+                RemoteAuditOutcome::Failure,
+                Some("remote client not found or already revoked"),
+            )?;
+            return Err(CliErrorKind::workflow_parse(format!(
+                "remote client '{client_id}' not found or already revoked"
+            ))
+            .into());
+        }
+        record_remote_clients_audit(
+            db,
+            audit_event_id,
+            revoked_at,
+            Some(client_id),
+            "remote.clients.revoke",
+            RemoteAuditOutcome::Success,
+            None,
+        )?;
+        Ok(DaemonRemoteClientRevokeResponse {
+            client_id: client_id.to_string(),
+            revoked_at: revoked_at.to_string(),
+        })
+    }
+
+    /// Rotate a paired remote client's bearer token.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the client is unknown, revoked, the new token
+    /// is invalid, or persistence/audit fails.
+    pub(crate) fn rotate_client_with(
+        &self,
+        db: &DaemonDb,
+        token: &str,
+        audit_event_id: &str,
+        rotated_at: &str,
+    ) -> Result<DaemonRemoteClientRotateResponse, CliError> {
+        let client_id = self.trimmed_client_id()?;
+        let changed = db.rotate_remote_client_token(client_id, token, rotated_at)?;
+        if !changed {
+            record_remote_clients_audit(
+                db,
+                audit_event_id,
+                rotated_at,
+                Some(client_id),
+                "remote.clients.rotate",
+                RemoteAuditOutcome::Failure,
+                Some("remote client not found or revoked"),
+            )?;
+            return Err(CliErrorKind::workflow_parse(format!(
+                "remote client '{client_id}' not found or revoked"
+            ))
+            .into());
+        }
+        record_remote_clients_audit(
+            db,
+            audit_event_id,
+            rotated_at,
+            Some(client_id),
+            "remote.clients.rotate",
+            RemoteAuditOutcome::Success,
+            None,
+        )?;
+        Ok(DaemonRemoteClientRotateResponse {
+            client_id: client_id.to_string(),
+            token: token.to_string(),
+            token_hint: remote_token_hint(token),
+            rotated_at: rotated_at.to_string(),
+        })
+    }
+
+    fn trimmed_client_id(&self) -> Result<&str, CliError> {
+        let client_id = self.client_id.trim();
+        if client_id.is_empty() {
+            return Err(CliErrorKind::workflow_parse("remote client id is required").into());
+        }
+        Ok(client_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteClientsListResponse {
+    pub clients: Vec<DaemonRemoteClientSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteClientSummary {
+    pub client_id: String,
+    pub display_name: String,
+    pub platform: String,
+    pub role: String,
+    pub scopes: Vec<String>,
+    pub token_hint: String,
+    pub created_at: String,
+    pub last_seen_at: Option<String>,
+    pub revoked_at: Option<String>,
+    pub rotated_at: Option<String>,
+}
+
+impl DaemonRemoteClientSummary {
+    fn from_stored_client(client: &RemoteStoredClient) -> Self {
+        Self {
+            client_id: client.client_id.clone(),
+            display_name: client.display_name.clone(),
+            platform: client.platform.clone(),
+            role: client.role.as_str().to_string(),
+            scopes: client
+                .scopes
+                .iter()
+                .map(|scope| scope.as_str().to_string())
+                .collect(),
+            token_hint: client.token_hint.clone(),
+            created_at: client.created_at.clone(),
+            last_seen_at: client.last_seen_at.clone(),
+            revoked_at: client.revoked_at.clone(),
+            rotated_at: client.rotated_at.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteClientRevokeResponse {
+    pub client_id: String,
+    pub revoked_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteClientRotateResponse {
+    pub client_id: String,
+    pub token: String,
+    pub token_hint: String,
+    pub rotated_at: String,
+}
+
+fn record_remote_clients_audit(
+    db: &DaemonDb,
+    event_id: &str,
+    recorded_at: &str,
+    client_id: Option<&str>,
+    route_or_method: &str,
+    outcome: RemoteAuditOutcome,
+    error_detail: Option<&str>,
+) -> Result<(), CliError> {
+    db.record_remote_audit_event(&RemoteAuditEvent::new(
+        event_id,
+        recorded_at,
+        None,
+        client_id,
+        route_or_method,
+        RemoteAccessScope::Admin,
+        RemoteAuditScopeDecision::Allowed,
+        outcome,
+        None,
+        error_detail,
+    ))
+}

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod lifecycle;
 mod remote_cli;
+mod remote_clients;
 
 use std::path::{Path, PathBuf};
 

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -3,12 +3,9 @@ use harness_testkit::with_isolated_harness_env;
 
 use crate::app::command_context::{AppContext, Execute};
 use crate::daemon::db::DaemonDb;
-use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
-use crate::daemon::remote_identity::RemoteClientRegistration;
 use crate::daemon::remote_pairing::RemotePairingCode;
 use crate::daemon::state;
 
-use super::super::remote::{DaemonRemoteClientIdArgs, DaemonRemoteClientsCommand};
 use super::super::{DaemonRemoteCommand, DaemonRemotePairCommand, DaemonRemoteServeArgs};
 
 #[derive(Debug, Parser)]
@@ -278,22 +275,26 @@ fn daemon_remote_pair_create_accepts_fixed_scope_values() {
 
 #[test]
 fn daemon_remote_pair_create_rejects_unknown_scope() {
-    assert!(DaemonRemoteCommandTestHarness::try_parse_from([
-        "test",
-        "pair",
-        "create",
-        "--scopes",
-        "read,root",
-    ])
-    .is_err());
+    assert!(
+        DaemonRemoteCommandTestHarness::try_parse_from([
+            "test",
+            "pair",
+            "create",
+            "--scopes",
+            "read,root",
+        ])
+        .is_err()
+    );
 }
 
 #[test]
 fn daemon_remote_pair_create_rejects_invalid_ttl() {
-    assert!(DaemonRemoteCommandTestHarness::try_parse_from([
-        "test", "pair", "create", "--ttl", "tomorrow",
-    ])
-    .is_err());
+    assert!(
+        DaemonRemoteCommandTestHarness::try_parse_from([
+            "test", "pair", "create", "--ttl", "tomorrow",
+        ])
+        .is_err()
+    );
 }
 
 #[test]
@@ -421,158 +422,4 @@ fn daemon_remote_pair_create_execute_persists_pairing_in_daemon_db() {
         assert_eq!(scopes_json, "[\"read\"]");
         assert!(code_hash.starts_with("sha256:"));
     });
-}
-
-#[test]
-fn daemon_remote_clients_list_returns_token_safe_summaries_and_audits() {
-    let db = DaemonDb::open_in_memory().expect("open db");
-    register_remote_client(
-        &db,
-        "viewer",
-        RemoteRole::Viewer,
-        &[],
-        "viewer-token-secret",
-    );
-    register_remote_client(
-        &db,
-        "operator",
-        RemoteRole::Operator,
-        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
-        "operator-token-secret",
-    );
-
-    let response = DaemonRemoteClientsCommand::List
-        .list_clients_with(&db, "audit-list", "2026-06-21T14:00:00Z")
-        .expect("list clients");
-
-    assert_eq!(response.clients.len(), 2);
-    let viewer = response
-        .clients
-        .iter()
-        .find(|client| client.client_id == "viewer")
-        .expect("viewer client");
-    assert_eq!(viewer.role, "viewer");
-    assert_eq!(viewer.scopes, vec!["read"]);
-    assert_eq!(viewer.token_hint, "secret");
-    let operator = response
-        .clients
-        .iter()
-        .find(|client| client.client_id == "operator")
-        .expect("operator client");
-    assert_eq!(operator.scopes, vec!["read", "write"]);
-    let json = serde_json::to_string(&response).expect("serialize response");
-    assert!(!json.contains("viewer-token-secret"));
-    assert!(!json.contains("operator-token-secret"));
-    assert!(!json.contains("sha256:"));
-
-    let routes: Vec<_> = db
-        .load_remote_audit_events(10)
-        .expect("audit events")
-        .into_iter()
-        .map(|event| event.route_or_method)
-        .collect();
-    assert_eq!(routes, vec!["remote.clients.list"]);
-}
-
-#[test]
-fn daemon_remote_clients_revoke_denies_token_and_records_audit() {
-    let db = DaemonDb::open_in_memory().expect("open db");
-    register_remote_client(
-        &db,
-        "viewer",
-        RemoteRole::Viewer,
-        &[],
-        "viewer-token-secret",
-    );
-    let args = DaemonRemoteClientIdArgs {
-        client_id: "viewer".to_string(),
-    };
-
-    let response = args
-        .revoke_client_with(&db, "audit-revoke", "2026-06-21T14:01:00Z")
-        .expect("revoke client");
-
-    assert_eq!(response.client_id, "viewer");
-    assert_eq!(response.revoked_at, "2026-06-21T14:01:00Z");
-    assert!(db
-        .verify_remote_client_token("viewer", "viewer-token-secret")
-        .expect("verify revoked client")
-        .is_none());
-    assert!(
-        args.revoke_client_with(&db, "audit-revoke-again", "2026-06-21T14:01:30Z")
-            .is_err(),
-        "revoke must fail for already revoked clients"
-    );
-
-    let events = db.load_remote_audit_events(10).expect("audit events");
-    assert!(events
-        .iter()
-        .any(|event| event.route_or_method == "remote.clients.revoke"
-            && event.client_id.as_deref() == Some("viewer")));
-}
-
-#[test]
-fn daemon_remote_clients_rotate_returns_new_token_and_audits() {
-    let db = DaemonDb::open_in_memory().expect("open db");
-    register_remote_client(
-        &db,
-        "operator",
-        RemoteRole::Operator,
-        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
-        "old-token-secret",
-    );
-    let args = DaemonRemoteClientIdArgs {
-        client_id: "operator".to_string(),
-    };
-
-    let response = args
-        .rotate_client_with(
-            &db,
-            "manual-rotated-token-secret",
-            "audit-rotate",
-            "2026-06-21T14:02:00Z",
-        )
-        .expect("rotate client");
-
-    assert_eq!(response.client_id, "operator");
-    assert_eq!(response.token, "manual-rotated-token-secret");
-    assert_eq!(response.token_hint, "secret");
-    assert_eq!(response.rotated_at, "2026-06-21T14:02:00Z");
-    assert!(db
-        .verify_remote_client_token("operator", "old-token-secret")
-        .expect("old token rejected")
-        .is_none());
-    assert!(db
-        .verify_remote_client_token("operator", "manual-rotated-token-secret")
-        .expect("new token accepted")
-        .is_some());
-    let json = serde_json::to_string(&response).expect("serialize rotate response");
-    assert!(!json.contains("sha256:"));
-
-    let events = db.load_remote_audit_events(10).expect("audit events");
-    assert!(events
-        .iter()
-        .any(|event| event.route_or_method == "remote.clients.rotate"
-            && event.client_id.as_deref() == Some("operator")));
-}
-
-fn register_remote_client(
-    db: &DaemonDb,
-    client_id: &str,
-    role: RemoteRole,
-    scopes: &[RemoteAccessScope],
-    token: &str,
-) {
-    let registration = RemoteClientRegistration::new_for_tests(
-        client_id,
-        format!("{client_id} display"),
-        "macos",
-        role,
-        scopes,
-        token,
-        "2026-06-21T13:50:00Z",
-    )
-    .expect("registration");
-    db.register_remote_client(&registration)
-        .expect("register remote client");
 }

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -3,9 +3,12 @@ use harness_testkit::with_isolated_harness_env;
 
 use crate::app::command_context::{AppContext, Execute};
 use crate::daemon::db::DaemonDb;
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::RemoteClientRegistration;
 use crate::daemon::remote_pairing::RemotePairingCode;
 use crate::daemon::state;
 
+use super::super::remote::{DaemonRemoteClientIdArgs, DaemonRemoteClientsCommand};
 use super::super::{DaemonRemoteCommand, DaemonRemotePairCommand, DaemonRemoteServeArgs};
 
 #[derive(Debug, Parser)]
@@ -418,4 +421,158 @@ fn daemon_remote_pair_create_execute_persists_pairing_in_daemon_db() {
         assert_eq!(scopes_json, "[\"read\"]");
         assert!(code_hash.starts_with("sha256:"));
     });
+}
+
+#[test]
+fn daemon_remote_clients_list_returns_token_safe_summaries_and_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    register_remote_client(
+        &db,
+        "viewer",
+        RemoteRole::Viewer,
+        &[],
+        "viewer-token-secret",
+    );
+    register_remote_client(
+        &db,
+        "operator",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        "operator-token-secret",
+    );
+
+    let response = DaemonRemoteClientsCommand::List
+        .list_clients_with(&db, "audit-list", "2026-06-21T14:00:00Z")
+        .expect("list clients");
+
+    assert_eq!(response.clients.len(), 2);
+    let viewer = response
+        .clients
+        .iter()
+        .find(|client| client.client_id == "viewer")
+        .expect("viewer client");
+    assert_eq!(viewer.role, "viewer");
+    assert_eq!(viewer.scopes, vec!["read"]);
+    assert_eq!(viewer.token_hint, "secret");
+    let operator = response
+        .clients
+        .iter()
+        .find(|client| client.client_id == "operator")
+        .expect("operator client");
+    assert_eq!(operator.scopes, vec!["read", "write"]);
+    let json = serde_json::to_string(&response).expect("serialize response");
+    assert!(!json.contains("viewer-token-secret"));
+    assert!(!json.contains("operator-token-secret"));
+    assert!(!json.contains("sha256:"));
+
+    let routes: Vec<_> = db
+        .load_remote_audit_events(10)
+        .expect("audit events")
+        .into_iter()
+        .map(|event| event.route_or_method)
+        .collect();
+    assert_eq!(routes, vec!["remote.clients.list"]);
+}
+
+#[test]
+fn daemon_remote_clients_revoke_denies_token_and_records_audit() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    register_remote_client(
+        &db,
+        "viewer",
+        RemoteRole::Viewer,
+        &[],
+        "viewer-token-secret",
+    );
+    let args = DaemonRemoteClientIdArgs {
+        client_id: "viewer".to_string(),
+    };
+
+    let response = args
+        .revoke_client_with(&db, "audit-revoke", "2026-06-21T14:01:00Z")
+        .expect("revoke client");
+
+    assert_eq!(response.client_id, "viewer");
+    assert_eq!(response.revoked_at, "2026-06-21T14:01:00Z");
+    assert!(db
+        .verify_remote_client_token("viewer", "viewer-token-secret")
+        .expect("verify revoked client")
+        .is_none());
+    assert!(
+        args.revoke_client_with(&db, "audit-revoke-again", "2026-06-21T14:01:30Z")
+            .is_err(),
+        "revoke must fail for already revoked clients"
+    );
+
+    let events = db.load_remote_audit_events(10).expect("audit events");
+    assert!(events
+        .iter()
+        .any(|event| event.route_or_method == "remote.clients.revoke"
+            && event.client_id.as_deref() == Some("viewer")));
+}
+
+#[test]
+fn daemon_remote_clients_rotate_returns_new_token_and_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    register_remote_client(
+        &db,
+        "operator",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        "old-token-secret",
+    );
+    let args = DaemonRemoteClientIdArgs {
+        client_id: "operator".to_string(),
+    };
+
+    let response = args
+        .rotate_client_with(
+            &db,
+            "manual-rotated-token-secret",
+            "audit-rotate",
+            "2026-06-21T14:02:00Z",
+        )
+        .expect("rotate client");
+
+    assert_eq!(response.client_id, "operator");
+    assert_eq!(response.token, "manual-rotated-token-secret");
+    assert_eq!(response.token_hint, "secret");
+    assert_eq!(response.rotated_at, "2026-06-21T14:02:00Z");
+    assert!(db
+        .verify_remote_client_token("operator", "old-token-secret")
+        .expect("old token rejected")
+        .is_none());
+    assert!(db
+        .verify_remote_client_token("operator", "manual-rotated-token-secret")
+        .expect("new token accepted")
+        .is_some());
+    let json = serde_json::to_string(&response).expect("serialize rotate response");
+    assert!(!json.contains("sha256:"));
+
+    let events = db.load_remote_audit_events(10).expect("audit events");
+    assert!(events
+        .iter()
+        .any(|event| event.route_or_method == "remote.clients.rotate"
+            && event.client_id.as_deref() == Some("operator")));
+}
+
+fn register_remote_client(
+    db: &DaemonDb,
+    client_id: &str,
+    role: RemoteRole,
+    scopes: &[RemoteAccessScope],
+    token: &str,
+) {
+    let registration = RemoteClientRegistration::new_for_tests(
+        client_id,
+        format!("{client_id} display"),
+        "macos",
+        role,
+        scopes,
+        token,
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("registration");
+    db.register_remote_client(&registration)
+        .expect("register remote client");
 }

--- a/src/daemon/transport/tests/remote_clients.rs
+++ b/src/daemon/transport/tests/remote_clients.rs
@@ -1,0 +1,162 @@
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::RemoteClientRegistration;
+
+use super::super::remote::{DaemonRemoteClientIdArgs, DaemonRemoteClientsCommand};
+
+#[test]
+fn daemon_remote_clients_list_returns_token_safe_summaries_and_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    register_remote_client(
+        &db,
+        "viewer",
+        RemoteRole::Viewer,
+        &[],
+        "viewer-token-secret",
+    );
+    register_remote_client(
+        &db,
+        "operator",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        "operator-token-secret",
+    );
+
+    let response = DaemonRemoteClientsCommand::List
+        .list_clients_with(&db, "audit-list", "2026-06-21T14:00:00Z")
+        .expect("list clients");
+
+    assert_eq!(response.clients.len(), 2);
+    let viewer = response
+        .clients
+        .iter()
+        .find(|client| client.client_id == "viewer")
+        .expect("viewer client");
+    assert_eq!(viewer.role, "viewer");
+    assert_eq!(viewer.scopes, vec!["read"]);
+    assert_eq!(viewer.token_hint, "secret");
+    let operator = response
+        .clients
+        .iter()
+        .find(|client| client.client_id == "operator")
+        .expect("operator client");
+    assert_eq!(operator.scopes, vec!["read", "write"]);
+    let json = serde_json::to_string(&response).expect("serialize response");
+    assert!(!json.contains("viewer-token-secret"));
+    assert!(!json.contains("operator-token-secret"));
+    assert!(!json.contains("sha256:"));
+
+    let routes: Vec<_> = db
+        .load_remote_audit_events(10)
+        .expect("audit events")
+        .into_iter()
+        .map(|event| event.route_or_method)
+        .collect();
+    assert_eq!(routes, vec!["remote.clients.list"]);
+}
+
+#[test]
+fn daemon_remote_clients_revoke_denies_token_and_records_audit() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    register_remote_client(
+        &db,
+        "viewer",
+        RemoteRole::Viewer,
+        &[],
+        "viewer-token-secret",
+    );
+    let args = DaemonRemoteClientIdArgs {
+        client_id: "viewer".to_string(),
+    };
+
+    let response = args
+        .revoke_client_with(&db, "audit-revoke", "2026-06-21T14:01:00Z")
+        .expect("revoke client");
+
+    assert_eq!(response.client_id, "viewer");
+    assert_eq!(response.revoked_at, "2026-06-21T14:01:00Z");
+    assert!(
+        db.verify_remote_client_token("viewer", "viewer-token-secret")
+            .expect("verify revoked client")
+            .is_none()
+    );
+    assert!(
+        args.revoke_client_with(&db, "audit-revoke-again", "2026-06-21T14:01:30Z")
+            .is_err(),
+        "revoke must fail for already revoked clients"
+    );
+
+    let events = db.load_remote_audit_events(10).expect("audit events");
+    assert!(events.iter().any(|event| {
+        event.route_or_method == "remote.clients.revoke"
+            && event.client_id.as_deref() == Some("viewer")
+    }));
+}
+
+#[test]
+fn daemon_remote_clients_rotate_returns_new_token_and_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    register_remote_client(
+        &db,
+        "operator",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        "old-token-secret",
+    );
+    let args = DaemonRemoteClientIdArgs {
+        client_id: "operator".to_string(),
+    };
+
+    let response = args
+        .rotate_client_with(
+            &db,
+            "manual-rotated-token-secret",
+            "audit-rotate",
+            "2026-06-21T14:02:00Z",
+        )
+        .expect("rotate client");
+
+    assert_eq!(response.client_id, "operator");
+    assert_eq!(response.token, "manual-rotated-token-secret");
+    assert_eq!(response.token_hint, "secret");
+    assert_eq!(response.rotated_at, "2026-06-21T14:02:00Z");
+    assert!(
+        db.verify_remote_client_token("operator", "old-token-secret")
+            .expect("old token rejected")
+            .is_none()
+    );
+    assert!(
+        db.verify_remote_client_token("operator", "manual-rotated-token-secret")
+            .expect("new token accepted")
+            .is_some()
+    );
+    let json = serde_json::to_string(&response).expect("serialize rotate response");
+    assert!(!json.contains("sha256:"));
+
+    let events = db.load_remote_audit_events(10).expect("audit events");
+    assert!(events.iter().any(|event| {
+        event.route_or_method == "remote.clients.rotate"
+            && event.client_id.as_deref() == Some("operator")
+    }));
+}
+
+fn register_remote_client(
+    db: &DaemonDb,
+    client_id: &str,
+    role: RemoteRole,
+    scopes: &[RemoteAccessScope],
+    token: &str,
+) {
+    let registration = RemoteClientRegistration::new_for_tests(
+        client_id,
+        format!("{client_id} display"),
+        "macos",
+        role,
+        scopes,
+        token,
+        "2026-06-21T13:50:00Z",
+    )
+    .expect("registration");
+    db.register_remote_client(&registration)
+        .expect("register remote client");
+}

--- a/src/telemetry/providers.rs
+++ b/src/telemetry/providers.rs
@@ -64,11 +64,11 @@ impl<E: SdkSpanExporter> SdkSpanExporter for TokioSpanExporter<E> {
         ready(result)
     }
 
-    fn shutdown_with_timeout(&mut self, timeout: Duration) -> OTelSdkResult {
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         self.inner.shutdown_with_timeout(timeout)
     }
 
-    fn force_flush(&mut self) -> OTelSdkResult {
+    fn force_flush(&self) -> OTelSdkResult {
         self.inner.force_flush()
     }
 


### PR DESCRIPTION
## Motivation
Remote daemon pairing can create clients, but operators need token-safe list, revoke, and rotate commands before richer remote flows are exposed. Current main also mixed OpenTelemetry 0.31 and 0.32 crates after the dependency update, which blocked Rust validation.

## Implementation
- Adds remote clients list, revoke, and rotate execution backed by the remote identity DB and audit events.
- Keeps list output token-safe and returns the raw rotated token only in the rotate response.
- Splits remote client command and test code into focused modules under the repo file-size limit.
- Aligns the OpenTelemetry crate family on 0.32 with `tracing-opentelemetry` 0.33 and updates wrapper receivers for the new trait.
- Validated with `mise run cargo:local -- test daemon_remote_clients --lib`, `remote_cli`, `remote_identity`, `telemetry`, `git diff --check`, and `mise run harness:check`.