### PR TITLE
feat(daemon): report remote acme state

### DIFF
--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -56,6 +56,7 @@ mod diagnostics;
 mod imports;
 mod policy;
 mod rebuild;
+mod remote_acme;
 mod remote_identity;
 mod remote_pairing;
 mod review_writes;
@@ -100,6 +101,7 @@ use conversation::{
 };
 #[allow(unused_imports)]
 use diagnostics::import_daemon_events;
+pub(crate) use remote_acme::RemoteAcmeStoredState;
 pub(crate) use runtime::ensure_shared_db;
 #[cfg(test)]
 pub(crate) use schema::set_schema_init_hook;

--- a/src/daemon/db/remote_acme.rs
+++ b/src/daemon/db/remote_acme.rs
@@ -1,0 +1,118 @@
+use rusqlite::{OptionalExtension, params, types::Type};
+
+use super::{CliError, DaemonDb, db_error};
+use crate::daemon::remote_acme::RemoteRenewalOutcome;
+
+const SELECT_REMOTE_ACME_STATE_SQL: &str = "
+SELECT
+    NULLIF(TRIM(account_id), ''),
+    CASE WHEN COALESCE(TRIM(account_id), '') <> '' THEN 1 ELSE 0 END,
+    CASE
+        WHEN COALESCE(TRIM(certificate_pem), '') <> ''
+         AND COALESCE(TRIM(private_key_pem), '') <> ''
+         AND COALESCE(TRIM(certificate_fingerprint), '') <> ''
+        THEN 1 ELSE 0
+    END,
+    NULLIF(TRIM(certificate_fingerprint), ''),
+    renewal_status,
+    renewal_error,
+    updated_at
+FROM remote_acme_state
+WHERE singleton = 1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteAcmeRenewalStatus {
+    Unknown,
+    Succeeded,
+    Failed,
+}
+
+impl RemoteAcmeRenewalStatus {
+    #[must_use]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemoteAcmeStoredState {
+    pub(crate) account_configured: bool,
+    pub(crate) account_id: Option<String>,
+    pub(crate) certificate_configured: bool,
+    pub(crate) certificate_fingerprint: Option<String>,
+    pub(crate) renewal_status: RemoteAcmeRenewalStatus,
+    pub(crate) renewal_error: Option<String>,
+    pub(crate) updated_at: String,
+}
+
+impl DaemonDb {
+    /// Load token-safe remote ACME status from the singleton state row.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL or status parsing failures.
+    pub(crate) fn load_remote_acme_state(&self) -> Result<RemoteAcmeStoredState, CliError> {
+        self.conn
+            .query_row(SELECT_REMOTE_ACME_STATE_SQL, [], remote_acme_state_from_row)
+            .optional()
+            .map_err(|error| db_error(format!("load remote acme state: {error}")))?
+            .ok_or_else(|| db_error("remote acme singleton state row is missing"))
+    }
+
+    /// Persist a redacted ACME renewal failure report.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL failure.
+    pub(crate) fn record_remote_acme_renewal_failure(
+        &self,
+        detail: &str,
+        updated_at: &str,
+    ) -> Result<(), CliError> {
+        let report = RemoteRenewalOutcome::failure(detail).report().to_string();
+        self.conn
+            .execute(
+                "INSERT INTO remote_acme_state (
+                     singleton, renewal_status, renewal_error, updated_at
+                 ) VALUES (1, 'failed', ?1, ?2)
+                 ON CONFLICT(singleton) DO UPDATE SET
+                     renewal_status = excluded.renewal_status,
+                     renewal_error = excluded.renewal_error,
+                     updated_at = excluded.updated_at",
+                params![report, updated_at],
+            )
+            .map_err(|error| db_error(format!("record remote acme renewal failure: {error}")))?;
+        Ok(())
+    }
+}
+
+fn remote_acme_state_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteAcmeStoredState> {
+    let status_label = row.get::<_, String>(4)?;
+    Ok(RemoteAcmeStoredState {
+        account_id: row.get(0)?,
+        account_configured: row.get::<_, i64>(1)? != 0,
+        certificate_configured: row.get::<_, i64>(2)? != 0,
+        certificate_fingerprint: row.get(3)?,
+        renewal_status: parse_renewal_status_at_column(&status_label, 4)?,
+        renewal_error: row.get(5)?,
+        updated_at: row.get(6)?,
+    })
+}
+
+fn parse_renewal_status_at_column(
+    label: &str,
+    column: usize,
+) -> rusqlite::Result<RemoteAcmeRenewalStatus> {
+    match label {
+        "unknown" => Ok(RemoteAcmeRenewalStatus::Unknown),
+        "succeeded" => Ok(RemoteAcmeRenewalStatus::Succeeded),
+        "failed" => Ok(RemoteAcmeRenewalStatus::Failed),
+        _ => Err(rusqlite::Error::FromSqlConversionFailure(
+            column,
+            Type::Text,
+            format!("unknown remote acme renewal status '{label}'").into(),
+        )),
+    }
+}

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -17,6 +17,7 @@ mod mutations;
 mod performance;
 mod projects;
 mod reconcile;
+mod remote_acme;
 mod remote_identity;
 mod remote_pairing;
 mod runtime;

--- a/src/daemon/db/tests/remote_acme.rs
+++ b/src/daemon/db/tests/remote_acme.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+#[test]
+fn remote_acme_state_status_hides_private_key_and_tracks_material() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.conn
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'cert-pem',
+                 private_key_pem = 'key-secret',
+                 certificate_fingerprint = 'fp-1',
+                 renewal_status = 'succeeded',
+                 renewal_error = NULL,
+                 updated_at = '2026-06-21T15:00:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed acme state");
+
+    let state = db.load_remote_acme_state().expect("load acme state");
+
+    assert!(state.account_configured);
+    assert_eq!(state.account_id.as_deref(), Some("acct-1"));
+    assert!(state.certificate_configured);
+    assert_eq!(state.certificate_fingerprint.as_deref(), Some("fp-1"));
+    assert_eq!(state.renewal_status.as_str(), "succeeded");
+    assert_eq!(state.renewal_error, None);
+    assert_eq!(state.updated_at, "2026-06-21T15:00:00Z");
+    assert!(
+        !format!("{state:?}").contains("key-secret"),
+        "ACME status debug output must not expose private key material"
+    );
+}
+
+#[test]
+fn remote_acme_renewal_failure_persists_redacted_report() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+
+    db.record_remote_acme_renewal_failure(
+        "dns token=remote-secret&retry=1 secret=nested-secret",
+        "2026-06-21T15:01:00Z",
+    )
+    .expect("record renewal failure");
+
+    let state = db.load_remote_acme_state().expect("load acme state");
+    assert_eq!(state.renewal_status.as_str(), "failed");
+    assert_eq!(
+        state.renewal_error.as_deref(),
+        Some("renewal failed: dns token=<redacted>&retry=1 secret=<redacted>")
+    );
+    assert_eq!(state.updated_at, "2026-06-21T15:01:00Z");
+}

--- a/src/daemon/transport/mod.rs
+++ b/src/daemon/transport/mod.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod control;
 mod remote;
+mod remote_acme;
 mod remote_clients;
 #[cfg(test)]
 mod tests;

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -54,12 +54,12 @@ impl Execute for DaemonRemoteCommand {
         match self {
             Self::Pair { command } => command.execute(context),
             Self::Clients { command } => command.execute(context),
+            Self::Acme { command } => command.execute(context),
             Self::Serve(args) => {
                 args.remote_auth_scaffold_config()?;
                 Err(remote_execution_reserved_error())
             }
-            Self::Acme { .. }
-            | Self::Doctor
+            Self::Doctor
             | Self::InstallSystemd(_)
             | Self::UninstallSystemd(_)
             | Self::Status(_) => Err(remote_execution_reserved_error()),

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -27,6 +27,7 @@ impl Execute for DaemonRemoteAcmeCommand {
             Self::Renew => {
                 let response = self.renew_with(&db, audit_event_id.as_str(), now.as_str())?;
                 print_json(&response)?;
+                response.ensure_success()?;
             }
         }
         Ok(0)
@@ -141,6 +142,24 @@ impl DaemonRemoteAcmeRenewResponse {
             renewal_error: state.renewal_error.clone(),
             updated_at: state.updated_at.clone(),
         }
+    }
+
+    /// Return an error for renewal attempts that recorded a failure state.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the renewal status is not successful.
+    pub(crate) fn ensure_success(&self) -> Result<(), CliError> {
+        if self.renewal_status == "succeeded" {
+            return Ok(());
+        }
+        let detail = self
+            .renewal_error
+            .as_deref()
+            .unwrap_or("remote ACME renewal did not succeed");
+        Err(CliErrorKind::workflow_parse(format!(
+            "remote ACME renewal did not succeed: {detail}"
+        ))
+        .into())
     }
 }
 

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -1,0 +1,177 @@
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::app::command_context::{AppContext, Execute};
+use crate::daemon::db::{DaemonDb, RemoteAcmeStoredState};
+use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_identity::{
+    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision,
+};
+use crate::errors::{CliError, CliErrorKind};
+use crate::workspace::utc_now;
+
+use super::control::{adopt_daemon_root_for_transport_command, print_json};
+use super::remote::{DaemonRemoteAcmeCommand, open_remote_daemon_db};
+
+impl Execute for DaemonRemoteAcmeCommand {
+    fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
+        adopt_daemon_root_for_transport_command("daemon-remote-acme");
+        let db = open_remote_daemon_db()?;
+        let now = utc_now();
+        let audit_event_id = format!("remote-acme-{}-{}", self.action_label(), Uuid::new_v4());
+        match self {
+            Self::Status => {
+                let response = self.status_with(&db, audit_event_id.as_str(), now.as_str())?;
+                print_json(&response)?;
+            }
+            Self::Renew => {
+                let response = self.renew_with(&db, audit_event_id.as_str(), now.as_str())?;
+                print_json(&response)?;
+            }
+        }
+        Ok(0)
+    }
+}
+
+impl DaemonRemoteAcmeCommand {
+    /// Return token-safe ACME state and audit the status read.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when database reads or audit writes fail.
+    pub(crate) fn status_with(
+        &self,
+        db: &DaemonDb,
+        audit_event_id: &str,
+        now: &str,
+    ) -> Result<DaemonRemoteAcmeStatusResponse, CliError> {
+        let Self::Status = self else {
+            return Err(CliErrorKind::workflow_parse("remote acme command must be status").into());
+        };
+        let state = db.load_remote_acme_state()?;
+        record_remote_acme_audit(
+            db,
+            audit_event_id,
+            now,
+            "remote.acme.status",
+            RemoteAuditOutcome::Success,
+            None,
+        )?;
+        Ok(DaemonRemoteAcmeStatusResponse::from_state(&state))
+    }
+
+    /// Record the current renewal failure reason until real ACME issuance lands.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when database reads, writes, or audit writes fail.
+    pub(crate) fn renew_with(
+        &self,
+        db: &DaemonDb,
+        audit_event_id: &str,
+        now: &str,
+    ) -> Result<DaemonRemoteAcmeRenewResponse, CliError> {
+        let Self::Renew = self else {
+            return Err(CliErrorKind::workflow_parse("remote acme command must be renew").into());
+        };
+        let state = db.load_remote_acme_state()?;
+        let detail = renewal_failure_detail(&state);
+        db.record_remote_acme_renewal_failure(detail, now)?;
+        let state = db.load_remote_acme_state()?;
+        record_remote_acme_audit(
+            db,
+            audit_event_id,
+            now,
+            "remote.acme.renew",
+            RemoteAuditOutcome::Failure,
+            state.renewal_error.as_deref(),
+        )?;
+        Ok(DaemonRemoteAcmeRenewResponse::from_state(&state))
+    }
+
+    #[must_use]
+    const fn action_label(&self) -> &'static str {
+        match self {
+            Self::Status => "status",
+            Self::Renew => "renew",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteAcmeStatusResponse {
+    pub account_configured: bool,
+    pub account_id: Option<String>,
+    pub certificate_configured: bool,
+    pub certificate_fingerprint: Option<String>,
+    pub renewal_status: String,
+    pub renewal_error: Option<String>,
+    pub updated_at: String,
+}
+
+impl DaemonRemoteAcmeStatusResponse {
+    fn from_state(state: &RemoteAcmeStoredState) -> Self {
+        Self {
+            account_configured: state.account_configured,
+            account_id: state.account_id.clone(),
+            certificate_configured: state.certificate_configured,
+            certificate_fingerprint: state.certificate_fingerprint.clone(),
+            renewal_status: state.renewal_status.as_str().to_string(),
+            renewal_error: state.renewal_error.clone(),
+            updated_at: state.updated_at.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteAcmeRenewResponse {
+    pub account_configured: bool,
+    pub certificate_configured: bool,
+    pub certificate_fingerprint: Option<String>,
+    pub renewal_status: String,
+    pub renewal_error: Option<String>,
+    pub renewed_at: String,
+}
+
+impl DaemonRemoteAcmeRenewResponse {
+    fn from_state(state: &RemoteAcmeStoredState) -> Self {
+        Self {
+            account_configured: state.account_configured,
+            certificate_configured: state.certificate_configured,
+            certificate_fingerprint: state.certificate_fingerprint.clone(),
+            renewal_status: state.renewal_status.as_str().to_string(),
+            renewal_error: state.renewal_error.clone(),
+            renewed_at: state.updated_at.clone(),
+        }
+    }
+}
+
+fn renewal_failure_detail(state: &RemoteAcmeStoredState) -> &'static str {
+    if !state.account_configured {
+        "remote daemon requires persisted ACME state"
+    } else if !state.certificate_configured {
+        "remote daemon requires a persisted TLS certificate"
+    } else {
+        "remote ACME renewal client is not implemented"
+    }
+}
+
+fn record_remote_acme_audit(
+    db: &DaemonDb,
+    event_id: &str,
+    recorded_at: &str,
+    route_or_method: &str,
+    outcome: RemoteAuditOutcome,
+    error_detail: Option<&str>,
+) -> Result<(), CliError> {
+    db.record_remote_audit_event(&RemoteAuditEvent::new(
+        event_id,
+        recorded_at,
+        None,
+        None,
+        route_or_method,
+        RemoteAccessScope::Admin,
+        RemoteAuditScopeDecision::Allowed,
+        outcome,
+        None,
+        error_detail,
+    ))
+}

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -128,7 +128,7 @@ pub(crate) struct DaemonRemoteAcmeRenewResponse {
     pub certificate_fingerprint: Option<String>,
     pub renewal_status: String,
     pub renewal_error: Option<String>,
-    pub renewed_at: String,
+    pub updated_at: String,
 }
 
 impl DaemonRemoteAcmeRenewResponse {
@@ -139,7 +139,7 @@ impl DaemonRemoteAcmeRenewResponse {
             certificate_fingerprint: state.certificate_fingerprint.clone(),
             renewal_status: state.renewal_status.as_str().to_string(),
             renewal_error: state.renewal_error.clone(),
-            renewed_at: state.updated_at.clone(),
+            updated_at: state.updated_at.clone(),
         }
     }
 }

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -155,11 +155,8 @@ impl DaemonRemoteAcmeRenewResponse {
         let detail = self
             .renewal_error
             .as_deref()
-            .unwrap_or("remote ACME renewal did not succeed");
-        Err(CliErrorKind::workflow_parse(format!(
-            "remote ACME renewal did not succeed: {detail}"
-        ))
-        .into())
+            .unwrap_or("remote ACME renewal failed");
+        Err(CliErrorKind::workflow_parse(detail.to_string()).into())
     }
 }
 

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod lifecycle;
+mod remote_acme;
 mod remote_cli;
 mod remote_clients;
 

--- a/src/daemon/transport/tests/remote_acme.rs
+++ b/src/daemon/transport/tests/remote_acme.rs
@@ -94,6 +94,10 @@ fn daemon_remote_acme_renew_records_missing_state_failure_and_audit() {
     let json = serde_json::to_string(&response).expect("serialize renew response");
     assert!(json.contains("\"updated_at\""));
     assert!(!json.contains("\"renewed_at\""));
+    let error = response
+        .ensure_success()
+        .expect_err("failure renewal response must produce a command error");
+    assert!(error.to_string().contains("persisted ACME state"));
 
     let events = db.load_remote_audit_events(10).expect("audit events");
     assert!(events.iter().any(|event| {

--- a/src/daemon/transport/tests/remote_acme.rs
+++ b/src/daemon/transport/tests/remote_acme.rs
@@ -1,0 +1,99 @@
+use clap::Parser;
+
+use crate::daemon::db::DaemonDb;
+
+use super::super::remote::{DaemonRemoteAcmeCommand, DaemonRemoteCommand};
+
+#[derive(Debug, Parser)]
+struct DaemonRemoteCommandTestHarness {
+    #[command(subcommand)]
+    command: DaemonRemoteCommand,
+}
+
+#[test]
+fn daemon_remote_acme_cli_parses_status_and_renew() {
+    let status = DaemonRemoteCommandTestHarness::try_parse_from(["test", "acme", "status"])
+        .expect("parse acme status")
+        .command;
+    let renew = DaemonRemoteCommandTestHarness::try_parse_from(["test", "acme", "renew"])
+        .expect("parse acme renew")
+        .command;
+
+    assert!(matches!(
+        status,
+        DaemonRemoteCommand::Acme {
+            command: DaemonRemoteAcmeCommand::Status
+        }
+    ));
+    assert!(matches!(
+        renew,
+        DaemonRemoteCommand::Acme {
+            command: DaemonRemoteAcmeCommand::Renew
+        }
+    ));
+}
+
+#[test]
+fn daemon_remote_acme_status_reports_persisted_state_without_key() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.connection()
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'cert-pem',
+                 private_key_pem = 'key-secret',
+                 certificate_fingerprint = 'fp-1',
+                 renewal_status = 'succeeded',
+                 renewal_error = NULL,
+                 updated_at = '2026-06-21T15:10:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed acme state");
+
+    let response = DaemonRemoteAcmeCommand::Status
+        .status_with(&db, "audit-acme-status", "2026-06-21T15:11:00Z")
+        .expect("status response");
+
+    assert!(response.account_configured);
+    assert_eq!(response.account_id.as_deref(), Some("acct-1"));
+    assert!(response.certificate_configured);
+    assert_eq!(response.certificate_fingerprint.as_deref(), Some("fp-1"));
+    assert_eq!(response.renewal_status, "succeeded");
+    let json = serde_json::to_string(&response).expect("serialize response");
+    assert!(!json.contains("key-secret"));
+
+    let routes: Vec<_> = db
+        .load_remote_audit_events(10)
+        .expect("audit events")
+        .into_iter()
+        .map(|event| event.route_or_method)
+        .collect();
+    assert_eq!(routes, vec!["remote.acme.status"]);
+}
+
+#[test]
+fn daemon_remote_acme_renew_records_missing_state_failure_and_audit() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+
+    let response = DaemonRemoteAcmeCommand::Renew
+        .renew_with(&db, "audit-acme-renew", "2026-06-21T15:12:00Z")
+        .expect("renew response");
+
+    assert_eq!(response.renewal_status, "failed");
+    assert!(
+        response
+            .renewal_error
+            .as_deref()
+            .is_some_and(|error| error.contains("persisted ACME state"))
+    );
+
+    let state = db.load_remote_acme_state().expect("load acme state");
+    assert_eq!(state.renewal_status.as_str(), "failed");
+    assert_eq!(state.updated_at, "2026-06-21T15:12:00Z");
+
+    let events = db.load_remote_audit_events(10).expect("audit events");
+    assert!(events.iter().any(|event| {
+        event.route_or_method == "remote.acme.renew" && event.outcome.as_str() == "failure"
+    }));
+}

--- a/src/daemon/transport/tests/remote_acme.rs
+++ b/src/daemon/transport/tests/remote_acme.rs
@@ -91,6 +91,9 @@ fn daemon_remote_acme_renew_records_missing_state_failure_and_audit() {
     let state = db.load_remote_acme_state().expect("load acme state");
     assert_eq!(state.renewal_status.as_str(), "failed");
     assert_eq!(state.updated_at, "2026-06-21T15:12:00Z");
+    let json = serde_json::to_string(&response).expect("serialize renew response");
+    assert!(json.contains("\"updated_at\""));
+    assert!(!json.contains("\"renewed_at\""));
 
     let events = db.load_remote_audit_events(10).expect("audit events");
     assert!(events.iter().any(|event| {

--- a/src/daemon/transport/tests/remote_acme.rs
+++ b/src/daemon/transport/tests/remote_acme.rs
@@ -98,6 +98,7 @@ fn daemon_remote_acme_renew_records_missing_state_failure_and_audit() {
         .ensure_success()
         .expect_err("failure renewal response must produce a command error");
     assert!(error.to_string().contains("persisted ACME state"));
+    assert!(!error.to_string().contains("did not succeed"));
 
     let events = db.load_remote_audit_events(10).expect("audit events");
     assert!(events.iter().any(|event| {


### PR DESCRIPTION
## Motivation
Remote daemon ACME state needs an operator-visible status path before real issuance and renewals are wired. Status and renewal failure reports must not expose private key material or embedded secrets.

## Implementation
- Adds DB accessors for token-safe `remote_acme_state` status and redacted renewal failure persistence.
- Wires `harness daemon remote acme status|renew` execution with JSON responses and admin-scope audit events.
- Keeps `renew` fail-closed for now by recording the missing-state or not-implemented renewal reason instead of pretending issuance succeeded.
- Adds DB, transport, parser, redaction, and audit tests for the ACME status/renew slice.
- Validated with `mise run cargo:local -- test remote_acme --lib`, `remote_cli`, `remote_identity`, `git diff --check`, and `mise run harness:check`.