### PR TITLE
feat(daemon): install remote systemd service

### DIFF
--- a/src/daemon/transport/mod.rs
+++ b/src/daemon/transport/mod.rs
@@ -3,6 +3,8 @@ mod control;
 mod remote;
 mod remote_acme;
 mod remote_clients;
+mod remote_systemd;
+mod remote_systemd_lifecycle;
 #[cfg(test)]
 mod tests;
 

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -19,6 +19,7 @@ use crate::errors::{CliError, CliErrorKind};
 use crate::workspace::utc_now;
 
 use super::control::{adopt_daemon_root_for_transport_command, print_json};
+use super::remote_systemd::{DaemonRemoteSystemdArgs, DaemonRemoteSystemdInstallArgs};
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum DaemonRemoteCommand {
@@ -42,7 +43,7 @@ pub enum DaemonRemoteCommand {
     /// Run remote daemon diagnostics.
     Doctor,
     /// Install a hardened Linux systemd service.
-    InstallSystemd(DaemonRemoteSystemdArgs),
+    InstallSystemd(DaemonRemoteSystemdInstallArgs),
     /// Remove the Linux systemd service.
     UninstallSystemd(DaemonRemoteSystemdArgs),
     /// Show Linux systemd service status.
@@ -59,10 +60,10 @@ impl Execute for DaemonRemoteCommand {
                 args.remote_auth_scaffold_config()?;
                 Err(remote_execution_reserved_error())
             }
-            Self::Doctor
-            | Self::InstallSystemd(_)
-            | Self::UninstallSystemd(_)
-            | Self::Status(_) => Err(remote_execution_reserved_error()),
+            Self::InstallSystemd(args) => args.execute(context),
+            Self::UninstallSystemd(args) => args.uninstall(context),
+            Self::Status(args) => args.status(context),
+            Self::Doctor => Err(remote_execution_reserved_error()),
         }
     }
 }
@@ -287,13 +288,6 @@ pub enum DaemonRemoteAcmeCommand {
     Status,
     /// Renew the active certificate.
     Renew,
-}
-
-#[derive(Debug, Clone, Args)]
-pub struct DaemonRemoteSystemdArgs {
-    /// systemd unit name.
-    #[arg(long, default_value = "harness-remote-daemon")]
-    pub unit: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -11,8 +11,8 @@ use crate::errors::{CliError, CliErrorKind};
 use super::control::print_json;
 use super::remote::DaemonRemoteServeArgs;
 use super::remote_systemd_lifecycle::{
-    RemoteSystemdInstallReport, install_remote_systemd_with, run_systemctl, unit_service_name,
-    uninstall_remote_systemd_with, validate_unit_name,
+    RemoteSystemdInstallReport, install_remote_systemd_with, normalize_unit_name, run_systemctl,
+    unit_service_name, uninstall_remote_systemd_with, validate_unit_name,
 };
 
 const DEFAULT_UNIT: &str = "harness-remote-daemon";
@@ -184,19 +184,20 @@ impl RemoteSystemdInstallPlan {
         unit_path: PathBuf,
         env_path: PathBuf,
     ) -> Result<Self, CliError> {
-        validate_unit_name(&args.systemd.unit)?;
+        let unit = normalize_unit_name(&args.systemd.unit);
+        validate_unit_name(unit)?;
         let serve_config = args.serve.contract_config()?;
         let needs_bind_capability = serve_config.https_port < 1024 || serve_config.http_port < 1024;
         let unit_contents = render_unit(
-            &args.systemd.unit,
+            unit,
             &binary_path,
             &env_path,
             &serve_config,
             needs_bind_capability,
         );
-        let env_contents = render_env_file(&args.systemd.unit);
+        let env_contents = render_env_file(unit);
         Ok(Self {
-            unit: args.systemd.unit.clone(),
+            unit: unit.to_string(),
             binary_path,
             unit_path,
             env_path,
@@ -352,7 +353,7 @@ fn default_unit_path(unit: &str) -> PathBuf {
 }
 
 fn default_env_path(unit: &str) -> PathBuf {
-    let unit = unit.strip_suffix(".service").unwrap_or(unit);
+    let unit = normalize_unit_name(unit);
     Path::new(SYSTEMD_ENV_DIR).join(format!("{unit}.env"))
 }
 

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -5,6 +5,7 @@ use clap::Args;
 use serde::Serialize;
 
 use crate::app::command_context::{AppContext, Execute};
+use crate::daemon::remote::RemoteDaemonServeConfig;
 use crate::errors::{CliError, CliErrorKind};
 
 use super::control::print_json;
@@ -30,6 +31,9 @@ pub struct DaemonRemoteSystemdArgs {
     /// systemd unit name.
     #[arg(long, default_value = DEFAULT_UNIT)]
     pub unit: String,
+    /// Path for the `EnvironmentFile` referenced by the service unit.
+    #[arg(long)]
+    pub env_file: Option<PathBuf>,
     /// Output as JSON.
     #[arg(long)]
     pub json: bool,
@@ -88,7 +92,7 @@ impl DaemonRemoteSystemdArgs {
     pub fn uninstall(&self, _context: &AppContext) -> Result<i32, CliError> {
         ensure_linux_systemd()?;
         let unit_path = default_unit_path(&self.unit);
-        let env_path = default_env_path(&self.unit);
+        let env_path = self.env_path();
         let report =
             uninstall_remote_systemd_with(&self.unit, &unit_path, &env_path, &run_systemctl)?;
         if self.json {
@@ -110,6 +114,7 @@ impl DaemonRemoteSystemdArgs {
         let output = run_systemctl(&["status".to_string(), unit_service_name(&self.unit)])?;
         let response = RemoteSystemdStatusResponse {
             unit: self.unit.clone(),
+            env_path: self.env_path(),
             exit_code: output.exit_code,
             stdout: output.stdout,
             stderr: output.stderr,
@@ -121,6 +126,14 @@ impl DaemonRemoteSystemdArgs {
             eprint!("{}", response.stderr);
         }
         Ok(response.exit_code)
+    }
+}
+
+impl DaemonRemoteSystemdArgs {
+    fn env_path(&self) -> PathBuf {
+        self.env_file
+            .clone()
+            .unwrap_or_else(|| default_env_path(&self.unit))
     }
 }
 
@@ -168,7 +181,7 @@ impl RemoteSystemdInstallPlan {
             &args.systemd.unit,
             &binary_path,
             &env_path,
-            args,
+            &serve_config,
             needs_bind_capability,
         );
         let env_contents = render_env_file(&args.systemd.unit);
@@ -207,6 +220,7 @@ struct RemoteSystemdInstallResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct RemoteSystemdStatusResponse {
     unit: String,
+    env_path: PathBuf,
     exit_code: i32,
     stdout: String,
     stderr: String,
@@ -255,10 +269,10 @@ fn render_unit(
     unit: &str,
     binary_path: &Path,
     env_path: &Path,
-    args: &DaemonRemoteSystemdInstallArgs,
+    serve_config: &RemoteDaemonServeConfig,
     needs_bind_capability: bool,
 ) -> String {
-    let exec_start = shell_words::join(remote_serve_command(binary_path, &args.serve));
+    let exec_start = shell_words::join(remote_serve_command(binary_path, serve_config));
     let mut contents = format!(
         "[Unit]\n\
          Description=Harness remote daemon\n\
@@ -293,26 +307,26 @@ fn render_unit(
     contents
 }
 
-fn remote_serve_command(binary_path: &Path, args: &DaemonRemoteServeArgs) -> Vec<String> {
+fn remote_serve_command(binary_path: &Path, config: &RemoteDaemonServeConfig) -> Vec<String> {
     let mut command = vec![
         binary_path.display().to_string(),
         "daemon".to_string(),
         "remote".to_string(),
         "serve".to_string(),
         "--domain".to_string(),
-        args.domain.clone(),
+        config.domain.clone(),
         "--host".to_string(),
-        args.host.clone(),
+        config.host.clone(),
         "--https-port".to_string(),
-        args.https_port.to_string(),
+        config.https_port.to_string(),
         "--http-port".to_string(),
-        args.http_port.to_string(),
+        config.http_port.to_string(),
         "--acme-email".to_string(),
-        args.acme_email.clone(),
+        config.acme_email.clone(),
         "--acme-challenge".to_string(),
-        args.acme_challenge.as_str().to_string(),
+        config.acme_challenge.as_str().to_string(),
     ];
-    if let Some(provider) = args.acme_dns_provider {
+    if let Some(provider) = config.acme_dns_provider {
         command.push("--acme-dns-provider".to_string());
         command.push(provider.as_str().to_string());
     }

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -187,6 +187,8 @@ impl RemoteSystemdInstallPlan {
         let unit = normalize_unit_name(&args.systemd.unit);
         validate_unit_name(unit)?;
         let serve_config = args.serve.contract_config()?;
+        validate_systemd_directive_path("binary", &binary_path)?;
+        validate_systemd_directive_path("environment", &env_path)?;
         let needs_bind_capability = serve_config.https_port < 1024 || serve_config.http_port < 1024;
         let unit_contents = render_unit(
             unit,
@@ -299,6 +301,7 @@ fn render_unit(
          Restart=on-failure\n\
          RestartSec=5s\n\
          NoNewPrivileges=true\n\
+         DynamicUser=yes\n\
          PrivateTmp=true\n\
          ProtectSystem=strict\n\
          ProtectHome=true\n\
@@ -342,6 +345,22 @@ fn remote_serve_command(binary_path: &Path, config: &RemoteDaemonServeConfig) ->
         command.push(provider.as_str().to_string());
     }
     command
+}
+
+fn validate_systemd_directive_path(label: &str, path: &Path) -> Result<(), CliError> {
+    if path
+        .as_os_str()
+        .to_string_lossy()
+        .chars()
+        .any(char::is_whitespace)
+    {
+        return Err(CliErrorKind::workflow_parse(format!(
+            "systemd {label} path contains whitespace: {}",
+            path.display()
+        ))
+        .into());
+    }
+    Ok(())
 }
 
 fn render_env_file(unit: &str) -> String {

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -285,7 +285,7 @@ fn render_unit(
     serve_config: &RemoteDaemonServeConfig,
     needs_bind_capability: bool,
 ) -> String {
-    let exec_start = shell_words::join(remote_serve_command(binary_path, serve_config));
+    let exec_start = render_systemd_exec_start(&remote_serve_command(binary_path, serve_config));
     let mut contents = format!(
         "[Unit]\n\
          Description=Harness remote daemon\n\
@@ -348,6 +348,13 @@ fn remote_serve_command(binary_path: &Path, config: &RemoteDaemonServeConfig) ->
 }
 
 fn validate_systemd_directive_path(label: &str, path: &Path) -> Result<(), CliError> {
+    if !path.is_absolute() {
+        return Err(CliErrorKind::workflow_parse(format!(
+            "systemd {label} path must be absolute: {}",
+            path.display()
+        ))
+        .into());
+    }
     if path
         .as_os_str()
         .to_string_lossy()
@@ -361,6 +368,38 @@ fn validate_systemd_directive_path(label: &str, path: &Path) -> Result<(), CliEr
         .into());
     }
     Ok(())
+}
+
+fn render_systemd_exec_start(command: &[String]) -> String {
+    command
+        .iter()
+        .map(|argument| render_systemd_exec_argument(argument))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn render_systemd_exec_argument(argument: &str) -> String {
+    if !argument.is_empty() && argument.chars().all(is_systemd_bare_exec_char) {
+        return argument.to_string();
+    }
+    let mut quoted = String::with_capacity(argument.len() + 2);
+    quoted.push('"');
+    for character in argument.chars() {
+        match character {
+            '"' | '\\' => {
+                quoted.push('\\');
+                quoted.push(character);
+            }
+            '%' => quoted.push_str("%%"),
+            _ => quoted.push(character),
+        }
+    }
+    quoted.push('"');
+    quoted
+}
+
+fn is_systemd_bare_exec_char(character: char) -> bool {
+    !character.is_whitespace() && !matches!(character, '"' | '\'' | '\\')
 }
 
 fn render_env_file(unit: &str) -> String {

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -110,6 +110,7 @@ impl DaemonRemoteSystemdArgs {
     /// # Errors
     /// Returns [`CliError`] when Linux systemd is unavailable or status execution fails.
     pub fn status(&self, _context: &AppContext) -> Result<i32, CliError> {
+        self.validate()?;
         ensure_linux_systemd()?;
         let output = run_systemctl(&["status".to_string(), unit_service_name(&self.unit)])?;
         let response = RemoteSystemdStatusResponse {
@@ -130,10 +131,19 @@ impl DaemonRemoteSystemdArgs {
 }
 
 impl DaemonRemoteSystemdArgs {
+    fn validate(&self) -> Result<(), CliError> {
+        validate_unit_name(&self.unit)
+    }
+
     fn env_path(&self) -> PathBuf {
         self.env_file
             .clone()
             .unwrap_or_else(|| default_env_path(&self.unit))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn validate_for_tests(&self) -> Result<(), CliError> {
+        self.validate()
     }
 }
 
@@ -342,7 +352,13 @@ fn default_unit_path(unit: &str) -> PathBuf {
 }
 
 fn default_env_path(unit: &str) -> PathBuf {
+    let unit = unit.strip_suffix(".service").unwrap_or(unit);
     Path::new(SYSTEMD_ENV_DIR).join(format!("{unit}.env"))
+}
+
+#[cfg(test)]
+pub(crate) fn default_env_path_for_tests(unit: &str) -> PathBuf {
+    default_env_path(unit)
 }
 
 fn ensure_linux_systemd() -> Result<(), CliError> {

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -1,0 +1,343 @@
+use std::env::current_exe;
+use std::path::{Path, PathBuf};
+
+use clap::Args;
+use serde::Serialize;
+
+use crate::app::command_context::{AppContext, Execute};
+use crate::errors::{CliError, CliErrorKind};
+
+use super::control::print_json;
+use super::remote::DaemonRemoteServeArgs;
+use super::remote_systemd_lifecycle::{
+    RemoteSystemdInstallReport, install_remote_systemd_with, run_systemctl, unit_service_name,
+    uninstall_remote_systemd_with, validate_unit_name,
+};
+
+const DEFAULT_UNIT: &str = "harness-remote-daemon";
+const SYSTEMD_UNIT_DIR: &str = "/etc/systemd/system";
+const SYSTEMD_ENV_DIR: &str = "/etc/harness";
+
+#[derive(Debug, Clone, Args)]
+pub struct DaemonRemoteSystemdUnitArgs {
+    /// systemd unit name.
+    #[arg(long, default_value = DEFAULT_UNIT)]
+    pub unit: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct DaemonRemoteSystemdArgs {
+    /// systemd unit name.
+    #[arg(long, default_value = DEFAULT_UNIT)]
+    pub unit: String,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct DaemonRemoteSystemdInstallArgs {
+    #[command(flatten)]
+    pub serve: DaemonRemoteServeArgs,
+    #[command(flatten)]
+    pub systemd: DaemonRemoteSystemdUnitArgs,
+    /// Explicit path to the harness binary. Defaults to the current executable.
+    #[arg(long)]
+    pub binary_path: Option<PathBuf>,
+    /// Path for the `EnvironmentFile` referenced by the service unit.
+    #[arg(long)]
+    pub env_file: Option<PathBuf>,
+    /// Render and report the install plan without writing files or calling systemctl.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for DaemonRemoteSystemdInstallArgs {
+    fn execute(&self, _context: &AppContext) -> Result<i32, CliError> {
+        let binary = self.resolve_binary_path()?;
+        let unit_path = default_unit_path(&self.systemd.unit);
+        let env_path = self
+            .env_file
+            .clone()
+            .unwrap_or_else(|| default_env_path(&self.systemd.unit));
+        let plan = RemoteSystemdInstallPlan::new(self, binary, unit_path, env_path)?;
+
+        if self.dry_run {
+            print_install_response(&RemoteSystemdInstallResponse::dry_run(plan), self.json)?;
+            return Ok(0);
+        }
+        ensure_linux_systemd()?;
+
+        let report = install_remote_systemd_with(&plan, &run_systemctl)?;
+        print_install_response(
+            &RemoteSystemdInstallResponse::applied(plan, report),
+            self.json,
+        )?;
+        Ok(0)
+    }
+}
+
+impl DaemonRemoteSystemdArgs {
+    /// Remove a remote daemon systemd unit and its environment file.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when Linux systemd is unavailable or file removal fails.
+    pub fn uninstall(&self, _context: &AppContext) -> Result<i32, CliError> {
+        ensure_linux_systemd()?;
+        let unit_path = default_unit_path(&self.unit);
+        let env_path = default_env_path(&self.unit);
+        let report =
+            uninstall_remote_systemd_with(&self.unit, &unit_path, &env_path, &run_systemctl)?;
+        if self.json {
+            print_json(&report)?;
+        } else if report.unit_removed || report.env_removed {
+            println!("removed {}", self.unit);
+        } else {
+            println!("not installed");
+        }
+        Ok(0)
+    }
+
+    /// Show the current systemd status for the remote daemon unit.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when Linux systemd is unavailable or status execution fails.
+    pub fn status(&self, _context: &AppContext) -> Result<i32, CliError> {
+        ensure_linux_systemd()?;
+        let output = run_systemctl(&["status".to_string(), unit_service_name(&self.unit)])?;
+        let response = RemoteSystemdStatusResponse {
+            unit: self.unit.clone(),
+            exit_code: output.exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        };
+        if self.json {
+            print_json(&response)?;
+        } else {
+            print!("{}", response.stdout);
+            eprint!("{}", response.stderr);
+        }
+        Ok(response.exit_code)
+    }
+}
+
+impl DaemonRemoteSystemdInstallArgs {
+    fn resolve_binary_path(&self) -> Result<PathBuf, CliError> {
+        self.binary_path.clone().map_or_else(
+            || {
+                current_exe().map_err(|error| {
+                    CliError::from(CliErrorKind::workflow_io(format!(
+                        "resolve current harness binary: {error}"
+                    )))
+                })
+            },
+            Ok,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemoteSystemdInstallPlan {
+    pub unit: String,
+    pub binary_path: PathBuf,
+    pub unit_path: PathBuf,
+    pub env_path: PathBuf,
+    pub unit_contents: String,
+    pub env_contents: String,
+    pub needs_bind_capability: bool,
+}
+
+impl RemoteSystemdInstallPlan {
+    /// Build a validated install plan for production execution.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the remote serve contract is invalid or the unit is unsafe.
+    pub(crate) fn new(
+        args: &DaemonRemoteSystemdInstallArgs,
+        binary_path: PathBuf,
+        unit_path: PathBuf,
+        env_path: PathBuf,
+    ) -> Result<Self, CliError> {
+        validate_unit_name(&args.systemd.unit)?;
+        let serve_config = args.serve.contract_config()?;
+        let needs_bind_capability = serve_config.https_port < 1024 || serve_config.http_port < 1024;
+        let unit_contents = render_unit(
+            &args.systemd.unit,
+            &binary_path,
+            &env_path,
+            args,
+            needs_bind_capability,
+        );
+        let env_contents = render_env_file(&args.systemd.unit);
+        Ok(Self {
+            unit: args.systemd.unit.clone(),
+            binary_path,
+            unit_path,
+            env_path,
+            unit_contents,
+            env_contents,
+            needs_bind_capability,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_tests(
+        args: &DaemonRemoteSystemdInstallArgs,
+        binary_path: PathBuf,
+        unit_path: PathBuf,
+        env_path: PathBuf,
+    ) -> Result<Self, CliError> {
+        Self::new(args, binary_path, unit_path, env_path)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RemoteSystemdInstallResponse {
+    unit: String,
+    unit_path: PathBuf,
+    env_path: PathBuf,
+    needs_bind_capability: bool,
+    dry_run: bool,
+    applied: Option<RemoteSystemdInstallReport>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RemoteSystemdStatusResponse {
+    unit: String,
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+impl RemoteSystemdInstallResponse {
+    fn dry_run(plan: RemoteSystemdInstallPlan) -> Self {
+        Self::from_plan(plan, true, None)
+    }
+
+    fn applied(plan: RemoteSystemdInstallPlan, report: RemoteSystemdInstallReport) -> Self {
+        Self::from_plan(plan, false, Some(report))
+    }
+
+    fn from_plan(
+        plan: RemoteSystemdInstallPlan,
+        dry_run: bool,
+        applied: Option<RemoteSystemdInstallReport>,
+    ) -> Self {
+        Self {
+            unit: plan.unit,
+            unit_path: plan.unit_path,
+            env_path: plan.env_path,
+            needs_bind_capability: plan.needs_bind_capability,
+            dry_run,
+            applied,
+        }
+    }
+}
+
+fn print_install_response(
+    response: &RemoteSystemdInstallResponse,
+    json: bool,
+) -> Result<(), CliError> {
+    if json {
+        print_json(response)?;
+    } else if response.dry_run {
+        println!("{}", response.unit_path.display());
+    } else {
+        println!("installed {}", response.unit);
+    }
+    Ok(())
+}
+
+fn render_unit(
+    unit: &str,
+    binary_path: &Path,
+    env_path: &Path,
+    args: &DaemonRemoteSystemdInstallArgs,
+    needs_bind_capability: bool,
+) -> String {
+    let exec_start = shell_words::join(remote_serve_command(binary_path, &args.serve));
+    let mut contents = format!(
+        "[Unit]\n\
+         Description=Harness remote daemon\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         EnvironmentFile={}\n\
+         Environment=HARNESS_DAEMON_DATA_HOME=%S/{unit}\n\
+         Environment=HARNESS_DAEMON_OWNERSHIP=external\n\
+         ExecStart={exec_start}\n\
+         Restart=on-failure\n\
+         RestartSec=5s\n\
+         NoNewPrivileges=true\n\
+         PrivateTmp=true\n\
+         ProtectSystem=strict\n\
+         ProtectHome=true\n\
+         RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX\n\
+         StateDirectory={unit}\n\
+         StateDirectoryMode=0700\n\
+         UMask=0077\n",
+        env_path.display()
+    );
+    if needs_bind_capability {
+        contents.push_str(
+            "AmbientCapabilities=CAP_NET_BIND_SERVICE\n\
+             CapabilityBoundingSet=CAP_NET_BIND_SERVICE\n",
+        );
+    }
+    contents.push_str("\n[Install]\nWantedBy=multi-user.target\n");
+    contents
+}
+
+fn remote_serve_command(binary_path: &Path, args: &DaemonRemoteServeArgs) -> Vec<String> {
+    let mut command = vec![
+        binary_path.display().to_string(),
+        "daemon".to_string(),
+        "remote".to_string(),
+        "serve".to_string(),
+        "--domain".to_string(),
+        args.domain.clone(),
+        "--host".to_string(),
+        args.host.clone(),
+        "--https-port".to_string(),
+        args.https_port.to_string(),
+        "--http-port".to_string(),
+        args.http_port.to_string(),
+        "--acme-email".to_string(),
+        args.acme_email.clone(),
+        "--acme-challenge".to_string(),
+        args.acme_challenge.as_str().to_string(),
+    ];
+    if let Some(provider) = args.acme_dns_provider {
+        command.push("--acme-dns-provider".to_string());
+        command.push(provider.as_str().to_string());
+    }
+    command
+}
+
+fn render_env_file(unit: &str) -> String {
+    format!("# harness remote daemon environment for {unit}\n")
+}
+
+fn default_unit_path(unit: &str) -> PathBuf {
+    Path::new(SYSTEMD_UNIT_DIR).join(unit_service_name(unit))
+}
+
+fn default_env_path(unit: &str) -> PathBuf {
+    Path::new(SYSTEMD_ENV_DIR).join(format!("{unit}.env"))
+}
+
+fn ensure_linux_systemd() -> Result<(), CliError> {
+    if cfg!(target_os = "linux") {
+        Ok(())
+    } else {
+        Err(
+            CliErrorKind::workflow_io("remote daemon systemd lifecycle requires Linux".to_string())
+                .into(),
+        )
+    }
+}

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -415,7 +415,7 @@ fn render_systemd_exec_argument(argument: &str) -> String {
 }
 
 fn is_systemd_bare_exec_char(character: char) -> bool {
-    !character.is_whitespace() && !matches!(character, '"' | '\'' | '\\')
+    !character.is_whitespace() && !matches!(character, '"' | '%' | '\'' | '\\')
 }
 
 fn render_env_file(unit: &str) -> String {

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -189,6 +189,9 @@ impl RemoteSystemdInstallPlan {
         let serve_config = args.serve.contract_config()?;
         validate_systemd_directive_path("binary", &binary_path)?;
         validate_systemd_directive_path("environment", &env_path)?;
+        validate_systemd_exec_value("domain", &serve_config.domain)?;
+        validate_systemd_exec_value("host", &serve_config.host)?;
+        validate_systemd_exec_value("acme email", &serve_config.acme_email)?;
         let needs_bind_capability = serve_config.https_port < 1024 || serve_config.http_port < 1024;
         let unit_contents = render_unit(
             unit,
@@ -348,6 +351,7 @@ fn remote_serve_command(binary_path: &Path, config: &RemoteDaemonServeConfig) ->
 }
 
 fn validate_systemd_directive_path(label: &str, path: &Path) -> Result<(), CliError> {
+    let rendered = path.as_os_str().to_string_lossy();
     if !path.is_absolute() {
         return Err(CliErrorKind::workflow_parse(format!(
             "systemd {label} path must be absolute: {}",
@@ -355,15 +359,27 @@ fn validate_systemd_directive_path(label: &str, path: &Path) -> Result<(), CliEr
         ))
         .into());
     }
-    if path
-        .as_os_str()
-        .to_string_lossy()
-        .chars()
-        .any(char::is_whitespace)
-    {
+    if rendered.chars().any(char::is_whitespace) {
         return Err(CliErrorKind::workflow_parse(format!(
             "systemd {label} path contains whitespace: {}",
             path.display()
+        ))
+        .into());
+    }
+    if rendered.contains('%') {
+        return Err(CliErrorKind::workflow_parse(format!(
+            "systemd {label} path cannot contain '%': {}",
+            path.display()
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+fn validate_systemd_exec_value(label: &str, value: &str) -> Result<(), CliError> {
+    if value.chars().any(char::is_control) {
+        return Err(CliErrorKind::workflow_parse(format!(
+            "systemd {label} contains control characters"
         ))
         .into());
     }

--- a/src/daemon/transport/remote_systemd_lifecycle.rs
+++ b/src/daemon/transport/remote_systemd_lifecycle.rs
@@ -61,11 +61,7 @@ where
     run_checked(run_systemctl, &["daemon-reload".to_string()])?;
     run_checked(
         run_systemctl,
-        &[
-            "enable".to_string(),
-            "--now".to_string(),
-            unit_service_name(&plan.unit),
-        ],
+        &["enable".to_string(), unit_service_name(&plan.unit)],
     )?;
     Ok(RemoteSystemdInstallReport {
         unit_path: plan.unit_path.clone(),
@@ -74,7 +70,7 @@ where
         env_written,
         daemon_reloaded: true,
         enabled: true,
-        started: true,
+        started: false,
     })
 }
 

--- a/src/daemon/transport/remote_systemd_lifecycle.rs
+++ b/src/daemon/transport/remote_systemd_lifecycle.rs
@@ -1,4 +1,5 @@
 use std::io::ErrorKind;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -158,14 +159,40 @@ fn write_if_changed(path: &Path, contents: &str, mode: u32) -> Result<bool, CliE
             )))
         })?;
     }
-    fs::write(path, contents).map_err(|error| {
+    write_atomic(path, contents, mode)?;
+    Ok(true)
+}
+
+fn write_atomic(path: &Path, contents: &str, mode: u32) -> Result<(), CliError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut temp = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
         CliError::from(CliErrorKind::workflow_io(format!(
-            "write {}: {error}",
+            "create temp file for {}: {error}",
             path.display()
         )))
     })?;
-    set_file_mode(path, mode)?;
-    Ok(true)
+    set_file_mode(temp.path(), mode)?;
+    temp.write_all(contents.as_bytes()).map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "write temp file for {}: {error}",
+            path.display()
+        )))
+    })?;
+    temp.flush().map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "flush temp file for {}: {error}",
+            path.display()
+        )))
+    })?;
+    temp.persist(path)
+        .map_err(|error| {
+            CliError::from(CliErrorKind::workflow_io(format!(
+                "persist {}: {}",
+                path.display(),
+                error.error
+            )))
+        })
+        .map(|_| ())
 }
 
 fn remove_if_exists(path: &Path) -> Result<bool, CliError> {

--- a/src/daemon/transport/remote_systemd_lifecycle.rs
+++ b/src/daemon/transport/remote_systemd_lifecycle.rs
@@ -43,6 +43,8 @@ pub(crate) struct RemoteSystemdUninstallReport {
     pub unit_removed: bool,
     pub env_removed: bool,
     pub disabled: bool,
+    pub disable_exit_code: Option<i32>,
+    pub disable_error: Option<String>,
     pub daemon_reloaded: bool,
 }
 
@@ -86,17 +88,20 @@ where
 {
     validate_unit_name(unit)?;
     let service = unit_service_name(unit);
-    let _ = run_systemctl(&["disable".to_string(), "--now".to_string(), service]);
+    let disable_result = run_systemctl(&["disable".to_string(), "--now".to_string(), service]);
     let unit_removed = remove_if_exists(unit_path)?;
     let env_removed = remove_if_exists(env_path)?;
     run_checked(run_systemctl, &["daemon-reload".to_string()])?;
+    let (disabled, disable_exit_code, disable_error) = disable_report(disable_result);
     Ok(RemoteSystemdUninstallReport {
         unit: unit.to_string(),
         unit_path: unit_path.to_path_buf(),
         env_path: env_path.to_path_buf(),
         unit_removed,
         env_removed,
-        disabled: true,
+        disabled,
+        disable_exit_code,
+        disable_error,
         daemon_reloaded: true,
     })
 }
@@ -170,6 +175,22 @@ fn remove_if_exists(path: &Path) -> Result<bool, CliError> {
         Err(error) => {
             Err(CliErrorKind::workflow_io(format!("remove {}: {error}", path.display())).into())
         }
+    }
+}
+
+fn disable_report(
+    result: Result<RemoteSystemdCommandOutput, CliError>,
+) -> (bool, Option<i32>, Option<String>) {
+    match result {
+        Ok(output) => {
+            let error = if output.exit_code == 0 {
+                None
+            } else {
+                Some(output.stderr.trim().to_string())
+            };
+            (output.exit_code == 0, Some(output.exit_code), error)
+        }
+        Err(error) => (false, None, Some(error.to_string())),
     }
 }
 

--- a/src/daemon/transport/remote_systemd_lifecycle.rs
+++ b/src/daemon/transport/remote_systemd_lifecycle.rs
@@ -1,0 +1,209 @@
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use fs_err as fs;
+use serde::Serialize;
+
+use crate::errors::{CliError, CliErrorKind};
+
+use super::remote_systemd::RemoteSystemdInstallPlan;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct RemoteSystemdCommandOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "CLI JSON report exposes independent systemd operation flags"
+)]
+pub(crate) struct RemoteSystemdInstallReport {
+    pub unit_path: PathBuf,
+    pub env_path: PathBuf,
+    pub unit_written: bool,
+    pub env_written: bool,
+    pub daemon_reloaded: bool,
+    pub enabled: bool,
+    pub started: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "CLI JSON report exposes independent systemd operation flags"
+)]
+pub(crate) struct RemoteSystemdUninstallReport {
+    pub unit: String,
+    pub unit_path: PathBuf,
+    pub env_path: PathBuf,
+    pub unit_removed: bool,
+    pub env_removed: bool,
+    pub disabled: bool,
+    pub daemon_reloaded: bool,
+}
+
+pub(crate) fn install_remote_systemd_with<RunSystemctl>(
+    plan: &RemoteSystemdInstallPlan,
+    run_systemctl: &RunSystemctl,
+) -> Result<RemoteSystemdInstallReport, CliError>
+where
+    RunSystemctl: Fn(&[String]) -> Result<RemoteSystemdCommandOutput, CliError>,
+{
+    let unit_written = write_if_changed(&plan.unit_path, &plan.unit_contents, 0o644)?;
+    let env_written = write_if_changed(&plan.env_path, &plan.env_contents, 0o600)?;
+    run_checked(run_systemctl, &["daemon-reload".to_string()])?;
+    run_checked(
+        run_systemctl,
+        &[
+            "enable".to_string(),
+            "--now".to_string(),
+            unit_service_name(&plan.unit),
+        ],
+    )?;
+    Ok(RemoteSystemdInstallReport {
+        unit_path: plan.unit_path.clone(),
+        env_path: plan.env_path.clone(),
+        unit_written,
+        env_written,
+        daemon_reloaded: true,
+        enabled: true,
+        started: true,
+    })
+}
+
+pub(crate) fn uninstall_remote_systemd_with<RunSystemctl>(
+    unit: &str,
+    unit_path: &Path,
+    env_path: &Path,
+    run_systemctl: &RunSystemctl,
+) -> Result<RemoteSystemdUninstallReport, CliError>
+where
+    RunSystemctl: Fn(&[String]) -> Result<RemoteSystemdCommandOutput, CliError>,
+{
+    validate_unit_name(unit)?;
+    let service = unit_service_name(unit);
+    let _ = run_systemctl(&["disable".to_string(), "--now".to_string(), service]);
+    let unit_removed = remove_if_exists(unit_path)?;
+    let env_removed = remove_if_exists(env_path)?;
+    run_checked(run_systemctl, &["daemon-reload".to_string()])?;
+    Ok(RemoteSystemdUninstallReport {
+        unit: unit.to_string(),
+        unit_path: unit_path.to_path_buf(),
+        env_path: env_path.to_path_buf(),
+        unit_removed,
+        env_removed,
+        disabled: true,
+        daemon_reloaded: true,
+    })
+}
+
+pub(super) fn run_systemctl(args: &[String]) -> Result<RemoteSystemdCommandOutput, CliError> {
+    let output = Command::new("systemctl")
+        .args(args)
+        .output()
+        .map_err(|error| {
+            CliError::from(CliErrorKind::workflow_io(format!(
+                "run systemctl {}: {error}",
+                shell_words::join(args.iter().map(String::as_str))
+            )))
+        })?;
+    Ok(RemoteSystemdCommandOutput {
+        exit_code: output.status.code().unwrap_or(1),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+pub(super) fn unit_service_name(unit: &str) -> String {
+    if unit.ends_with(".service") {
+        unit.to_string()
+    } else {
+        format!("{unit}.service")
+    }
+}
+
+pub(super) fn validate_unit_name(unit: &str) -> Result<(), CliError> {
+    if !unit.is_empty()
+        && !unit.contains('/')
+        && !unit.contains('\\')
+        && !unit.contains("..")
+        && unit
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    {
+        return Ok(());
+    }
+    Err(CliErrorKind::workflow_parse(format!("unsafe systemd unit name '{unit}'")).into())
+}
+
+fn write_if_changed(path: &Path, contents: &str, mode: u32) -> Result<bool, CliError> {
+    if matches!(fs::read_to_string(path), Ok(existing) if existing == contents) {
+        set_file_mode(path, mode)?;
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            CliError::from(CliErrorKind::workflow_io(format!(
+                "create directory {}: {error}",
+                parent.display()
+            )))
+        })?;
+    }
+    fs::write(path, contents).map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "write {}: {error}",
+            path.display()
+        )))
+    })?;
+    set_file_mode(path, mode)?;
+    Ok(true)
+}
+
+fn remove_if_exists(path: &Path) -> Result<bool, CliError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+        Err(error) => {
+            Err(CliErrorKind::workflow_io(format!("remove {}: {error}", path.display())).into())
+        }
+    }
+}
+
+#[cfg(unix)]
+fn set_file_mode(path: &Path, mode: u32) -> Result<(), CliError> {
+    use std::fs::Permissions;
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, Permissions::from_mode(mode)).map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "set permissions {}: {error}",
+            path.display()
+        )))
+    })
+}
+
+#[cfg(not(unix))]
+fn set_file_mode(_path: &Path, _mode: u32) -> Result<(), CliError> {
+    Ok(())
+}
+
+fn run_checked<RunSystemctl>(runner: &RunSystemctl, args: &[String]) -> Result<(), CliError>
+where
+    RunSystemctl: Fn(&[String]) -> Result<RemoteSystemdCommandOutput, CliError>,
+{
+    let output = runner(args)?;
+    if output.exit_code == 0 {
+        return Ok(());
+    }
+    Err(CliErrorKind::workflow_io(format!(
+        "systemctl {} failed with exit code {}: {}",
+        shell_words::join(args.iter().map(String::as_str)),
+        output.exit_code,
+        output.stderr.trim()
+    ))
+    .into())
+}

--- a/src/daemon/transport/remote_systemd_lifecycle.rs
+++ b/src/daemon/transport/remote_systemd_lifecycle.rs
@@ -132,6 +132,10 @@ pub(super) fn unit_service_name(unit: &str) -> String {
     }
 }
 
+pub(super) fn normalize_unit_name(unit: &str) -> &str {
+    unit.strip_suffix(".service").unwrap_or(unit)
+}
+
 pub(super) fn validate_unit_name(unit: &str) -> Result<(), CliError> {
     if !unit.is_empty()
         && !unit.contains('/')

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -4,6 +4,7 @@ mod remote_acme;
 mod remote_cli;
 mod remote_clients;
 mod remote_systemd;
+mod remote_systemd_plan;
 
 use std::path::{Path, PathBuf};
 

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -3,6 +3,7 @@ mod lifecycle;
 mod remote_acme;
 mod remote_cli;
 mod remote_clients;
+mod remote_systemd;
 
 use std::path::{Path, PathBuf};
 

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -4,7 +4,9 @@ use clap::Parser;
 use tempfile::tempdir;
 
 use super::super::remote::DaemonRemoteCommand;
-use super::super::remote_systemd::{DaemonRemoteSystemdInstallArgs, RemoteSystemdInstallPlan};
+use super::super::remote_systemd::{
+    DaemonRemoteSystemdInstallArgs, RemoteSystemdInstallPlan, default_env_path_for_tests,
+};
 use super::super::remote_systemd_lifecycle::{
     RemoteSystemdCommandOutput,
     install_remote_systemd_with, uninstall_remote_systemd_with,
@@ -220,6 +222,36 @@ fn remote_systemd_high_ports_omit_bind_capability() {
 }
 
 #[test]
+fn remote_systemd_default_env_path_strips_service_suffix() {
+    assert_eq!(
+        default_env_path_for_tests("harness-remote-daemon"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env")
+    );
+    assert_eq!(
+        default_env_path_for_tests("harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env")
+    );
+}
+
+#[test]
+fn remote_systemd_status_rejects_unsafe_unit_name() {
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "status",
+        "--unit",
+        "../harness-remote-daemon",
+    ])
+    .expect("parse status")
+    .command;
+
+    let DaemonRemoteCommand::Status(args) = parsed else {
+        panic!("expected status");
+    };
+
+    assert!(args.validate_for_tests().is_err());
+}
+
+#[test]
 fn remote_systemd_uninstall_reports_disable_failure() {
     let temp = tempdir().expect("temp dir");
     let unit_path = temp.path().join("systemd").join("remote.service");
@@ -262,6 +294,10 @@ fn remote_systemd_install_writes_files_with_secret_permissions_idempotently() {
         .join("systemd")
         .join("harness-remote-daemon.service");
     let env_path = temp.path().join("harness").join("remote-daemon.env");
+    std::fs::create_dir_all(unit_path.parent().expect("unit parent")).expect("unit dir");
+    std::fs::create_dir_all(env_path.parent().expect("env parent")).expect("env dir");
+    std::fs::write(&unit_path, "stale unit").expect("write stale unit");
+    std::fs::write(&env_path, "stale env").expect("write stale env");
     let args = install_args([
         "test",
         "--domain",

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -223,6 +223,33 @@ fn remote_systemd_high_ports_omit_bind_capability() {
 
 #[test]
 fn remote_systemd_default_env_path_strips_service_suffix() {
+    let args = install_args([
+        "test",
+        "--unit",
+        "harness-remote-daemon.service",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        default_env_path_for_tests("harness-remote-daemon.service"),
+    )
+    .expect("systemd install plan");
+
+    assert_eq!(plan.unit, "harness-remote-daemon");
+    assert!(
+        plan.unit_contents
+            .contains("Environment=HARNESS_DAEMON_DATA_HOME=%S/harness-remote-daemon")
+    );
+    assert!(
+        plan.unit_contents
+            .contains("StateDirectory=harness-remote-daemon")
+    );
+    assert!(!plan.unit_contents.contains("StateDirectory=harness-remote-daemon.service"));
     assert_eq!(
         default_env_path_for_tests("harness-remote-daemon"),
         PathBuf::from("/etc/harness/harness-remote-daemon.env")

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -136,6 +136,7 @@ fn remote_systemd_unit_is_hardened_and_runs_remote_serve() {
             .contains("Environment=HARNESS_DAEMON_OWNERSHIP=external")
     );
     assert!(plan.unit_contents.contains("NoNewPrivileges=true"));
+    assert!(plan.unit_contents.contains("DynamicUser=yes"));
     assert!(plan.unit_contents.contains("PrivateTmp=true"));
     assert!(plan.unit_contents.contains("ProtectSystem=strict"));
     assert!(plan.unit_contents.contains("ProtectHome=true"));
@@ -218,6 +219,56 @@ fn remote_systemd_high_ports_omit_bind_capability() {
         !plan
             .unit_contents
             .contains("CapabilityBoundingSet=CAP_NET_BIND_SERVICE")
+    );
+}
+
+#[test]
+fn remote_systemd_rejects_binary_path_with_whitespace() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+
+    let error = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness remote"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect_err("reject whitespace in binary path");
+
+    assert!(
+        error
+            .to_string()
+            .contains("systemd binary path contains whitespace")
+    );
+}
+
+#[test]
+fn remote_systemd_rejects_env_path_with_whitespace() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+
+    let error = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/remote daemon.env"),
+    )
+    .expect_err("reject whitespace in environment path");
+
+    assert!(
+        error
+            .to_string()
+            .contains("systemd environment path contains whitespace")
     );
 }
 

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -1,0 +1,255 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use tempfile::tempdir;
+
+use super::super::remote::DaemonRemoteCommand;
+use super::super::remote_systemd::{DaemonRemoteSystemdInstallArgs, RemoteSystemdInstallPlan};
+use super::super::remote_systemd_lifecycle::{
+    RemoteSystemdCommandOutput,
+    install_remote_systemd_with, uninstall_remote_systemd_with,
+};
+
+#[derive(Debug, Parser)]
+struct DaemonRemoteCommandTestHarness {
+    #[command(subcommand)]
+    command: DaemonRemoteCommand,
+}
+
+#[test]
+fn daemon_remote_install_systemd_parses_remote_serve_contract() {
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "install-systemd",
+        "--unit",
+        "harness-remote",
+        "--binary-path",
+        "/usr/local/bin/harness",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+        "--dry-run",
+        "--json",
+    ])
+    .expect("parse install-systemd")
+    .command;
+
+    match parsed {
+        DaemonRemoteCommand::InstallSystemd(args) => {
+            assert_eq!(args.systemd.unit, "harness-remote");
+            assert_eq!(
+                args.binary_path,
+                Some(PathBuf::from("/usr/local/bin/harness"))
+            );
+            assert!(args.dry_run);
+            assert!(args.json);
+            assert_eq!(args.serve.domain, "daemon.example.com");
+            assert_eq!(args.serve.acme_email, "ops@example.com");
+        }
+        other => panic!("expected install-systemd, got {other:?}"),
+    }
+}
+
+#[test]
+fn remote_systemd_unit_is_hardened_and_runs_remote_serve() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect("systemd install plan");
+
+    assert!(plan.needs_bind_capability);
+    assert!(plan.unit_contents.contains(
+        "ExecStart=/usr/local/bin/harness daemon remote serve --domain daemon.example.com"
+    ));
+    assert!(plan.unit_contents.contains("--https-port 443"));
+    assert!(plan.unit_contents.contains("--http-port 80"));
+    assert!(plan.unit_contents.contains("--acme-email ops@example.com"));
+    assert!(plan.unit_contents.contains("--acme-challenge tls-alpn"));
+    assert!(
+        plan.unit_contents
+            .contains("EnvironmentFile=/etc/harness/harness-remote-daemon.env")
+    );
+    assert!(
+        plan.unit_contents
+            .contains("Environment=HARNESS_DAEMON_DATA_HOME=%S/harness-remote-daemon")
+    );
+    assert!(
+        plan.unit_contents
+            .contains("Environment=HARNESS_DAEMON_OWNERSHIP=external")
+    );
+    assert!(plan.unit_contents.contains("NoNewPrivileges=true"));
+    assert!(plan.unit_contents.contains("PrivateTmp=true"));
+    assert!(plan.unit_contents.contains("ProtectSystem=strict"));
+    assert!(plan.unit_contents.contains("ProtectHome=true"));
+    assert!(
+        plan.unit_contents
+            .contains("RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX")
+    );
+    assert!(
+        plan.unit_contents
+            .contains("StateDirectory=harness-remote-daemon")
+    );
+    assert!(plan.unit_contents.contains("StateDirectoryMode=0700"));
+    assert!(plan.unit_contents.contains("UMask=0077"));
+    assert!(
+        plan.unit_contents
+            .contains("AmbientCapabilities=CAP_NET_BIND_SERVICE")
+    );
+    assert!(
+        plan.unit_contents
+            .contains("CapabilityBoundingSet=CAP_NET_BIND_SERVICE")
+    );
+}
+
+#[test]
+fn remote_systemd_high_ports_omit_bind_capability() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--https-port",
+        "8443",
+        "--http-port",
+        "8080",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect("systemd install plan");
+
+    assert!(!plan.needs_bind_capability);
+    assert!(
+        !plan
+            .unit_contents
+            .contains("AmbientCapabilities=CAP_NET_BIND_SERVICE")
+    );
+    assert!(
+        !plan
+            .unit_contents
+            .contains("CapabilityBoundingSet=CAP_NET_BIND_SERVICE")
+    );
+}
+
+#[test]
+fn remote_systemd_install_writes_files_with_secret_permissions_idempotently() {
+    let temp = tempdir().expect("temp dir");
+    let unit_path = temp
+        .path()
+        .join("systemd")
+        .join("harness-remote-daemon.service");
+    let env_path = temp.path().join("harness").join("remote-daemon.env");
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        unit_path.clone(),
+        env_path.clone(),
+    )
+    .expect("systemd install plan");
+    let runner = |_args: &[String]| {
+        Ok(RemoteSystemdCommandOutput {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    };
+
+    let first = install_remote_systemd_with(&plan, &runner).expect("first install");
+    let second = install_remote_systemd_with(&plan, &runner).expect("second install");
+
+    assert!(first.unit_written);
+    assert!(first.env_written);
+    assert!(!second.unit_written);
+    assert!(!second.env_written);
+    assert_eq!(
+        std::fs::read_to_string(&unit_path).expect("unit file"),
+        plan.unit_contents
+    );
+    assert_eq!(
+        std::fs::read_to_string(&env_path).expect("env file"),
+        plan.env_contents
+    );
+    assert_secret_file_mode(&env_path);
+}
+
+#[test]
+fn remote_systemd_uninstall_is_idempotent() {
+    let temp = tempdir().expect("temp dir");
+    let unit_path = temp
+        .path()
+        .join("systemd")
+        .join("harness-remote-daemon.service");
+    let env_path = temp.path().join("harness").join("remote-daemon.env");
+    std::fs::create_dir_all(unit_path.parent().expect("unit parent")).expect("unit dir");
+    std::fs::create_dir_all(env_path.parent().expect("env parent")).expect("env dir");
+    std::fs::write(&unit_path, "unit").expect("write unit");
+    std::fs::write(&env_path, "env").expect("write env");
+    let runner = |_args: &[String]| {
+        Ok(RemoteSystemdCommandOutput {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    };
+
+    let first =
+        uninstall_remote_systemd_with("harness-remote-daemon", &unit_path, &env_path, &runner)
+            .expect("first uninstall");
+    let second =
+        uninstall_remote_systemd_with("harness-remote-daemon", &unit_path, &env_path, &runner)
+            .expect("second uninstall");
+
+    assert!(first.unit_removed);
+    assert!(first.env_removed);
+    assert!(!second.unit_removed);
+    assert!(!second.env_removed);
+}
+
+fn install_args<const N: usize>(args: [&str; N]) -> DaemonRemoteSystemdInstallArgs {
+    #[derive(Debug, Parser)]
+    struct Harness {
+        #[command(flatten)]
+        args: DaemonRemoteSystemdInstallArgs,
+    }
+
+    Harness::try_parse_from(args)
+        .expect("parse install args")
+        .args
+}
+
+#[cfg(unix)]
+fn assert_secret_file_mode(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let mode = std::fs::metadata(path)
+        .expect("env metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o600);
+}
+
+#[cfg(not(unix))]
+fn assert_secret_file_mode(_path: &std::path::Path) {}

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -52,6 +52,51 @@ fn daemon_remote_install_systemd_parses_remote_serve_contract() {
 }
 
 #[test]
+fn daemon_remote_systemd_lifecycle_parses_custom_env_file() {
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "uninstall-systemd",
+        "--unit",
+        "harness-remote",
+        "--env-file",
+        "/srv/harness/remote.env",
+        "--json",
+    ])
+    .expect("parse uninstall-systemd")
+    .command;
+
+    match parsed {
+        DaemonRemoteCommand::UninstallSystemd(args) => {
+            assert_eq!(args.unit, "harness-remote");
+            assert_eq!(args.env_file, Some(PathBuf::from("/srv/harness/remote.env")));
+            assert!(args.json);
+        }
+        other => panic!("expected uninstall-systemd, got {other:?}"),
+    }
+
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "status",
+        "--unit",
+        "harness-remote",
+        "--env-file",
+        "/srv/harness/remote.env",
+        "--json",
+    ])
+    .expect("parse status")
+    .command;
+
+    match parsed {
+        DaemonRemoteCommand::Status(args) => {
+            assert_eq!(args.unit, "harness-remote");
+            assert_eq!(args.env_file, Some(PathBuf::from("/srv/harness/remote.env")));
+            assert!(args.json);
+        }
+        other => panic!("expected status, got {other:?}"),
+    }
+}
+
+#[test]
 fn remote_systemd_unit_is_hardened_and_runs_remote_serve() {
     let args = install_args([
         "test",
@@ -113,6 +158,34 @@ fn remote_systemd_unit_is_hardened_and_runs_remote_serve() {
 }
 
 #[test]
+fn remote_systemd_execstart_uses_trimmed_remote_serve_config() {
+    let args = install_args([
+        "test",
+        "--domain",
+        " daemon.example.com ",
+        "--host",
+        " 0.0.0.0 ",
+        "--acme-email",
+        " ops@example.com ",
+    ]);
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect("systemd install plan");
+
+    assert!(
+        plan.unit_contents
+            .contains("--domain daemon.example.com --host 0.0.0.0")
+    );
+    assert!(plan.unit_contents.contains("--acme-email ops@example.com"));
+    assert!(!plan.unit_contents.contains("' daemon.example.com '"));
+    assert!(!plan.unit_contents.contains("' ops@example.com '"));
+}
+
+#[test]
 fn remote_systemd_high_ports_omit_bind_capability() {
     let args = install_args([
         "test",
@@ -144,6 +217,41 @@ fn remote_systemd_high_ports_omit_bind_capability() {
             .unit_contents
             .contains("CapabilityBoundingSet=CAP_NET_BIND_SERVICE")
     );
+}
+
+#[test]
+fn remote_systemd_uninstall_reports_disable_failure() {
+    let temp = tempdir().expect("temp dir");
+    let unit_path = temp.path().join("systemd").join("remote.service");
+    let env_path = temp.path().join("harness").join("remote.env");
+    std::fs::create_dir_all(unit_path.parent().expect("unit parent")).expect("unit dir");
+    std::fs::create_dir_all(env_path.parent().expect("env parent")).expect("env dir");
+    std::fs::write(&unit_path, "unit").expect("write unit");
+    std::fs::write(&env_path, "env").expect("write env");
+    let runner = |args: &[String]| {
+        if args.first().map(String::as_str) == Some("disable") {
+            return Ok(RemoteSystemdCommandOutput {
+                exit_code: 5,
+                stdout: String::new(),
+                stderr: "unit not loaded".to_string(),
+            });
+        }
+        Ok(RemoteSystemdCommandOutput {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    };
+
+    let report = uninstall_remote_systemd_with("remote", &unit_path, &env_path, &runner)
+        .expect("uninstall continues after disable failure");
+
+    assert!(!report.disabled);
+    assert_eq!(report.disable_exit_code, Some(5));
+    assert_eq!(report.disable_error.as_deref(), Some("unit not loaded"));
+    assert!(report.unit_removed);
+    assert!(report.env_removed);
+    assert!(report.daemon_reloaded);
 }
 
 #[test]

--- a/src/daemon/transport/tests/remote_systemd_plan.rs
+++ b/src/daemon/transport/tests/remote_systemd_plan.rs
@@ -1,0 +1,150 @@
+use std::cell::RefCell;
+use std::path::PathBuf;
+
+use clap::Parser;
+use tempfile::tempdir;
+
+use super::super::remote_systemd::{DaemonRemoteSystemdInstallArgs, RemoteSystemdInstallPlan};
+use super::super::remote_systemd_lifecycle::{
+    RemoteSystemdCommandOutput, install_remote_systemd_with,
+};
+
+#[test]
+fn remote_systemd_install_enables_without_starting_reserved_serve() {
+    let temp = tempdir().expect("temp dir");
+    let unit_path = temp
+        .path()
+        .join("systemd")
+        .join("harness-remote-daemon.service");
+    let env_path = temp.path().join("harness").join("remote-daemon.env");
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        unit_path,
+        env_path,
+    )
+    .expect("systemd install plan");
+    let calls = RefCell::new(Vec::new());
+    let runner = |args: &[String]| {
+        calls.borrow_mut().push(args.to_vec());
+        Ok(RemoteSystemdCommandOutput {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    };
+
+    let report = install_remote_systemd_with(&plan, &runner).expect("install systemd");
+
+    assert!(report.enabled);
+    assert!(!report.started);
+    assert_eq!(
+        calls.borrow().as_slice(),
+        [
+            vec!["daemon-reload".to_string()],
+            vec![
+                "enable".to_string(),
+                "harness-remote-daemon.service".to_string(),
+            ],
+        ]
+    );
+}
+
+#[test]
+fn remote_systemd_plan_rejects_relative_binary_path() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+
+    let error = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("target/debug/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect_err("reject relative binary path");
+
+    assert!(
+        error
+            .to_string()
+            .contains("systemd binary path must be absolute")
+    );
+}
+
+#[test]
+fn remote_systemd_plan_rejects_relative_env_path() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+
+    let error = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("remote-daemon.env"),
+    )
+    .expect_err("reject relative environment path");
+
+    assert!(
+        error
+            .to_string()
+            .contains("systemd environment path must be absolute")
+    );
+}
+
+#[test]
+fn remote_systemd_execstart_uses_systemd_double_quotes() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon example.com",
+        "--acme-email",
+        "ops team@example.com",
+    ]);
+
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect("systemd install plan");
+
+    assert!(
+        plan.unit_contents
+            .contains("--domain \"daemon example.com\" --host")
+    );
+    assert!(
+        plan.unit_contents
+            .contains("--acme-email \"ops team@example.com\"")
+    );
+    assert!(!plan.unit_contents.contains("'daemon example.com'"));
+    assert!(!plan.unit_contents.contains("'ops team@example.com'"));
+}
+
+fn install_args<const N: usize>(args: [&str; N]) -> DaemonRemoteSystemdInstallArgs {
+    #[derive(Debug, Parser)]
+    struct Harness {
+        #[command(flatten)]
+        args: DaemonRemoteSystemdInstallArgs,
+    }
+
+    Harness::try_parse_from(args)
+        .expect("parse install args")
+        .args
+}

--- a/src/daemon/transport/tests/remote_systemd_plan.rs
+++ b/src/daemon/transport/tests/remote_systemd_plan.rs
@@ -198,6 +198,31 @@ fn remote_systemd_execstart_uses_systemd_double_quotes() {
     assert!(!plan.unit_contents.contains("'ops team@example.com'"));
 }
 
+#[test]
+fn remote_systemd_execstart_escapes_percent_specifiers() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon%h.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect("systemd install plan");
+
+    assert!(
+        plan.unit_contents
+            .contains("--domain \"daemon%%h.example.com\" --host")
+    );
+    assert!(!plan.unit_contents.contains("--domain daemon%h.example.com"));
+}
+
 fn install_args<const N: usize>(args: [&str; N]) -> DaemonRemoteSystemdInstallArgs {
     #[derive(Debug, Parser)]
     struct Harness {

--- a/src/daemon/transport/tests/remote_systemd_plan.rs
+++ b/src/daemon/transport/tests/remote_systemd_plan.rs
@@ -108,6 +108,67 @@ fn remote_systemd_plan_rejects_relative_env_path() {
 }
 
 #[test]
+fn remote_systemd_plan_rejects_control_characters_in_remote_values() {
+    assert_control_character_rejected(
+        install_args([
+            "test",
+            "--domain",
+            "daemon\nexample.com",
+            "--acme-email",
+            "ops@example.com",
+        ]),
+        "systemd domain contains control characters",
+    );
+    assert_control_character_rejected(
+        install_args([
+            "test",
+            "--domain",
+            "daemon.example.com",
+            "--host",
+            "0.0.\r0.0",
+            "--acme-email",
+            "ops@example.com",
+        ]),
+        "systemd host contains control characters",
+    );
+    assert_control_character_rejected(
+        install_args([
+            "test",
+            "--domain",
+            "daemon.example.com",
+            "--acme-email",
+            "ops\nteam@example.com",
+        ]),
+        "systemd acme email contains control characters",
+    );
+}
+
+#[test]
+fn remote_systemd_plan_rejects_percent_in_env_path() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+
+    let error = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/remote%daemon.env"),
+    )
+    .expect_err("reject percent in environment path");
+
+    assert!(
+        error
+            .to_string()
+            .contains("systemd environment path cannot contain '%'")
+    );
+}
+
+#[test]
 fn remote_systemd_execstart_uses_systemd_double_quotes() {
     let args = install_args([
         "test",
@@ -147,4 +208,19 @@ fn install_args<const N: usize>(args: [&str; N]) -> DaemonRemoteSystemdInstallAr
     Harness::try_parse_from(args)
         .expect("parse install args")
         .args
+}
+
+fn assert_control_character_rejected(args: DaemonRemoteSystemdInstallArgs, expected: &str) {
+    let error = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect_err("reject control characters");
+
+    assert!(
+        error.to_string().contains(expected),
+        "{expected}: {error}"
+    );
 }


### PR DESCRIPTION
## Motivation
Remote daemon Linux installs need a first-class systemd path instead of leaving the CLI surface reserved.

## Implementation
- Add remote systemd install, uninstall, and status command plumbing.
- Render a hardened service unit with low-port capability handling and daemon state rooted in systemd StateDirectory.
- Add focused tests for CLI parsing, unit rendering, idempotent writes, 0600 env-file permissions, and uninstall idempotency.
- Validated with focused remote daemon tests plus `mise run check`.