### PR TITLE
feat(daemon): preflight remote serve tls

### DIFF
--- a/src/daemon/db/remote_acme.rs
+++ b/src/daemon/db/remote_acme.rs
@@ -1,7 +1,9 @@
 use rusqlite::{OptionalExtension, params, types::Type};
 
 use super::{CliError, DaemonDb, db_error};
-use crate::daemon::remote_acme::RemoteRenewalOutcome;
+use crate::daemon::remote_acme::{
+    RemoteAcmeRuntimeState, RemoteCertificateBundle, RemoteRenewalOutcome,
+};
 
 const SELECT_REMOTE_ACME_STATE_SQL: &str = "
 SELECT
@@ -17,6 +19,14 @@ SELECT
     renewal_status,
     renewal_error,
     updated_at
+FROM remote_acme_state
+WHERE singleton = 1";
+
+const SELECT_REMOTE_ACME_RUNTIME_STATE_SQL: &str = "
+SELECT
+    NULLIF(TRIM(account_id), ''),
+    certificate_pem,
+    private_key_pem
 FROM remote_acme_state
 WHERE singleton = 1";
 
@@ -62,6 +72,24 @@ impl DaemonDb {
             .ok_or_else(|| db_error("remote acme singleton state row is missing"))
     }
 
+    /// Load remote ACME account and certificate material for the TLS runtime.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL failures.
+    pub(crate) fn load_remote_acme_runtime_state(
+        &self,
+    ) -> Result<RemoteAcmeRuntimeState, CliError> {
+        self.conn
+            .query_row(
+                SELECT_REMOTE_ACME_RUNTIME_STATE_SQL,
+                [],
+                remote_acme_runtime_state_from_row,
+            )
+            .optional()
+            .map_err(|error| db_error(format!("load remote acme runtime state: {error}")))?
+            .ok_or_else(|| db_error("remote acme singleton state row is missing"))
+    }
+
     /// Persist a redacted ACME renewal failure report.
     ///
     /// # Errors
@@ -99,6 +127,26 @@ fn remote_acme_state_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Remot
         renewal_error: row.get(5)?,
         updated_at: row.get(6)?,
     })
+}
+
+fn remote_acme_runtime_state_from_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<RemoteAcmeRuntimeState> {
+    let Some(account_id) = row.get::<_, Option<String>>(0)? else {
+        return Ok(RemoteAcmeRuntimeState::default());
+    };
+    let certificate_pem = row.get::<_, Option<String>>(1)?;
+    let private_key_pem = row.get::<_, Option<String>>(2)?;
+    if let (Some(certificate_pem), Some(private_key_pem)) = (certificate_pem, private_key_pem)
+        && !certificate_pem.trim().is_empty()
+        && !private_key_pem.trim().is_empty()
+    {
+        return Ok(RemoteAcmeRuntimeState::with_account_and_certificate(
+            account_id,
+            RemoteCertificateBundle::new(&certificate_pem, &private_key_pem),
+        ));
+    }
+    Ok(RemoteAcmeRuntimeState::with_account(account_id))
 }
 
 fn parse_renewal_status_at_column(

--- a/src/daemon/db/remote_acme.rs
+++ b/src/daemon/db/remote_acme.rs
@@ -75,7 +75,8 @@ impl DaemonDb {
     /// Load remote ACME account and certificate material for the TLS runtime.
     ///
     /// # Errors
-    /// Returns [`CliError`] on SQL failures.
+    /// Returns [`CliError`] when the singleton state row is missing or SQL
+    /// loading fails.
     pub(crate) fn load_remote_acme_runtime_state(
         &self,
     ) -> Result<RemoteAcmeRuntimeState, CliError> {

--- a/src/daemon/db/tests/remote_acme.rs
+++ b/src/daemon/db/tests/remote_acme.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
+use crate::daemon::remote_acme::build_remote_acme_runtime_plan;
 
 #[test]
 fn remote_acme_state_status_hides_private_key_and_tracks_material() {
@@ -34,6 +36,60 @@ fn remote_acme_state_status_hides_private_key_and_tracks_material() {
 }
 
 #[test]
+fn remote_acme_runtime_state_loads_certificate_material_for_serve() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.conn
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'cert-pem',
+                 private_key_pem = 'key-secret',
+                 certificate_fingerprint = 'stored-fp',
+                 renewal_status = 'succeeded',
+                 renewal_error = NULL,
+                 updated_at = '2026-06-21T15:00:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed acme runtime state");
+
+    let state = db
+        .load_remote_acme_runtime_state()
+        .expect("load acme runtime state");
+    let plan = build_remote_acme_runtime_plan(&remote_serve_config(), &state)
+        .expect("runtime state should plan remote TLS serve");
+
+    assert_eq!(plan.public_https_origin(), "https://daemon.example.com");
+    assert!(plan.certificate().has_material());
+    assert_ne!(plan.certificate().fingerprint(), "stored-fp");
+}
+
+#[test]
+fn remote_acme_runtime_state_preserves_account_only_failure() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.conn
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = NULL,
+                 private_key_pem = NULL,
+                 certificate_fingerprint = NULL,
+                 updated_at = '2026-06-21T15:00:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed account-only acme state");
+
+    let state = db
+        .load_remote_acme_runtime_state()
+        .expect("load acme runtime state");
+    let error = build_remote_acme_runtime_plan(&remote_serve_config(), &state)
+        .expect_err("account-only state should fail without TLS material");
+
+    assert!(error.to_string().contains("persisted TLS certificate"));
+}
+
+#[test]
 fn remote_acme_renewal_failure_persists_redacted_report() {
     let db = DaemonDb::open_in_memory().expect("open db");
 
@@ -50,4 +106,16 @@ fn remote_acme_renewal_failure_persists_redacted_report() {
         Some("renewal failed: dns token=<redacted>&retry=1 secret=<redacted>")
     );
     assert_eq!(state.updated_at, "2026-06-21T15:01:00Z");
+}
+
+fn remote_serve_config() -> RemoteDaemonServeConfig {
+    RemoteDaemonServeConfig {
+        domain: "daemon.example.com".to_string(),
+        host: "0.0.0.0".to_string(),
+        https_port: 443,
+        http_port: 80,
+        acme_email: "ops@example.com".to_string(),
+        acme_challenge: RemoteAcmeChallenge::TlsAlpn,
+        acme_dns_provider: None,
+    }
 }

--- a/src/daemon/transport/mod.rs
+++ b/src/daemon/transport/mod.rs
@@ -3,6 +3,7 @@ mod control;
 mod remote;
 mod remote_acme;
 mod remote_clients;
+mod remote_serve;
 mod remote_systemd;
 mod remote_systemd_lifecycle;
 #[cfg(test)]

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -19,6 +19,7 @@ use crate::errors::{CliError, CliErrorKind};
 use crate::workspace::utc_now;
 
 use super::control::{adopt_daemon_root_for_transport_command, print_json};
+use super::remote_serve::execute_remote_serve;
 use super::remote_systemd::{DaemonRemoteSystemdArgs, DaemonRemoteSystemdInstallArgs};
 
 #[derive(Debug, Clone, Subcommand)]
@@ -56,10 +57,7 @@ impl Execute for DaemonRemoteCommand {
             Self::Pair { command } => command.execute(context),
             Self::Clients { command } => command.execute(context),
             Self::Acme { command } => command.execute(context),
-            Self::Serve(args) => {
-                args.remote_auth_scaffold_config()?;
-                Err(remote_execution_reserved_error())
-            }
+            Self::Serve(args) => execute_remote_serve(args),
             Self::InstallSystemd(args) => args.execute(context),
             Self::UninstallSystemd(args) => args.uninstall(context),
             Self::Status(args) => args.status(context),

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -1,5 +1,4 @@
 use crate::daemon::db::DaemonDb;
-use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::remote_acme::{RemoteAcmeRuntimePlan, build_remote_acme_runtime_plan};
 use crate::daemon::service::DaemonServeConfig;
 use crate::errors::{CliError, CliErrorKind};
@@ -34,13 +33,7 @@ pub(crate) fn build_remote_serve_execution_plan(
     let acme_state = db.load_remote_acme_runtime_state()?;
     let acme_plan = build_remote_acme_runtime_plan(&remote_config, &acme_state)
         .map_err(|error| CliError::from(CliErrorKind::workflow_parse(error.to_string())))?;
-    let service_config = DaemonServeConfig {
-        host: remote_config.host,
-        port: remote_config.https_port,
-        auth_mode: DaemonHttpAuthMode::Remote,
-        remote_domain: Some(remote_config.domain),
-        ..DaemonServeConfig::default()
-    };
+    let service_config = args.remote_auth_scaffold_config()?;
     Ok(RemoteDaemonServeExecutionPlan {
         service_config,
         acme_plan,

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -49,7 +49,7 @@ pub(crate) fn build_remote_serve_execution_plan(
 
 fn run_remote_serve_plan(plan: &RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
     Err(CliErrorKind::workflow_parse(format!(
-        "remote daemon HTTPS listener is unavailable after TLS preflight for {} on {}:{}",
+        "remote daemon HTTPS listener is not implemented yet; TLS preflight passed for {} on {}:{}",
         plan.acme_plan.public_https_origin(),
         plan.service_config.host,
         plan.service_config.port

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -1,0 +1,58 @@
+use crate::daemon::db::DaemonDb;
+use crate::daemon::http::DaemonHttpAuthMode;
+use crate::daemon::remote_acme::{RemoteAcmeRuntimePlan, build_remote_acme_runtime_plan};
+use crate::daemon::service::DaemonServeConfig;
+use crate::errors::{CliError, CliErrorKind};
+
+use super::control::adopt_daemon_root_for_transport_command;
+use super::remote::{DaemonRemoteServeArgs, open_remote_daemon_db};
+
+#[derive(Debug, Clone)]
+pub(crate) struct RemoteDaemonServeExecutionPlan {
+    pub(crate) service_config: DaemonServeConfig,
+    pub(crate) acme_plan: RemoteAcmeRuntimePlan,
+}
+
+pub(super) fn execute_remote_serve(args: &DaemonRemoteServeArgs) -> Result<i32, CliError> {
+    adopt_daemon_root_for_transport_command("daemon-remote-serve");
+    let db = open_remote_daemon_db()?;
+    let plan = build_remote_serve_execution_plan(args, &db)?;
+    run_remote_serve_plan(&plan)
+}
+
+/// Build the remote daemon serve execution plan from static CLI config and
+/// persisted ACME runtime state.
+///
+/// # Errors
+/// Returns [`CliError`] when remote config is invalid or persisted ACME TLS
+/// state is incomplete.
+pub(crate) fn build_remote_serve_execution_plan(
+    args: &DaemonRemoteServeArgs,
+    db: &DaemonDb,
+) -> Result<RemoteDaemonServeExecutionPlan, CliError> {
+    let remote_config = args.contract_config()?;
+    let acme_state = db.load_remote_acme_runtime_state()?;
+    let acme_plan = build_remote_acme_runtime_plan(&remote_config, &acme_state)
+        .map_err(|error| CliError::from(CliErrorKind::workflow_parse(error.to_string())))?;
+    let service_config = DaemonServeConfig {
+        host: remote_config.host,
+        port: remote_config.https_port,
+        auth_mode: DaemonHttpAuthMode::Remote,
+        remote_domain: Some(remote_config.domain),
+        ..DaemonServeConfig::default()
+    };
+    Ok(RemoteDaemonServeExecutionPlan {
+        service_config,
+        acme_plan,
+    })
+}
+
+fn run_remote_serve_plan(plan: &RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
+    Err(CliErrorKind::workflow_parse(format!(
+        "remote daemon HTTPS listener is unavailable after TLS preflight for {} on {}:{}",
+        plan.acme_plan.public_https_origin(),
+        plan.service_config.host,
+        plan.service_config.port
+    ))
+    .into())
+}

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -7,7 +7,7 @@ use crate::errors::{CliError, CliErrorKind};
 use super::control::adopt_daemon_root_for_transport_command;
 use super::remote::{DaemonRemoteServeArgs, open_remote_daemon_db};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct RemoteDaemonServeExecutionPlan {
     pub(crate) service_config: DaemonServeConfig,
     pub(crate) acme_plan: RemoteAcmeRuntimePlan,

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -3,6 +3,7 @@ mod lifecycle;
 mod remote_acme;
 mod remote_cli;
 mod remote_clients;
+mod remote_serve;
 mod remote_systemd;
 mod remote_systemd_plan;
 

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -48,20 +48,7 @@ fn daemon_remote_serve_execute_requires_persisted_acme_state() {
 #[test]
 fn daemon_remote_serve_execution_plan_uses_remote_auth_and_tls() {
     let db = DaemonDb::open_in_memory().expect("open db");
-    db.connection()
-        .execute(
-            "UPDATE remote_acme_state
-             SET account_id = 'acct-1',
-                 certificate_pem = 'cert-pem',
-                 private_key_pem = 'key-secret',
-                 certificate_fingerprint = 'stored-fp',
-                 renewal_status = 'succeeded',
-                 renewal_error = NULL,
-                 updated_at = '2026-06-21T15:00:00Z'
-             WHERE singleton = 1",
-            [],
-        )
-        .expect("seed acme state");
+    seed_acme_state(&db);
 
     let plan = build_remote_serve_execution_plan(&remote_serve_args(), &db)
         .expect("remote serve should plan from persisted TLS state");
@@ -85,6 +72,25 @@ fn daemon_remote_serve_execution_plan_uses_remote_auth_and_tls() {
     assert!(plan.acme_plan.certificate().has_material());
 }
 
+#[test]
+fn daemon_remote_serve_execute_reports_explicit_unimplemented_listener() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    with_isolated_harness_env(temp.path(), || {
+        state::ensure_daemon_dirs().expect("daemon dirs");
+        let db = DaemonDb::open(&state::daemon_root().join("harness.db")).expect("open daemon db");
+        seed_acme_state(&db);
+        let command = DaemonRemoteCommand::Serve(remote_serve_args());
+
+        let error = command
+            .execute(&AppContext)
+            .expect_err("remote serve should fail before listener implementation");
+        let message = error.to_string();
+
+        assert!(message.contains("not implemented yet"));
+        assert!(message.contains("TLS preflight passed"));
+    });
+}
+
 fn remote_serve_args() -> DaemonRemoteServeArgs {
     DaemonRemoteServeArgsTestHarness::try_parse_from([
         "test",
@@ -95,4 +101,21 @@ fn remote_serve_args() -> DaemonRemoteServeArgs {
     ])
     .expect("parse remote serve args")
     .args
+}
+
+fn seed_acme_state(db: &DaemonDb) {
+    db.connection()
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'cert-pem',
+                 private_key_pem = 'key-secret',
+                 certificate_fingerprint = 'stored-fp',
+                 renewal_status = 'succeeded',
+                 renewal_error = NULL,
+                 updated_at = '2026-06-21T15:00:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed acme state");
 }

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -20,8 +20,10 @@ fn daemon_remote_serve_execution_plan_requires_persisted_acme_state() {
     let db = DaemonDb::open_in_memory().expect("open db");
     let args = remote_serve_args();
 
-    let error = build_remote_serve_execution_plan(&args, &db)
-        .expect_err("remote serve should fail closed without persisted ACME state");
+    let error = match build_remote_serve_execution_plan(&args, &db) {
+        Ok(_) => panic!("remote serve should fail closed without persisted ACME state"),
+        Err(error) => error,
+    };
     let message = error.to_string();
 
     assert!(message.contains("persisted ACME state"));

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -1,0 +1,98 @@
+use clap::Parser;
+use harness_testkit::with_isolated_harness_env;
+
+use crate::app::command_context::{AppContext, Execute};
+use crate::daemon::db::DaemonDb;
+use crate::daemon::http::DaemonHttpAuthMode;
+use crate::daemon::state;
+
+use super::super::remote::{DaemonRemoteCommand, DaemonRemoteServeArgs};
+use super::super::remote_serve::build_remote_serve_execution_plan;
+
+#[derive(Debug, Parser)]
+struct DaemonRemoteServeArgsTestHarness {
+    #[command(flatten)]
+    args: DaemonRemoteServeArgs,
+}
+
+#[test]
+fn daemon_remote_serve_execution_plan_requires_persisted_acme_state() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let args = remote_serve_args();
+
+    let error = build_remote_serve_execution_plan(&args, &db)
+        .expect_err("remote serve should fail closed without persisted ACME state");
+    let message = error.to_string();
+
+    assert!(message.contains("persisted ACME state"));
+    assert!(!message.contains("reserved"));
+}
+
+#[test]
+fn daemon_remote_serve_execute_requires_persisted_acme_state() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    with_isolated_harness_env(temp.path(), || {
+        state::ensure_daemon_dirs().expect("daemon dirs");
+        let command = DaemonRemoteCommand::Serve(remote_serve_args());
+
+        let error = command
+            .execute(&AppContext)
+            .expect_err("remote serve should fail closed before starting");
+        let message = error.to_string();
+
+        assert!(message.contains("persisted ACME state"));
+        assert!(!message.contains("reserved"));
+    });
+}
+
+#[test]
+fn daemon_remote_serve_execution_plan_uses_remote_auth_and_tls() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.connection()
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'cert-pem',
+                 private_key_pem = 'key-secret',
+                 certificate_fingerprint = 'stored-fp',
+                 renewal_status = 'succeeded',
+                 renewal_error = NULL,
+                 updated_at = '2026-06-21T15:00:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed acme state");
+
+    let plan = build_remote_serve_execution_plan(&remote_serve_args(), &db)
+        .expect("remote serve should plan from persisted TLS state");
+
+    assert_eq!(plan.service_config.host, "0.0.0.0");
+    assert_eq!(plan.service_config.port, 443);
+    assert_eq!(plan.service_config.auth_mode, DaemonHttpAuthMode::Remote);
+    assert_eq!(
+        plan.service_config.remote_domain.as_deref(),
+        Some("daemon.example.com")
+    );
+    assert_eq!(
+        plan.acme_plan.public_https_origin(),
+        "https://daemon.example.com"
+    );
+    assert_eq!(
+        plan.acme_plan.public_wss_url(),
+        "wss://daemon.example.com/v1/ws"
+    );
+    assert!(plan.acme_plan.uses_rustls_https());
+    assert!(plan.acme_plan.certificate().has_material());
+}
+
+fn remote_serve_args() -> DaemonRemoteServeArgs {
+    DaemonRemoteServeArgsTestHarness::try_parse_from([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ])
+    .expect("parse remote serve args")
+    .args
+}


### PR DESCRIPTION
## Motivation

Remote daemon serve still returned the reserved implementation error before it checked persisted ACME/TLS state. That kept the public command path from exercising the fail-closed TLS preflight required before a remote listener can exist.

## Implementation

- Load runtime ACME account and certificate material separately from the redacted status API.
- Add a remote serve execution plan that combines remote-auth service config with the persisted ACME runtime plan.
- Route `harness daemon remote serve` through the preflight path so missing ACME state fails closed instead of hitting the placeholder.
- Add focused DB, planning, and command-path tests for the new behavior.
