### PR TITLE
feat(remote): serve daemon over tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,6 +3626,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ shell-words = "1.1.0"
 regex = "1.11.1"
 ssh-key = { version = "0.7.0-rc.10", features = ["crypto", "encryption"] }
 tokio = { version = "1.50.0", features = ["rt-multi-thread", "time", "process", "io-std", "io-util", "sync", "macros", "net", "tracing", "test-util"] }
+tokio-rustls = "0.26.4"
 tokio-util = { version = "0.7.18", features = ["compat"] }
 console-subscriber = { version = "0.5", optional = true }
 reqwest = { version = "0.13.2", features = ["json"] }

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
@@ -7,9 +8,11 @@ use std::time::Instant;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::MatchedPath;
+use axum::extract::connect_info::Connected;
 use axum::http::Request;
 use axum::middleware::{self, Next};
 use axum::response::Response;
+use axum::serve::{IncomingStream, Listener};
 use tokio::net::TcpListener;
 #[cfg(test)]
 use tokio::runtime::{Handle, RuntimeFlavor};
@@ -23,8 +26,8 @@ use crate::daemon::agent_acp::AcpAgentManagerHandle;
 use crate::daemon::agent_tui::AgentTuiManagerHandle;
 use crate::daemon::codex_controller::CodexControllerHandle;
 use crate::daemon::db::{AsyncDaemonDb, DaemonDb, canonical_db_unavailable};
-use crate::daemon::remote_pairing::RemotePairingRateLimiter;
 use crate::daemon::protocol::StreamEvent;
+use crate::daemon::remote_pairing::RemotePairingRateLimiter;
 use crate::daemon::service::{
     WakeDispatch, register_local_clone_progress_sender, run_local_clone_gc,
 };
@@ -104,6 +107,29 @@ pub(crate) fn require_async_db<'a>(
         .get()
         .map(AsRef::as_ref)
         .ok_or_else(|| canonical_db_unavailable(operation))
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DaemonConnectInfo {
+    remote_addr: SocketAddr,
+}
+
+impl DaemonConnectInfo {
+    #[must_use]
+    pub(crate) const fn new(remote_addr: SocketAddr) -> Self {
+        Self { remote_addr }
+    }
+
+    #[must_use]
+    pub const fn remote_addr(self) -> SocketAddr {
+        self.remote_addr
+    }
+}
+
+impl Connected<IncomingStream<'_, TcpListener>> for DaemonConnectInfo {
+    fn connect_info(stream: IncomingStream<'_, TcpListener>) -> Self {
+        Self::new(*stream.remote_addr())
+    }
 }
 
 #[cfg(test)]
@@ -304,11 +330,16 @@ fn recover_poisoned_mutation_lock_map(
 ///
 /// # Errors
 /// Returns `CliError` on listener failures.
-pub async fn serve(
-    listener: TcpListener,
+pub(crate) async fn serve<L>(
+    listener: L,
     state: DaemonHttpState,
     mut shutdown_rx: watch::Receiver<bool>,
-) -> Result<(), CliError> {
+) -> Result<(), CliError>
+where
+    L: Listener<Addr = SocketAddr>,
+    L::Addr: Debug,
+    for<'a> DaemonConnectInfo: Connected<IncomingStream<'a, L>>,
+{
     // Hand the broadcast sender to the reviews files module so
     // local-clone progress events surface on the same WS push channel.
     register_local_clone_progress_sender(state.sender.clone());
@@ -339,23 +370,26 @@ pub async fn serve(
 
     let app = daemon_http_router(state);
 
-    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
-        .with_graceful_shutdown(async move {
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<DaemonConnectInfo>(),
+    )
+    .with_graceful_shutdown(async move {
+        if *shutdown_rx.borrow() {
+            return;
+        }
+        while shutdown_rx.changed().await.is_ok() {
             if *shutdown_rx.borrow() {
-                return;
+                break;
             }
-            while shutdown_rx.changed().await.is_ok() {
-                if *shutdown_rx.borrow() {
-                    break;
-                }
-            }
-        })
-        .await
-        .map_err(|error| {
-            CliError::from(CliErrorKind::workflow_io(format!(
-                "serve daemon http api: {error}"
-            )))
-        })
+        }
+    })
+    .await
+    .map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "serve daemon http api: {error}"
+        )))
+    })
 }
 
 fn daemon_http_router(state: DaemonHttpState) -> Router<()> {

--- a/src/daemon/http/remote_pairing.rs
+++ b/src/daemon/http/remote_pairing.rs
@@ -23,7 +23,7 @@ use crate::errors::{CliError, CliErrorKind};
 use crate::workspace::utc_now;
 
 use super::response::{extract_request_id, timed_json, timed_response};
-use super::DaemonHttpState;
+use super::{DaemonConnectInfo, DaemonHttpState};
 
 pub(super) fn remote_pairing_routes() -> Router<DaemonHttpState> {
     Router::new().route(http_paths::REMOTE_PAIR_CLAIM, post(post_remote_pair_claim))
@@ -51,14 +51,19 @@ pub(crate) struct RemotePairClaimHttpResponse {
 }
 
 async fn post_remote_pair_claim(
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    ConnectInfo(connect_info): ConnectInfo<DaemonConnectInfo>,
     headers: HeaderMap,
     State(state): State<DaemonHttpState>,
     Json(request): Json<RemotePairClaimHttpRequest>,
 ) -> Response {
     let start = Instant::now();
     let request_id = extract_request_id(&headers);
-    match claim_remote_pairing(peer_addr, &state, &request, request_id.as_str()) {
+    match claim_remote_pairing(
+        connect_info.remote_addr(),
+        &state,
+        &request,
+        request_id.as_str(),
+    ) {
         Ok(response) => timed_json(
             "POST",
             http_paths::REMOTE_PAIR_CLAIM,

--- a/src/daemon/http/tests/remote_pairing.rs
+++ b/src/daemon/http/tests/remote_pairing.rs
@@ -349,7 +349,7 @@ async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, Joi
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
     let app = super::super::daemon_http_router(state)
-        .into_make_service_with_connect_info::<std::net::SocketAddr>();
+        .into_make_service_with_connect_info::<crate::daemon::http::DaemonConnectInfo>();
     let server = tokio::spawn(async move {
         axum::serve(listener, app).await.expect("serve router");
     });

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -40,6 +40,7 @@ pub mod remote_auth;
 pub(crate) mod remote_crypto;
 pub mod remote_identity;
 pub mod remote_pairing;
+pub mod remote_tls;
 pub mod service;
 pub mod snapshot;
 pub mod state;

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -236,11 +236,21 @@ impl Dns01ProviderAction {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RemoteCertificateBundle {
     certificate_pem: String,
     private_key_pem: String,
     fingerprint: String,
+}
+
+impl fmt::Debug for RemoteCertificateBundle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RemoteCertificateBundle")
+            .field("certificate_pem", &"<redacted>")
+            .field("private_key_pem", &"<redacted>")
+            .field("fingerprint", &self.fingerprint)
+            .finish()
+    }
 }
 
 impl RemoteCertificateBundle {
@@ -267,6 +277,16 @@ impl RemoteCertificateBundle {
     #[must_use]
     pub fn fingerprint(&self) -> &str {
         &self.fingerprint
+    }
+
+    #[must_use]
+    pub(crate) fn certificate_pem(&self) -> &str {
+        &self.certificate_pem
+    }
+
+    #[must_use]
+    pub(crate) fn private_key_pem(&self) -> &str {
+        &self.private_key_pem
     }
 
     #[must_use]

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -169,6 +169,19 @@ fn remote_certificate_reload_tracks_generation_and_noops_unchanged_bundle() {
 }
 
 #[test]
+fn remote_certificate_bundle_debug_redacts_pem_material() {
+    let bundle = RemoteCertificateBundle::new_for_tests(
+        "-----BEGIN CERTIFICATE-----cert-secret",
+        "-----BEGIN PRIVATE KEY-----key-secret",
+    );
+    let debug = format!("{bundle:?}");
+
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains("cert-secret"));
+    assert!(!debug.contains("key-secret"));
+}
+
+#[test]
 fn remote_renewal_failure_status_is_reported_without_secret_detail() {
     let outcome = RemoteRenewalOutcome::failure("dns token secret=super-secret-token failed");
 

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -1,0 +1,189 @@
+use std::error::Error;
+use std::fmt;
+use std::io;
+use std::net::SocketAddr;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use axum::extract::connect_info::Connected;
+use axum::serve::IncomingStream;
+use axum::serve::Listener;
+use rustls::ServerConfig;
+use rustls::crypto::ring::default_provider;
+use rustls::pki_types::pem::PemObject as _;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio::time::sleep;
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::server::TlsStream;
+
+use super::http::DaemonConnectInfo;
+use super::remote_acme::RemoteCertificateBundle;
+
+#[cfg(test)]
+#[path = "remote_tls_tests.rs"]
+mod tests;
+
+static RUSTLS_PROVIDER: OnceLock<()> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteTlsConfigError {
+    MissingCertificate,
+    MissingPrivateKey,
+    InvalidCertificatePem(String),
+    InvalidPrivateKeyPem(String),
+    InvalidServerConfig(String),
+}
+
+impl fmt::Display for RemoteTlsConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingCertificate => write!(f, "remote TLS certificate PEM is required"),
+            Self::MissingPrivateKey => write!(f, "remote TLS private key PEM is required"),
+            Self::InvalidCertificatePem(error) => {
+                write!(f, "remote TLS certificate PEM is invalid: {error}")
+            }
+            Self::InvalidPrivateKeyPem(error) => {
+                write!(f, "remote TLS private key PEM is invalid: {error}")
+            }
+            Self::InvalidServerConfig(error) => {
+                write!(f, "remote TLS server config is invalid: {error}")
+            }
+        }
+    }
+}
+
+impl Error for RemoteTlsConfigError {}
+
+/// Build the rustls server config used by the internet-facing daemon listener.
+///
+/// # Errors
+/// Returns [`RemoteTlsConfigError`] when the persisted ACME certificate bundle
+/// is missing, malformed, or rejected by rustls.
+pub fn build_remote_tls_server_config(
+    bundle: &RemoteCertificateBundle,
+) -> Result<Arc<ServerConfig>, RemoteTlsConfigError> {
+    ensure_rustls_provider();
+    let cert_chain = parse_certificate_chain(bundle.certificate_pem())?;
+    let private_key = parse_private_key(bundle.private_key_pem())?;
+    let mut config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(cert_chain, private_key)
+        .map_err(|error| RemoteTlsConfigError::InvalidServerConfig(error.to_string()))?;
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    Ok(Arc::new(config))
+}
+
+pub struct RemoteTlsListener {
+    listener: TcpListener,
+    acceptor: TlsAcceptor,
+}
+
+impl RemoteTlsListener {
+    /// Bind a TCP socket and wrap each accepted stream in rustls.
+    ///
+    /// # Errors
+    /// Returns [`io::Error`] when the TCP listener cannot bind.
+    pub async fn bind<A>(addr: A, config: Arc<ServerConfig>) -> io::Result<Self>
+    where
+        A: ToSocketAddrs,
+    {
+        Ok(Self {
+            listener: TcpListener::bind(addr).await?,
+            acceptor: TlsAcceptor::from(config),
+        })
+    }
+}
+
+impl Listener for RemoteTlsListener {
+    type Io = TlsStream<TcpStream>;
+    type Addr = SocketAddr;
+
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "TLS listener accept loop handles TCP and handshake retry paths"
+    )]
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            let (stream, addr) = match self.listener.accept().await {
+                Ok(connection) => connection,
+                Err(error) => {
+                    handle_tcp_accept_error(error).await;
+                    continue;
+                }
+            };
+            match self.acceptor.accept(stream).await {
+                Ok(tls_stream) => return (tls_stream, addr),
+                Err(error) => {
+                    tracing::warn!(
+                        remote_addr = %addr,
+                        %error,
+                        "remote TLS handshake failed"
+                    );
+                }
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<Self::Addr> {
+        self.listener.local_addr()
+    }
+}
+
+impl Connected<IncomingStream<'_, RemoteTlsListener>> for DaemonConnectInfo {
+    fn connect_info(stream: IncomingStream<'_, RemoteTlsListener>) -> Self {
+        Self::new(*stream.remote_addr())
+    }
+}
+
+fn parse_certificate_chain(
+    pem: &str,
+) -> Result<Vec<CertificateDer<'static>>, RemoteTlsConfigError> {
+    if pem.trim().is_empty() {
+        return Err(RemoteTlsConfigError::MissingCertificate);
+    }
+    let certs = CertificateDer::pem_slice_iter(pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| RemoteTlsConfigError::InvalidCertificatePem(error.to_string()))?;
+    if certs.is_empty() {
+        return Err(RemoteTlsConfigError::InvalidCertificatePem(
+            "no certificate PEM blocks found".to_string(),
+        ));
+    }
+    Ok(certs)
+}
+
+fn parse_private_key(pem: &str) -> Result<PrivateKeyDer<'static>, RemoteTlsConfigError> {
+    if pem.trim().is_empty() {
+        return Err(RemoteTlsConfigError::MissingPrivateKey);
+    }
+    PrivateKeyDer::from_pem_slice(pem.as_bytes())
+        .map_err(|error| RemoteTlsConfigError::InvalidPrivateKeyPem(error.to_string()))
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+async fn handle_tcp_accept_error(error: io::Error) {
+    if is_connection_error(&error) {
+        return;
+    }
+    tracing::error!(%error, "remote TLS TCP accept failed");
+    sleep(Duration::from_secs(1)).await;
+}
+
+fn is_connection_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionReset
+    )
+}
+
+fn ensure_rustls_provider() {
+    RUSTLS_PROVIDER.get_or_init(|| {
+        let _ = default_provider().install_default();
+    });
+}

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -13,6 +13,7 @@ use rustls::crypto::ring::default_provider;
 use rustls::pki_types::pem::PemObject as _;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio::task::yield_now;
 use tokio::time::sleep;
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls::server::TlsStream;
@@ -167,6 +168,7 @@ fn parse_private_key(pem: &str) -> Result<PrivateKeyDer<'static>, RemoteTlsConfi
 )]
 async fn handle_tcp_accept_error(error: io::Error) {
     if is_transient_accept_error(&error) {
+        yield_now().await;
         return;
     }
     tracing::error!(%error, "remote TLS TCP accept failed");
@@ -185,7 +187,15 @@ fn is_transient_accept_error(error: &io::Error) -> bool {
 }
 
 fn ensure_rustls_provider() {
-    RUSTLS_PROVIDER.get_or_init(|| {
-        let _ = default_provider().install_default();
-    });
+    RUSTLS_PROVIDER.get_or_init(install_remote_tls_rustls_provider);
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+fn install_remote_tls_rustls_provider() {
+    if default_provider().install_default().is_err() {
+        tracing::warn!("rustls crypto provider was already installed before remote TLS setup");
+    }
 }

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -26,7 +26,6 @@ use super::remote_acme::RemoteCertificateBundle;
 mod tests;
 
 static RUSTLS_PROVIDER: OnceLock<()> = OnceLock::new();
-const TLS_HANDSHAKE_FAILURE_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteTlsConfigError {
@@ -112,7 +111,7 @@ impl Listener for RemoteTlsListener {
             };
             match self.acceptor.accept(stream).await {
                 Ok(tls_stream) => return (tls_stream, addr),
-                Err(error) => handle_tls_handshake_error(addr, error).await,
+                Err(error) => handle_tls_handshake_error(addr, &error),
             }
         }
     }
@@ -181,13 +180,12 @@ fn is_transient_accept_error(error: &io::Error) -> bool {
     clippy::cognitive_complexity,
     reason = "tracing macro expansion; tokio-rs/tracing#553"
 )]
-async fn handle_tls_handshake_error(addr: SocketAddr, error: io::Error) {
+fn handle_tls_handshake_error(addr: SocketAddr, error: &io::Error) {
     tracing::debug!(
         remote_addr = %addr,
         %error,
         "remote TLS handshake failed"
     );
-    sleep(TLS_HANDSHAKE_FAILURE_RETRY_DELAY).await;
 }
 
 fn ensure_rustls_provider() {

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -26,7 +26,7 @@ use super::remote_acme::RemoteCertificateBundle;
 mod tests;
 
 static RUSTLS_PROVIDER: OnceLock<()> = OnceLock::new();
-const TLS_HANDSHAKE_FAILURE_RETRY_DELAY: Duration = Duration::from_millis(10);
+const TLS_HANDSHAKE_FAILURE_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteTlsConfigError {
@@ -182,7 +182,7 @@ fn is_transient_accept_error(error: &io::Error) -> bool {
     reason = "tracing macro expansion; tokio-rs/tracing#553"
 )]
 async fn handle_tls_handshake_error(addr: SocketAddr, error: io::Error) {
-    tracing::warn!(
+    tracing::debug!(
         remote_addr = %addr,
         %error,
         "remote TLS handshake failed"

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -166,19 +166,21 @@ fn parse_private_key(pem: &str) -> Result<PrivateKeyDer<'static>, RemoteTlsConfi
     reason = "tracing macro expansion; tokio-rs/tracing#553"
 )]
 async fn handle_tcp_accept_error(error: io::Error) {
-    if is_connection_error(&error) {
+    if is_transient_accept_error(&error) {
         return;
     }
     tracing::error!(%error, "remote TLS TCP accept failed");
     sleep(Duration::from_secs(1)).await;
 }
 
-fn is_connection_error(error: &io::Error) -> bool {
+fn is_transient_accept_error(error: &io::Error) -> bool {
     matches!(
         error.kind(),
         io::ErrorKind::ConnectionRefused
             | io::ErrorKind::ConnectionAborted
             | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::Interrupted
+            | io::ErrorKind::WouldBlock
     )
 }
 

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -26,6 +26,7 @@ use super::remote_acme::RemoteCertificateBundle;
 mod tests;
 
 static RUSTLS_PROVIDER: OnceLock<()> = OnceLock::new();
+const TLS_HANDSHAKE_FAILURE_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteTlsConfigError {
@@ -100,10 +101,6 @@ impl Listener for RemoteTlsListener {
     type Io = TlsStream<TcpStream>;
     type Addr = SocketAddr;
 
-    #[expect(
-        clippy::cognitive_complexity,
-        reason = "TLS listener accept loop handles TCP and handshake retry paths"
-    )]
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {
         loop {
             let (stream, addr) = match self.listener.accept().await {
@@ -115,13 +112,7 @@ impl Listener for RemoteTlsListener {
             };
             match self.acceptor.accept(stream).await {
                 Ok(tls_stream) => return (tls_stream, addr),
-                Err(error) => {
-                    tracing::warn!(
-                        remote_addr = %addr,
-                        %error,
-                        "remote TLS handshake failed"
-                    );
-                }
+                Err(error) => handle_tls_handshake_error(addr, error).await,
             }
         }
     }
@@ -184,6 +175,19 @@ fn is_transient_accept_error(error: &io::Error) -> bool {
             | io::ErrorKind::Interrupted
             | io::ErrorKind::WouldBlock
     )
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+async fn handle_tls_handshake_error(addr: SocketAddr, error: io::Error) {
+    tracing::warn!(
+        remote_addr = %addr,
+        %error,
+        "remote TLS handshake failed"
+    );
+    sleep(TLS_HANDSHAKE_FAILURE_RETRY_DELAY).await;
 }
 
 fn ensure_rustls_provider() {

--- a/src/daemon/remote_tls_tests.rs
+++ b/src/daemon/remote_tls_tests.rs
@@ -1,8 +1,9 @@
 use std::io;
+use std::net::SocketAddr;
 
 use super::{
-    RemoteTlsConfigError, build_remote_tls_server_config, handle_tcp_accept_error,
-    is_transient_accept_error,
+    RemoteTlsConfigError, TLS_HANDSHAKE_FAILURE_RETRY_DELAY, build_remote_tls_server_config,
+    handle_tcp_accept_error, handle_tls_handshake_error, is_transient_accept_error,
 };
 use crate::daemon::remote_acme::RemoteCertificateBundle;
 
@@ -51,6 +52,20 @@ fn remote_tls_accept_retries_transient_tcp_errors_without_backoff() {
 #[tokio::test]
 async fn remote_tls_accept_transient_errors_do_not_backoff() {
     handle_tcp_accept_error(io::Error::from(io::ErrorKind::WouldBlock)).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn remote_tls_handshake_failures_backoff_before_retry() {
+    let retry = tokio::spawn(handle_tls_handshake_error(
+        SocketAddr::from(([127, 0, 0, 1], 443)),
+        io::Error::from(io::ErrorKind::InvalidData),
+    ));
+
+    tokio::task::yield_now().await;
+    assert!(!retry.is_finished());
+
+    tokio::time::advance(TLS_HANDSHAKE_FAILURE_RETRY_DELAY).await;
+    retry.await.expect("handshake retry delay should complete");
 }
 
 const TEST_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----

--- a/src/daemon/remote_tls_tests.rs
+++ b/src/daemon/remote_tls_tests.rs
@@ -1,10 +1,9 @@
 use std::io;
 use std::net::SocketAddr;
-use std::time::Duration;
 
 use super::{
-    RemoteTlsConfigError, TLS_HANDSHAKE_FAILURE_RETRY_DELAY, build_remote_tls_server_config,
-    handle_tcp_accept_error, handle_tls_handshake_error, is_transient_accept_error,
+    RemoteTlsConfigError, build_remote_tls_server_config, handle_tcp_accept_error,
+    handle_tls_handshake_error, is_transient_accept_error,
 };
 use crate::daemon::remote_acme::RemoteCertificateBundle;
 
@@ -55,23 +54,13 @@ async fn remote_tls_accept_transient_errors_do_not_backoff() {
     handle_tcp_accept_error(io::Error::from(io::ErrorKind::WouldBlock)).await;
 }
 
-#[tokio::test(start_paused = true)]
-async fn remote_tls_handshake_failures_backoff_before_retry() {
-    let retry = tokio::spawn(handle_tls_handshake_error(
-        SocketAddr::from(([127, 0, 0, 1], 443)),
-        io::Error::from(io::ErrorKind::InvalidData),
-    ));
-
-    tokio::task::yield_now().await;
-    assert!(!retry.is_finished());
-
-    tokio::time::advance(TLS_HANDSHAKE_FAILURE_RETRY_DELAY).await;
-    retry.await.expect("handshake retry delay should complete");
-}
-
 #[test]
-fn remote_tls_handshake_failure_retry_delay_has_internet_facing_floor() {
-    assert!(TLS_HANDSHAKE_FAILURE_RETRY_DELAY >= Duration::from_millis(100));
+fn remote_tls_handshake_failures_do_not_delay_accept_loop() {
+    let error = io::Error::from(io::ErrorKind::InvalidData);
+    handle_tls_handshake_error(
+        SocketAddr::from(([127, 0, 0, 1], 443)),
+        &error,
+    );
 }
 
 const TEST_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----

--- a/src/daemon/remote_tls_tests.rs
+++ b/src/daemon/remote_tls_tests.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use super::{
     RemoteTlsConfigError, TLS_HANDSHAKE_FAILURE_RETRY_DELAY, build_remote_tls_server_config,
@@ -66,6 +67,11 @@ async fn remote_tls_handshake_failures_backoff_before_retry() {
 
     tokio::time::advance(TLS_HANDSHAKE_FAILURE_RETRY_DELAY).await;
     retry.await.expect("handshake retry delay should complete");
+}
+
+#[test]
+fn remote_tls_handshake_failure_retry_delay_has_internet_facing_floor() {
+    assert!(TLS_HANDSHAKE_FAILURE_RETRY_DELAY >= Duration::from_millis(100));
 }
 
 const TEST_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----

--- a/src/daemon/remote_tls_tests.rs
+++ b/src/daemon/remote_tls_tests.rs
@@ -1,6 +1,9 @@
 use std::io;
 
-use super::{RemoteTlsConfigError, build_remote_tls_server_config, is_transient_accept_error};
+use super::{
+    RemoteTlsConfigError, build_remote_tls_server_config, handle_tcp_accept_error,
+    is_transient_accept_error,
+};
 use crate::daemon::remote_acme::RemoteCertificateBundle;
 
 #[test]
@@ -43,6 +46,11 @@ fn remote_tls_accept_retries_transient_tcp_errors_without_backoff() {
     ] {
         assert!(is_transient_accept_error(&io::Error::from(kind)));
     }
+}
+
+#[tokio::test]
+async fn remote_tls_accept_transient_errors_do_not_backoff() {
+    handle_tcp_accept_error(io::Error::from(io::ErrorKind::WouldBlock)).await;
 }
 
 const TEST_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----

--- a/src/daemon/remote_tls_tests.rs
+++ b/src/daemon/remote_tls_tests.rs
@@ -1,0 +1,80 @@
+use super::{RemoteTlsConfigError, build_remote_tls_server_config};
+use crate::daemon::remote_acme::RemoteCertificateBundle;
+
+#[test]
+fn remote_tls_server_config_rejects_blank_certificate_material() {
+    let bundle = RemoteCertificateBundle::new_for_tests("   ", TEST_PRIVATE_KEY_PEM);
+    let error = build_remote_tls_server_config(&bundle)
+        .expect_err("blank certificate should not build remote TLS config");
+
+    assert_eq!(error, RemoteTlsConfigError::MissingCertificate);
+}
+
+#[test]
+fn remote_tls_server_config_rejects_blank_private_key_material() {
+    let bundle = RemoteCertificateBundle::new_for_tests(TEST_CERTIFICATE_PEM, "\n\t");
+    let error = build_remote_tls_server_config(&bundle)
+        .expect_err("blank key should not build remote TLS config");
+
+    assert_eq!(error, RemoteTlsConfigError::MissingPrivateKey);
+}
+
+#[test]
+fn remote_tls_server_config_builds_http_alpn_from_pem_material() {
+    let bundle = RemoteCertificateBundle::new_for_tests(TEST_CERTIFICATE_PEM, TEST_PRIVATE_KEY_PEM);
+    let config = build_remote_tls_server_config(&bundle).expect("valid remote TLS config");
+
+    assert_eq!(
+        config.alpn_protocols,
+        vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+    );
+}
+
+const TEST_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIIDGzCCAgOgAwIBAgIUO6qbgSSvho2GLuSvxiWE6x7/H+wwDQYJKoZIhvcNAQEL
+BQAwHTEbMBkGA1UEAwwSZGFlbW9uLmV4YW1wbGUuY29tMB4XDTI2MDcwOTExNTAx
+MloXDTI2MDcxMDExNTAxMlowHTEbMBkGA1UEAwwSZGFlbW9uLmV4YW1wbGUuY29t
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApCKXa4o1OtABLolsV/fs
+E1njTM+x0qBJFKYVW+3Pi8MCAnnQZ+yYzQ4D8Wfv1zjOy1Y/UYdIiqxBFLNp0erD
+xW+b4kuHSKuGDb15ZAys6iRA5bcTKnz8QGKVzmFIwAbS4dPJNzRb7AuDqpOE0Hxh
+E6kF/sa/GFz+aW1adDvZZkYrszUPn/3C2DvBjZFEwQgmEX4CUuNySw43tHh+EjFP
+nt+Bl5yRazZ/WNfDM3pjjnJcxaYNgP8wv1Hf4AAZqnVi17sH9Z7e3ChJZQF/fNgJ
+0+IOd5z9Q9QTlmDgeVgTIn4cgPFs9VKmCsjByek0bIRlybwl4jhuut6KhvrnXCFY
+DwIDAQABo1MwUTAdBgNVHQ4EFgQUEQWSux09fVAsGngLhkNIpOgPzj0wHwYDVR0j
+BBgwFoAUEQWSux09fVAsGngLhkNIpOgPzj0wDwYDVR0TAQH/BAUwAwEB/zANBgkq
+hkiG9w0BAQsFAAOCAQEAEPjbUJyM/J/wBxMIK4JrAJEX2hmkhpHGCp88OKavf6W/
+IalWjl70Df+FSc5yBePFKjUUo6S96r5Q4CXBx+DNfRgN26HDk2w55eivYnmi1nNc
+VHs+G7SrVjiNijOgozt45HQR4CvAgPxcZoGu1U4lmprrx7HaWIC+56y6MFghb4Kg
++InZkMWy6ySoFbYjMSsPBifaKnuF1NUTPjL0VE8oNyNftIvFjjZuctvHjhlK+FMP
+Tys9LeCcV0h6PMHH+/hQLJC4R3RuS2uu55KtmTnhHMjNB3M56XfWb/y18n3GVkys
+yy4u0xXmF216ZT32j2SxkTQxQOVG9EqmwaZUcuACYQ==
+-----END CERTIFICATE-----"#;
+
+const TEST_PRIVATE_KEY_PEM: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCkIpdrijU60AEu
+iWxX9+wTWeNMz7HSoEkUphVb7c+LwwICedBn7JjNDgPxZ+/XOM7LVj9Rh0iKrEEU
+s2nR6sPFb5viS4dIq4YNvXlkDKzqJEDltxMqfPxAYpXOYUjABtLh08k3NFvsC4Oq
+k4TQfGETqQX+xr8YXP5pbVp0O9lmRiuzNQ+f/cLYO8GNkUTBCCYRfgJS43JLDje0
+eH4SMU+e34GXnJFrNn9Y18MzemOOclzFpg2A/zC/Ud/gABmqdWLXuwf1nt7cKEll
+AX982AnT4g53nP1D1BOWYOB5WBMifhyA8Wz1UqYKyMHJ6TRshGXJvCXiOG663oqG
++udcIVgPAgMBAAECggEAOfp2HmitsN607Cli+hf7bkJ8Ri+/krVH22FnfhedDrON
+zC4Xbf5nY1emEOo0EIRil/UZXMU63LFIM/XEVYBmMyHfoKopWYQtUEEz1iGcGwE/
+Y2WuAX4w5NVuMX6v4hUG/PqAw11dcx4GHoUJj1PAPt+f3IV8DzEaNUeJgjF58+QY
+SmSyjvCqhri6CzZD7Ypu6y3RkoAHzWsBC0L3BDzChNSIjYnPIEWr+VZQoQ2LQjR9
+tzrmffalCQReePpfoAhHhWY0ECMx1gQY9XKUMqrVhptpIswS3WPz2tY864Px24qq
+KL72TdodRiyG0oBbygUvB2uiQ6IeSrN4NGJtzuxjYQKBgQDfBg6FUMEjm7dYd78k
+n4vRHS4Sh6dVx0xCJalZ9V/tri6crY/yih48VYWxzAiBEh/yKhr6Q+SduoIf37Jn
+5MQQyIAdN6rdYJvNdP/HIQcuIQO4eWvlf5Ztsoecyww90rtQLFbhnfLQVm9e+rmX
+qZuYONz123lLe0qJKI8yJcdc+QKBgQC8Z3jkX1imUguDNKXhMGNmvYsXIsbeJuGJ
+YemLlT7UVPpwVjIUL1tREWfabdtVVw7lLli9o0UjRGdG1NW/z9K4unt1kHeqmFhp
+KmCrt14Gyb+1DERFjc2Av1rv1uSONlfYb07k0PHhbFFHv9LwwZJWZRLVWzSwO5mL
+7l7xxlnHRwKBgBZeOCSc1dIpcvkXgX891TsS7yUCoADVbUuRFWwlVQq0lo42RiKw
+QZoRhcgwS4YOeE/Ec1I4bvx20Ug7GlybMCLyyQ6lH6j2YIn5uxGQuXSh8QqWewDY
+jBDSgBF0t/SXZxwCZnBYdBr7IE5pXSXd5/IbeeXark6ovfAFtl70NQuZAoGBAJXQ
+LahjTOnMWc02QyVCxff/hqeaBsrF3hfRXNWaksBi5lYHpIC6e4GGNq/RJVTCCl0h
+Mn1xY9u8W+dN/L4usqAj4WJFw3JK/Bp8ESzafZEmQiPkIjGwpZXYE6admVagTdAU
+CocWww/+gs9r8H9zXTsH2icABHCSo/FKVgMpN2CnAoGBAKyhHuD2+HadpZ+H6GaL
+2pPNV9/lqGJ+CgHUmf1xvPr6zOHQWRYAZ2J3/SslZyyNC1J+dBW+Fps3nnQ3lG62
+JBpZ8TiiuDYnOqjZTHejjLdFPS2py0ID0IfBlRE+m9oMFJsZbOR91Ra3zHHKBqMJ
+r3onbxBi+otiVHYyfV7mz6XW
+-----END PRIVATE KEY-----"#;

--- a/src/daemon/remote_tls_tests.rs
+++ b/src/daemon/remote_tls_tests.rs
@@ -1,4 +1,6 @@
-use super::{RemoteTlsConfigError, build_remote_tls_server_config};
+use std::io;
+
+use super::{RemoteTlsConfigError, build_remote_tls_server_config, is_transient_accept_error};
 use crate::daemon::remote_acme::RemoteCertificateBundle;
 
 #[test]
@@ -28,6 +30,19 @@ fn remote_tls_server_config_builds_http_alpn_from_pem_material() {
         config.alpn_protocols,
         vec![b"h2".to_vec(), b"http/1.1".to_vec()]
     );
+}
+
+#[test]
+fn remote_tls_accept_retries_transient_tcp_errors_without_backoff() {
+    for kind in [
+        io::ErrorKind::ConnectionRefused,
+        io::ErrorKind::ConnectionAborted,
+        io::ErrorKind::ConnectionReset,
+        io::ErrorKind::Interrupted,
+        io::ErrorKind::WouldBlock,
+    ] {
+        assert!(is_transient_accept_error(&io::Error::from(kind)));
+    }
 }
 
 const TEST_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----

--- a/src/daemon/service/mod.rs
+++ b/src/daemon/service/mod.rs
@@ -323,6 +323,7 @@ pub use reviews_files::{
 pub use reviews_thread_resolve::set_review_thread_resolved;
 pub use reviews_timeline::{clear_reviews_caches_with_timeline, fetch_review_timeline};
 pub use serve::serve;
+pub(crate) use serve::serve_remote_https;
 pub use sessions::{
     list_projects, list_sessions, session_detail, session_detail_core, session_extensions,
     session_timeline,

--- a/src/daemon/service/serve/audit.rs
+++ b/src/daemon/service/serve/audit.rs
@@ -26,6 +26,32 @@ pub(super) async fn record_daemon_started(
     .await;
 }
 
+pub(super) async fn record_remote_daemon_bound(
+    async_db: Option<&Arc<AsyncDaemonDb>>,
+    endpoint: &str,
+    sandboxed: bool,
+) {
+    record_daemon_lifecycle_event(
+        async_db,
+        "daemon.started",
+        "info",
+        "success",
+        "Remote daemon started",
+        &remote_daemon_bound_summary(endpoint),
+        serde_json::json!({
+            "endpoint": endpoint,
+            "sandboxed": sandboxed,
+            "pid": id(),
+            "state": "https_socket_bound",
+        }),
+    )
+    .await;
+}
+
+pub(super) fn remote_daemon_bound_summary(endpoint: &str) -> String {
+    format!("Remote daemon bound HTTPS socket for {endpoint}")
+}
+
 pub(super) async fn record_daemon_stopped(
     async_db: Option<&Arc<AsyncDaemonDb>>,
     serve_result: &Result<(), CliError>,

--- a/src/daemon/service/serve/mod.rs
+++ b/src/daemon/service/serve/mod.rs
@@ -9,11 +9,13 @@ mod machine_heartbeat_loop;
 mod manifest;
 mod open_db;
 mod policy_bootstrap;
+mod remote;
 mod shutdown_signals;
 mod task_board_orchestrator_loop;
 
 pub(crate) use config::{http_auth_mode, validate_serve_config};
 pub(crate) use open_db::{open_daemon_async_db, open_daemon_db};
+pub(crate) use remote::serve_remote_https;
 
 use super::{
     AgentTuiManagerHandle, Arc, CliError, CliErrorKind, CodexControllerHandle, DaemonHttpState,

--- a/src/daemon/service/serve/remote.rs
+++ b/src/daemon/service/serve/remote.rs
@@ -1,0 +1,176 @@
+use std::process::id as process_id;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::{broadcast, watch as tokio_watch};
+
+use crate::agents::acp::probe::schedule_probe_cache_refresh;
+use crate::daemon::agent_acp::AcpAgentManagerHandle;
+use crate::daemon::agent_tui::AgentTuiManagerHandle;
+use crate::daemon::codex_controller::CodexControllerHandle;
+use crate::daemon::db::{AsyncDaemonDb, DaemonDb};
+use crate::daemon::http::{self, AsyncDaemonDbSlot, DaemonHttpAuthMode, DaemonHttpState};
+use crate::daemon::remote_acme::RemoteAcmeRuntimePlan;
+use crate::daemon::remote_tls::{
+    RemoteTlsConfigError, RemoteTlsListener, build_remote_tls_server_config,
+};
+use crate::daemon::state::{self, DaemonManifest, HostBridgeManifest};
+use crate::daemon::voice::cleanup_abandoned_sessions;
+use crate::daemon::websocket::ReplayBuffer;
+use crate::errors::{CliError, CliErrorKind};
+use crate::workspace::orphan_cleanup::run_startup_sweep;
+use crate::workspace::utc_now;
+
+use super::super::{DaemonObserveRuntime, DaemonServeConfig, OBSERVE_RUNTIME, SHUTDOWN_SIGNAL};
+use super::background_tasks::{self, spawn_background_tasks};
+use super::binary_stamp::current_binary_stamp;
+use super::initialize_startup_state;
+use super::legacy_migration::log_legacy_daemon_root_migration;
+use super::shutdown_signals::ShutdownSignalGuard;
+
+/// Start the remote daemon HTTPS API.
+///
+/// # Errors
+/// Returns [`CliError`] if remote auth/TLS preflight fails or the HTTPS server
+/// cannot bind.
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "remote serve wires startup, runtime, and teardown in one lifecycle path"
+)]
+pub async fn serve_remote_https(
+    config: DaemonServeConfig,
+    acme_plan: RemoteAcmeRuntimePlan,
+) -> Result<(), CliError> {
+    validate_remote_https_config(&config)?;
+    super::super::log_sandbox_startup(config.sandboxed);
+    run_startup_sweep();
+
+    let legacy_migration_report = state::migrate_legacy_daemon_root_for_current_process()?;
+    log_legacy_daemon_root_migration(&legacy_migration_report);
+    state::ensure_daemon_dirs()?;
+    cleanup_abandoned_sessions()?;
+    let daemon_lock = state::acquire_singleton_lock()?;
+
+    let tls_config = build_remote_tls_server_config(acme_plan.certificate())
+        .map_err(|error| remote_tls_config_cli_error(&error))?;
+    let listener = RemoteTlsListener::bind((config.host.as_str(), config.port), tls_config)
+        .await
+        .map_err(|error| {
+            CliErrorKind::workflow_io(format!("bind remote HTTPS listener: {error}"))
+        })?;
+    let endpoint = acme_plan.public_https_origin();
+    let manifest = remote_daemon_manifest(&endpoint, config.sandboxed);
+    state::append_event("info", &format!("remote daemon listening on {endpoint}"))?;
+
+    let (sender, _) = broadcast::channel(256);
+    let (shutdown_tx, shutdown_rx) = tokio_watch::channel(false);
+    let db: Arc<OnceLock<Arc<Mutex<DaemonDb>>>> = Arc::new(OnceLock::new());
+    let async_db: Arc<OnceLock<Arc<AsyncDaemonDb>>> = Arc::new(OnceLock::new());
+    let _ = OBSERVE_RUNTIME.set(DaemonObserveRuntime {
+        sender: sender.clone(),
+        poll_interval: config.observe_interval,
+        running_sessions: Arc::default(),
+        db: db.clone(),
+        async_db: async_db.clone(),
+    });
+    let _ = SHUTDOWN_SIGNAL.set(shutdown_tx.clone());
+    let _shutdown_signal_guard = ShutdownSignalGuard::install(shutdown_tx.clone())?;
+    let replay_buffer = Arc::new(Mutex::new(ReplayBuffer::new(512)));
+    let prepared_sender = background_tasks::spawn_broadcast_fanout(&sender, &replay_buffer);
+    let daemon_epoch = manifest.started_at.clone();
+    let async_db_slot_for_audit = async_db.clone();
+
+    initialize_startup_state(&db, &async_db, sender.clone(), config.poll_interval).await?;
+    super::audit::record_daemon_started(async_db.get(), &endpoint, config.sandboxed).await;
+    schedule_probe_cache_refresh();
+
+    let codex_controller = CodexControllerHandle::new_with_async_db(
+        sender.clone(),
+        db.clone(),
+        async_db.clone(),
+        config.sandboxed,
+    );
+    let agent_tui_manager = AgentTuiManagerHandle::new_with_async_db(
+        sender.clone(),
+        db.clone(),
+        async_db.clone(),
+        config.sandboxed,
+    );
+    let acp_agent_manager =
+        AcpAgentManagerHandle::new_with_async_db(sender.clone(), db.clone(), async_db.clone());
+    let app_state = DaemonHttpState {
+        token: String::new(),
+        auth_mode: config.auth_mode,
+        remote_domain: config.remote_domain.clone(),
+        remote_pairing_limiter: http::default_remote_pairing_limiter(),
+        sender,
+        prepared_sender,
+        manifest,
+        daemon_epoch,
+        replay_buffer,
+        db,
+        async_db: AsyncDaemonDbSlot::from_inner(async_db),
+        db_path: Some(state::daemon_root().join("harness.db")),
+        codex_controller,
+        agent_tui_manager,
+        acp_agent_manager,
+        managed_agent_mutation_locks: http::ManagedAgentMutationLocks::default(),
+        recovery_snapshot: Arc::default(),
+    };
+    let _background = spawn_background_tasks(&app_state, config.poll_interval, shutdown_rx.clone());
+
+    let serve_result = http::serve(listener, app_state, shutdown_rx).await;
+    super::audit::record_daemon_stopped(async_db_slot_for_audit.get(), &serve_result).await;
+    let stop_event_result = if serve_result.is_ok() {
+        state::append_event("info", "remote daemon stopped")
+    } else {
+        Ok(())
+    };
+    drop(daemon_lock);
+
+    match (serve_result, stop_event_result) {
+        (Err(error), _) | (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn validate_remote_https_config(config: &DaemonServeConfig) -> Result<(), CliError> {
+    if config.auth_mode != DaemonHttpAuthMode::Remote {
+        return Err(CliErrorKind::workflow_parse(
+            "remote HTTPS serve requires remote authentication mode",
+        )
+        .into());
+    }
+    if config
+        .remote_domain
+        .as_deref()
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
+        return Err(
+            CliErrorKind::workflow_parse("remote HTTPS serve requires a remote domain").into(),
+        );
+    }
+    Ok(())
+}
+
+fn remote_daemon_manifest(endpoint: &str, sandboxed: bool) -> DaemonManifest {
+    let now = utc_now();
+    DaemonManifest {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        pid: process_id(),
+        endpoint: endpoint.to_string(),
+        started_at: now.clone(),
+        token_path: String::new(),
+        sandboxed,
+        host_bridge: HostBridgeManifest::default(),
+        revision: 0,
+        updated_at: now,
+        binary_stamp: current_binary_stamp(),
+        ownership: state::DaemonOwnership::from_env_or_default(),
+    }
+}
+
+fn remote_tls_config_cli_error(error: &RemoteTlsConfigError) -> CliError {
+    CliErrorKind::workflow_parse(format!("build remote TLS config: {error}")).into()
+}

--- a/src/daemon/service/serve/remote.rs
+++ b/src/daemon/service/serve/remote.rs
@@ -59,7 +59,7 @@ pub async fn serve_remote_https(
         })?;
     let endpoint = acme_plan.public_https_origin();
     let manifest = remote_daemon_manifest(&endpoint, config.sandboxed);
-    state::append_event("info", &format!("remote daemon listening on {endpoint}"))?;
+    state::append_event("info", &remote_bound_event_message(&endpoint))?;
 
     let (sender, _) = broadcast::channel(256);
     let (shutdown_tx, shutdown_rx) = tokio_watch::channel(false);
@@ -173,4 +173,21 @@ fn remote_daemon_manifest(endpoint: &str, sandboxed: bool) -> DaemonManifest {
 
 fn remote_tls_config_cli_error(error: &RemoteTlsConfigError) -> CliError {
     CliErrorKind::workflow_parse(format!("build remote TLS config: {error}")).into()
+}
+
+fn remote_bound_event_message(endpoint: &str) -> String {
+    format!("remote daemon bound HTTPS socket for {endpoint}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::remote_bound_event_message;
+
+    #[test]
+    fn remote_bound_event_message_does_not_claim_service_is_listening() {
+        let message = remote_bound_event_message("https://daemon.example.com");
+
+        assert!(message.contains("https://daemon.example.com"));
+        assert!(!message.contains("listening"));
+    }
 }

--- a/src/daemon/service/serve/remote.rs
+++ b/src/daemon/service/serve/remote.rs
@@ -181,7 +181,10 @@ fn remote_bound_event_message(endpoint: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::remote_bound_event_message;
+    use crate::daemon::http::DaemonHttpAuthMode;
+    use crate::daemon::service::DaemonServeConfig;
+
+    use super::{remote_bound_event_message, validate_remote_https_config};
 
     #[test]
     fn remote_bound_event_message_does_not_claim_service_is_listening() {
@@ -189,5 +192,45 @@ mod tests {
 
         assert!(message.contains("https://daemon.example.com"));
         assert!(!message.contains("listening"));
+    }
+
+    #[test]
+    fn validate_remote_https_config_requires_remote_auth_mode() {
+        let config = DaemonServeConfig {
+            remote_domain: Some("daemon.example.com".to_string()),
+            ..DaemonServeConfig::default()
+        };
+        let error = validate_remote_https_config(&config)
+            .expect_err("remote HTTPS should reject local auth mode");
+
+        assert!(
+            error
+                .to_string()
+                .contains("requires remote authentication mode")
+        );
+    }
+
+    #[test]
+    fn validate_remote_https_config_requires_remote_domain() {
+        let config = DaemonServeConfig {
+            auth_mode: DaemonHttpAuthMode::Remote,
+            remote_domain: Some("   ".to_string()),
+            ..DaemonServeConfig::default()
+        };
+        let error = validate_remote_https_config(&config)
+            .expect_err("remote HTTPS should reject blank domain");
+
+        assert!(error.to_string().contains("requires a remote domain"));
+    }
+
+    #[test]
+    fn validate_remote_https_config_accepts_remote_auth_and_domain() {
+        let config = DaemonServeConfig {
+            auth_mode: DaemonHttpAuthMode::Remote,
+            remote_domain: Some("daemon.example.com".to_string()),
+            ..DaemonServeConfig::default()
+        };
+
+        validate_remote_https_config(&config).expect("valid remote HTTPS config");
     }
 }

--- a/src/daemon/service/serve/remote.rs
+++ b/src/daemon/service/serve/remote.rs
@@ -80,7 +80,7 @@ pub async fn serve_remote_https(
     let async_db_slot_for_audit = async_db.clone();
 
     initialize_startup_state(&db, &async_db, sender.clone(), config.poll_interval).await?;
-    super::audit::record_daemon_started(async_db.get(), &endpoint, config.sandboxed).await;
+    super::audit::record_remote_daemon_bound(async_db.get(), &endpoint, config.sandboxed).await;
     schedule_probe_cache_refresh();
 
     let codex_controller = CodexControllerHandle::new_with_async_db(
@@ -180,11 +180,18 @@ fn remote_bound_event_message(endpoint: &str) -> String {
 }
 
 #[cfg(test)]
+fn remote_audit_bound_summary(endpoint: &str) -> String {
+    super::audit::remote_daemon_bound_summary(endpoint)
+}
+
+#[cfg(test)]
 mod tests {
     use crate::daemon::http::DaemonHttpAuthMode;
     use crate::daemon::service::DaemonServeConfig;
 
-    use super::{remote_bound_event_message, validate_remote_https_config};
+    use super::{
+        remote_audit_bound_summary, remote_bound_event_message, validate_remote_https_config,
+    };
 
     #[test]
     fn remote_bound_event_message_does_not_claim_service_is_listening() {
@@ -192,6 +199,15 @@ mod tests {
 
         assert!(message.contains("https://daemon.example.com"));
         assert!(!message.contains("listening"));
+    }
+
+    #[test]
+    fn remote_audit_bound_summary_does_not_claim_service_is_listening() {
+        let summary = remote_audit_bound_summary("https://daemon.example.com");
+
+        assert!(summary.contains("https://daemon.example.com"));
+        assert!(summary.contains("bound HTTPS socket"));
+        assert!(!summary.contains("listening"));
     }
 
     #[test]

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -1,8 +1,10 @@
+use std::thread;
+
 use crate::daemon::db::DaemonDb;
 use crate::daemon::remote_acme::{RemoteAcmeRuntimePlan, build_remote_acme_runtime_plan};
 use crate::daemon::service::{self, DaemonServeConfig};
 use crate::errors::{CliError, CliErrorKind};
-use tokio::runtime::Runtime;
+use tokio::runtime::{Handle, Runtime};
 
 use super::control::adopt_daemon_root_for_transport_command;
 use super::remote::{DaemonRemoteServeArgs, open_remote_daemon_db};
@@ -14,7 +16,6 @@ pub(crate) struct RemoteDaemonServeExecutionPlan {
 }
 
 pub(super) fn execute_remote_serve(args: &DaemonRemoteServeArgs) -> Result<i32, CliError> {
-    adopt_daemon_root_for_transport_command("daemon-remote-serve");
     execute_remote_serve_with(args, open_remote_daemon_db, run_remote_serve_plan)
 }
 
@@ -27,6 +28,7 @@ where
     OpenDb: FnOnce() -> Result<DaemonDb, CliError>,
     Run: FnOnce(RemoteDaemonServeExecutionPlan) -> Result<i32, CliError>,
 {
+    adopt_daemon_root_for_transport_command("daemon-remote-serve");
     let db = open_db()?;
     let plan = build_remote_serve_execution_plan(args, &db)?;
     run_plan(plan)
@@ -54,6 +56,44 @@ pub(crate) fn build_remote_serve_execution_plan(
 }
 
 fn run_remote_serve_plan(plan: RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
+    match remote_serve_runtime_mode() {
+        RemoteServeRuntimeMode::ExistingTokioRuntime => run_remote_serve_plan_on_thread(plan),
+        RemoteServeRuntimeMode::NewTokioRuntime => run_remote_serve_plan_on_runtime(plan),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteServeRuntimeMode {
+    ExistingTokioRuntime,
+    NewTokioRuntime,
+}
+
+pub(crate) fn remote_serve_runtime_mode() -> RemoteServeRuntimeMode {
+    if Handle::try_current().is_ok() {
+        RemoteServeRuntimeMode::ExistingTokioRuntime
+    } else {
+        RemoteServeRuntimeMode::NewTokioRuntime
+    }
+}
+
+fn run_remote_serve_plan_on_thread(plan: RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
+    thread::Builder::new()
+        .name("harness-remote-daemon".to_string())
+        .spawn(move || run_remote_serve_plan_on_runtime(plan))
+        .map_err(|error| {
+            CliError::from(CliErrorKind::workflow_io(format!(
+                "spawn remote daemon runtime thread: {error}"
+            )))
+        })?
+        .join()
+        .map_err(|_| {
+            CliError::from(CliErrorKind::workflow_io(
+                "remote daemon runtime thread panicked",
+            ))
+        })?
+}
+
+fn run_remote_serve_plan_on_runtime(plan: RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
     let runtime = Runtime::new().map_err(|error| {
         CliError::from(CliErrorKind::workflow_io(format!(
             "create remote daemon tokio runtime: {error}"

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -1,7 +1,8 @@
 use crate::daemon::db::DaemonDb;
 use crate::daemon::remote_acme::{RemoteAcmeRuntimePlan, build_remote_acme_runtime_plan};
-use crate::daemon::service::DaemonServeConfig;
+use crate::daemon::service::{self, DaemonServeConfig};
 use crate::errors::{CliError, CliErrorKind};
+use tokio::runtime::Runtime;
 
 use super::control::adopt_daemon_root_for_transport_command;
 use super::remote::{DaemonRemoteServeArgs, open_remote_daemon_db};
@@ -14,9 +15,21 @@ pub(crate) struct RemoteDaemonServeExecutionPlan {
 
 pub(super) fn execute_remote_serve(args: &DaemonRemoteServeArgs) -> Result<i32, CliError> {
     adopt_daemon_root_for_transport_command("daemon-remote-serve");
-    let db = open_remote_daemon_db()?;
+    execute_remote_serve_with(args, open_remote_daemon_db, run_remote_serve_plan)
+}
+
+pub(crate) fn execute_remote_serve_with<OpenDb, Run>(
+    args: &DaemonRemoteServeArgs,
+    open_db: OpenDb,
+    run_plan: Run,
+) -> Result<i32, CliError>
+where
+    OpenDb: FnOnce() -> Result<DaemonDb, CliError>,
+    Run: FnOnce(RemoteDaemonServeExecutionPlan) -> Result<i32, CliError>,
+{
+    let db = open_db()?;
     let plan = build_remote_serve_execution_plan(args, &db)?;
-    run_remote_serve_plan(&plan)
+    run_plan(plan)
 }
 
 /// Build the remote daemon serve execution plan from static CLI config and
@@ -40,12 +53,15 @@ pub(crate) fn build_remote_serve_execution_plan(
     })
 }
 
-fn run_remote_serve_plan(plan: &RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
-    Err(CliErrorKind::workflow_parse(format!(
-        "remote daemon HTTPS listener is not implemented yet; TLS preflight passed for {} on {}:{}",
-        plan.acme_plan.public_https_origin(),
-        plan.service_config.host,
-        plan.service_config.port
-    ))
-    .into())
+fn run_remote_serve_plan(plan: RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
+    let runtime = Runtime::new().map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "create remote daemon tokio runtime: {error}"
+        )))
+    })?;
+    runtime.block_on(service::serve_remote_https(
+        plan.service_config,
+        plan.acme_plan,
+    ))?;
+    Ok(0)
 }

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -7,7 +7,7 @@ use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::state;
 
 use super::super::remote::{DaemonRemoteCommand, DaemonRemoteServeArgs};
-use super::super::remote_serve::build_remote_serve_execution_plan;
+use super::super::remote_serve::{build_remote_serve_execution_plan, execute_remote_serve_with};
 
 #[derive(Debug, Parser)]
 struct DaemonRemoteServeArgsTestHarness {
@@ -75,22 +75,27 @@ fn daemon_remote_serve_execution_plan_uses_remote_auth_and_tls() {
 }
 
 #[test]
-fn daemon_remote_serve_execute_reports_explicit_unimplemented_listener() {
-    let temp = tempfile::tempdir().expect("temp dir");
-    with_isolated_harness_env(temp.path(), || {
-        state::ensure_daemon_dirs().expect("daemon dirs");
-        let db = DaemonDb::open(&state::daemon_root().join("harness.db")).expect("open daemon db");
-        seed_acme_state(&db);
-        let command = DaemonRemoteCommand::Serve(remote_serve_args());
+fn daemon_remote_serve_execute_invokes_https_runner_after_preflight() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    seed_acme_state(&db);
 
-        let error = command
-            .execute(&AppContext)
-            .expect_err("remote serve should fail before listener implementation");
-        let message = error.to_string();
+    let exit = execute_remote_serve_with(
+        &remote_serve_args(),
+        || Ok(db),
+        |plan| {
+            assert_eq!(plan.service_config.host, "0.0.0.0");
+            assert_eq!(plan.service_config.port, 443);
+            assert_eq!(
+                plan.acme_plan.public_https_origin(),
+                "https://daemon.example.com"
+            );
+            assert!(plan.acme_plan.certificate().has_material());
+            Ok(0)
+        },
+    )
+    .expect("remote serve should invoke https runner after preflight");
 
-        assert!(message.contains("not implemented yet"));
-        assert!(message.contains("TLS preflight passed"));
-    });
+    assert_eq!(exit, 0);
 }
 
 fn remote_serve_args() -> DaemonRemoteServeArgs {

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -7,7 +7,10 @@ use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::state;
 
 use super::super::remote::{DaemonRemoteCommand, DaemonRemoteServeArgs};
-use super::super::remote_serve::{build_remote_serve_execution_plan, execute_remote_serve_with};
+use super::super::remote_serve::{
+    RemoteServeRuntimeMode, build_remote_serve_execution_plan, execute_remote_serve_with,
+    remote_serve_runtime_mode,
+};
 
 #[derive(Debug, Parser)]
 struct DaemonRemoteServeArgsTestHarness {
@@ -96,6 +99,29 @@ fn daemon_remote_serve_execute_invokes_https_runner_after_preflight() {
     .expect("remote serve should invoke https runner after preflight");
 
     assert_eq!(exit, 0);
+}
+
+#[test]
+fn daemon_remote_serve_runtime_mode_uses_new_runtime_without_current_runtime() {
+    assert_eq!(
+        remote_serve_runtime_mode(),
+        RemoteServeRuntimeMode::NewTokioRuntime
+    );
+}
+
+#[test]
+fn daemon_remote_serve_runtime_mode_detects_existing_tokio_runtime() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+
+    runtime.block_on(async {
+        assert_eq!(
+            remote_serve_runtime_mode(),
+            RemoteServeRuntimeMode::ExistingTokioRuntime
+        );
+    });
 }
 
 fn remote_serve_args() -> DaemonRemoteServeArgs {

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -79,26 +79,29 @@ fn daemon_remote_serve_execution_plan_uses_remote_auth_and_tls() {
 
 #[test]
 fn daemon_remote_serve_execute_invokes_https_runner_after_preflight() {
-    let db = DaemonDb::open_in_memory().expect("open db");
-    seed_acme_state(&db);
+    let temp = tempfile::tempdir().expect("temp dir");
+    with_isolated_harness_env(temp.path(), || {
+        let db = DaemonDb::open_in_memory().expect("open db");
+        seed_acme_state(&db);
 
-    let exit = execute_remote_serve_with(
-        &remote_serve_args(),
-        || Ok(db),
-        |plan| {
-            assert_eq!(plan.service_config.host, "0.0.0.0");
-            assert_eq!(plan.service_config.port, 443);
-            assert_eq!(
-                plan.acme_plan.public_https_origin(),
-                "https://daemon.example.com"
-            );
-            assert!(plan.acme_plan.certificate().has_material());
-            Ok(0)
-        },
-    )
-    .expect("remote serve should invoke https runner after preflight");
+        let exit = execute_remote_serve_with(
+            &remote_serve_args(),
+            || Ok(db),
+            |plan| {
+                assert_eq!(plan.service_config.host, "0.0.0.0");
+                assert_eq!(plan.service_config.port, 443);
+                assert_eq!(
+                    plan.acme_plan.public_https_origin(),
+                    "https://daemon.example.com"
+                );
+                assert!(plan.acme_plan.certificate().has_material());
+                Ok(0)
+            },
+        )
+        .expect("remote serve should invoke https runner after preflight");
 
-    assert_eq!(exit, 0);
+        assert_eq!(exit, 0);
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Motivation
Remote daemon serve should move past TLS preflight and run an HTTPS/WSS listener without loosening local loopback daemon behavior.

## Implementation
- Add rustls server config construction from persisted ACME certificate material with ALPN coverage.
- Add a TLS axum listener and remote HTTPS service lifecycle that uses remote auth and skips local manifest persistence.
- Replace the placeholder remote serve runner with the HTTPS runner and keep preflight test injection for proof.