### PR TITLE
feat(remote): diagnose remote readiness

### DIFF
--- a/src/daemon/transport/mod.rs
+++ b/src/daemon/transport/mod.rs
@@ -3,6 +3,7 @@ mod control;
 mod remote;
 mod remote_acme;
 mod remote_clients;
+mod remote_doctor;
 mod remote_serve;
 mod remote_systemd;
 mod remote_systemd_lifecycle;

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -19,6 +19,7 @@ use crate::errors::{CliError, CliErrorKind};
 use crate::workspace::utc_now;
 
 use super::control::{adopt_daemon_root_for_transport_command, print_json};
+use super::remote_doctor::execute_remote_doctor;
 use super::remote_serve::execute_remote_serve;
 use super::remote_systemd::{DaemonRemoteSystemdArgs, DaemonRemoteSystemdInstallArgs};
 
@@ -61,16 +62,9 @@ impl Execute for DaemonRemoteCommand {
             Self::InstallSystemd(args) => args.execute(context),
             Self::UninstallSystemd(args) => args.uninstall(context),
             Self::Status(args) => args.status(context),
-            Self::Doctor => Err(remote_execution_reserved_error()),
+            Self::Doctor => execute_remote_doctor(),
         }
     }
-}
-
-fn remote_execution_reserved_error() -> CliError {
-    CliErrorKind::workflow_parse(
-        "remote daemon execution is reserved for the next implementation phase",
-    )
-    .into()
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/daemon/transport/remote_doctor.rs
+++ b/src/daemon/transport/remote_doctor.rs
@@ -1,0 +1,193 @@
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::daemon::db::{DaemonDb, RemoteAcmeStoredState};
+use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_identity::{
+    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteStoredClient,
+};
+use crate::errors::CliError;
+use crate::workspace::utc_now;
+
+use super::control::{adopt_daemon_root_for_transport_command, print_json};
+use super::remote::open_remote_daemon_db;
+
+pub(super) fn execute_remote_doctor() -> Result<i32, CliError> {
+    adopt_daemon_root_for_transport_command("daemon-remote-doctor");
+    let db = open_remote_daemon_db()?;
+    let audit_event_id = format!("remote-doctor-{}", Uuid::new_v4());
+    let now = utc_now();
+    let response = run_remote_doctor_with(&db, audit_event_id.as_str(), now.as_str())?;
+    print_json(&response)?;
+    Ok(0)
+}
+
+/// Build a read-only remote daemon readiness diagnostic report.
+///
+/// # Errors
+/// Returns [`CliError`] when remote ACME/client state or audit persistence
+/// cannot be read or written.
+pub(crate) fn run_remote_doctor_with(
+    db: &DaemonDb,
+    audit_event_id: &str,
+    now: &str,
+) -> Result<DaemonRemoteDoctorResponse, CliError> {
+    let acme = db.load_remote_acme_state()?;
+    let clients = db.list_remote_clients()?;
+    let summary = DaemonRemoteDoctorSummary::from_state(&acme, &clients);
+    let checks = remote_doctor_checks(&summary);
+    let status = if checks.iter().any(DaemonRemoteDoctorCheck::failed) {
+        "not_ready"
+    } else {
+        "ready"
+    };
+    record_remote_doctor_audit(db, audit_event_id, now, RemoteAuditOutcome::Success)?;
+    Ok(DaemonRemoteDoctorResponse {
+        status: status.to_string(),
+        checks,
+        summary,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteDoctorResponse {
+    pub status: String,
+    pub checks: Vec<DaemonRemoteDoctorCheck>,
+    pub summary: DaemonRemoteDoctorSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteDoctorCheck {
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+impl DaemonRemoteDoctorCheck {
+    fn pass(name: &str, detail: impl Into<String>) -> Self {
+        Self::new(name, "pass", detail)
+    }
+
+    fn warn(name: &str, detail: impl Into<String>) -> Self {
+        Self::new(name, "warn", detail)
+    }
+
+    fn fail(name: &str, detail: impl Into<String>) -> Self {
+        Self::new(name, "fail", detail)
+    }
+
+    fn new(name: &str, status: &str, detail: impl Into<String>) -> Self {
+        Self {
+            name: name.to_string(),
+            status: status.to_string(),
+            detail: detail.into(),
+        }
+    }
+
+    fn failed(&self) -> bool {
+        self.status == "fail"
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DaemonRemoteDoctorSummary {
+    pub acme_account_configured: bool,
+    pub certificate_configured: bool,
+    pub certificate_fingerprint: Option<String>,
+    pub renewal_status: String,
+    pub renewal_error: Option<String>,
+    pub updated_at: String,
+    pub active_client_count: usize,
+    pub revoked_client_count: usize,
+}
+
+impl DaemonRemoteDoctorSummary {
+    fn from_state(acme: &RemoteAcmeStoredState, clients: &[RemoteStoredClient]) -> Self {
+        Self {
+            acme_account_configured: acme.account_configured,
+            certificate_configured: acme.certificate_configured,
+            certificate_fingerprint: acme.certificate_fingerprint.clone(),
+            renewal_status: acme.renewal_status.as_str().to_string(),
+            renewal_error: acme.renewal_error.clone(),
+            updated_at: acme.updated_at.clone(),
+            active_client_count: clients
+                .iter()
+                .filter(|client| client.revoked_at.is_none())
+                .count(),
+            revoked_client_count: clients
+                .iter()
+                .filter(|client| client.revoked_at.is_some())
+                .count(),
+        }
+    }
+}
+
+fn remote_doctor_checks(summary: &DaemonRemoteDoctorSummary) -> Vec<DaemonRemoteDoctorCheck> {
+    vec![
+        acme_account_check(summary),
+        tls_certificate_check(summary),
+        acme_renewal_check(summary),
+        remote_clients_check(summary),
+    ]
+}
+
+fn acme_account_check(summary: &DaemonRemoteDoctorSummary) -> DaemonRemoteDoctorCheck {
+    if summary.acme_account_configured {
+        DaemonRemoteDoctorCheck::pass("acme_account", "persisted ACME account configured")
+    } else {
+        DaemonRemoteDoctorCheck::fail("acme_account", "missing persisted ACME account")
+    }
+}
+
+fn tls_certificate_check(summary: &DaemonRemoteDoctorSummary) -> DaemonRemoteDoctorCheck {
+    if summary.certificate_configured {
+        DaemonRemoteDoctorCheck::pass("tls_certificate", "persisted TLS certificate configured")
+    } else {
+        DaemonRemoteDoctorCheck::fail("tls_certificate", "missing persisted TLS certificate")
+    }
+}
+
+fn acme_renewal_check(summary: &DaemonRemoteDoctorSummary) -> DaemonRemoteDoctorCheck {
+    match summary.renewal_status.as_str() {
+        "succeeded" => DaemonRemoteDoctorCheck::pass("acme_renewal", "renewal succeeded"),
+        "failed" => DaemonRemoteDoctorCheck::fail(
+            "acme_renewal",
+            summary
+                .renewal_error
+                .as_deref()
+                .unwrap_or("remote ACME renewal failed"),
+        ),
+        _ => DaemonRemoteDoctorCheck::warn("acme_renewal", "no renewal result recorded"),
+    }
+}
+
+fn remote_clients_check(summary: &DaemonRemoteDoctorSummary) -> DaemonRemoteDoctorCheck {
+    if summary.active_client_count == 0 {
+        DaemonRemoteDoctorCheck::warn("remote_clients", "no active remote clients")
+    } else {
+        DaemonRemoteDoctorCheck::pass(
+            "remote_clients",
+            format!("{} active remote clients", summary.active_client_count),
+        )
+    }
+}
+
+fn record_remote_doctor_audit(
+    db: &DaemonDb,
+    event_id: &str,
+    recorded_at: &str,
+    outcome: RemoteAuditOutcome,
+) -> Result<(), CliError> {
+    db.record_remote_audit_event(&RemoteAuditEvent::new(
+        event_id,
+        recorded_at,
+        None,
+        None,
+        "remote.doctor",
+        RemoteAccessScope::Read,
+        RemoteAuditScopeDecision::Allowed,
+        outcome,
+        None,
+        None,
+    ))
+}

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -3,6 +3,7 @@ mod lifecycle;
 mod remote_acme;
 mod remote_cli;
 mod remote_clients;
+mod remote_doctor;
 mod remote_serve;
 mod remote_systemd;
 mod remote_systemd_plan;

--- a/src/daemon/transport/tests/remote_doctor.rs
+++ b/src/daemon/transport/tests/remote_doctor.rs
@@ -1,0 +1,128 @@
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::RemoteClientRegistration;
+
+use super::super::remote_doctor::run_remote_doctor_with;
+
+#[test]
+fn daemon_remote_doctor_reports_missing_remote_readiness_and_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+
+    let response = run_remote_doctor_with(&db, "audit-remote-doctor", "2026-06-21T16:00:00Z")
+        .expect("remote doctor response");
+
+    assert_eq!(response.status, "not_ready");
+    assert_check(&response, "acme_account", "fail", "persisted ACME account");
+    assert_check(
+        &response,
+        "tls_certificate",
+        "fail",
+        "persisted TLS certificate",
+    );
+    assert_check(&response, "acme_renewal", "warn", "no renewal result");
+    assert_check(
+        &response,
+        "remote_clients",
+        "warn",
+        "no active remote clients",
+    );
+    assert!(!response.summary.acme_account_configured);
+    assert!(!response.summary.certificate_configured);
+    assert_eq!(response.summary.active_client_count, 0);
+    assert_eq!(response.summary.revoked_client_count, 0);
+
+    let json = serde_json::to_string(&response).expect("serialize response");
+    assert!(!json.contains("private_key"));
+    assert!(!json.contains("secret"));
+    assert!(!json.contains("reserved"));
+
+    let events = db.load_remote_audit_events(10).expect("audit events");
+    assert!(events.iter().any(|event| {
+        event.route_or_method == "remote.doctor"
+            && event.scope.as_str() == "read"
+            && event.outcome.as_str() == "success"
+    }));
+}
+
+#[test]
+fn daemon_remote_doctor_reports_ready_state_without_secret_material() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.connection()
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'cert-pem',
+                 private_key_pem = 'key-secret',
+                 certificate_fingerprint = 'fp-1',
+                 renewal_status = 'succeeded',
+                 renewal_error = NULL,
+                 updated_at = '2026-06-21T15:10:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed acme state");
+    register_client(&db, "client-active", None);
+    register_client(&db, "client-revoked", Some("2026-06-21T15:15:00Z"));
+
+    let response = run_remote_doctor_with(&db, "audit-remote-doctor", "2026-06-21T16:00:00Z")
+        .expect("remote doctor response");
+
+    assert_eq!(response.status, "ready");
+    assert_check(&response, "acme_account", "pass", "configured");
+    assert_check(&response, "tls_certificate", "pass", "configured");
+    assert_check(&response, "acme_renewal", "pass", "succeeded");
+    assert_check(&response, "remote_clients", "pass", "1 active");
+    assert!(response.summary.acme_account_configured);
+    assert!(response.summary.certificate_configured);
+    assert_eq!(
+        response.summary.certificate_fingerprint.as_deref(),
+        Some("fp-1")
+    );
+    assert_eq!(response.summary.active_client_count, 1);
+    assert_eq!(response.summary.revoked_client_count, 1);
+
+    let json = serde_json::to_string(&response).expect("serialize response");
+    assert!(json.contains("\"certificate_fingerprint\":\"fp-1\""));
+    assert!(!json.contains("key-secret"));
+    assert!(!json.contains("cert-pem"));
+}
+
+fn assert_check(
+    response: &super::super::remote_doctor::DaemonRemoteDoctorResponse,
+    name: &str,
+    status: &str,
+    detail: &str,
+) {
+    let check = response
+        .checks
+        .iter()
+        .find(|check| check.name == name)
+        .unwrap_or_else(|| panic!("missing check {name}"));
+    assert_eq!(check.status, status);
+    assert!(
+        check.detail.contains(detail),
+        "expected {name} detail to contain {detail:?}, got {:?}",
+        check.detail
+    );
+}
+
+fn register_client(db: &DaemonDb, client_id: &str, revoked_at: Option<&str>) {
+    let registration = RemoteClientRegistration::new_for_tests(
+        client_id,
+        "MacBook",
+        "macos",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        &format!("token-{client_id}"),
+        "2026-06-21T15:00:00Z",
+    )
+    .expect("registration");
+    db.register_remote_client(&registration)
+        .expect("register client");
+    if let Some(revoked_at) = revoked_at {
+        assert!(
+            db.revoke_remote_client(client_id, revoked_at)
+                .expect("revoke client")
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

`harness daemon remote doctor` still returned the generic reserved-phase error after the serve, ACME, clients, pairing, and systemd paths landed. Operators need a read-only check that reports whether persisted remote state is ready without exposing ACME or token material.

## Implementation

- Route `daemon remote doctor` through a new remote doctor transport module.
- Report ACME account, TLS certificate, renewal, and active-client readiness as token-safe JSON.
- Record a read-scope `remote.doctor` audit event and cover ready/not-ready states with focused tests.