### PR TITLE
feat(remote): persist acme renewals

### DIFF
--- a/src/daemon/db/remote_acme.rs
+++ b/src/daemon/db/remote_acme.rs
@@ -115,6 +115,41 @@ impl DaemonDb {
             .map_err(|error| db_error(format!("record remote acme renewal failure: {error}")))?;
         Ok(())
     }
+
+    /// Persist a successful ACME renewal certificate bundle.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL failure or if the singleton state row is
+    /// unexpectedly missing.
+    pub(crate) fn record_remote_acme_renewal_success(
+        &self,
+        bundle: &RemoteCertificateBundle,
+        updated_at: &str,
+    ) -> Result<(), CliError> {
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE remote_acme_state
+                 SET certificate_pem = ?1,
+                     private_key_pem = ?2,
+                     certificate_fingerprint = ?3,
+                     renewal_status = 'succeeded',
+                     renewal_error = NULL,
+                     updated_at = ?4
+                 WHERE singleton = 1",
+                params![
+                    bundle.certificate_pem(),
+                    bundle.private_key_pem(),
+                    bundle.fingerprint(),
+                    updated_at,
+                ],
+            )
+            .map_err(|error| db_error(format!("record remote acme renewal success: {error}")))?;
+        if changed == 0 {
+            return Err(db_error("remote acme singleton state row is missing"));
+        }
+        Ok(())
+    }
 }
 
 fn remote_acme_state_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteAcmeStoredState> {

--- a/src/daemon/db/tests/remote_acme.rs
+++ b/src/daemon/db/tests/remote_acme.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
-use crate::daemon::remote_acme::build_remote_acme_runtime_plan;
+use crate::daemon::remote_acme::{RemoteCertificateBundle, build_remote_acme_runtime_plan};
 
 #[test]
 fn remote_acme_state_status_hides_private_key_and_tracks_material() {
@@ -106,6 +106,48 @@ fn remote_acme_renewal_failure_persists_redacted_report() {
         Some("renewal failed: dns token=<redacted>&retry=1 secret=<redacted>")
     );
     assert_eq!(state.updated_at, "2026-06-21T15:01:00Z");
+}
+
+#[test]
+fn remote_acme_renewal_success_persists_certificate_and_clears_error() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.conn
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'old-cert',
+                 private_key_pem = 'old-key',
+                 certificate_fingerprint = 'old-fp',
+                 renewal_status = 'failed',
+                 renewal_error = 'renewal failed: old error',
+                 updated_at = '2026-06-21T15:00:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed failed acme state");
+    let bundle = RemoteCertificateBundle::new_for_tests("new-cert-pem", "new-key-secret");
+
+    db.record_remote_acme_renewal_success(&bundle, "2026-06-21T15:02:00Z")
+        .expect("record renewal success");
+
+    let state = db.load_remote_acme_state().expect("load acme state");
+    assert_eq!(state.renewal_status.as_str(), "succeeded");
+    assert_eq!(state.renewal_error, None);
+    assert_eq!(
+        state.certificate_fingerprint.as_deref(),
+        Some(bundle.fingerprint())
+    );
+    assert_eq!(state.updated_at, "2026-06-21T15:02:00Z");
+
+    let runtime_state = db
+        .load_remote_acme_runtime_state()
+        .expect("load acme runtime state");
+    let runtime_plan = build_remote_acme_runtime_plan(&remote_serve_config(), &runtime_state)
+        .expect("renewed certificate should be usable for remote serve");
+    assert_eq!(
+        runtime_plan.certificate().fingerprint(),
+        bundle.fingerprint()
+    );
 }
 
 fn remote_serve_config() -> RemoteDaemonServeConfig {

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -263,6 +263,11 @@ impl RemoteAcmeRenewalRequest {
 }
 
 pub trait RemoteAcmeRenewalIssuer {
+    #[must_use]
+    fn supports_initial_certificate(&self) -> bool {
+        false
+    }
+
     /// Issue or renew the remote daemon certificate for the supplied account.
     ///
     /// # Errors

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -236,6 +236,44 @@ impl Dns01ProviderAction {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteAcmeRenewalRequest {
+    account_id: String,
+    previous_certificate_fingerprint: Option<String>,
+}
+
+impl RemoteAcmeRenewalRequest {
+    #[must_use]
+    pub fn new(account_id: impl Into<String>, previous_fingerprint: Option<&str>) -> Self {
+        Self {
+            account_id: account_id.into(),
+            previous_certificate_fingerprint: previous_fingerprint.map(ToOwned::to_owned),
+        }
+    }
+
+    #[must_use]
+    pub fn account_id(&self) -> &str {
+        &self.account_id
+    }
+
+    #[must_use]
+    pub fn previous_certificate_fingerprint(&self) -> Option<&str> {
+        self.previous_certificate_fingerprint.as_deref()
+    }
+}
+
+pub trait RemoteAcmeRenewalIssuer {
+    /// Issue or renew the remote daemon certificate for the supplied account.
+    ///
+    /// # Errors
+    /// Returns a redaction-ready operator detail when the issuer cannot produce
+    /// a certificate bundle.
+    fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String>;
+}
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct RemoteCertificateBundle {
     certificate_pem: String,

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -4,6 +4,9 @@ use uuid::Uuid;
 use crate::app::command_context::{AppContext, Execute};
 use crate::daemon::db::{DaemonDb, RemoteAcmeStoredState};
 use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_acme::{
+    RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest, RemoteCertificateBundle,
+};
 use crate::daemon::remote_identity::{
     RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision,
 };
@@ -70,19 +73,36 @@ impl DaemonRemoteAcmeCommand {
         audit_event_id: &str,
         now: &str,
     ) -> Result<DaemonRemoteAcmeRenewResponse, CliError> {
+        self.renew_with_issuer(db, audit_event_id, now, &RemoteAcmeUnavailableIssuer)
+    }
+
+    /// Renew the remote certificate through the supplied issuer and persist the
+    /// token-safe result for status/serve consumers.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when database reads/writes or audit writes fail.
+    pub(crate) fn renew_with_issuer<I>(
+        &self,
+        db: &DaemonDb,
+        audit_event_id: &str,
+        now: &str,
+        issuer: &I,
+    ) -> Result<DaemonRemoteAcmeRenewResponse, CliError>
+    where
+        I: RemoteAcmeRenewalIssuer,
+    {
         let Self::Renew = self else {
             return Err(CliErrorKind::workflow_parse("remote acme command must be renew").into());
         };
         let state = db.load_remote_acme_state()?;
-        let detail = renewal_failure_detail(&state);
-        db.record_remote_acme_renewal_failure(detail, now)?;
+        let outcome = renew_remote_acme_certificate(db, &state, issuer, now)?;
         let state = db.load_remote_acme_state()?;
         record_remote_acme_audit(
             db,
             audit_event_id,
             now,
             "remote.acme.renew",
-            RemoteAuditOutcome::Failure,
+            outcome,
             state.renewal_error.as_deref(),
         )?;
         Ok(DaemonRemoteAcmeRenewResponse::from_state(&state))
@@ -167,6 +187,44 @@ fn renewal_failure_detail(state: &RemoteAcmeStoredState) -> &'static str {
         "remote daemon requires a persisted TLS certificate"
     } else {
         "remote ACME renewal client is not implemented"
+    }
+}
+
+fn renew_remote_acme_certificate<I>(
+    db: &DaemonDb,
+    state: &RemoteAcmeStoredState,
+    issuer: &I,
+    now: &str,
+) -> Result<RemoteAuditOutcome, CliError>
+where
+    I: RemoteAcmeRenewalIssuer,
+{
+    let Some(account_id) = state.account_id.as_deref() else {
+        db.record_remote_acme_renewal_failure(renewal_failure_detail(state), now)?;
+        return Ok(RemoteAuditOutcome::Failure);
+    };
+    let request =
+        RemoteAcmeRenewalRequest::new(account_id, state.certificate_fingerprint.as_deref());
+    match issuer.renew_certificate(&request) {
+        Ok(bundle) => {
+            db.record_remote_acme_renewal_success(&bundle, now)?;
+            Ok(RemoteAuditOutcome::Success)
+        }
+        Err(detail) => {
+            db.record_remote_acme_renewal_failure(&detail, now)?;
+            Ok(RemoteAuditOutcome::Failure)
+        }
+    }
+}
+
+struct RemoteAcmeUnavailableIssuer;
+
+impl RemoteAcmeRenewalIssuer for RemoteAcmeUnavailableIssuer {
+    fn renew_certificate(
+        &self,
+        _request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        Err("remote ACME renewal client is not implemented".to_string())
     }
 }
 

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -203,6 +203,10 @@ where
         db.record_remote_acme_renewal_failure(renewal_failure_detail(state), now)?;
         return Ok(RemoteAuditOutcome::Failure);
     };
+    if !state.certificate_configured && !issuer.supports_initial_certificate() {
+        db.record_remote_acme_renewal_failure(renewal_failure_detail(state), now)?;
+        return Ok(RemoteAuditOutcome::Failure);
+    }
     let request =
         RemoteAcmeRenewalRequest::new(account_id, state.certificate_fingerprint.as_deref());
     match issuer.renew_certificate(&request) {

--- a/src/daemon/transport/tests/remote_acme.rs
+++ b/src/daemon/transport/tests/remote_acme.rs
@@ -110,6 +110,43 @@ fn daemon_remote_acme_renew_records_missing_state_failure_and_audit() {
 }
 
 #[test]
+fn daemon_remote_acme_renew_preserves_missing_certificate_failure() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.connection()
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = NULL,
+                 private_key_pem = NULL,
+                 certificate_fingerprint = NULL,
+                 renewal_status = 'unknown',
+                 renewal_error = NULL,
+                 updated_at = '2026-06-21T15:10:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed account-only acme state");
+
+    let response = DaemonRemoteAcmeCommand::Renew
+        .renew_with(&db, "audit-acme-renew", "2026-06-21T15:12:00Z")
+        .expect("renew response");
+
+    assert_eq!(response.renewal_status, "failed");
+    assert!(
+        response
+            .renewal_error
+            .as_deref()
+            .is_some_and(|error| error.contains("persisted TLS certificate"))
+    );
+    assert!(
+        !response
+            .renewal_error
+            .as_deref()
+            .is_some_and(|error| error.contains("not implemented"))
+    );
+}
+
+#[test]
 fn daemon_remote_acme_renew_persists_success_from_issuer_and_audits() {
     let db = DaemonDb::open_in_memory().expect("open db");
     db.connection()
@@ -170,6 +207,10 @@ struct FakeRenewalIssuer {
 }
 
 impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
+    fn supports_initial_certificate(&self) -> bool {
+        true
+    }
+
     fn renew_certificate(
         &self,
         request: &RemoteAcmeRenewalRequest,

--- a/src/daemon/transport/tests/remote_acme.rs
+++ b/src/daemon/transport/tests/remote_acme.rs
@@ -1,6 +1,9 @@
 use clap::Parser;
 
 use crate::daemon::db::DaemonDb;
+use crate::daemon::remote_acme::{
+    RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest, RemoteCertificateBundle,
+};
 
 use super::super::remote::{DaemonRemoteAcmeCommand, DaemonRemoteCommand};
 
@@ -104,4 +107,75 @@ fn daemon_remote_acme_renew_records_missing_state_failure_and_audit() {
     assert!(events.iter().any(|event| {
         event.route_or_method == "remote.acme.renew" && event.outcome.as_str() == "failure"
     }));
+}
+
+#[test]
+fn daemon_remote_acme_renew_persists_success_from_issuer_and_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.connection()
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'old-cert-pem',
+                 private_key_pem = 'old-key-secret',
+                 certificate_fingerprint = 'old-fp',
+                 renewal_status = 'failed',
+                 renewal_error = 'renewal failed: old error',
+                 updated_at = '2026-06-21T15:10:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed acme state");
+    let issuer = FakeRenewalIssuer {
+        expected_account_id: "acct-1",
+        bundle: RemoteCertificateBundle::new_for_tests("new-cert-pem", "new-key-secret"),
+    };
+
+    let response = DaemonRemoteAcmeCommand::Renew
+        .renew_with_issuer(&db, "audit-acme-renew", "2026-06-21T15:12:00Z", &issuer)
+        .expect("renew response");
+
+    assert!(response.account_configured);
+    assert!(response.certificate_configured);
+    assert_eq!(response.renewal_status, "succeeded");
+    assert_eq!(response.renewal_error, None);
+    assert_eq!(
+        response.certificate_fingerprint.as_deref(),
+        Some(issuer.bundle.fingerprint())
+    );
+    response.ensure_success().expect("renewal should succeed");
+
+    let json = serde_json::to_string(&response).expect("serialize renew response");
+    assert!(!json.contains("new-key-secret"));
+    assert!(!json.contains("new-cert-pem"));
+    assert!(!json.contains("old-key-secret"));
+
+    let state = db.load_remote_acme_state().expect("load acme state");
+    assert_eq!(state.renewal_status.as_str(), "succeeded");
+    assert_eq!(state.renewal_error, None);
+    assert_eq!(
+        state.certificate_fingerprint.as_deref(),
+        Some(issuer.bundle.fingerprint())
+    );
+
+    let events = db.load_remote_audit_events(10).expect("audit events");
+    assert!(events.iter().any(|event| {
+        event.route_or_method == "remote.acme.renew" && event.outcome.as_str() == "success"
+    }));
+}
+
+struct FakeRenewalIssuer {
+    expected_account_id: &'static str,
+    bundle: RemoteCertificateBundle,
+}
+
+impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
+    fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        assert_eq!(request.account_id(), self.expected_account_id);
+        assert_eq!(request.previous_certificate_fingerprint(), Some("old-fp"));
+        Ok(self.bundle.clone())
+    }
 }


### PR DESCRIPTION
## Motivation

Remote ACME renewal still only records failure state. Before wiring the real issuer, the daemon needs a tested renewal path that can persist a successful certificate bundle, clear stale failure state, and audit the outcome without exposing PEM material.

## Implementation

- Add a renewal request and issuer seam for the remote ACME path.
- Persist successful renewal certificate material and make it immediately usable by the remote serve runtime loader.
- Add focused DB and transport tests for success persistence, token-safe JSON, and success/failure audit outcomes.