### PR TITLE
feat(remote): run dns exec hooks

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -36,6 +36,7 @@ pub mod ordering;
 pub mod protocol;
 pub mod remote;
 pub mod remote_acme;
+pub mod remote_acme_dns;
 pub mod remote_auth;
 pub(crate) mod remote_crypto;
 pub mod remote_identity;

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -9,6 +9,9 @@ use super::remote::{
     RemoteAcmeChallenge, RemoteDaemonConfigError, RemoteDaemonServeConfig, RemoteDnsProvider,
     validate_remote_serve_config,
 };
+pub use super::remote_acme_dns::{
+    Dns01ExecHookError, Dns01ExecHookInvocation, Dns01ExecHookOperation,
+};
 
 #[cfg(test)]
 #[path = "remote_acme_tests.rs"]
@@ -233,6 +236,35 @@ impl Dns01ProviderAction {
                 )
             }
         }
+    }
+
+    /// Run the generic DNS-01 exec hook for this provider action.
+    ///
+    /// # Errors
+    /// Returns [`Dns01ExecHookError`] when this action is not for the exec
+    /// provider, the hook program is blank, or the injected runner fails.
+    pub fn run_exec_hook_with<Run>(
+        &self,
+        hook_program: &str,
+        operation: Dns01ExecHookOperation,
+        runner: Run,
+    ) -> Result<(), Dns01ExecHookError>
+    where
+        Run: FnOnce(&Dns01ExecHookInvocation) -> Result<(), String>,
+    {
+        if self.provider != RemoteDnsProvider::Exec {
+            return Err(Dns01ExecHookError::WrongProvider);
+        }
+        let program = hook_program.trim();
+        if program.is_empty() {
+            return Err(Dns01ExecHookError::MissingCommand);
+        }
+        let invocation = Dns01ExecHookInvocation::new(
+            program,
+            [operation.as_str(), self.fqdn.as_str(), self.digest.as_str()],
+        );
+        runner(&invocation)
+            .map_err(|detail| Dns01ExecHookError::runner_failed(redact_secret_detail(&detail)))
     }
 }
 

--- a/src/daemon/remote_acme_dns.rs
+++ b/src/daemon/remote_acme_dns.rs
@@ -1,0 +1,68 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dns01ExecHookOperation {
+    Present,
+    Cleanup,
+}
+
+impl Dns01ExecHookOperation {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Present => "present",
+            Self::Cleanup => "cleanup",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dns01ExecHookInvocation {
+    program: String,
+    args: Vec<String>,
+}
+
+impl Dns01ExecHookInvocation {
+    pub(crate) fn new<const N: usize>(program: &str, args: [&str; N]) -> Self {
+        Self {
+            program: program.to_string(),
+            args: args.into_iter().map(ToOwned::to_owned).collect(),
+        }
+    }
+
+    #[must_use]
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    #[must_use]
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Dns01ExecHookError {
+    WrongProvider,
+    MissingCommand,
+    RunnerFailed(String),
+}
+
+impl Dns01ExecHookError {
+    pub(crate) const fn runner_failed(detail: String) -> Self {
+        Self::RunnerFailed(detail)
+    }
+}
+
+impl fmt::Display for Dns01ExecHookError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongProvider => write!(f, "DNS-01 exec hook requires the exec DNS provider"),
+            Self::MissingCommand => write!(f, "DNS-01 exec hook command is required"),
+            Self::RunnerFailed(detail) => write!(f, "DNS-01 exec hook failed: {detail}"),
+        }
+    }
+}
+
+impl Error for Dns01ExecHookError {}

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -1,8 +1,9 @@
 use std::error::Error;
 
 use super::{
-    AcmeHttp01ChallengeStore, Dns01ProviderAction, RemoteAcmeRuntimeState, RemoteCertificateBundle,
-    RemoteCertificateSlot, RemoteRenewalOutcome, build_remote_acme_runtime_plan,
+    AcmeHttp01ChallengeStore, Dns01ExecHookOperation, Dns01ProviderAction, RemoteAcmeRuntimeState,
+    RemoteCertificateBundle, RemoteCertificateSlot, RemoteRenewalOutcome,
+    build_remote_acme_runtime_plan,
 };
 use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
 
@@ -154,6 +155,108 @@ fn remote_dns01_providers_report_required_operations() {
         exec.command_preview()
             .contains("_acme-challenge.daemon.example.com")
     );
+}
+
+#[test]
+fn remote_dns01_exec_hook_invokes_present_and_cleanup_commands() {
+    let action = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Exec,
+        "_acme-challenge.daemon.example.com",
+        "digest-value",
+    );
+
+    let mut invocations = Vec::new();
+    action
+        .run_exec_hook_with(
+            "/usr/local/bin/harness-acme-dns",
+            Dns01ExecHookOperation::Present,
+            |invocation| {
+                invocations.push(invocation.clone());
+                Ok(())
+            },
+        )
+        .expect("present hook");
+    action
+        .run_exec_hook_with(
+            "/usr/local/bin/harness-acme-dns",
+            Dns01ExecHookOperation::Cleanup,
+            |invocation| {
+                invocations.push(invocation.clone());
+                Ok(())
+            },
+        )
+        .expect("cleanup hook");
+
+    assert_eq!(invocations.len(), 2);
+    assert_eq!(invocations[0].program(), "/usr/local/bin/harness-acme-dns");
+    assert_eq!(
+        invocations[0].args(),
+        &[
+            "present",
+            "_acme-challenge.daemon.example.com",
+            "digest-value"
+        ]
+    );
+    assert_eq!(
+        invocations[1].args(),
+        &[
+            "cleanup",
+            "_acme-challenge.daemon.example.com",
+            "digest-value"
+        ]
+    );
+}
+
+#[test]
+fn remote_dns01_exec_hook_rejects_invalid_provider_and_blank_program() {
+    let cloudflare = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Cloudflare,
+        "_acme-challenge.daemon.example.com",
+        "digest-value",
+    );
+    let exec = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Exec,
+        "_acme-challenge.daemon.example.com",
+        "digest-value",
+    );
+
+    let wrong_provider = cloudflare
+        .run_exec_hook_with(
+            "/usr/local/bin/harness-acme-dns",
+            Dns01ExecHookOperation::Present,
+            |_| Ok(()),
+        )
+        .expect_err("cloudflare cannot run exec hook");
+    assert!(wrong_provider.to_string().contains("exec DNS provider"));
+
+    let blank_program = exec
+        .run_exec_hook_with("  ", Dns01ExecHookOperation::Present, |_| Ok(()))
+        .expect_err("blank hook program should fail");
+    assert!(
+        blank_program
+            .to_string()
+            .contains("hook command is required")
+    );
+}
+
+#[test]
+fn remote_dns01_exec_hook_redacts_runner_failure_detail() {
+    let action = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Exec,
+        "_acme-challenge.daemon.example.com",
+        "digest-value",
+    );
+
+    let error = action
+        .run_exec_hook_with(
+            "/usr/local/bin/harness-acme-dns",
+            Dns01ExecHookOperation::Present,
+            |_| Err("dns hook failed token=super-secret".to_string()),
+        )
+        .expect_err("runner failure should surface");
+
+    assert!(error.to_string().contains("dns hook failed"));
+    assert!(!error.to_string().contains("super-secret"));
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

DNS-01 support currently reports required provider operations but does not model the generic exec-hook provider behavior. The remote ACME path needs a deterministic exec hook invocation before a real DNS-01 issuer can drive TXT record present/cleanup flows.

## Implementation

- Add DNS-01 exec-hook operation, invocation, and redacted error types.
- Teach `Dns01ProviderAction` to invoke a supplied exec-hook runner only for the exec DNS provider.
- Cover present/cleanup command shape, provider validation, blank hook rejection, and redacted runner failures with focused tests.