### PR TITLE
feat(remote): model dns provider changes

### DIFF
--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -10,7 +10,9 @@ use super::remote::{
     validate_remote_serve_config,
 };
 pub use super::remote_acme_dns::{
-    Dns01ExecHookError, Dns01ExecHookInvocation, Dns01ExecHookOperation,
+    CloudflareDns01ChangeRequest, Dns01ChangeOperation, Dns01ExecHookError,
+    Dns01ExecHookInvocation, Dns01ExecHookOperation, Dns01ProviderChangeError,
+    Route53Dns01ChangeBatch,
 };
 
 #[cfg(test)]
@@ -236,6 +238,48 @@ impl Dns01ProviderAction {
                 )
             }
         }
+    }
+
+    /// Build the Cloudflare DNS-01 change request for this provider action.
+    ///
+    /// # Errors
+    /// Returns [`Dns01ProviderChangeError`] when this action is not for the
+    /// Cloudflare provider or the zone id is blank.
+    pub fn cloudflare_change_request(
+        &self,
+        zone_id: &str,
+        operation: Dns01ChangeOperation,
+    ) -> Result<CloudflareDns01ChangeRequest, Dns01ProviderChangeError> {
+        if self.provider != RemoteDnsProvider::Cloudflare {
+            return Err(Dns01ProviderChangeError::wrong_provider("cloudflare"));
+        }
+        CloudflareDns01ChangeRequest::new(
+            zone_id,
+            self.fqdn.as_str(),
+            self.digest.as_str(),
+            operation,
+        )
+    }
+
+    /// Build the Route53 DNS-01 change batch for this provider action.
+    ///
+    /// # Errors
+    /// Returns [`Dns01ProviderChangeError`] when this action is not for the
+    /// Route53 provider or the hosted zone id is blank.
+    pub fn route53_change_batch(
+        &self,
+        hosted_zone_id: &str,
+        operation: Dns01ChangeOperation,
+    ) -> Result<Route53Dns01ChangeBatch, Dns01ProviderChangeError> {
+        if self.provider != RemoteDnsProvider::Route53 {
+            return Err(Dns01ProviderChangeError::wrong_provider("route53"));
+        }
+        Route53Dns01ChangeBatch::new(
+            hosted_zone_id,
+            self.fqdn.as_str(),
+            self.digest.as_str(),
+            operation,
+        )
     }
 
     /// Run the generic DNS-01 exec hook for this provider action.

--- a/src/daemon/remote_acme_dns.rs
+++ b/src/daemon/remote_acme_dns.rs
@@ -44,6 +44,7 @@ impl CloudflareDns01ChangeRequest {
             return Err(Dns01ProviderChangeError::MissingCloudflareZoneId);
         }
         let name = dns01_record_name(name)?;
+        let content = dns01_record_content(content)?;
         Ok(Self {
             operation,
             zone_id: zone_id.to_string(),
@@ -106,7 +107,7 @@ impl Route53Dns01ChangeBatch {
             operation,
             hosted_zone_id: hosted_zone_id.to_string(),
             name: route53_record_name(name)?,
-            quoted_value: route53_txt_value(content),
+            quoted_value: route53_txt_value(dns01_record_content(content)?),
         })
     }
 
@@ -147,6 +148,7 @@ pub enum Dns01ProviderChangeError {
     MissingCloudflareZoneId,
     MissingRoute53HostedZoneId,
     MissingRecordName,
+    MissingRecordContent,
 }
 
 impl Dns01ProviderChangeError {
@@ -170,6 +172,7 @@ impl fmt::Display for Dns01ProviderChangeError {
                 write!(f, "route53 hosted zone id is required")
             }
             Self::MissingRecordName => write!(f, "DNS-01 TXT record name is required"),
+            Self::MissingRecordContent => write!(f, "DNS-01 TXT record content is required"),
         }
     }
 }
@@ -248,6 +251,14 @@ fn dns01_record_name(name: &str) -> Result<&str, Dns01ProviderChangeError> {
         return Err(Dns01ProviderChangeError::MissingRecordName);
     }
     Ok(name)
+}
+
+fn dns01_record_content(content: &str) -> Result<&str, Dns01ProviderChangeError> {
+    let content = content.trim();
+    if content.is_empty() {
+        return Err(Dns01ProviderChangeError::MissingRecordContent);
+    }
+    Ok(content)
 }
 
 fn route53_record_name(name: &str) -> Result<String, Dns01ProviderChangeError> {

--- a/src/daemon/remote_acme_dns.rs
+++ b/src/daemon/remote_acme_dns.rs
@@ -43,6 +43,7 @@ impl CloudflareDns01ChangeRequest {
         if zone_id.is_empty() {
             return Err(Dns01ProviderChangeError::MissingCloudflareZoneId);
         }
+        let name = dns01_record_name(name)?;
         Ok(Self {
             operation,
             zone_id: zone_id.to_string(),
@@ -104,7 +105,7 @@ impl Route53Dns01ChangeBatch {
         Ok(Self {
             operation,
             hosted_zone_id: hosted_zone_id.to_string(),
-            name: route53_record_name(name),
+            name: route53_record_name(name)?,
             quoted_value: route53_txt_value(content),
         })
     }
@@ -145,6 +146,7 @@ pub enum Dns01ProviderChangeError {
     WrongProvider(&'static str),
     MissingCloudflareZoneId,
     MissingRoute53HostedZoneId,
+    MissingRecordName,
 }
 
 impl Dns01ProviderChangeError {
@@ -167,6 +169,7 @@ impl fmt::Display for Dns01ProviderChangeError {
             Self::MissingRoute53HostedZoneId => {
                 write!(f, "route53 hosted zone id is required")
             }
+            Self::MissingRecordName => write!(f, "DNS-01 TXT record name is required"),
         }
     }
 }
@@ -239,12 +242,20 @@ impl fmt::Display for Dns01ExecHookError {
 
 impl Error for Dns01ExecHookError {}
 
-fn route53_record_name(name: &str) -> String {
+fn dns01_record_name(name: &str) -> Result<&str, Dns01ProviderChangeError> {
     let name = name.trim();
+    if name.is_empty() {
+        return Err(Dns01ProviderChangeError::MissingRecordName);
+    }
+    Ok(name)
+}
+
+fn route53_record_name(name: &str) -> Result<String, Dns01ProviderChangeError> {
+    let name = dns01_record_name(name)?;
     if name.ends_with('.') {
-        name.to_string()
+        Ok(name.to_string())
     } else {
-        format!("{name}.")
+        Ok(format!("{name}."))
     }
 }
 

--- a/src/daemon/remote_acme_dns.rs
+++ b/src/daemon/remote_acme_dns.rs
@@ -2,6 +2,178 @@ use std::error::Error;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dns01ChangeOperation {
+    Present,
+    Cleanup,
+}
+
+impl Dns01ChangeOperation {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Present => "present",
+            Self::Cleanup => "cleanup",
+        }
+    }
+
+    const fn route53_action(self) -> &'static str {
+        match self {
+            Self::Present => "UPSERT",
+            Self::Cleanup => "DELETE",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloudflareDns01ChangeRequest {
+    operation: Dns01ChangeOperation,
+    zone_id: String,
+    name: String,
+    content: String,
+}
+
+impl CloudflareDns01ChangeRequest {
+    pub(crate) fn new(
+        zone_id: &str,
+        name: &str,
+        content: &str,
+        operation: Dns01ChangeOperation,
+    ) -> Result<Self, Dns01ProviderChangeError> {
+        let zone_id = zone_id.trim();
+        if zone_id.is_empty() {
+            return Err(Dns01ProviderChangeError::MissingCloudflareZoneId);
+        }
+        Ok(Self {
+            operation,
+            zone_id: zone_id.to_string(),
+            name: name.to_string(),
+            content: content.to_string(),
+        })
+    }
+
+    #[must_use]
+    pub fn operation(&self) -> Dns01ChangeOperation {
+        self.operation
+    }
+
+    #[must_use]
+    pub fn zone_id(&self) -> &str {
+        &self.zone_id
+    }
+
+    #[must_use]
+    pub const fn record_type(&self) -> &'static str {
+        "TXT"
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    #[must_use]
+    pub const fn ttl_seconds(&self) -> u32 {
+        120
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Route53Dns01ChangeBatch {
+    operation: Dns01ChangeOperation,
+    hosted_zone_id: String,
+    name: String,
+    quoted_value: String,
+}
+
+impl Route53Dns01ChangeBatch {
+    pub(crate) fn new(
+        hosted_zone_id: &str,
+        name: &str,
+        content: &str,
+        operation: Dns01ChangeOperation,
+    ) -> Result<Self, Dns01ProviderChangeError> {
+        let hosted_zone_id = hosted_zone_id.trim();
+        if hosted_zone_id.is_empty() {
+            return Err(Dns01ProviderChangeError::MissingRoute53HostedZoneId);
+        }
+        Ok(Self {
+            operation,
+            hosted_zone_id: hosted_zone_id.to_string(),
+            name: route53_record_name(name),
+            quoted_value: route53_txt_value(content),
+        })
+    }
+
+    #[must_use]
+    pub fn hosted_zone_id(&self) -> &str {
+        &self.hosted_zone_id
+    }
+
+    #[must_use]
+    pub const fn record_type(&self) -> &'static str {
+        "TXT"
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn quoted_value(&self) -> &str {
+        &self.quoted_value
+    }
+
+    #[must_use]
+    pub const fn ttl_seconds(&self) -> u32 {
+        60
+    }
+
+    #[must_use]
+    pub fn action(&self) -> &'static str {
+        self.operation.route53_action()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Dns01ProviderChangeError {
+    WrongProvider(&'static str),
+    MissingCloudflareZoneId,
+    MissingRoute53HostedZoneId,
+}
+
+impl Dns01ProviderChangeError {
+    #[must_use]
+    pub(crate) const fn wrong_provider(provider: &'static str) -> Self {
+        Self::WrongProvider(provider)
+    }
+}
+
+impl fmt::Display for Dns01ProviderChangeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongProvider(provider) => {
+                write!(
+                    f,
+                    "DNS-01 provider change requires the {provider} DNS provider"
+                )
+            }
+            Self::MissingCloudflareZoneId => write!(f, "cloudflare DNS zone id is required"),
+            Self::MissingRoute53HostedZoneId => {
+                write!(f, "route53 hosted zone id is required")
+            }
+        }
+    }
+}
+
+impl Error for Dns01ProviderChangeError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Dns01ExecHookOperation {
     Present,
     Cleanup,
@@ -66,3 +238,16 @@ impl fmt::Display for Dns01ExecHookError {
 }
 
 impl Error for Dns01ExecHookError {}
+
+fn route53_record_name(name: &str) -> String {
+    let name = name.trim();
+    if name.ends_with('.') {
+        name.to_string()
+    } else {
+        format!("{name}.")
+    }
+}
+
+fn route53_txt_value(content: &str) -> String {
+    format!("\"{}\"", content.replace('\\', "\\\\").replace('"', "\\\""))
+}

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use super::{
-    AcmeHttp01ChallengeStore, Dns01ExecHookOperation, Dns01ProviderAction, RemoteAcmeRuntimeState,
-    RemoteCertificateBundle, RemoteCertificateSlot, RemoteRenewalOutcome,
+    AcmeHttp01ChallengeStore, Dns01ChangeOperation, Dns01ExecHookOperation, Dns01ProviderAction,
+    RemoteAcmeRuntimeState, RemoteCertificateBundle, RemoteCertificateSlot, RemoteRenewalOutcome,
     build_remote_acme_runtime_plan,
 };
 use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
@@ -154,6 +154,91 @@ fn remote_dns01_providers_report_required_operations() {
     assert!(
         exec.command_preview()
             .contains("_acme-challenge.daemon.example.com")
+    );
+}
+
+#[test]
+fn remote_dns01_cloudflare_builds_present_and_cleanup_requests() {
+    let action = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Cloudflare,
+        "_acme-challenge.daemon.example.com",
+        "digest-value",
+    );
+
+    let present = action
+        .cloudflare_change_request("zone-123", Dns01ChangeOperation::Present)
+        .expect("cloudflare present request");
+    let cleanup = action
+        .cloudflare_change_request("zone-123", Dns01ChangeOperation::Cleanup)
+        .expect("cloudflare cleanup request");
+
+    assert_eq!(present.zone_id(), "zone-123");
+    assert_eq!(present.record_type(), "TXT");
+    assert_eq!(present.name(), "_acme-challenge.daemon.example.com");
+    assert_eq!(present.content(), "digest-value");
+    assert_eq!(present.ttl_seconds(), 120);
+    assert_eq!(present.operation().as_str(), "present");
+    assert_eq!(cleanup.operation().as_str(), "cleanup");
+}
+
+#[test]
+fn remote_dns01_route53_builds_present_and_cleanup_change_batches() {
+    let action = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Route53,
+        "_acme-challenge.daemon.example.com",
+        "digest-value",
+    );
+
+    let present = action
+        .route53_change_batch("Z123456", Dns01ChangeOperation::Present)
+        .expect("route53 present change");
+    let cleanup = action
+        .route53_change_batch("Z123456", Dns01ChangeOperation::Cleanup)
+        .expect("route53 cleanup change");
+
+    assert_eq!(present.hosted_zone_id(), "Z123456");
+    assert_eq!(present.record_type(), "TXT");
+    assert_eq!(present.name(), "_acme-challenge.daemon.example.com.");
+    assert_eq!(present.quoted_value(), "\"digest-value\"");
+    assert_eq!(present.ttl_seconds(), 60);
+    assert_eq!(present.action(), "UPSERT");
+    assert_eq!(cleanup.action(), "DELETE");
+}
+
+#[test]
+fn remote_dns01_native_provider_requests_validate_provider_and_zone_ids() {
+    let cloudflare = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Cloudflare,
+        "_acme-challenge.daemon.example.com",
+        "digest-value",
+    );
+    let route53 = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Route53,
+        "_acme-challenge.daemon.example.com",
+        "digest-value",
+    );
+
+    let missing_zone = cloudflare
+        .cloudflare_change_request("  ", Dns01ChangeOperation::Present)
+        .expect_err("cloudflare zone id is required");
+    assert!(missing_zone.to_string().contains("zone id is required"));
+
+    let wrong_provider = route53
+        .cloudflare_change_request("zone-123", Dns01ChangeOperation::Present)
+        .expect_err("route53 cannot build cloudflare requests");
+    assert!(
+        wrong_provider
+            .to_string()
+            .contains("cloudflare DNS provider")
+    );
+
+    let missing_hosted_zone = route53
+        .route53_change_batch("  ", Dns01ChangeOperation::Present)
+        .expect_err("route53 hosted zone id is required");
+    assert!(
+        missing_hosted_zone
+            .to_string()
+            .contains("hosted zone id is required")
     );
 }
 

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -240,6 +240,13 @@ fn remote_dns01_native_provider_requests_validate_provider_and_zone_ids() {
             .to_string()
             .contains("hosted zone id is required")
     );
+
+    let blank_route53_name =
+        Dns01ProviderAction::for_provider(RemoteDnsProvider::Route53, "   ", "digest-value");
+    let missing_name = blank_route53_name
+        .route53_change_batch("Z123456", Dns01ChangeOperation::Present)
+        .expect_err("route53 record name is required");
+    assert!(missing_name.to_string().contains("record name is required"));
 }
 
 #[test]

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -247,6 +247,34 @@ fn remote_dns01_native_provider_requests_validate_provider_and_zone_ids() {
         .route53_change_batch("Z123456", Dns01ChangeOperation::Present)
         .expect_err("route53 record name is required");
     assert!(missing_name.to_string().contains("record name is required"));
+
+    let blank_cloudflare_content = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Cloudflare,
+        "_acme-challenge.daemon.example.com",
+        "   ",
+    );
+    let missing_cloudflare_content = blank_cloudflare_content
+        .cloudflare_change_request("zone-123", Dns01ChangeOperation::Present)
+        .expect_err("cloudflare record content is required");
+    assert!(
+        missing_cloudflare_content
+            .to_string()
+            .contains("record content is required")
+    );
+
+    let blank_route53_content = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Route53,
+        "_acme-challenge.daemon.example.com",
+        "   ",
+    );
+    let missing_route53_content = blank_route53_content
+        .route53_change_batch("Z123456", Dns01ChangeOperation::Present)
+        .expect_err("route53 record content is required");
+    assert!(
+        missing_route53_content
+            .to_string()
+            .contains("record content is required")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Motivation
DNS-01 support needs provider-specific change shapes before the renewal client can safely call Cloudflare or Route53. The prior slice only modeled the generic exec hook path.

## Implementation
- Add Cloudflare DNS-01 TXT change requests with operation, zone id, record name, content, and TTL validation.
- Add Route53 DNS-01 change batches with hosted zone validation, normalized record names, quoted TXT values, and UPSERT/DELETE actions.
- Cover provider mismatch and blank zone inputs with focused remote ACME tests.