### PR TITLE
feat(remote): run dns challenge lifecycle

### DIFF
--- a/src/daemon/remote_acme_dns_runner.rs
+++ b/src/daemon/remote_acme_dns_runner.rs
@@ -68,11 +68,24 @@ pub enum Dns01ProviderExecutionError {
     ProviderChange(Dns01ProviderChangeError),
     ExecHook(Dns01ExecHookError),
     RunnerFailed(String),
+    IssueFailed(String),
+    IssueAndCleanupFailed { issue: String, cleanup: String },
 }
 
 impl Dns01ProviderExecutionError {
     fn runner_failed(detail: &str) -> Self {
         Self::RunnerFailed(redact_secret_detail(detail))
+    }
+
+    fn issue_failed(detail: &str) -> Self {
+        Self::IssueFailed(redact_secret_detail(detail))
+    }
+
+    fn issue_and_cleanup_failed(issue: &str, cleanup: &str) -> Self {
+        Self::IssueAndCleanupFailed {
+            issue: redact_secret_detail(issue),
+            cleanup: redact_secret_detail(cleanup),
+        }
     }
 }
 
@@ -88,6 +101,13 @@ impl fmt::Display for Dns01ProviderExecutionError {
             Self::ProviderChange(error) => write!(f, "{error}"),
             Self::ExecHook(error) => write!(f, "{error}"),
             Self::RunnerFailed(detail) => write!(f, "DNS-01 provider change failed: {detail}"),
+            Self::IssueFailed(detail) => write!(f, "DNS-01 challenge issue failed: {detail}"),
+            Self::IssueAndCleanupFailed { issue, cleanup } => {
+                write!(
+                    f,
+                    "DNS-01 challenge issue failed: {issue}; cleanup also failed: {cleanup}"
+                )
+            }
         }
     }
 }
@@ -97,7 +117,10 @@ impl Error for Dns01ProviderExecutionError {
         match self {
             Self::ProviderChange(error) => Some(error),
             Self::ExecHook(error) => Some(error),
-            Self::WrongProviderConfig(_) | Self::RunnerFailed(_) => None,
+            Self::WrongProviderConfig(_)
+            | Self::RunnerFailed(_)
+            | Self::IssueFailed(_)
+            | Self::IssueAndCleanupFailed { .. } => None,
         }
     }
 }
@@ -248,6 +271,43 @@ impl Dns01ProviderAction {
                     |invocation| runner.run_exec_hook(invocation),
                 )
                 .map_err(Dns01ProviderExecutionError::from)
+            }
+        }
+    }
+
+    /// Run a complete DNS-01 provider challenge lifecycle.
+    ///
+    /// The provider TXT record is presented first, the supplied issuance step is
+    /// executed second, and cleanup is attempted even when issuance fails.
+    ///
+    /// # Errors
+    /// Returns [`Dns01ProviderExecutionError`] when present fails, the issuance
+    /// step fails, cleanup fails, or both issuance and cleanup fail.
+    pub fn run_challenge_with<Runner, Issue>(
+        &self,
+        config: &Dns01ProviderExecutionConfig,
+        runner: &mut Runner,
+        issue: Issue,
+    ) -> Result<(), Dns01ProviderExecutionError>
+    where
+        Runner: Dns01ProviderChangeRunner,
+        Issue: FnOnce(&mut Runner) -> Result<(), String>,
+    {
+        self.run_change_with(config, Dns01ChangeOperation::Present, runner)?;
+        let issue_result = issue(runner);
+        let cleanup_result = self.run_change_with(config, Dns01ChangeOperation::Cleanup, runner);
+
+        match (issue_result, cleanup_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(issue_detail), Ok(())) => {
+                Err(Dns01ProviderExecutionError::issue_failed(&issue_detail))
+            }
+            (Ok(()), Err(cleanup_error)) => Err(cleanup_error),
+            (Err(issue_detail), Err(cleanup_error)) => {
+                Err(Dns01ProviderExecutionError::issue_and_cleanup_failed(
+                    &issue_detail,
+                    &cleanup_error.to_string(),
+                ))
             }
         }
     }

--- a/src/daemon/remote_acme_dns_runner.rs
+++ b/src/daemon/remote_acme_dns_runner.rs
@@ -87,6 +87,17 @@ impl Dns01ProviderExecutionError {
             cleanup: redact_secret_detail(cleanup),
         }
     }
+
+    fn redacted_detail(&self) -> String {
+        match self {
+            Self::RunnerFailed(detail)
+            | Self::IssueFailed(detail)
+            | Self::ExecHook(Dns01ExecHookError::RunnerFailed(detail)) => detail.clone(),
+            Self::ProviderChange(error) => error.to_string(),
+            Self::ExecHook(error) => error.to_string(),
+            Self::WrongProviderConfig(_) | Self::IssueAndCleanupFailed { .. } => self.to_string(),
+        }
+    }
 }
 
 impl fmt::Display for Dns01ProviderExecutionError {
@@ -304,9 +315,10 @@ impl Dns01ProviderAction {
             }
             (Ok(()), Err(cleanup_error)) => Err(cleanup_error),
             (Err(issue_detail), Err(cleanup_error)) => {
+                let cleanup_detail = cleanup_error.redacted_detail();
                 Err(Dns01ProviderExecutionError::issue_and_cleanup_failed(
                     &issue_detail,
-                    &cleanup_error.to_string(),
+                    &cleanup_detail,
                 ))
             }
         }

--- a/src/daemon/remote_acme_dns_runner_tests.rs
+++ b/src/daemon/remote_acme_dns_runner_tests.rs
@@ -94,6 +94,72 @@ fn remote_dns01_provider_runner_rejects_wrong_config_and_redacts_runner_errors()
     assert!(!failure.to_string().contains("super-secret"));
 }
 
+#[test]
+fn remote_dns01_provider_runner_runs_present_issue_cleanup_in_order() {
+    let mut runner = RecordingDns01Runner::default();
+    let action = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Cloudflare,
+        "_acme-challenge.daemon.example.com",
+        "cloudflare-digest",
+    );
+
+    action
+        .run_challenge_with(
+            &Dns01ProviderExecutionConfig::cloudflare("zone-123"),
+            &mut runner,
+            |runner| {
+                runner.record_issue();
+                Ok(())
+            },
+        )
+        .expect("challenge lifecycle");
+
+    assert_eq!(
+        runner.events,
+        vec![
+            "cloudflare:present:zone-123:_acme-challenge.daemon.example.com:cloudflare-digest"
+                .to_string(),
+            "issue".to_string(),
+            "cloudflare:cleanup:zone-123:_acme-challenge.daemon.example.com:cloudflare-digest"
+                .to_string(),
+        ]
+    );
+}
+
+#[test]
+fn remote_dns01_provider_runner_cleans_up_after_issue_failure() {
+    let mut runner = RecordingDns01Runner::default();
+    let action = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Route53,
+        "_acme-challenge.daemon.example.com",
+        "route53-digest",
+    );
+
+    let error = action
+        .run_challenge_with(
+            &Dns01ProviderExecutionConfig::route53("Z123456"),
+            &mut runner,
+            |runner| {
+                runner.record_issue();
+                Err("issuer token=super-secret failed".to_string())
+            },
+        )
+        .expect_err("issuer failure should surface");
+
+    assert!(error.to_string().contains("issuer"));
+    assert!(!error.to_string().contains("super-secret"));
+    assert_eq!(
+        runner.events,
+        vec![
+            "route53:UPSERT:Z123456:_acme-challenge.daemon.example.com.:\"route53-digest\""
+                .to_string(),
+            "issue".to_string(),
+            "route53:DELETE:Z123456:_acme-challenge.daemon.example.com.:\"route53-digest\""
+                .to_string(),
+        ]
+    );
+}
+
 #[derive(Default)]
 struct RecordingDns01Runner {
     events: Vec<String>,
@@ -140,6 +206,10 @@ impl Dns01ProviderChangeRunner for RecordingDns01Runner {
 }
 
 impl RecordingDns01Runner {
+    fn record_issue(&mut self) {
+        self.events.push("issue".to_string());
+    }
+
     fn maybe_fail(&self) -> Result<(), String> {
         match &self.fail_detail {
             Some(detail) => Err(detail.clone()),

--- a/src/daemon/remote_acme_dns_runner_tests.rs
+++ b/src/daemon/remote_acme_dns_runner_tests.rs
@@ -160,10 +160,52 @@ fn remote_dns01_provider_runner_cleans_up_after_issue_failure() {
     );
 }
 
+#[test]
+fn remote_dns01_provider_runner_reports_issue_and_cleanup_failure_without_nested_prefix() {
+    let mut runner = RecordingDns01Runner {
+        cleanup_fail_detail: Some("cleanup secret=cleanup-secret failed".to_string()),
+        ..RecordingDns01Runner::default()
+    };
+    let action = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Cloudflare,
+        "_acme-challenge.daemon.example.com",
+        "cloudflare-digest",
+    );
+
+    let error = action
+        .run_challenge_with(
+            &Dns01ProviderExecutionConfig::cloudflare("zone-123"),
+            &mut runner,
+            |runner| {
+                runner.record_issue();
+                Err("issuer token=issue-secret failed".to_string())
+            },
+        )
+        .expect_err("issue and cleanup failure should surface");
+    let message = error.to_string();
+
+    assert!(message.contains("issuer"));
+    assert!(message.contains("cleanup also failed"));
+    assert!(!message.contains("issue-secret"));
+    assert!(!message.contains("cleanup-secret"));
+    assert!(!message.contains("cleanup also failed: DNS-01 provider change failed"));
+    assert_eq!(
+        runner.events,
+        vec![
+            "cloudflare:present:zone-123:_acme-challenge.daemon.example.com:cloudflare-digest"
+                .to_string(),
+            "issue".to_string(),
+            "cloudflare:cleanup:zone-123:_acme-challenge.daemon.example.com:cloudflare-digest"
+                .to_string(),
+        ]
+    );
+}
+
 #[derive(Default)]
 struct RecordingDns01Runner {
     events: Vec<String>,
     fail_detail: Option<String>,
+    cleanup_fail_detail: Option<String>,
 }
 
 impl Dns01ProviderChangeRunner for RecordingDns01Runner {
@@ -171,7 +213,7 @@ impl Dns01ProviderChangeRunner for RecordingDns01Runner {
         &mut self,
         request: &CloudflareDns01ChangeRequest,
     ) -> Result<(), String> {
-        self.maybe_fail()?;
+        let is_cleanup = request.operation() == Dns01ChangeOperation::Cleanup;
         self.events.push(format!(
             "cloudflare:{}:{}:{}:{}",
             request.operation().as_str(),
@@ -179,11 +221,12 @@ impl Dns01ProviderChangeRunner for RecordingDns01Runner {
             request.name(),
             request.content()
         ));
+        self.maybe_fail(is_cleanup)?;
         Ok(())
     }
 
     fn apply_route53_change(&mut self, batch: &Route53Dns01ChangeBatch) -> Result<(), String> {
-        self.maybe_fail()?;
+        let is_cleanup = batch.action() == "DELETE";
         self.events.push(format!(
             "route53:{}:{}:{}:{}",
             batch.action(),
@@ -191,16 +234,21 @@ impl Dns01ProviderChangeRunner for RecordingDns01Runner {
             batch.name(),
             batch.quoted_value()
         ));
+        self.maybe_fail(is_cleanup)?;
         Ok(())
     }
 
     fn run_exec_hook(&mut self, invocation: &Dns01ExecHookInvocation) -> Result<(), String> {
-        self.maybe_fail()?;
+        let is_cleanup = invocation
+            .args()
+            .first()
+            .is_some_and(|arg| arg == "cleanup");
         self.events.push(format!(
             "exec:{}:{}",
             invocation.program(),
             invocation.args().join(" ")
         ));
+        self.maybe_fail(is_cleanup)?;
         Ok(())
     }
 }
@@ -210,7 +258,10 @@ impl RecordingDns01Runner {
         self.events.push("issue".to_string());
     }
 
-    fn maybe_fail(&self) -> Result<(), String> {
+    fn maybe_fail(&self, is_cleanup: bool) -> Result<(), String> {
+        if is_cleanup && let Some(detail) = &self.cleanup_fail_detail {
+            return Err(detail.clone());
+        }
         match &self.fail_detail {
             Some(detail) => Err(detail.clone()),
             None => Ok(()),


### PR DESCRIPTION
## Motivation
DNS-01 dispatch can run individual provider changes, but issuance needs a complete lifecycle that presents the TXT record, runs the ACME step, and still cleans up when issuance fails.

## Implementation
- Add `run_challenge_with` to run present, issue, and cleanup through the provider runner.
- Redact issue failures and report combined issue plus cleanup failures without leaking provider details.
- Add focused tests for ordered lifecycle execution and cleanup after issue failure.