### PR TITLE
feat(remote): persist acme serve config

### DIFF
--- a/src/daemon/db/async_bootstrap.rs
+++ b/src/daemon/db/async_bootstrap.rs
@@ -86,6 +86,8 @@ const fn migration_effect_column(migration_version: i64) -> Option<(&'static str
         16 => Some(("policy_workspace", "global_policy_enforcement_enabled")),
         19 => Some(("policy_workspace", "scenarios_json")),
         20 => Some(("policy_canvases", "live_document_json")),
+        21 => Some(("remote_clients", "client_id")),
+        22 => Some(("remote_acme_state", "domain")),
         _ => None,
     }
 }
@@ -114,6 +116,8 @@ const fn migration_floor_version(migration_version: i64) -> u64 {
         18 => 24,
         19 => 25,
         20 => 26,
+        21 => 27,
+        22 => 28,
         _ => u64::MAX,
     }
 }

--- a/src/daemon/db/migrations/0022_daemon_v28_remote_acme_config.sql
+++ b/src/daemon/db/migrations/0022_daemon_v28_remote_acme_config.sql
@@ -1,0 +1,9 @@
+ALTER TABLE remote_acme_state ADD COLUMN domain TEXT;
+ALTER TABLE remote_acme_state ADD COLUMN host TEXT;
+ALTER TABLE remote_acme_state ADD COLUMN https_port INTEGER;
+ALTER TABLE remote_acme_state ADD COLUMN http_port INTEGER;
+ALTER TABLE remote_acme_state ADD COLUMN acme_email TEXT;
+ALTER TABLE remote_acme_state ADD COLUMN acme_challenge TEXT;
+ALTER TABLE remote_acme_state ADD COLUMN acme_dns_provider TEXT;
+
+UPDATE schema_meta SET value = '28' WHERE key = 'version';

--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -83,6 +83,7 @@ mod schema_v24;
 mod schema_v25;
 mod schema_v26;
 mod schema_v27;
+mod schema_v28;
 mod session_data;
 mod signals;
 mod summaries;
@@ -276,7 +277,7 @@ impl fmt::Debug for DaemonDb {
     }
 }
 
-pub(crate) const SCHEMA_VERSION: &str = "27";
+pub(crate) const SCHEMA_VERSION: &str = "28";
 
 /// Summary of what was imported from file-based storage.
 #[derive(Debug, Default)]

--- a/src/daemon/db/remote_acme.rs
+++ b/src/daemon/db/remote_acme.rs
@@ -1,6 +1,9 @@
 use rusqlite::{OptionalExtension, params, types::Type};
 
 use super::{CliError, DaemonDb, db_error};
+use crate::daemon::remote::{
+    RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider, validate_remote_serve_config,
+};
 use crate::daemon::remote_acme::{
     RemoteAcmeRuntimeState, RemoteCertificateBundle, RemoteRenewalOutcome,
 };
@@ -18,7 +21,14 @@ SELECT
     NULLIF(TRIM(certificate_fingerprint), ''),
     renewal_status,
     renewal_error,
-    updated_at
+    updated_at,
+    NULLIF(TRIM(domain), ''),
+    NULLIF(TRIM(host), ''),
+    https_port,
+    http_port,
+    NULLIF(TRIM(acme_email), ''),
+    NULLIF(TRIM(acme_challenge), ''),
+    NULLIF(TRIM(acme_dns_provider), '')
 FROM remote_acme_state
 WHERE singleton = 1";
 
@@ -52,6 +62,7 @@ impl RemoteAcmeRenewalStatus {
 pub(crate) struct RemoteAcmeStoredState {
     pub(crate) account_configured: bool,
     pub(crate) account_id: Option<String>,
+    pub(crate) serve_config: Option<RemoteDaemonServeConfig>,
     pub(crate) certificate_configured: bool,
     pub(crate) certificate_fingerprint: Option<String>,
     pub(crate) renewal_status: RemoteAcmeRenewalStatus,
@@ -70,6 +81,61 @@ impl DaemonDb {
             .optional()
             .map_err(|error| db_error(format!("load remote acme state: {error}")))?
             .ok_or_else(|| db_error("remote acme singleton state row is missing"))
+    }
+
+    /// Load the persisted remote ACME serve config used by certificate issuance.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the singleton state row is missing, SQL loading
+    /// fails, or the stored config is internally invalid.
+    pub(crate) fn load_remote_acme_serve_config(
+        &self,
+    ) -> Result<Option<RemoteDaemonServeConfig>, CliError> {
+        self.load_remote_acme_state()
+            .map(|state| state.serve_config)
+    }
+
+    /// Persist the remote serve config needed for later ACME issuance.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the config is invalid, the singleton state row
+    /// is missing, or the write fails.
+    pub(crate) fn record_remote_acme_serve_config(
+        &self,
+        config: &RemoteDaemonServeConfig,
+        updated_at: &str,
+    ) -> Result<(), CliError> {
+        validate_remote_serve_config(config)
+            .map_err(|error| db_error(format!("validate remote acme serve config: {error}")))?;
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE remote_acme_state
+                 SET domain = ?1,
+                     host = ?2,
+                     https_port = ?3,
+                     http_port = ?4,
+                     acme_email = ?5,
+                     acme_challenge = ?6,
+                     acme_dns_provider = ?7,
+                     updated_at = ?8
+                 WHERE singleton = 1",
+                params![
+                    config.domain.trim(),
+                    config.host.trim(),
+                    i64::from(config.https_port),
+                    i64::from(config.http_port),
+                    config.acme_email.trim(),
+                    config.acme_challenge.as_str(),
+                    config.acme_dns_provider.map(RemoteDnsProvider::as_str),
+                    updated_at,
+                ],
+            )
+            .map_err(|error| db_error(format!("record remote acme serve config: {error}")))?;
+        if changed == 0 {
+            return Err(db_error("remote acme singleton state row is missing"));
+        }
+        Ok(())
     }
 
     /// Load remote ACME account and certificate material for the TLS runtime.
@@ -157,12 +223,124 @@ fn remote_acme_state_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Remot
     Ok(RemoteAcmeStoredState {
         account_id: row.get(0)?,
         account_configured: row.get::<_, i64>(1)? != 0,
+        serve_config: remote_acme_serve_config_from_row(row)?,
         certificate_configured: row.get::<_, i64>(2)? != 0,
         certificate_fingerprint: row.get(3)?,
         renewal_status: parse_renewal_status_at_column(&status_label, 4)?,
         renewal_error: row.get(5)?,
         updated_at: row.get(6)?,
     })
+}
+
+fn remote_acme_serve_config_from_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<Option<RemoteDaemonServeConfig>> {
+    let domain = row.get::<_, Option<String>>(7)?;
+    let host = row.get::<_, Option<String>>(8)?;
+    let tls_listener_port = row.get::<_, Option<i64>>(9)?;
+    let challenge_listener_port = row.get::<_, Option<i64>>(10)?;
+    let acme_email = row.get::<_, Option<String>>(11)?;
+    let acme_challenge = row.get::<_, Option<String>>(12)?;
+    let acme_dns_provider = row.get::<_, Option<String>>(13)?;
+    if domain.is_none()
+        && host.is_none()
+        && tls_listener_port.is_none()
+        && challenge_listener_port.is_none()
+        && acme_email.is_none()
+        && acme_challenge.is_none()
+        && acme_dns_provider.is_none()
+    {
+        return Ok(None);
+    }
+    let config = RemoteDaemonServeConfig {
+        domain: required_acme_config_text(domain, 7, "domain")?,
+        host: required_acme_config_text(host, 8, "host")?,
+        https_port: required_acme_config_port(tls_listener_port, 9, "https_port")?,
+        http_port: required_acme_config_port(challenge_listener_port, 10, "http_port")?,
+        acme_email: required_acme_config_text(acme_email, 11, "acme_email")?,
+        acme_challenge: parse_acme_challenge_at_column(
+            &required_acme_config_text(acme_challenge, 12, "acme_challenge")?,
+            12,
+        )?,
+        acme_dns_provider: acme_dns_provider
+            .as_deref()
+            .map(|label| parse_dns_provider_at_column(label, 13))
+            .transpose()?,
+    };
+    validate_remote_serve_config(&config).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            7,
+            Type::Text,
+            format!("invalid remote acme serve config: {error}").into(),
+        )
+    })?;
+    Ok(Some(config))
+}
+
+fn required_acme_config_text(
+    value: Option<String>,
+    column: usize,
+    label: &str,
+) -> rusqlite::Result<String> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                column,
+                Type::Text,
+                format!("remote acme serve config {label} is required").into(),
+            )
+        })
+}
+
+fn required_acme_config_port(
+    value: Option<i64>,
+    column: usize,
+    label: &str,
+) -> rusqlite::Result<u16> {
+    let value = value.ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            column,
+            Type::Integer,
+            format!("remote acme serve config {label} is required").into(),
+        )
+    })?;
+    u16::try_from(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            column,
+            Type::Integer,
+            format!("invalid remote acme serve config {label}: {error}").into(),
+        )
+    })
+}
+
+fn parse_acme_challenge_at_column(
+    label: &str,
+    column: usize,
+) -> rusqlite::Result<RemoteAcmeChallenge> {
+    match label {
+        "tls-alpn" => Ok(RemoteAcmeChallenge::TlsAlpn),
+        "http" => Ok(RemoteAcmeChallenge::Http),
+        "dns" => Ok(RemoteAcmeChallenge::Dns),
+        _ => Err(rusqlite::Error::FromSqlConversionFailure(
+            column,
+            Type::Text,
+            format!("unknown remote acme challenge '{label}'").into(),
+        )),
+    }
+}
+
+fn parse_dns_provider_at_column(label: &str, column: usize) -> rusqlite::Result<RemoteDnsProvider> {
+    match label {
+        "cloudflare" => Ok(RemoteDnsProvider::Cloudflare),
+        "route53" => Ok(RemoteDnsProvider::Route53),
+        "exec" => Ok(RemoteDnsProvider::Exec),
+        _ => Err(rusqlite::Error::FromSqlConversionFailure(
+            column,
+            Type::Text,
+            format!("unknown remote DNS provider '{label}'").into(),
+        )),
+    }
 }
 
 fn remote_acme_runtime_state_from_row(

--- a/src/daemon/db/remote_acme.rs
+++ b/src/daemon/db/remote_acme.rs
@@ -83,18 +83,6 @@ impl DaemonDb {
             .ok_or_else(|| db_error("remote acme singleton state row is missing"))
     }
 
-    /// Load the persisted remote ACME serve config used by certificate issuance.
-    ///
-    /// # Errors
-    /// Returns [`CliError`] when the singleton state row is missing, SQL loading
-    /// fails, or the stored config is internally invalid.
-    pub(crate) fn load_remote_acme_serve_config(
-        &self,
-    ) -> Result<Option<RemoteDaemonServeConfig>, CliError> {
-        self.load_remote_acme_state()
-            .map(|state| state.serve_config)
-    }
-
     /// Persist the remote serve config needed for later ACME issuance.
     ///
     /// # Errors

--- a/src/daemon/db/schema.rs
+++ b/src/daemon/db/schema.rs
@@ -181,6 +181,9 @@ impl DaemonDb {
         if version_number <= 26 {
             self.migrate_v26_to_v27()?;
         }
+        if version_number <= 27 {
+            self.migrate_v27_to_v28()?;
+        }
         Ok(())
     }
 
@@ -280,6 +283,10 @@ impl DaemonDb {
 
     fn migrate_v26_to_v27(&self) -> Result<(), CliError> {
         super::schema_v27::run(&self.conn)
+    }
+
+    fn migrate_v27_to_v28(&self) -> Result<(), CliError> {
+        super::schema_v28::run(&self.conn)
     }
 }
 

--- a/src/daemon/db/schema_repairs.rs
+++ b/src/daemon/db/schema_repairs.rs
@@ -31,6 +31,16 @@ const CURRENT_SCHEMA_POLICY_COLUMNS: &[(&str, &str)] = &[
 const DEPRECATED_SCHEMA_POLICY_COLUMNS: &[(&str, &str)] =
     &[("policy_workspace", "enforcement_snapshot_json")];
 
+const CURRENT_SCHEMA_REMOTE_ACME_COLUMNS: &[(&str, &str)] = &[
+    ("remote_acme_state", "domain"),
+    ("remote_acme_state", "host"),
+    ("remote_acme_state", "https_port"),
+    ("remote_acme_state", "http_port"),
+    ("remote_acme_state", "acme_email"),
+    ("remote_acme_state", "acme_challenge"),
+    ("remote_acme_state", "acme_dns_provider"),
+];
+
 pub(super) fn current_schema_shape_needs_repair(
     conn: &super::Connection,
 ) -> Result<bool, CliError> {
@@ -53,6 +63,11 @@ pub(super) fn current_schema_shape_needs_repair(
         }
     }
     for (table, column) in CURRENT_SCHEMA_POLICY_COLUMNS {
+        if !column_exists(conn, table, column)? {
+            return Ok(true);
+        }
+    }
+    for (table, column) in CURRENT_SCHEMA_REMOTE_ACME_COLUMNS {
         if !column_exists(conn, table, column)? {
             return Ok(true);
         }
@@ -84,6 +99,7 @@ pub(super) fn repair_current_schema_shape(db: &DaemonDb) -> Result<(), CliError>
     super::schema_v25::run(&db.conn)?;
     super::schema_v26::run(&db.conn)?;
     super::schema_v27::run(&db.conn)?;
+    super::schema_v28::run(&db.conn)?;
     db.conn
         .execute(
             "UPDATE schema_meta SET value = ?1 WHERE key = 'version'",

--- a/src/daemon/db/schema_v28.rs
+++ b/src/daemon/db/schema_v28.rs
@@ -1,0 +1,27 @@
+use rusqlite::Connection;
+
+use super::{CliError, db_error};
+
+const REMOTE_ACME_CONFIG_DDL: &str =
+    include_str!("migrations/0022_daemon_v28_remote_acme_config.sql");
+
+pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
+    let already_applied: bool = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('remote_acme_state') WHERE name = 'domain'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .is_ok_and(|count| count > 0);
+    if already_applied {
+        return conn
+            .execute(
+                "UPDATE schema_meta SET value = '28' WHERE key = 'version'",
+                [],
+            )
+            .map(|_| ())
+            .map_err(|error| db_error(format!("stamp schema v28: {error}")));
+    }
+    conn.execute_batch(REMOTE_ACME_CONFIG_DDL)
+        .map_err(|error| db_error(format!("migrate v27 -> v28 remote acme config: {error}")))
+}

--- a/src/daemon/db/schema_v28.rs
+++ b/src/daemon/db/schema_v28.rs
@@ -2,18 +2,12 @@ use rusqlite::Connection;
 
 use super::{CliError, db_error};
 
-const REMOTE_ACME_CONFIG_COLUMNS: &[(&str, &str)] = &[
-    ("domain", "TEXT"),
-    ("host", "TEXT"),
-    ("https_port", "INTEGER"),
-    ("http_port", "INTEGER"),
-    ("acme_email", "TEXT"),
-    ("acme_challenge", "TEXT"),
-    ("acme_dns_provider", "TEXT"),
-];
+const REMOTE_ACME_CONFIG_DDL: &str =
+    include_str!("migrations/0022_daemon_v28_remote_acme_config.sql");
+const ADD_REMOTE_ACME_COLUMN_PREFIX: &str = "ALTER TABLE remote_acme_state ADD COLUMN ";
 
 pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
-    for (column, definition) in REMOTE_ACME_CONFIG_COLUMNS {
+    for (column, definition) in remote_acme_config_columns()? {
         if remote_acme_state_column_exists(conn, column)? {
             continue;
         }
@@ -29,6 +23,27 @@ pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
     )
     .map(|_| ())
     .map_err(|error| db_error(format!("stamp schema v28: {error}")))
+}
+
+fn remote_acme_config_columns() -> Result<Vec<(&'static str, &'static str)>, CliError> {
+    let columns = REMOTE_ACME_CONFIG_DDL
+        .lines()
+        .filter_map(remote_acme_config_column_from_ddl_line)
+        .collect::<Vec<_>>();
+    if columns.is_empty() {
+        return Err(db_error("remote acme v28 migration has no column DDL"));
+    }
+    Ok(columns)
+}
+
+fn remote_acme_config_column_from_ddl_line(
+    line: &'static str,
+) -> Option<(&'static str, &'static str)> {
+    let statement = line
+        .trim()
+        .strip_prefix(ADD_REMOTE_ACME_COLUMN_PREFIX)?
+        .strip_suffix(';')?;
+    statement.split_once(' ')
 }
 
 fn remote_acme_state_column_exists(conn: &Connection, column: &str) -> Result<bool, CliError> {

--- a/src/daemon/db/schema_v28.rs
+++ b/src/daemon/db/schema_v28.rs
@@ -2,26 +2,45 @@ use rusqlite::Connection;
 
 use super::{CliError, db_error};
 
-const REMOTE_ACME_CONFIG_DDL: &str =
-    include_str!("migrations/0022_daemon_v28_remote_acme_config.sql");
+const REMOTE_ACME_CONFIG_COLUMNS: &[(&str, &str)] = &[
+    ("domain", "TEXT"),
+    ("host", "TEXT"),
+    ("https_port", "INTEGER"),
+    ("http_port", "INTEGER"),
+    ("acme_email", "TEXT"),
+    ("acme_challenge", "TEXT"),
+    ("acme_dns_provider", "TEXT"),
+];
 
 pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
-    let already_applied: bool = conn
-        .query_row(
-            "SELECT COUNT(*) FROM pragma_table_info('remote_acme_state') WHERE name = 'domain'",
+    for (column, definition) in REMOTE_ACME_CONFIG_COLUMNS {
+        if remote_acme_state_column_exists(conn, column)? {
+            continue;
+        }
+        conn.execute(
+            &format!("ALTER TABLE remote_acme_state ADD COLUMN {column} {definition}"),
             [],
-            |row| row.get::<_, i64>(0),
         )
-        .is_ok_and(|count| count > 0);
-    if already_applied {
-        return conn
-            .execute(
-                "UPDATE schema_meta SET value = '28' WHERE key = 'version'",
-                [],
-            )
-            .map(|_| ())
-            .map_err(|error| db_error(format!("stamp schema v28: {error}")));
+        .map_err(|error| db_error(format!("add remote acme state {column} column: {error}")))?;
     }
-    conn.execute_batch(REMOTE_ACME_CONFIG_DDL)
-        .map_err(|error| db_error(format!("migrate v27 -> v28 remote acme config: {error}")))
+    conn.execute(
+        "UPDATE schema_meta SET value = '28' WHERE key = 'version'",
+        [],
+    )
+    .map(|_| ())
+    .map_err(|error| db_error(format!("stamp schema v28: {error}")))
+}
+
+fn remote_acme_state_column_exists(conn: &Connection, column: &str) -> Result<bool, CliError> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('remote_acme_state') WHERE name = ?1",
+        [column],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|count| count > 0)
+    .map_err(|error| {
+        db_error(format!(
+            "inspect remote acme state {column} column: {error}"
+        ))
+    })
 }

--- a/src/daemon/db/tests/async_pool.rs
+++ b/src/daemon/db/tests/async_pool.rs
@@ -27,7 +27,7 @@ async fn connect_reads_current_schema_version() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=20).collect::<Vec<i64>>()
+        (1..=22).collect::<Vec<i64>>()
     );
 }
 
@@ -52,7 +52,7 @@ async fn connect_bootstraps_empty_database_with_sqlx_migrations() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=20).collect::<Vec<i64>>()
+        (1..=22).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -144,7 +144,7 @@ async fn connect_migrates_legacy_schema_before_opening_pool() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=20).collect::<Vec<i64>>()
+        (1..=22).collect::<Vec<i64>>()
     );
 }
 
@@ -188,7 +188,7 @@ async fn connect_preserves_existing_db_when_baseline_checksum_drifted() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=20).collect::<Vec<i64>>()
+        (1..=22).collect::<Vec<i64>>()
     );
 }
 
@@ -247,7 +247,7 @@ async fn connect_accepts_v22_db_with_recorded_policy_snapshot_migration() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=20).collect::<Vec<i64>>()
+        (1..=22).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -280,7 +280,7 @@ async fn connect_seeds_v18_sqlx_ledger_when_sync_schema_already_applied() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=20).collect::<Vec<i64>>()
+        (1..=22).collect::<Vec<i64>>()
     );
 }
 
@@ -370,7 +370,7 @@ async fn connect_repairs_v8_active_sessions_without_leader_before_opening_pool()
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=20).collect::<Vec<i64>>()
+        (1..=22).collect::<Vec<i64>>()
     );
     drop(async_db);
 

--- a/src/daemon/db/tests/remote_acme.rs
+++ b/src/daemon/db/tests/remote_acme.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
 use crate::daemon::remote_acme::{RemoteCertificateBundle, build_remote_acme_runtime_plan};
 
 #[test]
@@ -32,6 +32,107 @@ fn remote_acme_state_status_hides_private_key_and_tracks_material() {
     assert!(
         !format!("{state:?}").contains("key-secret"),
         "ACME status debug output must not expose private key material"
+    );
+}
+
+#[test]
+fn remote_acme_state_persists_serve_config_for_issuance() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let config = RemoteDaemonServeConfig {
+        domain: " daemon.example.com ".to_string(),
+        host: " 0.0.0.0 ".to_string(),
+        https_port: 8443,
+        http_port: 8080,
+        acme_email: " ops@example.com ".to_string(),
+        acme_challenge: RemoteAcmeChallenge::Dns,
+        acme_dns_provider: Some(RemoteDnsProvider::Cloudflare),
+    };
+
+    db.record_remote_acme_serve_config(&config, "2026-06-21T15:03:00Z")
+        .expect("record remote acme serve config");
+
+    let state = db.load_remote_acme_state().expect("load acme state");
+    let stored = state
+        .serve_config
+        .as_ref()
+        .expect("serve config should be stored");
+    assert_eq!(stored.domain, "daemon.example.com");
+    assert_eq!(stored.host, "0.0.0.0");
+    assert_eq!(stored.https_port, 8443);
+    assert_eq!(stored.http_port, 8080);
+    assert_eq!(stored.acme_email, "ops@example.com");
+    assert_eq!(stored.acme_challenge, RemoteAcmeChallenge::Dns);
+    assert_eq!(
+        stored.acme_dns_provider,
+        Some(RemoteDnsProvider::Cloudflare)
+    );
+    assert_eq!(state.updated_at, "2026-06-21T15:03:00Z");
+
+    let loaded = db
+        .load_remote_acme_serve_config()
+        .expect("load remote acme serve config")
+        .expect("stored remote acme serve config");
+    assert_eq!(loaded, *stored);
+}
+
+#[test]
+fn migrates_v27_remote_acme_state_to_serve_config_columns() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("harness.db");
+    {
+        let db = DaemonDb::open(&path).expect("open current db");
+        db.conn
+            .execute_batch(
+                "CREATE TABLE remote_acme_state_v27 (
+                     singleton               INTEGER PRIMARY KEY CHECK (singleton = 1),
+                     account_id              TEXT,
+                     certificate_pem         TEXT,
+                     private_key_pem         TEXT,
+                     certificate_fingerprint TEXT,
+                     renewal_status          TEXT NOT NULL DEFAULT 'unknown',
+                     renewal_error           TEXT,
+                     updated_at              TEXT NOT NULL
+                 ) WITHOUT ROWID;
+                 INSERT INTO remote_acme_state_v27 (
+                     singleton, account_id, certificate_pem, private_key_pem,
+                     certificate_fingerprint, renewal_status, renewal_error, updated_at
+                 )
+                 SELECT singleton, account_id, certificate_pem, private_key_pem,
+                        certificate_fingerprint, renewal_status, renewal_error, updated_at
+                 FROM remote_acme_state;
+                 DROP TABLE remote_acme_state;
+                 ALTER TABLE remote_acme_state_v27 RENAME TO remote_acme_state;
+                 UPDATE schema_meta SET value = '27' WHERE key = 'version';",
+            )
+            .expect("downgrade remote acme state");
+    }
+
+    let db = DaemonDb::open(&path).expect("open migrated db");
+
+    assert_eq!(db.schema_version().expect("version"), SCHEMA_VERSION);
+    for column in [
+        "domain",
+        "host",
+        "https_port",
+        "http_port",
+        "acme_email",
+        "acme_challenge",
+        "acme_dns_provider",
+    ] {
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('remote_acme_state') WHERE name = ?1",
+                [column],
+                |row| row.get(0),
+            )
+            .expect("query remote acme column");
+        assert_eq!(count, 1, "missing remote_acme_state column: {column}");
+    }
+    assert!(
+        db.load_remote_acme_serve_config()
+            .expect("load migrated serve config")
+            .is_none()
     );
 }
 

--- a/src/daemon/db/tests/remote_acme.rs
+++ b/src/daemon/db/tests/remote_acme.rs
@@ -69,10 +69,26 @@ fn remote_acme_state_persists_serve_config_for_issuance() {
     assert_eq!(state.updated_at, "2026-06-21T15:03:00Z");
 
     let loaded = db
-        .load_remote_acme_serve_config()
-        .expect("load remote acme serve config")
+        .load_remote_acme_state()
+        .expect("load remote acme state")
+        .serve_config
         .expect("stored remote acme serve config");
     assert_eq!(loaded, *stored);
+}
+
+#[test]
+fn remote_acme_serve_config_rejects_blank_host_before_persisting() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let mut config = remote_serve_config();
+    config.host = "   ".to_string();
+
+    let error = db
+        .record_remote_acme_serve_config(&config, "2026-06-21T15:03:00Z")
+        .expect_err("blank host should not be persisted");
+
+    assert!(error.to_string().contains("bind host"));
+    let state = db.load_remote_acme_state().expect("load acme state");
+    assert_eq!(state.serve_config, None);
 }
 
 #[test]
@@ -129,10 +145,11 @@ fn migrates_v27_remote_acme_state_to_serve_config_columns() {
             .expect("query remote acme column");
         assert_eq!(count, 1, "missing remote_acme_state column: {column}");
     }
-    assert!(
-        db.load_remote_acme_serve_config()
-            .expect("load migrated serve config")
-            .is_none()
+    assert_eq!(
+        db.load_remote_acme_state()
+            .expect("load migrated acme state")
+            .serve_config,
+        None
     );
 }
 

--- a/src/daemon/db/tests/remote_acme.rs
+++ b/src/daemon/db/tests/remote_acme.rs
@@ -137,6 +137,64 @@ fn migrates_v27_remote_acme_state_to_serve_config_columns() {
 }
 
 #[test]
+fn repairs_partially_applied_v28_remote_acme_config_columns() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("harness.db");
+    {
+        let db = DaemonDb::open(&path).expect("open current db");
+        db.conn
+            .execute_batch(
+                "CREATE TABLE remote_acme_state_v27 (
+                     singleton               INTEGER PRIMARY KEY CHECK (singleton = 1),
+                     account_id              TEXT,
+                     certificate_pem         TEXT,
+                     private_key_pem         TEXT,
+                     certificate_fingerprint TEXT,
+                     renewal_status          TEXT NOT NULL DEFAULT 'unknown',
+                     renewal_error           TEXT,
+                     updated_at              TEXT NOT NULL,
+                     domain                  TEXT
+                 ) WITHOUT ROWID;
+                 INSERT INTO remote_acme_state_v27 (
+                     singleton, account_id, certificate_pem, private_key_pem,
+                     certificate_fingerprint, renewal_status, renewal_error, updated_at, domain
+                 )
+                 SELECT singleton, account_id, certificate_pem, private_key_pem,
+                        certificate_fingerprint, renewal_status, renewal_error, updated_at,
+                        'daemon.example.com'
+                 FROM remote_acme_state;
+                 DROP TABLE remote_acme_state;
+                 ALTER TABLE remote_acme_state_v27 RENAME TO remote_acme_state;
+                 UPDATE schema_meta SET value = '27' WHERE key = 'version';",
+            )
+            .expect("simulate partial v28 remote acme state");
+    }
+
+    let db = DaemonDb::open(&path).expect("open repaired db");
+
+    assert_eq!(db.schema_version().expect("version"), SCHEMA_VERSION);
+    for column in [
+        "domain",
+        "host",
+        "https_port",
+        "http_port",
+        "acme_email",
+        "acme_challenge",
+        "acme_dns_provider",
+    ] {
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('remote_acme_state') WHERE name = ?1",
+                [column],
+                |row| row.get(0),
+            )
+            .expect("query remote acme column");
+        assert_eq!(count, 1, "missing remote_acme_state column: {column}");
+    }
+}
+
+#[test]
 fn remote_acme_runtime_state_loads_certificate_material_for_serve() {
     let db = DaemonDb::open_in_memory().expect("open db");
     db.conn

--- a/src/daemon/remote.rs
+++ b/src/daemon/remote.rs
@@ -134,6 +134,7 @@ pub struct RemoteDaemonServeConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteDaemonConfigError {
     MissingDomain,
+    MissingHost,
     MissingAcmeEmail,
     MissingHttpsPort,
     MissingHttpPort,
@@ -145,6 +146,7 @@ impl fmt::Display for RemoteDaemonConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MissingDomain => write!(f, "remote daemon domain is required"),
+            Self::MissingHost => write!(f, "remote daemon bind host is required"),
             Self::MissingAcmeEmail => write!(f, "remote daemon ACME email is required"),
             Self::MissingHttpsPort => write!(f, "remote daemon HTTPS port must be non-zero"),
             Self::MissingHttpPort => write!(f, "remote daemon HTTP-01 port must be non-zero"),
@@ -173,6 +175,9 @@ pub fn validate_remote_serve_config(
 ) -> Result<(), RemoteDaemonConfigError> {
     if config.domain.trim().is_empty() {
         return Err(RemoteDaemonConfigError::MissingDomain);
+    }
+    if config.host.trim().is_empty() {
+        return Err(RemoteDaemonConfigError::MissingHost);
     }
     if config.acme_email.trim().is_empty() {
         return Err(RemoteDaemonConfigError::MissingAcmeEmail);

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -206,14 +206,20 @@ impl AcmeHttp01ChallengeStore {
 pub struct RemoteAcmeRenewalRequest {
     account_id: String,
     previous_certificate_fingerprint: Option<String>,
+    serve_config: RemoteDaemonServeConfig,
 }
 
 impl RemoteAcmeRenewalRequest {
     #[must_use]
-    pub fn new(account_id: impl Into<String>, previous_fingerprint: Option<&str>) -> Self {
+    pub fn new(
+        account_id: impl Into<String>,
+        previous_fingerprint: Option<&str>,
+        serve_config: &RemoteDaemonServeConfig,
+    ) -> Self {
         Self {
             account_id: account_id.into(),
             previous_certificate_fingerprint: previous_fingerprint.map(ToOwned::to_owned),
+            serve_config: serve_config.clone(),
         }
     }
 
@@ -225,6 +231,11 @@ impl RemoteAcmeRenewalRequest {
     #[must_use]
     pub fn previous_certificate_fingerprint(&self) -> Option<&str> {
         self.previous_certificate_fingerprint.as_deref()
+    }
+
+    #[must_use]
+    pub const fn serve_config(&self) -> &RemoteDaemonServeConfig {
+        &self.serve_config
     }
 }
 

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::app::command_context::{AppContext, Execute};
 use crate::daemon::db::{DaemonDb, RemoteAcmeStoredState};
-use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote::{RemoteAccessScope, RemoteDaemonServeConfig};
 use crate::daemon::remote_acme::{
     RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest, RemoteCertificateBundle,
 };
@@ -95,7 +95,9 @@ impl DaemonRemoteAcmeCommand {
             return Err(CliErrorKind::workflow_parse("remote acme command must be renew").into());
         };
         let state = db.load_remote_acme_state()?;
-        let outcome = renew_remote_acme_certificate(db, &state, issuer, now)?;
+        let serve_config = db.load_remote_acme_serve_config()?;
+        let outcome =
+            renew_remote_acme_certificate(db, &state, serve_config.as_ref(), issuer, now)?;
         let state = db.load_remote_acme_state()?;
         record_remote_acme_audit(
             db,
@@ -121,6 +123,13 @@ impl DaemonRemoteAcmeCommand {
 pub(crate) struct DaemonRemoteAcmeStatusResponse {
     pub account_configured: bool,
     pub account_id: Option<String>,
+    pub domain: Option<String>,
+    pub host: Option<String>,
+    pub https_port: Option<u16>,
+    pub http_port: Option<u16>,
+    pub acme_email: Option<String>,
+    pub acme_challenge: Option<String>,
+    pub acme_dns_provider: Option<String>,
     pub certificate_configured: bool,
     pub certificate_fingerprint: Option<String>,
     pub renewal_status: String,
@@ -130,9 +139,19 @@ pub(crate) struct DaemonRemoteAcmeStatusResponse {
 
 impl DaemonRemoteAcmeStatusResponse {
     fn from_state(state: &RemoteAcmeStoredState) -> Self {
+        let serve_config = state.serve_config.as_ref();
         Self {
             account_configured: state.account_configured,
             account_id: state.account_id.clone(),
+            domain: serve_config.map(|config| config.domain.clone()),
+            host: serve_config.map(|config| config.host.clone()),
+            https_port: serve_config.map(|config| config.https_port),
+            http_port: serve_config.map(|config| config.http_port),
+            acme_email: serve_config.map(|config| config.acme_email.clone()),
+            acme_challenge: serve_config.map(|config| config.acme_challenge.as_str().to_string()),
+            acme_dns_provider: serve_config
+                .and_then(|config| config.acme_dns_provider)
+                .map(|provider| provider.as_str().to_string()),
             certificate_configured: state.certificate_configured,
             certificate_fingerprint: state.certificate_fingerprint.clone(),
             renewal_status: state.renewal_status.as_str().to_string(),
@@ -190,9 +209,14 @@ fn renewal_failure_detail(state: &RemoteAcmeStoredState) -> &'static str {
     }
 }
 
+fn missing_serve_config_failure_detail() -> &'static str {
+    "remote daemon requires persisted remote ACME serve config"
+}
+
 fn renew_remote_acme_certificate<I>(
     db: &DaemonDb,
     state: &RemoteAcmeStoredState,
+    serve_config: Option<&RemoteDaemonServeConfig>,
     issuer: &I,
     now: &str,
 ) -> Result<RemoteAuditOutcome, CliError>
@@ -203,12 +227,19 @@ where
         db.record_remote_acme_renewal_failure(renewal_failure_detail(state), now)?;
         return Ok(RemoteAuditOutcome::Failure);
     };
+    let Some(serve_config) = serve_config else {
+        db.record_remote_acme_renewal_failure(missing_serve_config_failure_detail(), now)?;
+        return Ok(RemoteAuditOutcome::Failure);
+    };
     if !state.certificate_configured && !issuer.supports_initial_certificate() {
         db.record_remote_acme_renewal_failure(renewal_failure_detail(state), now)?;
         return Ok(RemoteAuditOutcome::Failure);
     }
-    let request =
-        RemoteAcmeRenewalRequest::new(account_id, state.certificate_fingerprint.as_deref());
+    let request = RemoteAcmeRenewalRequest::new(
+        account_id,
+        state.certificate_fingerprint.as_deref(),
+        serve_config,
+    );
     match issuer.renew_certificate(&request) {
         Ok(bundle) => {
             db.record_remote_acme_renewal_success(&bundle, now)?;

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -95,9 +95,8 @@ impl DaemonRemoteAcmeCommand {
             return Err(CliErrorKind::workflow_parse("remote acme command must be renew").into());
         };
         let state = db.load_remote_acme_state()?;
-        let serve_config = db.load_remote_acme_serve_config()?;
         let outcome =
-            renew_remote_acme_certificate(db, &state, serve_config.as_ref(), issuer, now)?;
+            renew_remote_acme_certificate(db, &state, state.serve_config.as_ref(), issuer, now)?;
         let state = db.load_remote_acme_state()?;
         record_remote_acme_audit(
             db,

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -4,6 +4,7 @@ use crate::daemon::db::DaemonDb;
 use crate::daemon::remote_acme::{RemoteAcmeRuntimePlan, build_remote_acme_runtime_plan};
 use crate::daemon::service::{self, DaemonServeConfig};
 use crate::errors::{CliError, CliErrorKind};
+use crate::workspace::utc_now;
 use tokio::runtime::{Handle, Runtime};
 
 use super::control::adopt_daemon_root_for_transport_command;
@@ -45,6 +46,7 @@ pub(crate) fn build_remote_serve_execution_plan(
     db: &DaemonDb,
 ) -> Result<RemoteDaemonServeExecutionPlan, CliError> {
     let remote_config = args.contract_config()?;
+    db.record_remote_acme_serve_config(&remote_config, utc_now().as_str())?;
     let acme_state = db.load_remote_acme_runtime_state()?;
     let acme_plan = build_remote_acme_runtime_plan(&remote_config, &acme_state)
         .map_err(|error| CliError::from(CliErrorKind::workflow_parse(error.to_string())))?;

--- a/src/daemon/transport/tests/remote_acme.rs
+++ b/src/daemon/transport/tests/remote_acme.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 use crate::daemon::db::DaemonDb;
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
 use crate::daemon::remote_acme::{
     RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest, RemoteCertificateBundle,
 };
@@ -39,6 +40,8 @@ fn daemon_remote_acme_cli_parses_status_and_renew() {
 #[test]
 fn daemon_remote_acme_status_reports_persisted_state_without_key() {
     let db = DaemonDb::open_in_memory().expect("open db");
+    db.record_remote_acme_serve_config(&remote_dns_serve_config(), "2026-06-21T15:09:30Z")
+        .expect("record remote acme serve config");
     db.connection()
         .execute(
             "UPDATE remote_acme_state
@@ -63,6 +66,13 @@ fn daemon_remote_acme_status_reports_persisted_state_without_key() {
     assert!(response.certificate_configured);
     assert_eq!(response.certificate_fingerprint.as_deref(), Some("fp-1"));
     assert_eq!(response.renewal_status, "succeeded");
+    assert_eq!(response.domain.as_deref(), Some("daemon.example.com"));
+    assert_eq!(response.host.as_deref(), Some("0.0.0.0"));
+    assert_eq!(response.https_port, Some(443));
+    assert_eq!(response.http_port, Some(80));
+    assert_eq!(response.acme_email.as_deref(), Some("ops@example.com"));
+    assert_eq!(response.acme_challenge.as_deref(), Some("dns"));
+    assert_eq!(response.acme_dns_provider.as_deref(), Some("cloudflare"));
     let json = serde_json::to_string(&response).expect("serialize response");
     assert!(!json.contains("key-secret"));
 
@@ -73,6 +83,18 @@ fn daemon_remote_acme_status_reports_persisted_state_without_key() {
         .map(|event| event.route_or_method)
         .collect();
     assert_eq!(routes, vec!["remote.acme.status"]);
+}
+
+fn remote_dns_serve_config() -> RemoteDaemonServeConfig {
+    RemoteDaemonServeConfig {
+        domain: "daemon.example.com".to_string(),
+        host: "0.0.0.0".to_string(),
+        https_port: 443,
+        http_port: 80,
+        acme_email: "ops@example.com".to_string(),
+        acme_challenge: RemoteAcmeChallenge::Dns,
+        acme_dns_provider: Some(RemoteDnsProvider::Cloudflare),
+    }
 }
 
 #[test]
@@ -112,6 +134,8 @@ fn daemon_remote_acme_renew_records_missing_state_failure_and_audit() {
 #[test]
 fn daemon_remote_acme_renew_preserves_missing_certificate_failure() {
     let db = DaemonDb::open_in_memory().expect("open db");
+    db.record_remote_acme_serve_config(&remote_dns_serve_config(), "2026-06-21T15:09:30Z")
+        .expect("record remote acme serve config");
     db.connection()
         .execute(
             "UPDATE remote_acme_state
@@ -147,8 +171,46 @@ fn daemon_remote_acme_renew_preserves_missing_certificate_failure() {
 }
 
 #[test]
+fn daemon_remote_acme_renew_requires_persisted_serve_config() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    db.connection()
+        .execute(
+            "UPDATE remote_acme_state
+             SET account_id = 'acct-1',
+                 certificate_pem = 'old-cert-pem',
+                 private_key_pem = 'old-key-secret',
+                 certificate_fingerprint = 'old-fp',
+                 renewal_status = 'succeeded',
+                 renewal_error = NULL,
+                 updated_at = '2026-06-21T15:10:00Z'
+             WHERE singleton = 1",
+            [],
+        )
+        .expect("seed acme state without serve config");
+
+    let response = DaemonRemoteAcmeCommand::Renew
+        .renew_with_issuer(
+            &db,
+            "audit-acme-renew",
+            "2026-06-21T15:12:00Z",
+            &PanicRenewalIssuer,
+        )
+        .expect("renew response");
+
+    assert_eq!(response.renewal_status, "failed");
+    assert!(
+        response
+            .renewal_error
+            .as_deref()
+            .is_some_and(|error| error.contains("remote ACME serve config"))
+    );
+}
+
+#[test]
 fn daemon_remote_acme_renew_persists_success_from_issuer_and_audits() {
     let db = DaemonDb::open_in_memory().expect("open db");
+    db.record_remote_acme_serve_config(&remote_dns_serve_config(), "2026-06-21T15:09:30Z")
+        .expect("record remote acme serve config");
     db.connection()
         .execute(
             "UPDATE remote_acme_state
@@ -206,6 +268,8 @@ struct FakeRenewalIssuer {
     bundle: RemoteCertificateBundle,
 }
 
+struct PanicRenewalIssuer;
+
 impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
     fn supports_initial_certificate(&self) -> bool {
         true
@@ -217,6 +281,23 @@ impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
     ) -> Result<RemoteCertificateBundle, String> {
         assert_eq!(request.account_id(), self.expected_account_id);
         assert_eq!(request.previous_certificate_fingerprint(), Some("old-fp"));
+        let serve_config = request.serve_config();
+        assert_eq!(serve_config.domain, "daemon.example.com");
+        assert_eq!(serve_config.acme_email, "ops@example.com");
+        assert_eq!(serve_config.acme_challenge, RemoteAcmeChallenge::Dns);
+        assert_eq!(
+            serve_config.acme_dns_provider,
+            Some(RemoteDnsProvider::Cloudflare)
+        );
         Ok(self.bundle.clone())
+    }
+}
+
+impl RemoteAcmeRenewalIssuer for PanicRenewalIssuer {
+    fn renew_certificate(
+        &self,
+        _request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        panic!("issuer must not run without persisted serve config")
     }
 }

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -31,6 +31,16 @@ fn daemon_remote_serve_execution_plan_requires_persisted_acme_state() {
 
     assert!(message.contains("persisted ACME state"));
     assert!(!message.contains("reserved"));
+
+    let stored = db
+        .load_remote_acme_serve_config()
+        .expect("load persisted remote serve config")
+        .expect("remote serve config should be persisted before ACME preflight fails");
+    assert_eq!(stored.domain, "daemon.example.com");
+    assert_eq!(stored.host, "0.0.0.0");
+    assert_eq!(stored.https_port, 443);
+    assert_eq!(stored.http_port, 80);
+    assert_eq!(stored.acme_email, "ops@example.com");
 }
 
 #[test]

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -33,8 +33,9 @@ fn daemon_remote_serve_execution_plan_requires_persisted_acme_state() {
     assert!(!message.contains("reserved"));
 
     let stored = db
-        .load_remote_acme_serve_config()
-        .expect("load persisted remote serve config")
+        .load_remote_acme_state()
+        .expect("load persisted remote acme state")
+        .serve_config
         .expect("remote serve config should be persisted before ACME preflight fails");
     assert_eq!(stored.domain, "daemon.example.com");
     assert_eq!(stored.host, "0.0.0.0");


### PR DESCRIPTION
## Motivation
Remote ACME renewal needs durable serve settings before it can issue or renew certificates after daemon restart. The previous state only stored account and certificate material, so renew had no domain, challenge, ports, or DNS provider context.

## Implementation
- Add schema v28 fields for the remote ACME serve config.
- Persist validated remote serve config before ACME preflight.
- Load the config into ACME status and renewal requests, and fail closed when it is missing.
- Cover config persistence, v27 migration, status output, renewal request wiring, and serve bootstrap behavior.