### PR TITLE
feat(remote): pin pairing server identity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ http = "1.4.2"
 instant-acme = { version = "0.8.5", default-features = false, features = ["hyper-rustls", "rcgen", "ring"] }
 pathdiff = "0.2.3"
 rcgen = { version = "0.14.8", default-features = false, features = ["pem", "ring", "x509-parser"] }
+x509-parser = "=0.18.1"
 gray_matter = { version = "0.3.2", default-features = false, features = ["yaml"] }
 tar = "0.4.44"
 user_dirs = "0.2.0"
@@ -112,7 +113,6 @@ assert_cmd = "=2.2.0"
 predicates = "=3.1.4"
 tempfile = "=3.27.0"
 insta = "=1.46.3"
-x509-parser = "=0.18.1"
 harness-testkit = { path = "testkit" }
 temp-env = { version = "=0.3.6", features = ["async_closure"] }
 syn = { version = "=2.0.117", features = ["full"] }

--- a/src/daemon/db/remote_acme.rs
+++ b/src/daemon/db/remote_acme.rs
@@ -40,7 +40,8 @@ WHERE singleton = 1";
 const SELECT_REMOTE_ACME_ISSUANCE_STATE_SQL: &str = "
 SELECT
     NULLIF(TRIM(account_id), ''),
-    NULLIF(TRIM(account_credentials_json), '')
+    NULLIF(TRIM(account_credentials_json), ''),
+    CASE WHEN COALESCE(TRIM(private_key_pem), '') <> '' THEN private_key_pem END
 FROM remote_acme_state
 WHERE singleton = 1";
 
@@ -284,7 +285,10 @@ fn remote_acme_issuance_state_from_row(
     let account_id = row.get::<_, Option<String>>(0)?;
     let serialized = row.get::<_, Option<String>>(1)?;
     let account = remote_acme_account_from_columns(account_id, serialized)?;
-    Ok(RemoteAcmeIssuanceState { account })
+    Ok(RemoteAcmeIssuanceState {
+        account,
+        previous_private_key_pem: row.get(2)?,
+    })
 }
 
 fn remote_acme_account_from_columns(

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -42,6 +42,7 @@ mod remote_acme_dns_provider;
 pub mod remote_acme_dns_runner;
 mod remote_acme_issuer;
 pub mod remote_auth;
+pub(crate) mod remote_certificate_identity;
 pub(crate) mod remote_crypto;
 pub mod remote_identity;
 pub mod remote_pairing;

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -9,6 +9,7 @@ use super::remote::{
     RemoteAcmeChallenge, RemoteDaemonConfigError, RemoteDaemonServeConfig,
     validate_remote_serve_config,
 };
+use super::remote_certificate_identity::RemotePrivateKeyPem;
 pub use super::remote_acme_dns::{
     CloudflareDns01ChangeRequest, Dns01ChangeOperation, Dns01ExecHookError,
     Dns01ExecHookInvocation, Dns01ExecHookOperation, Dns01ProviderChangeError,
@@ -206,6 +207,7 @@ impl AcmeHttp01ChallengeStore {
 pub struct RemoteAcmeRenewalRequest {
     account: RemoteAcmeAccountCredentials,
     previous_certificate_fingerprint: Option<String>,
+    previous_private_key_pem: Option<RemotePrivateKeyPem>,
     serve_config: RemoteDaemonServeConfig,
 }
 
@@ -214,11 +216,13 @@ impl RemoteAcmeRenewalRequest {
     pub fn new(
         account: &RemoteAcmeAccountCredentials,
         previous_fingerprint: Option<&str>,
+        previous_private_key_pem: Option<&str>,
         serve_config: &RemoteDaemonServeConfig,
     ) -> Self {
         Self {
             account: account.clone(),
             previous_certificate_fingerprint: previous_fingerprint.map(ToOwned::to_owned),
+            previous_private_key_pem: previous_private_key_pem.map(RemotePrivateKeyPem::new),
             serve_config: serve_config.clone(),
         }
     }
@@ -241,6 +245,11 @@ impl RemoteAcmeRenewalRequest {
     #[must_use]
     pub fn previous_certificate_fingerprint(&self) -> Option<&str> {
         self.previous_certificate_fingerprint.as_deref()
+    }
+
+    #[must_use]
+    pub fn previous_private_key_pem(&self) -> Option<&str> {
+        self.previous_private_key_pem.as_ref().map(RemotePrivateKeyPem::as_str)
     }
 
     #[must_use]
@@ -368,12 +377,17 @@ impl RemoteAcmeAccountCredentials {
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct RemoteAcmeIssuanceState {
     pub(crate) account: Option<RemoteAcmeAccountCredentials>,
+    pub(crate) previous_private_key_pem: Option<String>,
 }
 
 impl fmt::Debug for RemoteAcmeIssuanceState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RemoteAcmeIssuanceState")
             .field("account_configured", &self.account.is_some())
+            .field(
+                "private_key_configured",
+                &self.previous_private_key_pem.is_some(),
+            )
             .finish()
     }
 }
@@ -429,6 +443,12 @@ impl RemoteCertificateBundle {
     #[must_use]
     pub(crate) fn private_key_pem(&self) -> &str {
         &self.private_key_pem
+    }
+
+    pub(crate) fn spki_sha256_pin(
+        &self,
+    ) -> Result<String, super::remote_certificate_identity::RemoteCertificateIdentityError> {
+        super::remote_certificate_identity::spki_sha256_pin(self)
     }
 
     #[must_use]

--- a/src/daemon/remote_acme_issuer.rs
+++ b/src/daemon/remote_acme_issuer.rs
@@ -10,6 +10,7 @@ use instant_acme::{
     Account, AccountBuilder, AccountCredentials, AuthorizationStatus, ChallengeHandle,
     ChallengeType, Identifier, LetsEncrypt, NewAccount, NewOrder, Order, OrderStatus, RetryPolicy,
 };
+use rcgen::{CertificateParams, DistinguishedName, KeyPair};
 use tokio::runtime::{Handle, Runtime};
 
 use super::remote::{
@@ -184,6 +185,7 @@ where
         &self,
         credentials: &RemoteAcmeAccountCredentials,
         config: &RemoteDaemonServeConfig,
+        previous_private_key_pem: Option<&str>,
     ) -> Result<RemoteCertificateBundle, String> {
         validate_remote_serve_config(config).map_err(|error| error.to_string())?;
         let account = self.restore_account(credentials).await?;
@@ -193,15 +195,26 @@ where
             .await
             .map_err(|error| redacted_acme_error(&error))?;
         self.complete_authorizations(&mut order, config).await?;
-        let private_key = order
-            .finalize()
+        let private_key = previous_private_key_pem.map_or_else(
+            || KeyPair::generate().map_err(|error| error.to_string()),
+            |pem| KeyPair::from_pem(pem).map_err(|error| error.to_string()),
+        )?;
+        let private_key_pem = private_key.serialize_pem();
+        let mut params = CertificateParams::new(vec![config.domain.trim().to_string()])
+            .map_err(|error| error.to_string())?;
+        params.distinguished_name = DistinguishedName::new();
+        let csr = params
+            .serialize_request(&private_key)
+            .map_err(|error| error.to_string())?;
+        order
+            .finalize_csr(csr.der())
             .await
             .map_err(|error| redacted_acme_error(&error))?;
         let certificate = order
             .poll_certificate(&self.retry_policy)
             .await
             .map_err(|error| redacted_acme_error(&error))?;
-        Ok(RemoteCertificateBundle::new(&certificate, &private_key))
+        Ok(RemoteCertificateBundle::new(&certificate, &private_key_pem))
     }
 
     async fn restore_account(
@@ -397,7 +410,11 @@ impl RemoteAcmeRenewalIssuer for SystemRemoteAcmeIssuer {
         let provisioner =
             SystemRemoteAcmeChallengeProvisioner::from_environment(request.serve_config())?;
         let issuer = InstantAcmeIssuer::production(provisioner);
-        run_acme_future(issuer.issue_certificate(request.account(), request.serve_config()))
+        run_acme_future(issuer.issue_certificate(
+            request.account(),
+            request.serve_config(),
+            request.previous_private_key_pem(),
+        ))
     }
 }
 

--- a/src/daemon/remote_acme_issuer_test_support.rs
+++ b/src/daemon/remote_acme_issuer_test_support.rs
@@ -197,7 +197,6 @@ pub(super) fn acme_happy_path() -> Vec<ScriptedResponse> {
         response(Method::POST, AUTHORIZATION_URL, AUTHORIZATION_PENDING_BODY),
         response(Method::POST, CHALLENGE_URL, CHALLENGE_PENDING_BODY),
         response(Method::POST, ORDER_URL, ORDER_READY_BODY),
-        response(Method::POST, AUTHORIZATION_URL, AUTHORIZATION_VALID_BODY),
         response(Method::POST, FINALIZE_URL, ORDER_PROCESSING_BODY),
         response(Method::POST, ORDER_URL, ORDER_VALID_BODY),
         response(Method::POST, CERTIFICATE_URL, TEST_CERTIFICATE_PEM),
@@ -299,13 +298,6 @@ const TLS_CHALLENGE_PENDING_BODY: &str = r#"{
   "token":"tls-token",
   "status":"pending",
   "error":null
-}"#;
-const AUTHORIZATION_VALID_BODY: &str = r#"{
-  "identifier":{"type":"dns","value":"daemon.example.com"},
-  "status":"valid",
-  "challenges":[
-    {"type":"http-01","url":"https://acme.test/challenge/http/1","token":"http-token","status":"valid","error":null}
-  ]
 }"#;
 const ORDER_READY_BODY: &str = r#"{
   "status":"ready",

--- a/src/daemon/remote_acme_issuer_tests.rs
+++ b/src/daemon/remote_acme_issuer_tests.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use instant_acme::{Account, RetryPolicy};
+use rcgen::KeyPair;
 
 #[path = "remote_acme_issuer_test_support.rs"]
 mod support;
@@ -38,7 +39,7 @@ async fn instant_acme_issuer_completes_account_order_and_http01_issuance() {
         .await
         .expect("create ACME account");
     let bundle = issuer
-        .issue_certificate(&account, &config)
+        .issue_certificate(&account, &config, None)
         .await
         .expect("issue ACME certificate");
 
@@ -68,7 +69,7 @@ async fn instant_acme_issuer_completes_account_order_and_http01_issuance() {
     assert_eq!(provisioner.cleanup_count(), 1);
 
     let requests = http.requests();
-    assert_eq!(requests.len(), 13);
+    assert_eq!(requests.len(), 12);
     assert_eq!(
         jws_payload(&requests[2])["contact"][0],
         "mailto:ops@example.com"
@@ -78,10 +79,35 @@ async fn instant_acme_issuer_completes_account_order_and_http01_issuance() {
         "daemon.example.com"
     );
     assert!(
-        jws_payload(&requests[10])["csr"]
+        jws_payload(&requests[9])["csr"]
             .as_str()
             .is_some_and(|csr| !csr.is_empty())
     );
+    http.assert_exhausted();
+}
+
+#[tokio::test]
+async fn instant_acme_issuer_reuses_persisted_private_key_for_renewal() {
+    let http = ScriptedAcmeHttp::new(acme_happy_path());
+    let provisioner = RecordingProvisioner::default();
+    let issuer = test_issuer(http.clone(), provisioner);
+    let config = http_serve_config();
+    let account = issuer
+        .create_account(config.acme_email.as_str())
+        .await
+        .expect("create ACME account");
+    let private_key_pem = KeyPair::generate()
+        .expect("generate persisted key")
+        .serialize_pem();
+
+    let bundle = issuer
+        .issue_certificate(&account, &config, Some(private_key_pem.as_str()))
+        .await
+        .expect("renew ACME certificate");
+
+    assert_eq!(bundle.private_key_pem(), private_key_pem);
+    build_remote_tls_server_config(&bundle)
+        .expect("renewed certificate must match the persisted private key");
     http.assert_exhausted();
 }
 
@@ -137,7 +163,7 @@ async fn instant_acme_issuer_cleans_challenge_after_rejected_order() {
         .expect("create ACME account");
 
     issuer
-        .issue_certificate(&account, &config)
+        .issue_certificate(&account, &config, None)
         .await
         .expect_err("rejected order must fail issuance");
 
@@ -159,7 +185,7 @@ async fn instant_acme_issuer_redacts_challenge_cleanup_failure() {
         .expect("create ACME account");
 
     let error = issuer
-        .issue_certificate(&account, &config)
+        .issue_certificate(&account, &config, None)
         .await
         .expect_err("rejected order and cleanup must fail issuance");
 
@@ -193,7 +219,7 @@ async fn issue_for_challenge(
         .await
         .expect("create ACME account");
     issuer
-        .issue_certificate(&account, &config)
+        .issue_certificate(&account, &config, None)
         .await
         .expect("issue ACME certificate");
     http.assert_exhausted();

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -1,8 +1,14 @@
 use std::error::Error;
 
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use rcgen::{CertificateParams, KeyPair};
+use sha2::{Digest, Sha256};
+
 use super::{
     AcmeHttp01ChallengeStore, Dns01ChangeOperation, Dns01ExecHookOperation, Dns01ProviderAction,
-    RemoteAcmeRuntimeState, RemoteCertificateBundle, RemoteCertificateSlot, RemoteRenewalOutcome,
+    RemoteAcmeAccountCredentials, RemoteAcmeRenewalRequest, RemoteAcmeRuntimeState,
+    RemoteCertificateBundle, RemoteCertificateSlot, RemoteRenewalOutcome,
     build_remote_acme_runtime_plan,
 };
 use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
@@ -402,6 +408,59 @@ fn remote_certificate_bundle_debug_redacts_pem_material() {
     assert!(debug.contains("<redacted>"));
     assert!(!debug.contains("cert-secret"));
     assert!(!debug.contains("key-secret"));
+}
+
+#[test]
+fn remote_certificate_bundle_reports_standard_spki_sha256_pin() {
+    let key = KeyPair::generate().expect("generate key");
+    let certificate = CertificateParams::new(vec!["daemon.example.com".to_string()])
+        .expect("certificate params")
+        .self_signed(&key)
+        .expect("self-sign certificate");
+    let bundle = RemoteCertificateBundle::new(certificate.pem().as_str(), &key.serialize_pem());
+    let public_key_pem = key.public_key_pem();
+    let encoded_spki = public_key_pem
+        .lines()
+        .filter(|line| !line.starts_with("-----"))
+        .collect::<String>();
+    let spki = STANDARD
+        .decode(encoded_spki)
+        .expect("decode public key PEM");
+    let expected = format!("sha256/{}", STANDARD.encode(Sha256::digest(spki)));
+
+    assert_eq!(bundle.spki_sha256_pin().expect("SPKI pin"), expected);
+}
+
+#[test]
+fn remote_certificate_bundle_rejects_malformed_certificate_for_spki_pin() {
+    let bundle = RemoteCertificateBundle::new_for_tests("not-a-certificate", "redacted-key");
+
+    let error = bundle
+        .spki_sha256_pin()
+        .expect_err("malformed certificate must not produce a pin");
+
+    assert!(error.to_string().contains("certificate PEM"));
+    assert!(!error.to_string().contains("redacted-key"));
+}
+
+#[test]
+fn remote_acme_renewal_request_debug_redacts_private_key() {
+    let account = RemoteAcmeAccountCredentials::new(
+        "https://acme.test/acct/1",
+        r#"{"id":"https://acme.test/acct/1"}"#,
+    )
+    .expect("account credentials");
+    let request = RemoteAcmeRenewalRequest::new(
+        &account,
+        Some("old-fingerprint"),
+        Some("private-key-secret"),
+        &tls_alpn_config(),
+    );
+
+    let debug = format!("{request:?}");
+
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains("private-key-secret"));
 }
 
 #[test]

--- a/src/daemon/remote_certificate_identity.rs
+++ b/src/daemon/remote_certificate_identity.rs
@@ -1,0 +1,77 @@
+use std::error::Error;
+use std::fmt;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use rustls::pki_types::CertificateDer;
+use rustls::pki_types::pem::PemObject as _;
+use sha2::{Digest, Sha256};
+use x509_parser::parse_x509_certificate;
+
+use super::remote_acme::RemoteCertificateBundle;
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct RemotePrivateKeyPem(String);
+
+impl RemotePrivateKeyPem {
+    pub(crate) fn new(value: &str) -> Self {
+        Self(value.to_string())
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for RemotePrivateKeyPem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RemoteCertificateIdentityError {
+    MissingCertificatePem,
+    InvalidCertificatePem(String),
+    InvalidCertificateDer(String),
+}
+
+impl fmt::Display for RemoteCertificateIdentityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingCertificatePem => {
+                write!(f, "remote certificate PEM contains no certificate block")
+            }
+            Self::InvalidCertificatePem(error) => {
+                write!(f, "remote certificate PEM is invalid: {error}")
+            }
+            Self::InvalidCertificateDer(error) => {
+                write!(f, "remote certificate DER is invalid: {error}")
+            }
+        }
+    }
+}
+
+impl Error for RemoteCertificateIdentityError {}
+
+pub(crate) fn spki_sha256_pin(
+    bundle: &RemoteCertificateBundle,
+) -> Result<String, RemoteCertificateIdentityError> {
+    let certificate = CertificateDer::pem_slice_iter(bundle.certificate_pem().as_bytes())
+        .next()
+        .ok_or(RemoteCertificateIdentityError::MissingCertificatePem)?
+        .map_err(|error| {
+            RemoteCertificateIdentityError::InvalidCertificatePem(error.to_string())
+        })?;
+    let (remainder, certificate) =
+        parse_x509_certificate(certificate.as_ref()).map_err(|error| {
+            RemoteCertificateIdentityError::InvalidCertificateDer(error.to_string())
+        })?;
+    if !remainder.is_empty() {
+        return Err(RemoteCertificateIdentityError::InvalidCertificateDer(
+            "trailing certificate data".to_string(),
+        ));
+    }
+    let digest = Sha256::digest(certificate.public_key().raw);
+    Ok(format!("sha256/{}", STANDARD.encode(digest)))
+}

--- a/src/daemon/transport/mod.rs
+++ b/src/daemon/transport/mod.rs
@@ -4,6 +4,7 @@ mod remote;
 mod remote_acme;
 mod remote_clients;
 mod remote_doctor;
+mod remote_pairing_invitation;
 mod remote_serve;
 mod remote_systemd;
 mod remote_systemd_lifecycle;

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -20,6 +20,7 @@ use crate::workspace::utc_now;
 
 use super::control::{adopt_daemon_root_for_transport_command, print_json};
 use super::remote_doctor::execute_remote_doctor;
+use super::remote_pairing_invitation::build_remote_pairing_invitation;
 use super::remote_serve::execute_remote_serve;
 use super::remote_systemd::{DaemonRemoteSystemdArgs, DaemonRemoteSystemdInstallArgs};
 
@@ -212,19 +213,31 @@ impl DaemonRemotePairCreateArgs {
             expires_at.as_str(),
         )
         .map_err(|error| CliErrorKind::workflow_parse(error.to_string()))?;
+        let role = record.role.as_str().to_string();
+        let scopes = record
+            .scopes
+            .iter()
+            .map(|scope| scope.as_str().to_string())
+            .collect::<Vec<_>>();
+        let invitation = build_remote_pairing_invitation(
+            db,
+            code.expose(),
+            role.as_str(),
+            &scopes,
+            record.expires_at.as_str(),
+        )?;
         let stored = db.create_remote_pairing_code(&record, audit_event_id)?;
         Ok(DaemonRemotePairCreateResponse {
             pairing_id: stored.pairing_id,
             code: code.expose().to_string(),
-            role: stored.role.as_str().to_string(),
-            scopes: stored
-                .scopes
-                .iter()
-                .map(|scope| scope.as_str().to_string())
-                .collect(),
+            role,
+            scopes,
             created_at: stored.created_at,
             expires_at: stored.expires_at,
             ttl_seconds: self.ttl.as_secs(),
+            endpoint: invitation.endpoint,
+            server_spki_sha256: invitation.server_spki_sha256,
+            pairing_url: invitation.pairing_url,
         })
     }
 }
@@ -238,6 +251,9 @@ pub(crate) struct DaemonRemotePairCreateResponse {
     pub created_at: String,
     pub expires_at: String,
     pub ttl_seconds: u64,
+    pub endpoint: String,
+    pub server_spki_sha256: String,
+    pub pairing_url: String,
 }
 
 pub(super) fn open_remote_daemon_db() -> Result<DaemonDb, CliError> {

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -241,6 +241,7 @@ where
     let request = RemoteAcmeRenewalRequest::new(
         &account,
         state.certificate_fingerprint.as_deref(),
+        issuance.previous_private_key_pem.as_deref(),
         serve_config,
     );
     match issuer.renew_certificate(&request) {

--- a/src/daemon/transport/remote_pairing_invitation.rs
+++ b/src/daemon/transport/remote_pairing_invitation.rs
@@ -1,0 +1,75 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::Serialize;
+
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote_acme::build_remote_acme_runtime_plan;
+use crate::errors::{CliError, CliErrorKind};
+
+pub(super) struct RemotePairingInvitation {
+    pub(super) endpoint: String,
+    pub(super) server_spki_sha256: String,
+    pub(super) pairing_url: String,
+}
+
+#[derive(Serialize)]
+struct RemotePairingInvitationPayload<'a> {
+    version: u8,
+    endpoint: &'a str,
+    code: &'a str,
+    server_spki_sha256: &'a str,
+    role: &'a str,
+    scopes: &'a [String],
+    expires_at: &'a str,
+}
+
+pub(super) fn build_remote_pairing_invitation(
+    db: &DaemonDb,
+    code: &str,
+    role: &str,
+    scopes: &[String],
+    expires_at: &str,
+) -> Result<RemotePairingInvitation, CliError> {
+    let state = db.load_remote_acme_state()?;
+    let serve_config = state
+        .serve_config
+        .as_ref()
+        .ok_or_else(|| remote_pairing_identity_error("persisted remote serve config is missing"))?;
+    let runtime_state = db.load_remote_acme_runtime_state()?;
+    let runtime_plan = build_remote_acme_runtime_plan(serve_config, &runtime_state)
+        .map_err(|error| remote_pairing_identity_error(error.to_string()))?;
+    let endpoint = runtime_plan.public_https_origin();
+    let server_spki_sha256 = runtime_plan
+        .certificate()
+        .spki_sha256_pin()
+        .map_err(|error| remote_pairing_identity_error(error.to_string()))?;
+    let payload = RemotePairingInvitationPayload {
+        version: 1,
+        endpoint: endpoint.as_str(),
+        code,
+        server_spki_sha256: server_spki_sha256.as_str(),
+        role,
+        scopes,
+        expires_at,
+    };
+    let payload = serde_json::to_vec(&payload).map_err(|error| {
+        CliErrorKind::workflow_parse(format!("encode remote pairing invitation: {error}"))
+    })?;
+    let pairing_url = format!(
+        "harness://remote-pair?payload={}",
+        URL_SAFE_NO_PAD.encode(payload)
+    );
+    Ok(RemotePairingInvitation {
+        endpoint,
+        server_spki_sha256,
+        pairing_url,
+    })
+}
+
+fn remote_pairing_identity_error(detail: impl AsRef<str>) -> CliError {
+    CliErrorKind::workflow_parse(format!(
+        "remote pairing requires a persisted remote TLS identity: {}",
+        detail.as_ref()
+    ))
+    .into()
+}

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -4,6 +4,7 @@ mod remote_acme;
 mod remote_cli;
 mod remote_clients;
 mod remote_doctor;
+mod remote_pairing_contract;
 mod remote_serve;
 mod remote_systemd;
 mod remote_systemd_plan;

--- a/src/daemon/transport/tests/remote_acme.rs
+++ b/src/daemon/transport/tests/remote_acme.rs
@@ -323,6 +323,7 @@ impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
     ) -> Result<RemoteCertificateBundle, String> {
         assert_eq!(request.account_id(), self.expected_account_id);
         assert_eq!(request.previous_certificate_fingerprint(), Some("old-fp"));
+        assert_eq!(request.previous_private_key_pem(), Some("old-key-secret"));
         let serve_config = request.serve_config();
         assert_eq!(serve_config.domain, "daemon.example.com");
         assert_eq!(serve_config.acme_email, "ops@example.com");
@@ -371,6 +372,7 @@ impl RemoteAcmeRenewalIssuer for InitialIssuanceIssuer {
         assert_eq!(request.account_id(), "https://acme.test/acct/initial");
         assert!(request.account_credentials().contains("account-key-secret"));
         assert_eq!(request.previous_certificate_fingerprint(), None);
+        assert_eq!(request.previous_private_key_pem(), None);
         Ok(RemoteCertificateBundle::new_for_tests(
             "initial-cert-pem",
             "initial-key-secret",

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -1,8 +1,13 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use clap::Parser;
 use harness_testkit::with_isolated_harness_env;
+use rcgen::{CertificateParams, KeyPair};
 
 use crate::app::command_context::{AppContext, Execute};
 use crate::daemon::db::DaemonDb;
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
+use crate::daemon::remote_acme::{RemoteAcmeAccountCredentials, RemoteCertificateBundle};
 use crate::daemon::remote_pairing::RemotePairingCode;
 use crate::daemon::state;
 
@@ -336,6 +341,7 @@ fn daemon_remote_pair_create_reports_ttl_overflow_as_too_large() {
 #[test]
 fn daemon_remote_pair_create_builds_persisted_record_and_response() {
     let db = DaemonDb::open_in_memory().expect("open db");
+    let expected_pin = seed_remote_tls_identity(&db);
     let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
         "test", "pair", "create", "--role", "operator", "--scopes", "read", "--ttl", "2m",
     ])
@@ -366,6 +372,25 @@ fn daemon_remote_pair_create_builds_persisted_record_and_response() {
     assert_eq!(response.ttl_seconds, 120);
     assert_eq!(response.created_at, "2026-06-21T13:40:00Z");
     assert_eq!(response.expires_at, "2026-06-21T13:42:00Z");
+    assert_eq!(response.endpoint, "https://daemon.example.com");
+    assert_eq!(response.server_spki_sha256, expected_pin);
+
+    let encoded_payload = response
+        .pairing_url
+        .strip_prefix("harness://remote-pair?payload=")
+        .expect("remote pairing deep link");
+    let payload = URL_SAFE_NO_PAD
+        .decode(encoded_payload)
+        .expect("decode invitation payload");
+    let payload: serde_json::Value =
+        serde_json::from_slice(&payload).expect("decode invitation JSON");
+    assert_eq!(payload["version"], 1);
+    assert_eq!(payload["endpoint"], "https://daemon.example.com");
+    assert_eq!(payload["code"], "manual-code-value");
+    assert_eq!(payload["server_spki_sha256"], expected_pin);
+    assert_eq!(payload["role"], "operator");
+    assert_eq!(payload["scopes"], serde_json::json!(["read"]));
+    assert_eq!(payload["expires_at"], "2026-06-21T13:42:00Z");
 
     let stored: (String, String) = db
         .connection()
@@ -395,6 +420,9 @@ fn daemon_remote_pair_create_execute_persists_pairing_in_daemon_db() {
         state::ensure_daemon_dirs().expect("daemon dirs");
         let daemon_root = state::daemon_root();
         let _lock = state::acquire_singleton_lock().expect("hold daemon lock");
+        let db = DaemonDb::open(&daemon_root.join("harness.db")).expect("open daemon db");
+        seed_remote_tls_identity(&db);
+        drop(db);
 
         let command = DaemonRemoteCommandTestHarness::try_parse_from([
             "test", "pair", "create", "--role", "viewer", "--ttl", "30s",
@@ -426,4 +454,36 @@ fn daemon_remote_pair_create_execute_persists_pairing_in_daemon_db() {
         assert_eq!(scopes_json, "[\"read\"]");
         assert!(code_hash.starts_with("sha256:"));
     });
+}
+
+fn seed_remote_tls_identity(db: &DaemonDb) -> String {
+    let config = RemoteDaemonServeConfig {
+        domain: "daemon.example.com".to_string(),
+        host: "0.0.0.0".to_string(),
+        https_port: 443,
+        http_port: 80,
+        acme_email: "ops@example.com".to_string(),
+        acme_challenge: RemoteAcmeChallenge::Http,
+        acme_dns_provider: None,
+    };
+    db.record_remote_acme_serve_config(&config, "2026-06-21T13:39:00Z")
+        .expect("record remote serve config");
+    let account = RemoteAcmeAccountCredentials::new(
+        "https://acme.test/acct/1",
+        r#"{"id":"https://acme.test/acct/1"}"#,
+    )
+    .expect("build account credentials");
+    db.record_remote_acme_account(&account, "2026-06-21T13:39:00Z")
+        .expect("record account credentials");
+    let key = KeyPair::generate().expect("generate TLS key");
+    let certificate = CertificateParams::new(vec!["daemon.example.com".to_string()])
+        .expect("certificate params")
+        .self_signed(&key)
+        .expect("self-sign test certificate");
+    let bundle = RemoteCertificateBundle::new(certificate.pem().as_str(), &key.serialize_pem());
+    db.record_remote_acme_renewal_success(&bundle, "2026-06-21T13:39:00Z")
+        .expect("record TLS certificate");
+    bundle
+        .spki_sha256_pin()
+        .expect("derive test certificate SPKI pin")
 }

--- a/src/daemon/transport/tests/remote_pairing_contract.rs
+++ b/src/daemon/transport/tests/remote_pairing_contract.rs
@@ -1,0 +1,46 @@
+use clap::Parser;
+
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote_pairing::RemotePairingCode;
+
+use super::super::{DaemonRemoteCommand, DaemonRemotePairCommand};
+
+#[derive(Debug, Parser)]
+struct DaemonRemoteCommandTestHarness {
+    #[command(subcommand)]
+    command: DaemonRemoteCommand,
+}
+
+#[test]
+fn daemon_remote_pair_create_fails_closed_without_remote_tls_identity() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from(["test", "pair", "create"])
+        .unwrap()
+        .command;
+    let DaemonRemoteCommand::Pair {
+        command: DaemonRemotePairCommand::Create(args),
+    } = parsed
+    else {
+        panic!("expected pair create");
+    };
+    let code = RemotePairingCode::from_value_for_tests("manual-code-value");
+
+    let error = args
+        .create_pairing_with(
+            &db,
+            "pairing-test",
+            "audit-pairing-test",
+            &code,
+            "2026-06-21T13:40:00Z",
+        )
+        .expect_err("pairing must require persisted TLS identity");
+
+    assert!(error.to_string().contains("persisted remote TLS identity"));
+    let stored_count: i64 = db
+        .connection()
+        .query_row("SELECT COUNT(*) FROM remote_pairing_codes", [], |row| {
+            row.get(0)
+        })
+        .expect("stored pairing count");
+    assert_eq!(stored_count, 0);
+}


### PR DESCRIPTION
## Motivation
Remote clients need a server identity that survives ACME renewal. The issuer generated a new key on every renewal, and pair creation exposed no endpoint or pin for a client profile.

## Implementation
- Reuse the persisted TLS private key when finalizing renewal CSRs.
- Derive a standard SHA-256 SPKI pin without exposing key material.
- Require persisted TLS identity before pairing and emit endpoint, pin, and a versioned deep link.
- Cover key reuse, redaction, SPKI derivation, fail-closed pairing, and invitation payloads with focused tests.