### PR TITLE
feat(remote): renew ACME certificates automatically

### DIFF
--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -57,6 +57,7 @@ mod imports;
 mod policy;
 mod rebuild;
 mod remote_acme;
+mod remote_acme_cas;
 mod remote_identity;
 mod remote_pairing;
 mod review_writes;

--- a/src/daemon/db/remote_acme_cas.rs
+++ b/src/daemon/db/remote_acme_cas.rs
@@ -1,0 +1,66 @@
+use rusqlite::params;
+
+use super::{CliError, DaemonDb, db_error};
+use crate::daemon::remote::{RemoteDaemonServeConfig, RemoteDnsProvider};
+use crate::daemon::remote_acme::RemoteCertificateBundle;
+
+impl DaemonDb {
+    /// Persist an automatically renewed certificate only when the ACME state
+    /// still matches the snapshot used to place the order.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the conditional update cannot execute.
+    pub(crate) fn record_remote_acme_renewal_success_if_current(
+        &self,
+        bundle: &RemoteCertificateBundle,
+        expected_fingerprint: &str,
+        expected_account_id: &str,
+        expected_config: &RemoteDaemonServeConfig,
+        updated_at: &str,
+    ) -> Result<bool, CliError> {
+        let changed = self
+            .connection()
+            .execute(
+                "UPDATE remote_acme_state
+                 SET certificate_pem = ?1,
+                     private_key_pem = ?2,
+                     certificate_fingerprint = ?3,
+                     renewal_status = 'succeeded',
+                     renewal_error = NULL,
+                     updated_at = ?4
+                 WHERE singleton = 1
+                   AND certificate_fingerprint = ?5
+                   AND account_id = ?6
+                   AND domain = ?7
+                   AND host = ?8
+                   AND https_port = ?9
+                   AND http_port = ?10
+                   AND acme_email = ?11
+                   AND acme_challenge = ?12
+                   AND acme_dns_provider IS ?13",
+                params![
+                    bundle.certificate_pem(),
+                    bundle.private_key_pem(),
+                    bundle.fingerprint(),
+                    updated_at,
+                    expected_fingerprint,
+                    expected_account_id,
+                    expected_config.domain.trim(),
+                    expected_config.host.trim(),
+                    i64::from(expected_config.https_port),
+                    i64::from(expected_config.http_port),
+                    expected_config.acme_email.trim(),
+                    expected_config.acme_challenge.as_str(),
+                    expected_config
+                        .acme_dns_provider
+                        .map(RemoteDnsProvider::as_str),
+                ],
+            )
+            .map_err(|error| {
+                db_error(format!(
+                    "record current remote acme renewal success: {error}"
+                ))
+            })?;
+        Ok(changed == 1)
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -41,6 +41,7 @@ pub mod remote_acme_dns;
 mod remote_acme_dns_provider;
 pub mod remote_acme_dns_runner;
 mod remote_acme_issuer;
+mod remote_acme_lease_guard;
 mod remote_acme_live;
 mod remote_acme_renewal;
 pub mod remote_auth;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -41,6 +41,8 @@ pub mod remote_acme_dns;
 mod remote_acme_dns_provider;
 pub mod remote_acme_dns_runner;
 mod remote_acme_issuer;
+mod remote_acme_live;
+mod remote_acme_renewal;
 pub mod remote_auth;
 pub(crate) mod remote_certificate_identity;
 pub(crate) mod remote_crypto;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -37,6 +37,7 @@ pub mod protocol;
 pub mod remote;
 pub mod remote_acme;
 mod remote_acme_challenge;
+mod remote_acme_cleanup;
 pub mod remote_acme_dns;
 mod remote_acme_dns_provider;
 pub mod remote_acme_dns_runner;

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -10,6 +10,7 @@ use super::remote::{
     RemoteAcmeChallenge, RemoteDaemonConfigError, RemoteDaemonServeConfig,
     validate_remote_serve_config,
 };
+use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 pub use super::remote_acme_dns::{
     CloudflareDns01ChangeRequest, Dns01ChangeOperation, Dns01ExecHookError,
     Dns01ExecHookInvocation, Dns01ExecHookOperation, Dns01ProviderChangeError,
@@ -291,6 +292,7 @@ pub(crate) trait RemoteAcmeAutomaticRenewalIssuer: Send + Sync {
     async fn renew_certificate_automatically(
         &self,
         request: &RemoteAcmeRenewalRequest,
+        cleanup_tracker: &RemoteAcmeCleanupTracker,
     ) -> Result<RemoteCertificateBundle, String>;
 }
 

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -9,7 +9,6 @@ use super::remote::{
     RemoteAcmeChallenge, RemoteDaemonConfigError, RemoteDaemonServeConfig,
     validate_remote_serve_config,
 };
-use super::remote_certificate_identity::RemotePrivateKeyPem;
 pub use super::remote_acme_dns::{
     CloudflareDns01ChangeRequest, Dns01ChangeOperation, Dns01ExecHookError,
     Dns01ExecHookInvocation, Dns01ExecHookOperation, Dns01ProviderChangeError,
@@ -19,6 +18,7 @@ pub use super::remote_acme_dns_runner::{
     Dns01ProviderAction, Dns01ProviderChangeRunner, Dns01ProviderExecutionConfig,
     Dns01ProviderExecutionError,
 };
+use super::remote_certificate_identity::RemotePrivateKeyPem;
 use super::remote_redaction::redact_secret_detail;
 
 #[cfg(test)]
@@ -249,7 +249,9 @@ impl RemoteAcmeRenewalRequest {
 
     #[must_use]
     pub fn previous_private_key_pem(&self) -> Option<&str> {
-        self.previous_private_key_pem.as_ref().map(RemotePrivateKeyPem::as_str)
+        self.previous_private_key_pem
+            .as_ref()
+            .map(RemotePrivateKeyPem::as_str)
     }
 
     #[must_use]
@@ -454,36 +456,6 @@ impl RemoteCertificateBundle {
     #[must_use]
     pub fn has_material(&self) -> bool {
         !self.certificate_pem.trim().is_empty() && !self.private_key_pem.trim().is_empty()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RemoteCertificateSlot {
-    bundle: RemoteCertificateBundle,
-    generation: u64,
-}
-
-impl RemoteCertificateSlot {
-    #[must_use]
-    pub const fn new(bundle: RemoteCertificateBundle) -> Self {
-        Self {
-            bundle,
-            generation: 1,
-        }
-    }
-
-    #[must_use]
-    pub const fn generation(&self) -> u64 {
-        self.generation
-    }
-
-    pub fn reload(&mut self, bundle: RemoteCertificateBundle) -> bool {
-        if self.bundle.fingerprint() == bundle.fingerprint() {
-            return false;
-        }
-        self.bundle = bundle;
-        self.generation += 1;
-        true
     }
 }
 

--- a/src/daemon/remote_acme.rs
+++ b/src/daemon/remote_acme.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
 
+use async_trait::async_trait;
 use sha2::{Digest, Sha256};
 
 use super::protocol::http_paths;
@@ -276,6 +277,18 @@ pub trait RemoteAcmeRenewalIssuer {
     /// Returns a redaction-ready operator detail when the issuer cannot produce
     /// a certificate bundle.
     fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String>;
+}
+
+#[async_trait]
+pub(crate) trait RemoteAcmeAutomaticRenewalIssuer: Send + Sync {
+    /// Renew a certificate without entering a nested blocking runtime.
+    ///
+    /// # Errors
+    /// Returns a redaction-ready operator detail when automatic renewal fails.
+    async fn renew_certificate_automatically(
         &self,
         request: &RemoteAcmeRenewalRequest,
     ) -> Result<RemoteCertificateBundle, String>;

--- a/src/daemon/remote_acme_challenge.rs
+++ b/src/daemon/remote_acme_challenge.rs
@@ -11,11 +11,7 @@ use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderValue, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::get;
-use rcgen::{CertificateParams, CustomExtension, DistinguishedName, KeyPair};
 use rustls::ServerConfig;
-use rustls::crypto::ring::default_provider;
-use rustls::crypto::ring::sign::any_supported_type;
-use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign::CertifiedKey;
 use tokio::net::TcpListener;
@@ -27,6 +23,7 @@ use tokio_rustls::TlsAcceptor;
 use super::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
 use super::remote_acme_dns_provider::{SystemDns01Lease, SystemDns01Provider};
 use super::remote_acme_issuer::{RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner};
+use super::remote_tls::build_remote_tls_alpn_challenge;
 
 const HTTP01_PREFIX: &str = "/.well-known/acme-challenge/";
 
@@ -193,37 +190,13 @@ fn tls_alpn01_server_config(
     digest: &[u8],
 ) -> Result<(Arc<ServerConfig>, Vec<u8>), String> {
     let domain = domain.trim();
-    if domain.is_empty() {
-        return Err("remote ACME TLS-ALPN-01 domain is required".to_string());
-    }
-    if digest.len() != 32 {
-        return Err("remote ACME TLS-ALPN-01 digest must contain 32 bytes".to_string());
-    }
-    let key = KeyPair::generate()
-        .map_err(|error| format!("generate remote ACME TLS-ALPN-01 key: {error}"))?;
-    let mut params = CertificateParams::new([domain.to_string()])
-        .map_err(|error| format!("build remote ACME TLS-ALPN-01 certificate: {error}"))?;
-    params.distinguished_name = DistinguishedName::new();
-    params
-        .custom_extensions
-        .push(CustomExtension::new_acme_identifier(digest));
-    let certificate = params
-        .self_signed(&key)
-        .map_err(|error| format!("sign remote ACME TLS-ALPN-01 certificate: {error}"))?;
-    let certificate_der = certificate.der().to_vec();
-    let private_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key.serialize_der()));
-    let signing_key = any_supported_type(&private_key)
-        .map_err(|error| format!("load remote ACME TLS-ALPN-01 key: {error}"))?;
-    let certified_key = Arc::new(CertifiedKey::new(
-        vec![CertificateDer::from(certificate_der.clone())],
-        signing_key,
-    ));
-    let _ = default_provider().install_default();
+    let challenge = build_remote_tls_alpn_challenge(domain, digest)?;
+    let certificate_der = challenge.certificate_der();
     let mut config = ServerConfig::builder()
         .with_no_client_auth()
         .with_cert_resolver(Arc::new(TlsAlpn01CertificateResolver {
             domain: domain.to_string(),
-            certified_key,
+            certified_key: challenge.certified_key(),
         }));
     config.alpn_protocols = vec![b"acme-tls/1".to_vec()];
     Ok((Arc::new(config), certificate_der))

--- a/src/daemon/remote_acme_challenge.rs
+++ b/src/daemon/remote_acme_challenge.rs
@@ -293,11 +293,18 @@ impl RemoteAcmeChallengeProvisioner for SystemRemoteAcmeChallengeProvisioner {
                     .dns
                     .as_ref()
                     .ok_or_else(|| "remote ACME DNS provider is not configured".to_string())?;
-                let lease = dns.present(provider, &record_name, &record_value).await?;
-                sleep(self.dns_propagation_delay).await;
-                Ok(SystemRemoteAcmeChallengeLease::Dns(lease))
+                dns.present(provider, &record_name, &record_value)
+                    .await
+                    .map(SystemRemoteAcmeChallengeLease::Dns)
             }
         }
+    }
+
+    async fn wait_ready(&self, lease: &Self::Lease) -> Result<(), String> {
+        if matches!(lease, SystemRemoteAcmeChallengeLease::Dns(_)) {
+            sleep(self.dns_propagation_delay).await;
+        }
+        Ok(())
     }
 
     async fn cleanup(&self, lease: Self::Lease) -> Result<(), String> {

--- a/src/daemon/remote_acme_cleanup.rs
+++ b/src/daemon/remote_acme_cleanup.rs
@@ -1,0 +1,111 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+use tokio::runtime::{Handle, Runtime};
+use tokio::sync::{Notify, oneshot};
+
+use super::remote_redaction::redact_secret_detail;
+
+#[derive(Clone, Default)]
+pub(crate) struct RemoteAcmeCleanupTracker {
+    state: Arc<RemoteAcmeCleanupState>,
+}
+
+#[derive(Default)]
+struct RemoteAcmeCleanupState {
+    active: AtomicUsize,
+    completed: Notify,
+}
+
+impl RemoteAcmeCleanupTracker {
+    pub(crate) fn spawn_cleanup<F>(&self, cleanup: F) -> oneshot::Receiver<Result<(), String>>
+    where
+        F: Future<Output = Result<(), String>> + Send + 'static,
+    {
+        let (result_tx, result_rx) = oneshot::channel();
+        self.state.active.fetch_add(1, Ordering::AcqRel);
+        let activity = RemoteAcmeCleanupActivity {
+            state: Arc::clone(&self.state),
+        };
+        let task = async move {
+            let _activity = activity;
+            let result = cleanup.await;
+            if let Err(unsent) = result_tx.send(result) {
+                log_cleanup_result(&unsent);
+            }
+        };
+        if let Ok(handle) = Handle::try_current() {
+            drop(handle.spawn(task));
+        } else {
+            spawn_fallback_runtime(task);
+        }
+        result_rx
+    }
+
+    pub(crate) async fn wait_for_cleanup(&self) {
+        loop {
+            let completed = self.state.completed.notified();
+            if self.state.active.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            completed.await;
+        }
+    }
+}
+
+struct RemoteAcmeCleanupActivity {
+    state: Arc<RemoteAcmeCleanupState>,
+}
+
+impl Drop for RemoteAcmeCleanupActivity {
+    fn drop(&mut self) {
+        if self.state.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.state.completed.notify_waiters();
+        }
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+fn spawn_fallback_runtime<F>(task: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    if let Err(error) = thread::Builder::new()
+        .name("harness-acme-cleanup".to_string())
+        .spawn(move || run_on_fallback_runtime(task))
+    {
+        tracing::error!(%error, "spawn remote ACME cleanup runtime");
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+fn run_on_fallback_runtime<F>(task: F)
+where
+    F: Future<Output = ()>,
+{
+    match Runtime::new() {
+        Ok(runtime) => runtime.block_on(task),
+        Err(error) => tracing::error!(%error, "create remote ACME cleanup runtime"),
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+fn log_cleanup_result(result: &Result<(), String>) {
+    if let Err(error) = result {
+        tracing::warn!(
+            error = %redact_secret_detail(error),
+            "remote ACME challenge cleanup after cancellation failed",
+        );
+    }
+}

--- a/src/daemon/remote_acme_issuer.rs
+++ b/src/daemon/remote_acme_issuer.rs
@@ -21,6 +21,7 @@ use super::remote_acme::{
     RemoteCertificateBundle,
 };
 use super::remote_acme_challenge::SystemRemoteAcmeChallengeProvisioner;
+use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use super::remote_acme_lease_guard::RemoteAcmeChallengeLeaseGuard;
 use super::remote_redaction::redact_secret_detail;
 
@@ -192,6 +193,22 @@ where
         config: &RemoteDaemonServeConfig,
         previous_private_key_pem: Option<&str>,
     ) -> Result<RemoteCertificateBundle, String> {
+        self.issue_certificate_with_cleanup(
+            credentials,
+            config,
+            previous_private_key_pem,
+            RemoteAcmeCleanupTracker::default(),
+        )
+        .await
+    }
+
+    pub(crate) async fn issue_certificate_with_cleanup(
+        &self,
+        credentials: &RemoteAcmeAccountCredentials,
+        config: &RemoteDaemonServeConfig,
+        previous_private_key_pem: Option<&str>,
+        cleanup_tracker: RemoteAcmeCleanupTracker,
+    ) -> Result<RemoteCertificateBundle, String> {
         validate_remote_serve_config(config).map_err(|error| error.to_string())?;
         let account = self.restore_account(credentials).await?;
         let identifiers = [Identifier::Dns(config.domain.trim().to_string())];
@@ -199,7 +216,8 @@ where
             .new_order(&NewOrder::new(&identifiers))
             .await
             .map_err(|error| redacted_acme_error(&error))?;
-        self.complete_authorizations(&mut order, config).await?;
+        self.complete_authorizations(&mut order, config, cleanup_tracker)
+            .await?;
         let private_key = previous_private_key_pem.map_or_else(
             || KeyPair::generate().map_err(|error| error.to_string()),
             |pem| KeyPair::from_pem(pem).map_err(|error| error.to_string()),
@@ -238,13 +256,15 @@ where
         &self,
         order: &mut Order,
         config: &RemoteDaemonServeConfig,
+        cleanup_tracker: RemoteAcmeCleanupTracker,
     ) -> Result<(), String> {
-        let mut leases = RemoteAcmeChallengeLeaseGuard::new(Arc::clone(&self.provisioner));
+        let mut leases =
+            RemoteAcmeChallengeLeaseGuard::new(Arc::clone(&self.provisioner), cleanup_tracker);
         let authorization_result = self
             .present_pending_authorizations(order, config, &mut leases)
             .await;
         if let Err(error) = authorization_result {
-            return Self::cleanup_after_error(leases, error);
+            return Self::cleanup_after_error(leases, error).await;
         }
         let poll_result = order
             .poll_ready(&self.retry_policy)
@@ -257,7 +277,7 @@ where
                     Err(format!("remote ACME order became {status:?}"))
                 }
             });
-        match (poll_result, leases.cleanup()) {
+        match (poll_result, leases.cleanup().await) {
             (Ok(()), Ok(())) => Ok(()),
             (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
             (Err(issue), Err(cleanup)) => Err(format!(
@@ -305,11 +325,11 @@ where
         Ok(())
     }
 
-    fn cleanup_after_error(
+    async fn cleanup_after_error(
         leases: RemoteAcmeChallengeLeaseGuard<P>,
         issue: String,
     ) -> Result<(), String> {
-        match leases.cleanup() {
+        match leases.cleanup().await {
             Ok(()) => Err(issue),
             Err(cleanup) => Err(format!(
                 "{issue}; remote ACME challenge cleanup also failed: {cleanup}"

--- a/src/daemon/remote_acme_issuer.rs
+++ b/src/daemon/remote_acme_issuer.rs
@@ -418,7 +418,7 @@ impl RemoteAcmeRenewalIssuer for SystemRemoteAcmeIssuer {
     }
 }
 
-fn run_acme_future<T, F>(future: F) -> Result<T, String>
+pub(crate) fn run_acme_future<T, F>(future: F) -> Result<T, String>
 where
     T: Send,
     F: Future<Output = Result<T, String>> + Send,

--- a/src/daemon/remote_acme_issuer.rs
+++ b/src/daemon/remote_acme_issuer.rs
@@ -21,6 +21,7 @@ use super::remote_acme::{
     RemoteCertificateBundle,
 };
 use super::remote_acme_challenge::SystemRemoteAcmeChallengeProvisioner;
+use super::remote_acme_lease_guard::RemoteAcmeChallengeLeaseGuard;
 use super::remote_redaction::redact_secret_detail;
 
 type AccountBuilderFactory = dyn Fn() -> Result<AccountBuilder, String> + Send + Sync + 'static;
@@ -95,15 +96,19 @@ impl fmt::Debug for RemoteAcmeChallengeMaterial {
 
 #[async_trait]
 pub(crate) trait RemoteAcmeChallengeProvisioner: Send + Sync {
-    type Lease: Send;
+    type Lease: Send + 'static;
 
     async fn present(&self, material: RemoteAcmeChallengeMaterial) -> Result<Self::Lease, String>;
+
+    async fn wait_ready(&self, _lease: &Self::Lease) -> Result<(), String> {
+        Ok(())
+    }
 
     async fn cleanup(&self, lease: Self::Lease) -> Result<(), String>;
 }
 
 pub(crate) struct InstantAcmeIssuer<P> {
-    provisioner: P,
+    provisioner: Arc<P>,
     directory_url: String,
     retry_policy: RetryPolicy,
     account_builder: Arc<AccountBuilderFactory>,
@@ -111,7 +116,7 @@ pub(crate) struct InstantAcmeIssuer<P> {
 
 impl<P> InstantAcmeIssuer<P>
 where
-    P: RemoteAcmeChallengeProvisioner,
+    P: RemoteAcmeChallengeProvisioner + 'static,
 {
     pub(crate) fn with_account_builder<F>(
         provisioner: P,
@@ -123,7 +128,7 @@ where
         F: Fn() -> Result<AccountBuilder, String> + Send + Sync + 'static,
     {
         Self {
-            provisioner,
+            provisioner: Arc::new(provisioner),
             directory_url: directory_url.trim().to_string(),
             retry_policy,
             account_builder: Arc::new(account_builder),
@@ -234,12 +239,12 @@ where
         order: &mut Order,
         config: &RemoteDaemonServeConfig,
     ) -> Result<(), String> {
-        let mut leases = Vec::new();
+        let mut leases = RemoteAcmeChallengeLeaseGuard::new(Arc::clone(&self.provisioner));
         let authorization_result = self
             .present_pending_authorizations(order, config, &mut leases)
             .await;
         if let Err(error) = authorization_result {
-            return self.cleanup_after_error(leases, error).await;
+            return Self::cleanup_after_error(leases, error);
         }
         let poll_result = order
             .poll_ready(&self.retry_policy)
@@ -252,7 +257,7 @@ where
                     Err(format!("remote ACME order became {status:?}"))
                 }
             });
-        match (poll_result, self.cleanup_all(leases).await) {
+        match (poll_result, leases.cleanup()) {
             (Ok(()), Ok(())) => Ok(()),
             (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
             (Err(issue), Err(cleanup)) => Err(format!(
@@ -265,7 +270,7 @@ where
         &self,
         order: &mut Order,
         config: &RemoteDaemonServeConfig,
-        leases: &mut Vec<P::Lease>,
+        leases: &mut RemoteAcmeChallengeLeaseGuard<P>,
     ) -> Result<(), String> {
         let mut authorizations = order.authorizations();
         while let Some(result) = authorizations.next().await {
@@ -288,38 +293,23 @@ where
             })?;
             let material = challenge_material(&challenge, config)?;
             let lease = self.provisioner.present(material).await?;
-            if let Err(error) = challenge
+            leases.push(lease);
+            self.provisioner
+                .wait_ready(leases.last().expect("presented ACME challenge lease"))
+                .await?;
+            challenge
                 .set_ready()
                 .await
-                .map_err(|error| redacted_acme_error(&error))
-            {
-                return self.cleanup_after_error(vec![lease], error).await;
-            }
-            leases.push(lease);
+                .map_err(|error| redacted_acme_error(&error))?;
         }
         Ok(())
     }
 
-    async fn cleanup_all(&self, leases: Vec<P::Lease>) -> Result<(), String> {
-        let mut failures = Vec::new();
-        for lease in leases {
-            if let Err(error) = self.provisioner.cleanup(lease).await {
-                failures.push(redact_secret_detail(&error));
-            }
-        }
-        if failures.is_empty() {
-            Ok(())
-        } else {
-            Err(failures.join("; "))
-        }
-    }
-
-    async fn cleanup_after_error(
-        &self,
-        leases: Vec<P::Lease>,
+    fn cleanup_after_error(
+        leases: RemoteAcmeChallengeLeaseGuard<P>,
         issue: String,
     ) -> Result<(), String> {
-        match self.cleanup_all(leases).await {
+        match leases.cleanup() {
             Ok(()) => Err(issue),
             Err(cleanup) => Err(format!(
                 "{issue}; remote ACME challenge cleanup also failed: {cleanup}"

--- a/src/daemon/remote_acme_issuer_test_support.rs
+++ b/src/daemon/remote_acme_issuer_test_support.rs
@@ -15,6 +15,7 @@ use rcgen::{
     DnType, IsCa, Issuer, KeyPair,
 };
 use rustls::pki_types::CertificateSigningRequestDer;
+use tokio::sync::Notify;
 
 use crate::daemon::remote::RemoteAcmeChallenge;
 
@@ -31,6 +32,13 @@ const REPLAY_NONCE: HeaderName = HeaderName::from_static("replay-nonce");
 #[derive(Clone)]
 pub(super) struct ScriptedAcmeHttp {
     inner: Arc<Mutex<ScriptedAcmeHttpState>>,
+    block_uri: Option<&'static str>,
+    blocked: Arc<Notify>,
+}
+
+#[derive(Clone)]
+pub(super) struct ScriptedAcmeHttpBlocker {
+    blocked: Arc<Notify>,
 }
 
 struct ScriptedAcmeHttpState {
@@ -47,7 +55,21 @@ impl ScriptedAcmeHttp {
                 requests: Vec::new(),
                 issued_certificate: None,
             })),
+            block_uri: None,
+            blocked: Arc::new(Notify::new()),
         }
+    }
+
+    pub(super) fn new_blocking(
+        responses: Vec<ScriptedResponse>,
+        block_uri: &'static str,
+    ) -> (Self, ScriptedAcmeHttpBlocker) {
+        let mut http = Self::new(responses);
+        http.block_uri = Some(block_uri);
+        let blocker = ScriptedAcmeHttpBlocker {
+            blocked: Arc::clone(&http.blocked),
+        };
+        (http, blocker)
     }
 
     pub(super) fn requests(&self) -> Vec<RecordedRequest> {
@@ -76,6 +98,8 @@ impl HttpClient for ScriptedAcmeHttp {
         request: Request<BodyWrapper<Bytes>>,
     ) -> Pin<Box<dyn Future<Output = Result<BytesResponse, AcmeError>> + Send>> {
         let inner = self.inner.clone();
+        let block_uri = self.block_uri;
+        let blocked = Arc::clone(&self.blocked);
         Box::pin(async move {
             let (parts, body) = request.into_parts();
             let body = body
@@ -88,6 +112,7 @@ impl HttpClient for ScriptedAcmeHttp {
                 uri: parts.uri.to_string(),
                 body: body.to_vec(),
             };
+            let should_block = block_uri == Some(recorded.uri.as_str());
             let (response, response_body) = {
                 let mut state = inner.lock().expect("lock HTTP script");
                 let response = state
@@ -108,8 +133,18 @@ impl HttpClient for ScriptedAcmeHttp {
                 state.requests.push(recorded);
                 (response, response_body)
             };
+            if should_block {
+                blocked.notify_one();
+                std::future::pending::<()>().await;
+            }
             Ok(response.into_response(response_body))
         })
+    }
+}
+
+impl ScriptedAcmeHttpBlocker {
+    pub(super) async fn wait_until_blocked(&self) {
+        self.blocked.notified().await;
     }
 }
 

--- a/src/daemon/remote_acme_issuer_tests.rs
+++ b/src/daemon/remote_acme_issuer_tests.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use instant_acme::{Account, RetryPolicy};
 use rcgen::KeyPair;
+use tokio::time::timeout;
 
 #[path = "remote_acme_issuer_test_support.rs"]
 mod support;
@@ -84,6 +85,32 @@ async fn instant_acme_issuer_completes_account_order_and_http01_issuance() {
             .is_some_and(|csr| !csr.is_empty())
     );
     http.assert_exhausted();
+}
+
+#[tokio::test]
+async fn instant_acme_issuer_cleans_challenge_when_issuance_is_cancelled() {
+    let (http, blocker) =
+        ScriptedAcmeHttp::new_blocking(acme_happy_path(), "https://acme.test/order/1");
+    let provisioner = RecordingProvisioner::default();
+    let issuer = test_issuer(http, provisioner.clone());
+    let config = http_serve_config();
+    let account = issuer
+        .create_account(config.acme_email.as_str())
+        .await
+        .expect("create ACME account");
+    let task = tokio::spawn(async move { issuer.issue_certificate(&account, &config, None).await });
+
+    timeout(Duration::from_secs(5), blocker.wait_until_blocked())
+        .await
+        .expect("ACME order poll did not block");
+    task.abort();
+    let cancellation = timeout(Duration::from_secs(1), task)
+        .await
+        .expect("cancel ACME issuance timeout")
+        .expect_err("cancelled ACME issuance should not complete");
+
+    assert!(cancellation.is_cancelled());
+    assert_eq!(provisioner.cleanup_count(), 1);
 }
 
 #[tokio::test]

--- a/src/daemon/remote_acme_issuer_tests.rs
+++ b/src/daemon/remote_acme_issuer_tests.rs
@@ -1,10 +1,10 @@
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use instant_acme::{Account, RetryPolicy};
 use rcgen::KeyPair;
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 #[path = "remote_acme_issuer_test_support.rs"]
 mod support;
@@ -16,6 +16,7 @@ use support::{
 
 use super::{InstantAcmeIssuer, RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner};
 use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
+use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use crate::daemon::remote_tls::build_remote_tls_server_config;
 
 #[tokio::test]
@@ -91,7 +92,47 @@ async fn instant_acme_issuer_completes_account_order_and_http01_issuance() {
 async fn instant_acme_issuer_cleans_challenge_when_issuance_is_cancelled() {
     let (http, blocker) =
         ScriptedAcmeHttp::new_blocking(acme_happy_path(), "https://acme.test/order/1");
-    let provisioner = RecordingProvisioner::default();
+    let provisioner = RecordingProvisioner::with_cleanup_delay(Duration::from_secs(1));
+    let issuer = test_issuer(http, provisioner.clone());
+    let config = http_serve_config();
+    let account = issuer
+        .create_account(config.acme_email.as_str())
+        .await
+        .expect("create ACME account");
+    let cleanup_tracker = RemoteAcmeCleanupTracker::default();
+    let task_cleanup_tracker = cleanup_tracker.clone();
+    let task = tokio::spawn(async move {
+        issuer
+            .issue_certificate_with_cleanup(&account, &config, None, task_cleanup_tracker)
+            .await
+    });
+
+    timeout(Duration::from_secs(5), blocker.wait_until_blocked())
+        .await
+        .expect("ACME order poll did not block");
+    let cancel_started = Instant::now();
+    task.abort();
+    let cancellation = timeout(Duration::from_secs(2), task)
+        .await
+        .expect("cancel ACME issuance timeout")
+        .expect_err("cancelled ACME issuance should not complete");
+    let cancel_elapsed = cancel_started.elapsed();
+
+    assert!(cancellation.is_cancelled());
+    assert!(
+        cancel_elapsed < Duration::from_millis(500),
+        "cancelling ACME issuance blocked for {cancel_elapsed:?}"
+    );
+    timeout(Duration::from_secs(2), cleanup_tracker.wait_for_cleanup())
+        .await
+        .expect("cancelled ACME cleanup timeout");
+    assert_eq!(provisioner.cleanup_count(), 1);
+}
+
+#[tokio::test]
+async fn instant_acme_issuer_cleanup_does_not_block_runtime() {
+    let http = ScriptedAcmeHttp::new(acme_happy_path());
+    let provisioner = RecordingProvisioner::with_cleanup_delay(Duration::from_secs(1));
     let issuer = test_issuer(http, provisioner.clone());
     let config = http_serve_config();
     let account = issuer
@@ -100,16 +141,19 @@ async fn instant_acme_issuer_cleans_challenge_when_issuance_is_cancelled() {
         .expect("create ACME account");
     let task = tokio::spawn(async move { issuer.issue_certificate(&account, &config, None).await });
 
-    timeout(Duration::from_secs(5), blocker.wait_until_blocked())
+    timeout(Duration::from_millis(500), async {
+        while !provisioner.cleanup_started() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("ACME cleanup blocked the runtime worker");
+    timeout(Duration::from_secs(2), task)
         .await
-        .expect("ACME order poll did not block");
-    task.abort();
-    let cancellation = timeout(Duration::from_secs(1), task)
-        .await
-        .expect("cancel ACME issuance timeout")
-        .expect_err("cancelled ACME issuance should not complete");
+        .expect("ACME issuance cleanup timeout")
+        .expect("join ACME issuance")
+        .expect("issue ACME certificate");
 
-    assert!(cancellation.is_cancelled());
     assert_eq!(provisioner.cleanup_count(), 1);
 }
 
@@ -276,6 +320,8 @@ struct RecordingProvisioner {
 struct RecordingProvisionerState {
     materials: Vec<RemoteAcmeChallengeMaterial>,
     cleanup_count: usize,
+    cleanup_delay: Duration,
+    cleanup_started: bool,
     cleanup_error: Option<String>,
 }
 
@@ -284,6 +330,15 @@ impl RecordingProvisioner {
         Self {
             inner: Arc::new(Mutex::new(RecordingProvisionerState {
                 cleanup_error: Some(error.to_string()),
+                ..RecordingProvisionerState::default()
+            })),
+        }
+    }
+
+    fn with_cleanup_delay(delay: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RecordingProvisionerState {
+                cleanup_delay: delay,
                 ..RecordingProvisionerState::default()
             })),
         }
@@ -299,6 +354,10 @@ impl RecordingProvisioner {
 
     fn cleanup_count(&self) -> usize {
         self.inner.lock().expect("lock provisioner").cleanup_count
+    }
+
+    fn cleanup_started(&self) -> bool {
+        self.inner.lock().expect("lock provisioner").cleanup_started
     }
 }
 
@@ -316,6 +375,12 @@ impl RemoteAcmeChallengeProvisioner for RecordingProvisioner {
     }
 
     async fn cleanup(&self, _lease: Self::Lease) -> Result<(), String> {
+        let delay = {
+            let mut state = self.inner.lock().map_err(|error| error.to_string())?;
+            state.cleanup_started = true;
+            state.cleanup_delay
+        };
+        sleep(delay).await;
         let mut state = self.inner.lock().map_err(|error| error.to_string())?;
         state.cleanup_count += 1;
         state.cleanup_error.clone().map_or(Ok(()), Err)

--- a/src/daemon/remote_acme_lease_guard.rs
+++ b/src/daemon/remote_acme_lease_guard.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use super::remote_acme_issuer::{RemoteAcmeChallengeProvisioner, run_acme_future};
+use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
+use super::remote_acme_issuer::RemoteAcmeChallengeProvisioner;
 use super::remote_redaction::redact_secret_detail;
 
 pub(crate) struct RemoteAcmeChallengeLeaseGuard<P>
@@ -8,6 +9,7 @@ where
     P: RemoteAcmeChallengeProvisioner + 'static,
 {
     provisioner: Arc<P>,
+    cleanup_tracker: RemoteAcmeCleanupTracker,
     leases: Option<Vec<P::Lease>>,
 }
 
@@ -15,9 +17,10 @@ impl<P> RemoteAcmeChallengeLeaseGuard<P>
 where
     P: RemoteAcmeChallengeProvisioner + 'static,
 {
-    pub(crate) fn new(provisioner: Arc<P>) -> Self {
+    pub(crate) fn new(provisioner: Arc<P>, cleanup_tracker: RemoteAcmeCleanupTracker) -> Self {
         Self {
             provisioner,
+            cleanup_tracker,
             leases: Some(Vec::new()),
         }
     }
@@ -33,19 +36,21 @@ where
         self.leases.as_ref().and_then(|leases| leases.last())
     }
 
-    pub(crate) fn cleanup(mut self) -> Result<(), String> {
-        self.cleanup_remaining()
-    }
-
-    fn cleanup_remaining(&mut self) -> Result<(), String> {
-        let Some(leases) = self.leases.take() else {
+    pub(crate) async fn cleanup(mut self) -> Result<(), String> {
+        let Some(cleanup) = self.take_cleanup() else {
             return Ok(());
         };
-        if leases.is_empty() {
-            return Ok(());
-        }
-        let provisioner = Arc::clone(&self.provisioner);
-        run_acme_future(cleanup_leases(provisioner, leases))
+        self.cleanup_tracker
+            .spawn_cleanup(cleanup)
+            .await
+            .map_err(|error| format!("join remote ACME challenge cleanup: {error}"))?
+    }
+
+    fn take_cleanup(
+        &mut self,
+    ) -> Option<impl Future<Output = Result<(), String>> + Send + 'static> {
+        let leases = self.leases.take().filter(|leases| !leases.is_empty())?;
+        Some(cleanup_leases(Arc::clone(&self.provisioner), leases))
     }
 }
 
@@ -54,21 +59,9 @@ where
     P: RemoteAcmeChallengeProvisioner + 'static,
 {
     fn drop(&mut self) {
-        let result = self.cleanup_remaining();
-        log_cancellation_cleanup(&result);
-    }
-}
-
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "tracing macro expansion; tokio-rs/tracing#553"
-)]
-fn log_cancellation_cleanup(result: &Result<(), String>) {
-    if let Err(error) = result {
-        tracing::warn!(
-            error = %redact_secret_detail(error),
-            "remote ACME challenge cleanup after cancellation failed",
-        );
+        if let Some(cleanup) = self.take_cleanup() {
+            drop(self.cleanup_tracker.spawn_cleanup(cleanup));
+        }
     }
 }
 

--- a/src/daemon/remote_acme_lease_guard.rs
+++ b/src/daemon/remote_acme_lease_guard.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;

--- a/src/daemon/remote_acme_lease_guard.rs
+++ b/src/daemon/remote_acme_lease_guard.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use super::remote_acme_issuer::{RemoteAcmeChallengeProvisioner, run_acme_future};
+use super::remote_redaction::redact_secret_detail;
+
+pub(crate) struct RemoteAcmeChallengeLeaseGuard<P>
+where
+    P: RemoteAcmeChallengeProvisioner + 'static,
+{
+    provisioner: Arc<P>,
+    leases: Option<Vec<P::Lease>>,
+}
+
+impl<P> RemoteAcmeChallengeLeaseGuard<P>
+where
+    P: RemoteAcmeChallengeProvisioner + 'static,
+{
+    pub(crate) fn new(provisioner: Arc<P>) -> Self {
+        Self {
+            provisioner,
+            leases: Some(Vec::new()),
+        }
+    }
+
+    pub(crate) fn push(&mut self, lease: P::Lease) {
+        self.leases
+            .as_mut()
+            .expect("active ACME lease guard")
+            .push(lease);
+    }
+
+    pub(crate) fn last(&self) -> Option<&P::Lease> {
+        self.leases.as_ref().and_then(|leases| leases.last())
+    }
+
+    pub(crate) fn cleanup(mut self) -> Result<(), String> {
+        self.cleanup_remaining()
+    }
+
+    fn cleanup_remaining(&mut self) -> Result<(), String> {
+        let Some(leases) = self.leases.take() else {
+            return Ok(());
+        };
+        if leases.is_empty() {
+            return Ok(());
+        }
+        let provisioner = Arc::clone(&self.provisioner);
+        run_acme_future(cleanup_leases(provisioner, leases))
+    }
+}
+
+impl<P> Drop for RemoteAcmeChallengeLeaseGuard<P>
+where
+    P: RemoteAcmeChallengeProvisioner + 'static,
+{
+    fn drop(&mut self) {
+        let result = self.cleanup_remaining();
+        log_cancellation_cleanup(&result);
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+fn log_cancellation_cleanup(result: &Result<(), String>) {
+    if let Err(error) = result {
+        tracing::warn!(
+            error = %redact_secret_detail(error),
+            "remote ACME challenge cleanup after cancellation failed",
+        );
+    }
+}
+
+async fn cleanup_leases<P>(provisioner: Arc<P>, leases: Vec<P::Lease>) -> Result<(), String>
+where
+    P: RemoteAcmeChallengeProvisioner + 'static,
+{
+    let mut failures = Vec::new();
+    for lease in leases {
+        if let Err(error) = provisioner.cleanup(lease).await {
+            failures.push(redact_secret_detail(&error));
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("; "))
+    }
+}

--- a/src/daemon/remote_acme_live.rs
+++ b/src/daemon/remote_acme_live.rs
@@ -104,6 +104,13 @@ impl RemoteAcmeChallengeProvisioner for LiveRemoteAcmeChallengeProvisioner {
                 .map_err(|error| error.to_string()),
         }
     }
+
+    async fn wait_ready(&self, lease: &Self::Lease) -> Result<(), String> {
+        match lease {
+            LiveRemoteAcmeChallengeLease::System(lease) => self.system.wait_ready(lease).await,
+            LiveRemoteAcmeChallengeLease::TlsAlpn(_) => Ok(()),
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/src/daemon/remote_acme_live.rs
+++ b/src/daemon/remote_acme_live.rs
@@ -1,0 +1,147 @@
+use std::fmt;
+
+use async_trait::async_trait;
+
+use super::remote::RemoteDaemonServeConfig;
+use super::remote_acme::{
+    RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
+    RemoteCertificateBundle,
+};
+use super::remote_acme_challenge::{
+    SystemRemoteAcmeChallengeLease, SystemRemoteAcmeChallengeProvisioner,
+};
+use super::remote_acme_issuer::{
+    InstantAcmeIssuer, RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner,
+    SystemRemoteAcmeIssuer, run_acme_future,
+};
+use super::remote_tls::{RemoteTlsAlpnChallengeLease, RemoteTlsConfigHandle};
+
+pub(crate) struct LiveRemoteAcmeChallengeProvisioner {
+    system: SystemRemoteAcmeChallengeProvisioner,
+    tls: RemoteTlsConfigHandle,
+    domain: String,
+    bind_host: String,
+    https_port: u16,
+}
+
+impl LiveRemoteAcmeChallengeProvisioner {
+    pub(crate) fn from_environment(
+        config: &RemoteDaemonServeConfig,
+        tls: RemoteTlsConfigHandle,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            system: SystemRemoteAcmeChallengeProvisioner::from_environment(config)?,
+            tls,
+            domain: config.domain.trim().to_string(),
+            bind_host: config.host.trim().to_string(),
+            https_port: config.https_port,
+        })
+    }
+
+    fn validate_tls_listener(
+        &self,
+        domain: &str,
+        bind_host: &str,
+        port: u16,
+    ) -> Result<(), String> {
+        let matches = self.domain.eq_ignore_ascii_case(domain.trim())
+            && self.bind_host == bind_host.trim()
+            && self.https_port == port;
+        if matches {
+            Ok(())
+        } else {
+            Err("remote ACME TLS-ALPN-01 material does not match the active listener".to_string())
+        }
+    }
+}
+
+pub(crate) enum LiveRemoteAcmeChallengeLease {
+    System(SystemRemoteAcmeChallengeLease),
+    TlsAlpn(RemoteTlsAlpnChallengeLease),
+}
+
+impl fmt::Debug for LiveRemoteAcmeChallengeLease {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::System(_) => f.write_str("System(<redacted>)"),
+            Self::TlsAlpn(lease) => f.debug_tuple("TlsAlpn").field(lease).finish(),
+        }
+    }
+}
+
+#[async_trait]
+impl RemoteAcmeChallengeProvisioner for LiveRemoteAcmeChallengeProvisioner {
+    type Lease = LiveRemoteAcmeChallengeLease;
+
+    async fn present(&self, material: RemoteAcmeChallengeMaterial) -> Result<Self::Lease, String> {
+        match material {
+            RemoteAcmeChallengeMaterial::TlsAlpn01 {
+                domain,
+                bind_host,
+                port,
+                digest,
+            } => {
+                self.validate_tls_listener(&domain, &bind_host, port)?;
+                self.tls
+                    .present_tls_alpn_challenge(&domain, &digest)
+                    .map(LiveRemoteAcmeChallengeLease::TlsAlpn)
+                    .map_err(|error| error.to_string())
+            }
+            material => self
+                .system
+                .present(material)
+                .await
+                .map(LiveRemoteAcmeChallengeLease::System),
+        }
+    }
+
+    async fn cleanup(&self, lease: Self::Lease) -> Result<(), String> {
+        match lease {
+            LiveRemoteAcmeChallengeLease::System(lease) => self.system.cleanup(lease).await,
+            LiveRemoteAcmeChallengeLease::TlsAlpn(lease) => self
+                .tls
+                .clear_tls_alpn_challenge(lease)
+                .map_err(|error| error.to_string()),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct LiveRemoteAcmeIssuer {
+    tls: RemoteTlsConfigHandle,
+}
+
+impl LiveRemoteAcmeIssuer {
+    pub(crate) const fn new(tls: RemoteTlsConfigHandle) -> Self {
+        Self { tls }
+    }
+}
+
+impl RemoteAcmeRenewalIssuer for LiveRemoteAcmeIssuer {
+    fn create_account(
+        &self,
+        config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        SystemRemoteAcmeIssuer.create_account(config)
+    }
+
+    fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        let provisioner = LiveRemoteAcmeChallengeProvisioner::from_environment(
+            request.serve_config(),
+            self.tls.clone(),
+        )?;
+        let issuer = InstantAcmeIssuer::production(provisioner);
+        run_acme_future(issuer.issue_certificate(
+            request.account(),
+            request.serve_config(),
+            request.previous_private_key_pem(),
+        ))
+    }
+}
+
+#[cfg(test)]
+#[path = "remote_acme_live_tests.rs"]
+mod tests;

--- a/src/daemon/remote_acme_live.rs
+++ b/src/daemon/remote_acme_live.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 
 use super::remote::RemoteDaemonServeConfig;
 use super::remote_acme::{
-    RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
-    RemoteCertificateBundle,
+    RemoteAcmeAccountCredentials, RemoteAcmeAutomaticRenewalIssuer, RemoteAcmeRenewalIssuer,
+    RemoteAcmeRenewalRequest, RemoteCertificateBundle,
 };
 use super::remote_acme_challenge::{
     SystemRemoteAcmeChallengeLease, SystemRemoteAcmeChallengeProvisioner,
@@ -115,6 +115,23 @@ impl LiveRemoteAcmeIssuer {
     pub(crate) const fn new(tls: RemoteTlsConfigHandle) -> Self {
         Self { tls }
     }
+
+    async fn issue_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        let provisioner = LiveRemoteAcmeChallengeProvisioner::from_environment(
+            request.serve_config(),
+            self.tls.clone(),
+        )?;
+        InstantAcmeIssuer::production(provisioner)
+            .issue_certificate(
+                request.account(),
+                request.serve_config(),
+                request.previous_private_key_pem(),
+            )
+            .await
+    }
 }
 
 impl RemoteAcmeRenewalIssuer for LiveRemoteAcmeIssuer {
@@ -129,16 +146,17 @@ impl RemoteAcmeRenewalIssuer for LiveRemoteAcmeIssuer {
         &self,
         request: &RemoteAcmeRenewalRequest,
     ) -> Result<RemoteCertificateBundle, String> {
-        let provisioner = LiveRemoteAcmeChallengeProvisioner::from_environment(
-            request.serve_config(),
-            self.tls.clone(),
-        )?;
-        let issuer = InstantAcmeIssuer::production(provisioner);
-        run_acme_future(issuer.issue_certificate(
-            request.account(),
-            request.serve_config(),
-            request.previous_private_key_pem(),
-        ))
+        run_acme_future(self.issue_certificate(request))
+    }
+}
+
+#[async_trait]
+impl RemoteAcmeAutomaticRenewalIssuer for LiveRemoteAcmeIssuer {
+    async fn renew_certificate_automatically(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        self.issue_certificate(request).await
     }
 }
 

--- a/src/daemon/remote_acme_live.rs
+++ b/src/daemon/remote_acme_live.rs
@@ -10,6 +10,7 @@ use super::remote_acme::{
 use super::remote_acme_challenge::{
     SystemRemoteAcmeChallengeLease, SystemRemoteAcmeChallengeProvisioner,
 };
+use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use super::remote_acme_issuer::{
     InstantAcmeIssuer, RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner,
     SystemRemoteAcmeIssuer, run_acme_future,
@@ -126,16 +127,18 @@ impl LiveRemoteAcmeIssuer {
     async fn issue_certificate(
         &self,
         request: &RemoteAcmeRenewalRequest,
+        cleanup_tracker: RemoteAcmeCleanupTracker,
     ) -> Result<RemoteCertificateBundle, String> {
         let provisioner = LiveRemoteAcmeChallengeProvisioner::from_environment(
             request.serve_config(),
             self.tls.clone(),
         )?;
         InstantAcmeIssuer::production(provisioner)
-            .issue_certificate(
+            .issue_certificate_with_cleanup(
                 request.account(),
                 request.serve_config(),
                 request.previous_private_key_pem(),
+                cleanup_tracker,
             )
             .await
     }
@@ -153,7 +156,7 @@ impl RemoteAcmeRenewalIssuer for LiveRemoteAcmeIssuer {
         &self,
         request: &RemoteAcmeRenewalRequest,
     ) -> Result<RemoteCertificateBundle, String> {
-        run_acme_future(self.issue_certificate(request))
+        run_acme_future(self.issue_certificate(request, RemoteAcmeCleanupTracker::default()))
     }
 }
 
@@ -162,8 +165,10 @@ impl RemoteAcmeAutomaticRenewalIssuer for LiveRemoteAcmeIssuer {
     async fn renew_certificate_automatically(
         &self,
         request: &RemoteAcmeRenewalRequest,
+        cleanup_tracker: &RemoteAcmeCleanupTracker,
     ) -> Result<RemoteCertificateBundle, String> {
-        self.issue_certificate(request).await
+        self.issue_certificate(request, cleanup_tracker.clone())
+            .await
     }
 }
 

--- a/src/daemon/remote_acme_live_tests.rs
+++ b/src/daemon/remote_acme_live_tests.rs
@@ -1,0 +1,118 @@
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
+use crate::daemon::remote_acme::RemoteCertificateBundle;
+use crate::daemon::remote_acme_challenge::SystemRemoteAcmeChallengeLease;
+use crate::daemon::remote_acme_issuer::{
+    RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner,
+};
+use crate::daemon::remote_tls::RemoteTlsConfigHandle;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::TcpStream;
+
+use super::{LiveRemoteAcmeChallengeLease, LiveRemoteAcmeChallengeProvisioner};
+
+#[tokio::test]
+async fn live_acme_provisioner_publishes_tls_alpn_on_existing_listener() {
+    let tls = RemoteTlsConfigHandle::new(generated_bundle()).expect("TLS config");
+    let provisioner =
+        LiveRemoteAcmeChallengeProvisioner::from_environment(&serve_config(), tls.clone())
+            .expect("live challenge provisioner");
+
+    let lease = provisioner
+        .present(RemoteAcmeChallengeMaterial::TlsAlpn01 {
+            domain: "daemon.example.com".to_string(),
+            bind_host: "0.0.0.0".to_string(),
+            port: 443,
+            digest: vec![7_u8; 32],
+        })
+        .await
+        .expect("present live TLS challenge");
+
+    assert!(tls.tls_alpn_challenge_active());
+    provisioner.cleanup(lease).await.expect("cleanup challenge");
+    assert!(!tls.tls_alpn_challenge_active());
+}
+
+#[tokio::test]
+async fn live_acme_provisioner_rejects_tls_alpn_for_wrong_bound_port() {
+    let tls = RemoteTlsConfigHandle::new(generated_bundle()).expect("TLS config");
+    let provisioner =
+        LiveRemoteAcmeChallengeProvisioner::from_environment(&serve_config(), tls.clone())
+            .expect("live challenge provisioner");
+
+    let error = provisioner
+        .present(RemoteAcmeChallengeMaterial::TlsAlpn01 {
+            domain: "daemon.example.com".to_string(),
+            bind_host: "0.0.0.0".to_string(),
+            port: 8443,
+            digest: vec![7_u8; 32],
+        })
+        .await
+        .expect_err("wrong bound port must fail closed");
+
+    assert!(error.contains("does not match the active listener"));
+    assert!(!tls.tls_alpn_challenge_active());
+}
+
+#[tokio::test]
+async fn live_acme_provisioner_delegates_http01_to_standalone_listener() {
+    let tls = RemoteTlsConfigHandle::new(generated_bundle()).expect("TLS config");
+    let mut config = serve_config();
+    config.acme_challenge = RemoteAcmeChallenge::Http;
+    config.http_port = 0;
+    let provisioner = LiveRemoteAcmeChallengeProvisioner::from_environment(&config, tls)
+        .expect("live challenge provisioner");
+
+    let lease = provisioner
+        .present(RemoteAcmeChallengeMaterial::Http01 {
+            domain: "daemon.example.com".to_string(),
+            bind_host: "127.0.0.1".to_string(),
+            port: 0,
+            token: "http-token".to_string(),
+            key_authorization: "http-token.key-authorization".to_string(),
+        })
+        .await
+        .expect("present HTTP-01 challenge");
+    let LiveRemoteAcmeChallengeLease::System(SystemRemoteAcmeChallengeLease::Http(server)) = &lease
+    else {
+        panic!("HTTP-01 must use the standalone system listener");
+    };
+    let mut stream = TcpStream::connect(server.local_addr())
+        .await
+        .expect("connect HTTP-01 listener");
+    stream
+        .write_all(
+            b"GET /.well-known/acme-challenge/http-token HTTP/1.1\r\nHost: daemon.example.com\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .expect("write HTTP-01 request");
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .await
+        .expect("read HTTP-01 response");
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    assert!(response.ends_with("http-token.key-authorization"));
+    provisioner.cleanup(lease).await.expect("cleanup challenge");
+}
+
+fn serve_config() -> RemoteDaemonServeConfig {
+    RemoteDaemonServeConfig {
+        domain: "daemon.example.com".to_string(),
+        host: "0.0.0.0".to_string(),
+        https_port: 443,
+        http_port: 80,
+        acme_email: "ops@example.com".to_string(),
+        acme_challenge: RemoteAcmeChallenge::TlsAlpn,
+        acme_dns_provider: None,
+    }
+}
+
+fn generated_bundle() -> RemoteCertificateBundle {
+    let key = rcgen::KeyPair::generate().expect("generate key");
+    let certificate = rcgen::CertificateParams::new(["daemon.example.com".to_string()])
+        .expect("certificate params")
+        .self_signed(&key)
+        .expect("self-sign certificate");
+    RemoteCertificateBundle::new(certificate.pem().as_str(), &key.serialize_pem())
+}

--- a/src/daemon/remote_acme_renewal.rs
+++ b/src/daemon/remote_acme_renewal.rs
@@ -1,0 +1,352 @@
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use tokio::sync::watch as tokio_watch;
+use tokio::task::{JoinHandle, spawn_blocking};
+use tokio::time::{MissedTickBehavior, interval};
+use uuid::Uuid;
+
+use super::db::DaemonDb;
+use super::remote::{RemoteAccessScope, RemoteDaemonServeConfig};
+use super::remote_acme::{
+    RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
+    RemoteCertificateBundle, RemoteRenewalOutcome, build_remote_acme_runtime_plan,
+};
+use super::remote_acme_live::LiveRemoteAcmeIssuer;
+use super::remote_certificate_identity::{RemoteCertificateIdentityError, certificate_not_after};
+use super::remote_identity::{RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision};
+use super::remote_tls::{RemoteTlsConfigHandle, build_remote_tls_server_config};
+use crate::errors::{CliError, CliErrorKind};
+
+const REMOTE_ACME_RENEWAL_WINDOW: ChronoDuration = ChronoDuration::days(30);
+const REMOTE_ACME_CHECK_INTERVAL: Duration = Duration::from_hours(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteAcmeRenewalCheckOutcome {
+    NotDue,
+    Reloaded,
+    Renewed,
+    Failed,
+}
+
+struct RemoteAcmeRenewalSnapshot {
+    config: RemoteDaemonServeConfig,
+    account: RemoteAcmeAccountCredentials,
+    bundle: RemoteCertificateBundle,
+    previous_private_key_pem: Option<String>,
+}
+
+pub(crate) fn remote_certificate_needs_renewal(
+    bundle: &RemoteCertificateBundle,
+    now: DateTime<Utc>,
+) -> Result<bool, RemoteCertificateIdentityError> {
+    let renew_at = certificate_not_after(bundle)? - REMOTE_ACME_RENEWAL_WINDOW;
+    Ok(now >= renew_at)
+}
+
+pub(crate) fn spawn_remote_acme_renewal_loop(
+    db: Arc<Mutex<DaemonDb>>,
+    tls: RemoteTlsConfigHandle,
+    shutdown_rx: tokio_watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    let issuer = Arc::new(LiveRemoteAcmeIssuer::new(tls.clone()));
+    spawn_remote_acme_renewal_loop_with(
+        db,
+        tls,
+        issuer,
+        shutdown_rx,
+        REMOTE_ACME_CHECK_INTERVAL,
+        Utc::now,
+    )
+}
+
+pub(crate) fn spawn_remote_acme_renewal_loop_with<I, Now>(
+    db: Arc<Mutex<DaemonDb>>,
+    tls: RemoteTlsConfigHandle,
+    issuer: Arc<I>,
+    shutdown_rx: tokio_watch::Receiver<bool>,
+    check_interval: Duration,
+    now: Now,
+) -> JoinHandle<()>
+where
+    I: RemoteAcmeRenewalIssuer + Send + Sync + 'static,
+    Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
+{
+    tokio::spawn(run_remote_acme_renewal_loop(
+        db,
+        tls,
+        issuer,
+        shutdown_rx,
+        check_interval,
+        Arc::new(now),
+    ))
+}
+
+async fn run_remote_acme_renewal_loop<I, Now>(
+    db: Arc<Mutex<DaemonDb>>,
+    tls: RemoteTlsConfigHandle,
+    issuer: Arc<I>,
+    mut shutdown_rx: tokio_watch::Receiver<bool>,
+    check_interval: Duration,
+    now: Arc<Now>,
+) where
+    I: RemoteAcmeRenewalIssuer + Send + Sync + 'static,
+    Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
+{
+    let mut ticker = interval(check_interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            () = wait_for_shutdown(&mut shutdown_rx) => break,
+            _ = ticker.tick() => {
+                let result = run_remote_acme_renewal_check_blocking(
+                    Arc::clone(&db),
+                    tls.clone(),
+                    Arc::clone(&issuer),
+                    Arc::clone(&now),
+                ).await;
+                log_renewal_check(&result);
+            }
+        }
+    }
+}
+
+async fn wait_for_shutdown(shutdown_rx: &mut tokio_watch::Receiver<bool>) {
+    if *shutdown_rx.borrow() {
+        return;
+    }
+    while shutdown_rx.changed().await.is_ok() {
+        if *shutdown_rx.borrow() {
+            break;
+        }
+    }
+}
+
+async fn run_remote_acme_renewal_check_blocking<I, Now>(
+    db: Arc<Mutex<DaemonDb>>,
+    tls: RemoteTlsConfigHandle,
+    issuer: Arc<I>,
+    now: Arc<Now>,
+) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
+where
+    I: RemoteAcmeRenewalIssuer + Send + Sync + 'static,
+    Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
+{
+    spawn_blocking(move || run_remote_acme_renewal_check(&db, &tls, issuer.as_ref(), now()))
+        .await
+        .map_err(|error| {
+            CliError::from(CliErrorKind::workflow_io(format!(
+                "join remote ACME renewal check: {error}"
+            )))
+        })?
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+fn log_renewal_check(result: &Result<RemoteAcmeRenewalCheckOutcome, CliError>) {
+    match result {
+        Ok(RemoteAcmeRenewalCheckOutcome::NotDue) => {
+            tracing::debug!("remote ACME certificate is outside the renewal window");
+        }
+        Ok(RemoteAcmeRenewalCheckOutcome::Reloaded) => {
+            tracing::info!("remote TLS certificate reloaded from persisted ACME state");
+        }
+        Ok(RemoteAcmeRenewalCheckOutcome::Renewed) => {
+            tracing::info!("remote ACME certificate renewed and reloaded");
+        }
+        Ok(RemoteAcmeRenewalCheckOutcome::Failed) => {
+            tracing::warn!("remote ACME automatic renewal failed; status was persisted");
+        }
+        Err(error) => {
+            tracing::warn!(%error, "remote ACME automatic renewal check failed");
+        }
+    }
+}
+
+pub(crate) fn run_remote_acme_renewal_check<I>(
+    db: &Arc<Mutex<DaemonDb>>,
+    tls: &RemoteTlsConfigHandle,
+    issuer: &I,
+    now: DateTime<Utc>,
+) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
+where
+    I: RemoteAcmeRenewalIssuer,
+{
+    let snapshot = load_renewal_snapshot(db)?;
+    let due = remote_certificate_needs_renewal(&snapshot.bundle, now).unwrap_or(true);
+    if !due && tls.certificate_fingerprint() == snapshot.bundle.fingerprint() {
+        return Ok(RemoteAcmeRenewalCheckOutcome::NotDue);
+    }
+    if !due && tls.reload(snapshot.bundle.clone()).is_ok() {
+        record_automatic_audit(
+            db,
+            now,
+            "remote.tls.reload.automatic",
+            RemoteAuditOutcome::Success,
+            None,
+        )?;
+        return Ok(RemoteAcmeRenewalCheckOutcome::Reloaded);
+    }
+    renew_due_certificate(db, tls, issuer, &snapshot, now)
+}
+
+fn load_renewal_snapshot(db: &Arc<Mutex<DaemonDb>>) -> Result<RemoteAcmeRenewalSnapshot, CliError> {
+    let db = lock_db(db)?;
+    let stored = db.load_remote_acme_state()?;
+    let config = stored.serve_config.ok_or_else(|| {
+        CliError::from(CliErrorKind::workflow_parse(
+            "remote automatic renewal requires persisted ACME serve config",
+        ))
+    })?;
+    let issuance = db.load_remote_acme_issuance_state()?;
+    let account = issuance.account.ok_or_else(|| {
+        CliError::from(CliErrorKind::workflow_parse(
+            "remote automatic renewal requires persisted ACME account credentials",
+        ))
+    })?;
+    let runtime_state = db.load_remote_acme_runtime_state()?;
+    let plan = build_remote_acme_runtime_plan(&config, &runtime_state)
+        .map_err(|error| CliError::from(CliErrorKind::workflow_parse(error.to_string())))?;
+    Ok(RemoteAcmeRenewalSnapshot {
+        config,
+        account,
+        bundle: plan.certificate().clone(),
+        previous_private_key_pem: issuance.previous_private_key_pem,
+    })
+}
+
+fn renew_due_certificate<I>(
+    db: &Arc<Mutex<DaemonDb>>,
+    tls: &RemoteTlsConfigHandle,
+    issuer: &I,
+    snapshot: &RemoteAcmeRenewalSnapshot,
+    now: DateTime<Utc>,
+) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
+where
+    I: RemoteAcmeRenewalIssuer,
+{
+    let request = RemoteAcmeRenewalRequest::new(
+        &snapshot.account,
+        Some(snapshot.bundle.fingerprint()),
+        snapshot.previous_private_key_pem.as_deref(),
+        &snapshot.config,
+    );
+    let bundle = match issuer.renew_certificate(&request) {
+        Ok(bundle) => bundle,
+        Err(detail) => return persist_renewal_failure(db, now, &detail),
+    };
+    if let Err(error) = build_remote_tls_server_config(&bundle) {
+        return persist_renewal_failure(
+            db,
+            now,
+            &format!("renewed remote TLS material is invalid: {error}"),
+        );
+    }
+    if !persist_renewal_success(db, now, &bundle, snapshot)? {
+        return reload_superseding_certificate(db, tls, now);
+    }
+    tls.reload(bundle).map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "publish renewed remote TLS certificate: {error}"
+        )))
+    })?;
+    Ok(RemoteAcmeRenewalCheckOutcome::Renewed)
+}
+
+fn persist_renewal_failure(
+    db: &Arc<Mutex<DaemonDb>>,
+    now: DateTime<Utc>,
+    detail: &str,
+) -> Result<RemoteAcmeRenewalCheckOutcome, CliError> {
+    let report = RemoteRenewalOutcome::failure(detail).report().to_string();
+    lock_db(db)?.record_remote_acme_renewal_failure(detail, &timestamp(now))?;
+    record_automatic_audit(
+        db,
+        now,
+        "remote.acme.renew.automatic",
+        RemoteAuditOutcome::Failure,
+        Some(&report),
+    )?;
+    Ok(RemoteAcmeRenewalCheckOutcome::Failed)
+}
+
+fn persist_renewal_success(
+    db: &Arc<Mutex<DaemonDb>>,
+    now: DateTime<Utc>,
+    bundle: &RemoteCertificateBundle,
+    snapshot: &RemoteAcmeRenewalSnapshot,
+) -> Result<bool, CliError> {
+    let persisted = lock_db(db)?.record_remote_acme_renewal_success_if_current(
+        bundle,
+        snapshot.bundle.fingerprint(),
+        snapshot.account.account_id(),
+        &snapshot.config,
+        &timestamp(now),
+    )?;
+    let route = if persisted {
+        "remote.acme.renew.automatic"
+    } else {
+        "remote.acme.renew.automatic.superseded"
+    };
+    record_automatic_audit(db, now, route, RemoteAuditOutcome::Success, None)?;
+    Ok(persisted)
+}
+
+fn reload_superseding_certificate(
+    db: &Arc<Mutex<DaemonDb>>,
+    tls: &RemoteTlsConfigHandle,
+    now: DateTime<Utc>,
+) -> Result<RemoteAcmeRenewalCheckOutcome, CliError> {
+    let latest = load_renewal_snapshot(db)?;
+    tls.reload(latest.bundle).map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "publish superseding remote TLS certificate: {error}"
+        )))
+    })?;
+    record_automatic_audit(
+        db,
+        now,
+        "remote.tls.reload.automatic",
+        RemoteAuditOutcome::Success,
+        None,
+    )?;
+    Ok(RemoteAcmeRenewalCheckOutcome::Reloaded)
+}
+
+fn record_automatic_audit(
+    db: &Arc<Mutex<DaemonDb>>,
+    now: DateTime<Utc>,
+    route_or_method: &str,
+    outcome: RemoteAuditOutcome,
+    error_detail: Option<&str>,
+) -> Result<(), CliError> {
+    lock_db(db)?.record_remote_audit_event(&RemoteAuditEvent::new(
+        format!("remote-acme-auto-{}", Uuid::new_v4()),
+        timestamp(now),
+        None,
+        None,
+        route_or_method,
+        RemoteAccessScope::Admin,
+        RemoteAuditScopeDecision::Allowed,
+        outcome,
+        None,
+        error_detail,
+    ))
+}
+
+fn timestamp(now: DateTime<Utc>) -> String {
+    now.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+fn lock_db(db: &Arc<Mutex<DaemonDb>>) -> Result<MutexGuard<'_, DaemonDb>, CliError> {
+    db.lock().map_err(|error| {
+        CliErrorKind::workflow_io(format!("daemon database lock poisoned: {error}")).into()
+    })
+}
+
+#[cfg(test)]
+#[path = "remote_acme_renewal_tests.rs"]
+mod tests;

--- a/src/daemon/remote_acme_renewal.rs
+++ b/src/daemon/remote_acme_renewal.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use tokio::sync::watch as tokio_watch;
 use tokio::task::JoinHandle;
-use tokio::time::{MissedTickBehavior, interval};
+use tokio::time::{MissedTickBehavior, interval, timeout};
 use uuid::Uuid;
 
 use super::db::DaemonDb;
@@ -13,6 +13,7 @@ use super::remote_acme::{
     RemoteAcmeAccountCredentials, RemoteAcmeAutomaticRenewalIssuer, RemoteAcmeRenewalRequest,
     RemoteCertificateBundle, RemoteRenewalOutcome, build_remote_acme_runtime_plan,
 };
+use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use super::remote_acme_live::LiveRemoteAcmeIssuer;
 use super::remote_certificate_identity::{RemoteCertificateIdentityError, certificate_not_after};
 use super::remote_identity::{RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision};
@@ -21,6 +22,7 @@ use crate::errors::{CliError, CliErrorKind};
 
 const REMOTE_ACME_RENEWAL_WINDOW: ChronoDuration = ChronoDuration::days(30);
 const REMOTE_ACME_CHECK_INTERVAL: Duration = Duration::from_hours(1);
+const REMOTE_ACME_SHUTDOWN_CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RemoteAcmeRenewalCheckOutcome {
@@ -132,14 +134,43 @@ where
     I: RemoteAcmeAutomaticRenewalIssuer + 'static,
     Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
 {
-    let check = run_remote_acme_renewal_check(&db, &tls, issuer.as_ref(), now());
-    tokio::pin!(check);
-    tokio::select! {
-        () = wait_for_shutdown(shutdown_rx) => RemoteAcmeRenewalLoopControl::Shutdown,
-        result = &mut check => {
-            log_renewal_check(&result);
-            RemoteAcmeRenewalLoopControl::Continue
-        },
+    let cleanup_tracker = RemoteAcmeCleanupTracker::default();
+    let control = {
+        let check = run_remote_acme_renewal_check_with_cleanup(
+            &db,
+            &tls,
+            issuer.as_ref(),
+            now(),
+            &cleanup_tracker,
+        );
+        tokio::pin!(check);
+        tokio::select! {
+            () = wait_for_shutdown(shutdown_rx) => RemoteAcmeRenewalLoopControl::Shutdown,
+            result = &mut check => {
+                log_renewal_check(&result);
+                RemoteAcmeRenewalLoopControl::Continue
+            },
+        }
+    };
+    if control == RemoteAcmeRenewalLoopControl::Shutdown {
+        wait_for_shutdown_cleanup(&cleanup_tracker).await;
+    }
+    control
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+async fn wait_for_shutdown_cleanup(cleanup_tracker: &RemoteAcmeCleanupTracker) {
+    if timeout(
+        REMOTE_ACME_SHUTDOWN_CLEANUP_TIMEOUT,
+        cleanup_tracker.wait_for_cleanup(),
+    )
+    .await
+    .is_err()
+    {
+        tracing::warn!("remote ACME challenge cleanup timed out during shutdown");
     }
 }
 
@@ -178,11 +209,26 @@ fn log_renewal_check(result: &Result<RemoteAcmeRenewalCheckOutcome, CliError>) {
     }
 }
 
+#[cfg(test)]
 pub(crate) async fn run_remote_acme_renewal_check<I>(
     db: &Arc<Mutex<DaemonDb>>,
     tls: &RemoteTlsConfigHandle,
     issuer: &I,
     now: DateTime<Utc>,
+) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
+where
+    I: RemoteAcmeAutomaticRenewalIssuer,
+{
+    let cleanup_tracker = RemoteAcmeCleanupTracker::default();
+    run_remote_acme_renewal_check_with_cleanup(db, tls, issuer, now, &cleanup_tracker).await
+}
+
+async fn run_remote_acme_renewal_check_with_cleanup<I>(
+    db: &Arc<Mutex<DaemonDb>>,
+    tls: &RemoteTlsConfigHandle,
+    issuer: &I,
+    now: DateTime<Utc>,
+    cleanup_tracker: &RemoteAcmeCleanupTracker,
 ) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
 where
     I: RemoteAcmeAutomaticRenewalIssuer,
@@ -202,7 +248,7 @@ where
         )?;
         return Ok(RemoteAcmeRenewalCheckOutcome::Reloaded);
     }
-    renew_due_certificate(db, tls, issuer, &snapshot, now).await
+    renew_due_certificate(db, tls, issuer, &snapshot, now, cleanup_tracker).await
 }
 
 fn load_renewal_snapshot(db: &Arc<Mutex<DaemonDb>>) -> Result<RemoteAcmeRenewalSnapshot, CliError> {
@@ -236,6 +282,7 @@ async fn renew_due_certificate<I>(
     issuer: &I,
     snapshot: &RemoteAcmeRenewalSnapshot,
     now: DateTime<Utc>,
+    cleanup_tracker: &RemoteAcmeCleanupTracker,
 ) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
 where
     I: RemoteAcmeAutomaticRenewalIssuer,
@@ -246,7 +293,10 @@ where
         snapshot.previous_private_key_pem.as_deref(),
         &snapshot.config,
     );
-    let bundle = match issuer.renew_certificate_automatically(&request).await {
+    let bundle = match issuer
+        .renew_certificate_automatically(&request, cleanup_tracker)
+        .await
+    {
         Ok(bundle) => bundle,
         Err(detail) => return persist_renewal_failure(db, now, &detail),
     };

--- a/src/daemon/remote_acme_renewal.rs
+++ b/src/daemon/remote_acme_renewal.rs
@@ -17,7 +17,10 @@ use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use super::remote_acme_live::LiveRemoteAcmeIssuer;
 use super::remote_certificate_identity::{RemoteCertificateIdentityError, certificate_not_after};
 use super::remote_identity::{RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision};
-use super::remote_tls::{RemoteTlsConfigHandle, build_remote_tls_server_config};
+use super::remote_redaction::redact_secret_detail;
+use super::remote_tls::{
+    RemoteTlsConfigError, RemoteTlsConfigHandle, build_remote_tls_server_config,
+};
 use crate::errors::{CliError, CliErrorKind};
 
 const REMOTE_ACME_RENEWAL_WINDOW: ChronoDuration = ChronoDuration::days(30);
@@ -239,14 +242,26 @@ where
 {
     let snapshot = load_renewal_snapshot(db)?;
     let due = remote_certificate_needs_renewal(&snapshot.bundle, now).unwrap_or(true);
-    if !due {
-        if tls.certificate_fingerprint() == snapshot.bundle.fingerprint() {
-            return Ok(RemoteAcmeRenewalCheckOutcome::NotDue);
-        }
-        if let Ok(reloaded) = tls.reload(snapshot.bundle.clone()) {
-            if !reloaded {
-                return Ok(RemoteAcmeRenewalCheckOutcome::NotDue);
-            }
+    if !due
+        && let Some(outcome) = reload_not_due_certificate(db, tls, &snapshot.bundle, now)?
+    {
+        return Ok(outcome);
+    }
+    renew_due_certificate(db, tls, issuer, &snapshot, now, cleanup_tracker).await
+}
+
+fn reload_not_due_certificate(
+    db: &Arc<Mutex<DaemonDb>>,
+    tls: &RemoteTlsConfigHandle,
+    bundle: &RemoteCertificateBundle,
+    now: DateTime<Utc>,
+) -> Result<Option<RemoteAcmeRenewalCheckOutcome>, CliError> {
+    if tls.certificate_fingerprint() == bundle.fingerprint() {
+        return Ok(Some(RemoteAcmeRenewalCheckOutcome::NotDue));
+    }
+    match tls.reload(bundle.clone()) {
+        Ok(false) => Ok(Some(RemoteAcmeRenewalCheckOutcome::NotDue)),
+        Ok(true) => {
             record_automatic_audit(
                 db,
                 now,
@@ -254,10 +269,24 @@ where
                 RemoteAuditOutcome::Success,
                 None,
             )?;
-            return Ok(RemoteAcmeRenewalCheckOutcome::Reloaded);
+            Ok(Some(RemoteAcmeRenewalCheckOutcome::Reloaded))
+        }
+        Err(error) => {
+            log_persisted_tls_reload_failure(&error);
+            Ok(None)
         }
     }
-    renew_due_certificate(db, tls, issuer, &snapshot, now, cleanup_tracker).await
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+fn log_persisted_tls_reload_failure(error: &RemoteTlsConfigError) {
+    tracing::warn!(
+        error = %redact_secret_detail(&error.to_string()),
+        "persisted remote TLS certificate reload failed; attempting early ACME renewal"
+    );
 }
 
 fn load_renewal_snapshot(db: &Arc<Mutex<DaemonDb>>) -> Result<RemoteAcmeRenewalSnapshot, CliError> {

--- a/src/daemon/remote_acme_renewal.rs
+++ b/src/daemon/remote_acme_renewal.rs
@@ -29,6 +29,7 @@ pub(crate) enum RemoteAcmeRenewalCheckOutcome {
     NotDue,
     Reloaded,
     Renewed,
+    Superseded,
     Failed,
 }
 
@@ -200,6 +201,9 @@ fn log_renewal_check(result: &Result<RemoteAcmeRenewalCheckOutcome, CliError>) {
         Ok(RemoteAcmeRenewalCheckOutcome::Renewed) => {
             tracing::info!("remote ACME certificate renewed and reloaded");
         }
+        Ok(RemoteAcmeRenewalCheckOutcome::Superseded) => {
+            tracing::info!("remote ACME renewal was superseded by the active certificate");
+        }
         Ok(RemoteAcmeRenewalCheckOutcome::Failed) => {
             tracing::warn!("remote ACME automatic renewal failed; status was persisted");
         }
@@ -235,18 +239,23 @@ where
 {
     let snapshot = load_renewal_snapshot(db)?;
     let due = remote_certificate_needs_renewal(&snapshot.bundle, now).unwrap_or(true);
-    if !due && tls.certificate_fingerprint() == snapshot.bundle.fingerprint() {
-        return Ok(RemoteAcmeRenewalCheckOutcome::NotDue);
-    }
-    if !due && tls.reload(snapshot.bundle.clone()).is_ok() {
-        record_automatic_audit(
-            db,
-            now,
-            "remote.tls.reload.automatic",
-            RemoteAuditOutcome::Success,
-            None,
-        )?;
-        return Ok(RemoteAcmeRenewalCheckOutcome::Reloaded);
+    if !due {
+        if tls.certificate_fingerprint() == snapshot.bundle.fingerprint() {
+            return Ok(RemoteAcmeRenewalCheckOutcome::NotDue);
+        }
+        if let Ok(reloaded) = tls.reload(snapshot.bundle.clone()) {
+            if !reloaded {
+                return Ok(RemoteAcmeRenewalCheckOutcome::NotDue);
+            }
+            record_automatic_audit(
+                db,
+                now,
+                "remote.tls.reload.automatic",
+                RemoteAuditOutcome::Success,
+                None,
+            )?;
+            return Ok(RemoteAcmeRenewalCheckOutcome::Reloaded);
+        }
     }
     renew_due_certificate(db, tls, issuer, &snapshot, now, cleanup_tracker).await
 }
@@ -363,11 +372,14 @@ fn reload_superseding_certificate(
     now: DateTime<Utc>,
 ) -> Result<RemoteAcmeRenewalCheckOutcome, CliError> {
     let latest = load_renewal_snapshot(db)?;
-    tls.reload(latest.bundle).map_err(|error| {
+    let reloaded = tls.reload(latest.bundle).map_err(|error| {
         CliError::from(CliErrorKind::workflow_io(format!(
             "publish superseding remote TLS certificate: {error}"
         )))
     })?;
+    if !reloaded {
+        return Ok(RemoteAcmeRenewalCheckOutcome::Superseded);
+    }
     record_automatic_audit(
         db,
         now,

--- a/src/daemon/remote_acme_renewal.rs
+++ b/src/daemon/remote_acme_renewal.rs
@@ -30,6 +30,12 @@ pub(crate) enum RemoteAcmeRenewalCheckOutcome {
     Failed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteAcmeRenewalLoopControl {
+    Continue,
+    Shutdown,
+}
+
 struct RemoteAcmeRenewalSnapshot {
     config: RemoteDaemonServeConfig,
     account: RemoteAcmeAccountCredentials,
@@ -100,15 +106,40 @@ async fn run_remote_acme_renewal_loop<I, Now>(
         tokio::select! {
             () = wait_for_shutdown(&mut shutdown_rx) => break,
             _ = ticker.tick() => {
-                let result = run_remote_acme_renewal_check_blocking(
+                let control = run_remote_acme_renewal_check_or_shutdown(
                     Arc::clone(&db),
                     tls.clone(),
                     Arc::clone(&issuer),
+                    &mut shutdown_rx,
                     Arc::clone(&now),
                 ).await;
-                log_renewal_check(&result);
+                if control == RemoteAcmeRenewalLoopControl::Shutdown {
+                    break;
+                }
             }
         }
+    }
+}
+
+async fn run_remote_acme_renewal_check_or_shutdown<I, Now>(
+    db: Arc<Mutex<DaemonDb>>,
+    tls: RemoteTlsConfigHandle,
+    issuer: Arc<I>,
+    shutdown_rx: &mut tokio_watch::Receiver<bool>,
+    now: Arc<Now>,
+) -> RemoteAcmeRenewalLoopControl
+where
+    I: RemoteAcmeRenewalIssuer + Send + Sync + 'static,
+    Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
+{
+    let check = run_remote_acme_renewal_check_blocking(db, tls, issuer, now);
+    tokio::pin!(check);
+    tokio::select! {
+        () = wait_for_shutdown(shutdown_rx) => RemoteAcmeRenewalLoopControl::Shutdown,
+        result = &mut check => {
+            log_renewal_check(&result);
+            RemoteAcmeRenewalLoopControl::Continue
+        },
     }
 }
 

--- a/src/daemon/remote_acme_renewal.rs
+++ b/src/daemon/remote_acme_renewal.rs
@@ -3,14 +3,14 @@ use std::time::Duration;
 
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use tokio::sync::watch as tokio_watch;
-use tokio::task::{JoinHandle, spawn_blocking};
+use tokio::task::JoinHandle;
 use tokio::time::{MissedTickBehavior, interval};
 use uuid::Uuid;
 
 use super::db::DaemonDb;
 use super::remote::{RemoteAccessScope, RemoteDaemonServeConfig};
 use super::remote_acme::{
-    RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
+    RemoteAcmeAccountCredentials, RemoteAcmeAutomaticRenewalIssuer, RemoteAcmeRenewalRequest,
     RemoteCertificateBundle, RemoteRenewalOutcome, build_remote_acme_runtime_plan,
 };
 use super::remote_acme_live::LiveRemoteAcmeIssuer;
@@ -76,7 +76,7 @@ pub(crate) fn spawn_remote_acme_renewal_loop_with<I, Now>(
     now: Now,
 ) -> JoinHandle<()>
 where
-    I: RemoteAcmeRenewalIssuer + Send + Sync + 'static,
+    I: RemoteAcmeAutomaticRenewalIssuer + 'static,
     Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
 {
     tokio::spawn(run_remote_acme_renewal_loop(
@@ -97,7 +97,7 @@ async fn run_remote_acme_renewal_loop<I, Now>(
     check_interval: Duration,
     now: Arc<Now>,
 ) where
-    I: RemoteAcmeRenewalIssuer + Send + Sync + 'static,
+    I: RemoteAcmeAutomaticRenewalIssuer + 'static,
     Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
 {
     let mut ticker = interval(check_interval);
@@ -129,10 +129,10 @@ async fn run_remote_acme_renewal_check_or_shutdown<I, Now>(
     now: Arc<Now>,
 ) -> RemoteAcmeRenewalLoopControl
 where
-    I: RemoteAcmeRenewalIssuer + Send + Sync + 'static,
+    I: RemoteAcmeAutomaticRenewalIssuer + 'static,
     Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
 {
-    let check = run_remote_acme_renewal_check_blocking(db, tls, issuer, now);
+    let check = run_remote_acme_renewal_check(&db, &tls, issuer.as_ref(), now());
     tokio::pin!(check);
     tokio::select! {
         () = wait_for_shutdown(shutdown_rx) => RemoteAcmeRenewalLoopControl::Shutdown,
@@ -152,25 +152,6 @@ async fn wait_for_shutdown(shutdown_rx: &mut tokio_watch::Receiver<bool>) {
             break;
         }
     }
-}
-
-async fn run_remote_acme_renewal_check_blocking<I, Now>(
-    db: Arc<Mutex<DaemonDb>>,
-    tls: RemoteTlsConfigHandle,
-    issuer: Arc<I>,
-    now: Arc<Now>,
-) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
-where
-    I: RemoteAcmeRenewalIssuer + Send + Sync + 'static,
-    Now: Fn() -> DateTime<Utc> + Send + Sync + 'static,
-{
-    spawn_blocking(move || run_remote_acme_renewal_check(&db, &tls, issuer.as_ref(), now()))
-        .await
-        .map_err(|error| {
-            CliError::from(CliErrorKind::workflow_io(format!(
-                "join remote ACME renewal check: {error}"
-            )))
-        })?
 }
 
 #[expect(
@@ -197,14 +178,14 @@ fn log_renewal_check(result: &Result<RemoteAcmeRenewalCheckOutcome, CliError>) {
     }
 }
 
-pub(crate) fn run_remote_acme_renewal_check<I>(
+pub(crate) async fn run_remote_acme_renewal_check<I>(
     db: &Arc<Mutex<DaemonDb>>,
     tls: &RemoteTlsConfigHandle,
     issuer: &I,
     now: DateTime<Utc>,
 ) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
 where
-    I: RemoteAcmeRenewalIssuer,
+    I: RemoteAcmeAutomaticRenewalIssuer,
 {
     let snapshot = load_renewal_snapshot(db)?;
     let due = remote_certificate_needs_renewal(&snapshot.bundle, now).unwrap_or(true);
@@ -221,7 +202,7 @@ where
         )?;
         return Ok(RemoteAcmeRenewalCheckOutcome::Reloaded);
     }
-    renew_due_certificate(db, tls, issuer, &snapshot, now)
+    renew_due_certificate(db, tls, issuer, &snapshot, now).await
 }
 
 fn load_renewal_snapshot(db: &Arc<Mutex<DaemonDb>>) -> Result<RemoteAcmeRenewalSnapshot, CliError> {
@@ -249,7 +230,7 @@ fn load_renewal_snapshot(db: &Arc<Mutex<DaemonDb>>) -> Result<RemoteAcmeRenewalS
     })
 }
 
-fn renew_due_certificate<I>(
+async fn renew_due_certificate<I>(
     db: &Arc<Mutex<DaemonDb>>,
     tls: &RemoteTlsConfigHandle,
     issuer: &I,
@@ -257,7 +238,7 @@ fn renew_due_certificate<I>(
     now: DateTime<Utc>,
 ) -> Result<RemoteAcmeRenewalCheckOutcome, CliError>
 where
-    I: RemoteAcmeRenewalIssuer,
+    I: RemoteAcmeAutomaticRenewalIssuer,
 {
     let request = RemoteAcmeRenewalRequest::new(
         &snapshot.account,
@@ -265,7 +246,7 @@ where
         snapshot.previous_private_key_pem.as_deref(),
         &snapshot.config,
     );
-    let bundle = match issuer.renew_certificate(&request) {
+    let bundle = match issuer.renew_certificate_automatically(&request).await {
         Ok(bundle) => bundle,
         Err(detail) => return persist_renewal_failure(db, now, &detail),
     };

--- a/src/daemon/remote_acme_renewal_race_tests.rs
+++ b/src/daemon/remote_acme_renewal_race_tests.rs
@@ -1,0 +1,149 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use super::{
+    RemoteAcmeRenewalCheckOutcome, RenewalFixture, at, certificate_bundle,
+    run_remote_acme_renewal_check,
+};
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote_acme::{
+    RemoteAcmeAutomaticRenewalIssuer, RemoteAcmeRenewalRequest, RemoteCertificateBundle,
+};
+use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
+use crate::daemon::remote_tls::RemoteTlsConfigHandle;
+
+#[tokio::test]
+async fn remote_acme_renewal_check_does_not_overwrite_concurrent_manual_renewal() {
+    let fixture = RenewalFixture::new((2026, 8, 1));
+    let manually_renewed = certificate_bundle((2026, 12, 1));
+    let automatic_result = certificate_bundle((2027, 1, 1));
+    let issuer = ConcurrentRenewalIssuer {
+        db: Arc::clone(&fixture.db),
+        manually_renewed: manually_renewed.clone(),
+        automatic_result,
+    };
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:00:00Z"),
+    )
+    .await
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Reloaded);
+    assert_eq!(
+        fixture.tls.certificate_fingerprint(),
+        manually_renewed.fingerprint()
+    );
+    let state = fixture
+        .db
+        .lock()
+        .expect("lock database")
+        .load_remote_acme_state()
+        .expect("load ACME state");
+    assert_eq!(
+        state.certificate_fingerprint.as_deref(),
+        Some(manually_renewed.fingerprint())
+    );
+}
+
+#[tokio::test]
+async fn concurrent_active_manual_certificate_is_not_audited_as_automatic_reload() {
+    let fixture = RenewalFixture::new((2026, 8, 1));
+    let manually_renewed = certificate_bundle((2026, 12, 1));
+    let issuer = ConcurrentActiveRenewalIssuer {
+        db: Arc::clone(&fixture.db),
+        tls: fixture.tls.clone(),
+        manually_renewed: manually_renewed.clone(),
+        automatic_result: certificate_bundle((2027, 1, 1)),
+    };
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:00:00Z"),
+    )
+    .await
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Superseded);
+    assert_eq!(fixture.tls.generation(), 2);
+    assert_eq!(
+        fixture.tls.certificate_fingerprint(),
+        manually_renewed.fingerprint()
+    );
+    let audits = fixture
+        .db
+        .lock()
+        .expect("lock database")
+        .load_remote_audit_events(10)
+        .expect("load audit events");
+    assert!(
+        audits
+            .iter()
+            .any(|audit| audit.route_or_method == "remote.acme.renew.automatic.superseded")
+    );
+    assert!(
+        audits
+            .iter()
+            .all(|audit| audit.route_or_method != "remote.tls.reload.automatic")
+    );
+}
+
+struct ConcurrentRenewalIssuer {
+    db: Arc<Mutex<DaemonDb>>,
+    manually_renewed: RemoteCertificateBundle,
+    automatic_result: RemoteCertificateBundle,
+}
+
+#[async_trait]
+impl RemoteAcmeAutomaticRenewalIssuer for ConcurrentRenewalIssuer {
+    async fn renew_certificate_automatically(
+        &self,
+        _request: &RemoteAcmeRenewalRequest,
+        _cleanup_tracker: &RemoteAcmeCleanupTracker,
+    ) -> Result<RemoteCertificateBundle, String> {
+        persist_manual_renewal(&self.db, &self.manually_renewed)?;
+        Ok(self.automatic_result.clone())
+    }
+}
+
+struct ConcurrentActiveRenewalIssuer {
+    db: Arc<Mutex<DaemonDb>>,
+    tls: RemoteTlsConfigHandle,
+    manually_renewed: RemoteCertificateBundle,
+    automatic_result: RemoteCertificateBundle,
+}
+
+#[async_trait]
+impl RemoteAcmeAutomaticRenewalIssuer for ConcurrentActiveRenewalIssuer {
+    async fn renew_certificate_automatically(
+        &self,
+        _request: &RemoteAcmeRenewalRequest,
+        _cleanup_tracker: &RemoteAcmeCleanupTracker,
+    ) -> Result<RemoteCertificateBundle, String> {
+        persist_manual_renewal(&self.db, &self.manually_renewed)?;
+        let reloaded = self
+            .tls
+            .reload(self.manually_renewed.clone())
+            .map_err(|error| error.to_string())?;
+        if !reloaded {
+            return Err("manual renewal did not update live TLS".to_string());
+        }
+        Ok(self.automatic_result.clone())
+    }
+}
+
+fn persist_manual_renewal(
+    db: &Arc<Mutex<DaemonDb>>,
+    bundle: &RemoteCertificateBundle,
+) -> Result<(), String> {
+    db.lock()
+        .map_err(|error| error.to_string())?
+        .record_remote_acme_renewal_success(bundle, "2026-07-10T00:00:00Z")
+        .map_err(|error| error.to_string())
+}

--- a/src/daemon/remote_acme_renewal_race_tests.rs
+++ b/src/daemon/remote_acme_renewal_race_tests.rs
@@ -1,9 +1,13 @@
+use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use tracing::instrument::WithSubscriber as _;
+use tracing_subscriber::fmt::writer::MakeWriter;
+use tracing_subscriber::layer::SubscriberExt as _;
 
 use super::{
-    RemoteAcmeRenewalCheckOutcome, RenewalFixture, at, certificate_bundle,
+    FakeRenewalIssuer, RemoteAcmeRenewalCheckOutcome, RenewalFixture, at, certificate_bundle,
     run_remote_acme_renewal_check,
 };
 use crate::daemon::db::DaemonDb;
@@ -94,6 +98,47 @@ async fn concurrent_active_manual_certificate_is_not_audited_as_automatic_reload
     );
 }
 
+#[tokio::test]
+async fn persisted_tls_reload_failure_logs_early_renewal_fallback() {
+    let fixture = RenewalFixture::new((2026, 9, 1));
+    let persisted_certificate = certificate_bundle((2026, 12, 1));
+    let wrong_key = certificate_bundle((2027, 1, 1));
+    let mismatched = RemoteCertificateBundle::new_for_tests(
+        persisted_certificate.certificate_pem(),
+        wrong_key.private_key_pem(),
+    );
+    fixture
+        .db
+        .lock()
+        .expect("lock database")
+        .record_remote_acme_renewal_success(&mismatched, "2026-07-10T00:00:00Z")
+        .expect("persist mismatched TLS material");
+    let issuer = FakeRenewalIssuer::succeed(certificate_bundle((2027, 1, 1)));
+    let output = SharedOutput::default();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_target(false)
+            .with_writer(output.clone()),
+    );
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:00:00Z"),
+    )
+    .with_subscriber(subscriber)
+    .await
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Renewed);
+    assert_eq!(issuer.renewal_count(), 1);
+    assert!(output.contents().contains(
+        "persisted remote TLS certificate reload failed; attempting early ACME renewal"
+    ));
+}
+
 struct ConcurrentRenewalIssuer {
     db: Arc<Mutex<DaemonDb>>,
     manually_renewed: RemoteCertificateBundle,
@@ -146,4 +191,37 @@ fn persist_manual_renewal(
         .map_err(|error| error.to_string())?
         .record_remote_acme_renewal_success(bundle, "2026-07-10T00:00:00Z")
         .map_err(|error| error.to_string())
+}
+
+#[derive(Clone, Default)]
+struct SharedOutput(Arc<Mutex<Vec<u8>>>);
+
+impl SharedOutput {
+    fn contents(&self) -> String {
+        String::from_utf8(self.0.lock().expect("output lock").clone()).expect("UTF-8 logs")
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedOutput {
+    type Writer = SharedOutputWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        SharedOutputWriter(Arc::clone(&self.0))
+    }
+}
+
+struct SharedOutputWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedOutputWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("output lock")
+            .extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }

--- a/src/daemon/remote_acme_renewal_tests.rs
+++ b/src/daemon/remote_acme_renewal_tests.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 
 use chrono::{DateTime, Utc};
 use rcgen::{CertificateParams, KeyPair, date_time_ymd};
@@ -243,13 +243,13 @@ async fn remote_acme_renewal_loop_checks_immediately_and_stops_on_shutdown() {
         || at("2026-07-10T00:00:00Z"),
     );
 
-    for _ in 0..50 {
-        if issuer.renewal_count() == 1 {
-            break;
+    timeout(Duration::from_secs(5), async {
+        while issuer.renewal_count() != 1 {
+            sleep(Duration::from_millis(10)).await;
         }
-        sleep(Duration::from_millis(10)).await;
-    }
-    assert_eq!(issuer.renewal_count(), 1);
+    })
+    .await
+    .expect("immediate renewal check timeout");
 
     shutdown_tx.send(true).expect("signal shutdown");
     timeout(Duration::from_secs(1), task)
@@ -258,6 +258,45 @@ async fn remote_acme_renewal_loop_checks_immediately_and_stops_on_shutdown() {
         .expect("renewal loop join");
     sleep(Duration::from_millis(30)).await;
     assert_eq!(issuer.renewal_count(), 1);
+}
+
+#[tokio::test]
+async fn remote_acme_renewal_loop_stops_while_check_is_in_flight() {
+    let fixture = RenewalFixture::new((2026, 8, 1));
+    let issuer = Arc::new(BlockingRenewalIssuer::new(certificate_bundle((
+        2026, 12, 1,
+    ))));
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let mut task = spawn_remote_acme_renewal_loop_with(
+        Arc::clone(&fixture.db),
+        fixture.tls.clone(),
+        Arc::clone(&issuer),
+        shutdown_rx,
+        Duration::from_secs(60),
+        || at("2026-07-10T00:00:00Z"),
+    );
+
+    timeout(Duration::from_secs(5), async {
+        while !issuer.started() {
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("renewal check start timeout");
+    shutdown_tx.send(true).expect("signal shutdown");
+
+    let stopped = timeout(Duration::from_millis(250), &mut task).await;
+    issuer.release();
+    if stopped.is_err() {
+        timeout(Duration::from_secs(5), task)
+            .await
+            .expect("renewal loop cleanup timeout")
+            .expect("renewal loop cleanup join");
+    }
+    assert!(
+        stopped.is_ok(),
+        "renewal loop did not stop while its check was in flight"
+    );
 }
 
 struct RenewalFixture {
@@ -342,6 +381,54 @@ impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
             Ordering::SeqCst,
         );
         self.result.lock().expect("lock issuer result").clone()
+    }
+}
+
+struct BlockingRenewalIssuer {
+    started: AtomicBool,
+    release: (Mutex<bool>, Condvar),
+    result: RemoteCertificateBundle,
+}
+
+impl BlockingRenewalIssuer {
+    fn new(result: RemoteCertificateBundle) -> Self {
+        Self {
+            started: AtomicBool::new(false),
+            release: (Mutex::new(false), Condvar::new()),
+            result,
+        }
+    }
+
+    fn started(&self) -> bool {
+        self.started.load(Ordering::SeqCst)
+    }
+
+    fn release(&self) {
+        let (released, condition) = &self.release;
+        *released.lock().expect("lock renewal release") = true;
+        condition.notify_all();
+    }
+}
+
+impl RemoteAcmeRenewalIssuer for BlockingRenewalIssuer {
+    fn create_account(
+        &self,
+        _config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        panic!("existing remote serve state must reuse its ACME account")
+    }
+
+    fn renew_certificate(
+        &self,
+        _request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        self.started.store(true, Ordering::SeqCst);
+        let (released, condition) = &self.release;
+        let mut released = released.lock().expect("lock renewal release");
+        while !*released {
+            released = condition.wait(released).expect("wait for renewal release");
+        }
+        Ok(self.result.clone())
     }
 }
 

--- a/src/daemon/remote_acme_renewal_tests.rs
+++ b/src/daemon/remote_acme_renewal_tests.rs
@@ -17,6 +17,7 @@ use crate::daemon::remote_acme::{
     RemoteAcmeAccountCredentials, RemoteAcmeAutomaticRenewalIssuer, RemoteAcmeRenewalRequest,
     RemoteCertificateBundle,
 };
+use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use crate::daemon::remote_identity::RemoteAuditOutcome;
 use crate::daemon::remote_tls::RemoteTlsConfigHandle;
 
@@ -368,6 +369,7 @@ impl RemoteAcmeAutomaticRenewalIssuer for FakeRenewalIssuer {
     async fn renew_certificate_automatically(
         &self,
         request: &RemoteAcmeRenewalRequest,
+        _cleanup_tracker: &RemoteAcmeCleanupTracker,
     ) -> Result<RemoteCertificateBundle, String> {
         self.renewals.fetch_add(1, Ordering::SeqCst);
         self.reused_previous_certificate_identity.store(
@@ -406,6 +408,7 @@ impl RemoteAcmeAutomaticRenewalIssuer for CancellableRenewalIssuer {
     async fn renew_certificate_automatically(
         &self,
         _request: &RemoteAcmeRenewalRequest,
+        _cleanup_tracker: &RemoteAcmeCleanupTracker,
     ) -> Result<RemoteCertificateBundle, String> {
         self.started.store(true, Ordering::SeqCst);
         self.active.store(true, Ordering::SeqCst);
@@ -434,6 +437,7 @@ impl RemoteAcmeAutomaticRenewalIssuer for ConcurrentRenewalIssuer {
     async fn renew_certificate_automatically(
         &self,
         _request: &RemoteAcmeRenewalRequest,
+        _cleanup_tracker: &RemoteAcmeCleanupTracker,
     ) -> Result<RemoteCertificateBundle, String> {
         self.db
             .lock()

--- a/src/daemon/remote_acme_renewal_tests.rs
+++ b/src/daemon/remote_acme_renewal_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Mutex};
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rcgen::{CertificateParams, KeyPair, date_time_ymd};
 use tokio::sync::watch;
@@ -13,7 +14,7 @@ use super::{
 use crate::daemon::db::DaemonDb;
 use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
 use crate::daemon::remote_acme::{
-    RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
+    RemoteAcmeAccountCredentials, RemoteAcmeAutomaticRenewalIssuer, RemoteAcmeRenewalRequest,
     RemoteCertificateBundle,
 };
 use crate::daemon::remote_identity::RemoteAuditOutcome;
@@ -29,8 +30,8 @@ fn remote_certificate_renewal_becomes_due_exactly_thirty_days_before_expiry() {
     assert!(remote_certificate_needs_renewal(&bundle, due).expect("expiry policy"));
 }
 
-#[test]
-fn remote_acme_renewal_check_skips_certificate_outside_renewal_window() {
+#[tokio::test]
+async fn remote_acme_renewal_check_skips_certificate_outside_renewal_window() {
     let fixture = RenewalFixture::new((2026, 9, 1));
     let issuer = FakeRenewalIssuer::succeed(certificate_bundle((2026, 12, 1)));
 
@@ -40,6 +41,7 @@ fn remote_acme_renewal_check_skips_certificate_outside_renewal_window() {
         &issuer,
         at("2026-07-10T00:00:00Z"),
     )
+    .await
     .expect("renewal check");
 
     assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::NotDue);
@@ -47,8 +49,8 @@ fn remote_acme_renewal_check_skips_certificate_outside_renewal_window() {
     assert_eq!(fixture.tls.generation(), 1);
 }
 
-#[test]
-fn remote_acme_renewal_check_persists_audits_and_reloads_due_certificate() {
+#[tokio::test]
+async fn remote_acme_renewal_check_persists_audits_and_reloads_due_certificate() {
     let fixture = RenewalFixture::new((2026, 8, 1));
     let renewed = certificate_bundle((2026, 12, 1));
     let issuer = FakeRenewalIssuer::succeed(renewed.clone());
@@ -59,6 +61,7 @@ fn remote_acme_renewal_check_persists_audits_and_reloads_due_certificate() {
         &issuer,
         at("2026-07-10T00:00:00Z"),
     )
+    .await
     .expect("renewal check");
 
     assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Renewed);
@@ -79,8 +82,8 @@ fn remote_acme_renewal_check_persists_audits_and_reloads_due_certificate() {
     assert_eq!(audits[0].error_detail, None);
 }
 
-#[test]
-fn remote_acme_renewal_check_keeps_active_certificate_and_redacts_failure() {
+#[tokio::test]
+async fn remote_acme_renewal_check_keeps_active_certificate_and_redacts_failure() {
     let fixture = RenewalFixture::new((2026, 8, 1));
     let issuer =
         FakeRenewalIssuer::fail("provider token=renewal-secret&retry=1 secret=nested-secret");
@@ -91,6 +94,7 @@ fn remote_acme_renewal_check_keeps_active_certificate_and_redacts_failure() {
         &issuer,
         at("2026-07-10T00:00:00Z"),
     )
+    .await
     .expect("renewal check");
 
     assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Failed);
@@ -118,8 +122,8 @@ fn remote_acme_renewal_check_keeps_active_certificate_and_redacts_failure() {
     );
 }
 
-#[test]
-fn remote_acme_renewal_check_rejects_mismatched_renewed_key_before_persisting() {
+#[tokio::test]
+async fn remote_acme_renewal_check_rejects_mismatched_renewed_key_before_persisting() {
     let fixture = RenewalFixture::new((2026, 8, 1));
     let certificate_key = KeyPair::generate().expect("generate certificate key");
     let wrong_key = KeyPair::generate().expect("generate wrong key");
@@ -140,6 +144,7 @@ fn remote_acme_renewal_check_rejects_mismatched_renewed_key_before_persisting() 
         &issuer,
         at("2026-07-10T00:00:00Z"),
     )
+    .await
     .expect("renewal check");
 
     assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Failed);
@@ -162,8 +167,8 @@ fn remote_acme_renewal_check_rejects_mismatched_renewed_key_before_persisting() 
     );
 }
 
-#[test]
-fn remote_acme_renewal_check_reloads_certificate_written_by_manual_renewal() {
+#[tokio::test]
+async fn remote_acme_renewal_check_reloads_certificate_written_by_manual_renewal() {
     let fixture = RenewalFixture::new((2026, 9, 1));
     let externally_renewed = certificate_bundle((2026, 12, 1));
     fixture
@@ -180,6 +185,7 @@ fn remote_acme_renewal_check_reloads_certificate_written_by_manual_renewal() {
         &issuer,
         at("2026-07-10T00:01:00Z"),
     )
+    .await
     .expect("renewal check");
 
     assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Reloaded);
@@ -191,8 +197,8 @@ fn remote_acme_renewal_check_reloads_certificate_written_by_manual_renewal() {
     );
 }
 
-#[test]
-fn remote_acme_renewal_check_does_not_overwrite_concurrent_manual_renewal() {
+#[tokio::test]
+async fn remote_acme_renewal_check_does_not_overwrite_concurrent_manual_renewal() {
     let fixture = RenewalFixture::new((2026, 8, 1));
     let manually_renewed = certificate_bundle((2026, 12, 1));
     let automatic_result = certificate_bundle((2027, 1, 1));
@@ -208,6 +214,7 @@ fn remote_acme_renewal_check_does_not_overwrite_concurrent_manual_renewal() {
         &issuer,
         at("2026-07-10T00:00:00Z"),
     )
+    .await
     .expect("renewal check");
 
     assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Reloaded);
@@ -263,11 +270,9 @@ async fn remote_acme_renewal_loop_checks_immediately_and_stops_on_shutdown() {
 #[tokio::test]
 async fn remote_acme_renewal_loop_stops_while_check_is_in_flight() {
     let fixture = RenewalFixture::new((2026, 8, 1));
-    let issuer = Arc::new(BlockingRenewalIssuer::new(certificate_bundle((
-        2026, 12, 1,
-    ))));
+    let issuer = Arc::new(CancellableRenewalIssuer::new());
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let mut task = spawn_remote_acme_renewal_loop_with(
+    let task = spawn_remote_acme_renewal_loop_with(
         Arc::clone(&fixture.db),
         fixture.tls.clone(),
         Arc::clone(&issuer),
@@ -285,17 +290,13 @@ async fn remote_acme_renewal_loop_stops_while_check_is_in_flight() {
     .expect("renewal check start timeout");
     shutdown_tx.send(true).expect("signal shutdown");
 
-    let stopped = timeout(Duration::from_millis(250), &mut task).await;
-    issuer.release();
-    if stopped.is_err() {
-        timeout(Duration::from_secs(5), task)
-            .await
-            .expect("renewal loop cleanup timeout")
-            .expect("renewal loop cleanup join");
-    }
+    timeout(Duration::from_secs(1), task)
+        .await
+        .expect("renewal loop did not stop while its check was in flight")
+        .expect("renewal loop join");
     assert!(
-        stopped.is_ok(),
-        "renewal loop did not stop while its check was in flight"
+        !issuer.active(),
+        "renewal operation remained active after the loop stopped"
     );
 }
 
@@ -362,15 +363,9 @@ impl FakeRenewalIssuer {
     }
 }
 
-impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
-    fn create_account(
-        &self,
-        _config: &RemoteDaemonServeConfig,
-    ) -> Result<RemoteAcmeAccountCredentials, String> {
-        panic!("existing remote serve state must reuse its ACME account")
-    }
-
-    fn renew_certificate(
+#[async_trait]
+impl RemoteAcmeAutomaticRenewalIssuer for FakeRenewalIssuer {
+    async fn renew_certificate_automatically(
         &self,
         request: &RemoteAcmeRenewalRequest,
     ) -> Result<RemoteCertificateBundle, String> {
@@ -384,18 +379,16 @@ impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
     }
 }
 
-struct BlockingRenewalIssuer {
+struct CancellableRenewalIssuer {
     started: AtomicBool,
-    release: (Mutex<bool>, Condvar),
-    result: RemoteCertificateBundle,
+    active: AtomicBool,
 }
 
-impl BlockingRenewalIssuer {
-    fn new(result: RemoteCertificateBundle) -> Self {
+impl CancellableRenewalIssuer {
+    const fn new() -> Self {
         Self {
             started: AtomicBool::new(false),
-            release: (Mutex::new(false), Condvar::new()),
-            result,
+            active: AtomicBool::new(false),
         }
     }
 
@@ -403,32 +396,30 @@ impl BlockingRenewalIssuer {
         self.started.load(Ordering::SeqCst)
     }
 
-    fn release(&self) {
-        let (released, condition) = &self.release;
-        *released.lock().expect("lock renewal release") = true;
-        condition.notify_all();
+    fn active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
     }
 }
 
-impl RemoteAcmeRenewalIssuer for BlockingRenewalIssuer {
-    fn create_account(
-        &self,
-        _config: &RemoteDaemonServeConfig,
-    ) -> Result<RemoteAcmeAccountCredentials, String> {
-        panic!("existing remote serve state must reuse its ACME account")
-    }
-
-    fn renew_certificate(
+#[async_trait]
+impl RemoteAcmeAutomaticRenewalIssuer for CancellableRenewalIssuer {
+    async fn renew_certificate_automatically(
         &self,
         _request: &RemoteAcmeRenewalRequest,
     ) -> Result<RemoteCertificateBundle, String> {
         self.started.store(true, Ordering::SeqCst);
-        let (released, condition) = &self.release;
-        let mut released = released.lock().expect("lock renewal release");
-        while !*released {
-            released = condition.wait(released).expect("wait for renewal release");
-        }
-        Ok(self.result.clone())
+        self.active.store(true, Ordering::SeqCst);
+        let _activity = RenewalActivityGuard(&self.active);
+        std::future::pending::<()>().await;
+        unreachable!("cancellable renewal should remain pending")
+    }
+}
+
+struct RenewalActivityGuard<'a>(&'a AtomicBool);
+
+impl Drop for RenewalActivityGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
     }
 }
 
@@ -438,15 +429,9 @@ struct ConcurrentRenewalIssuer {
     automatic_result: RemoteCertificateBundle,
 }
 
-impl RemoteAcmeRenewalIssuer for ConcurrentRenewalIssuer {
-    fn create_account(
-        &self,
-        _config: &RemoteDaemonServeConfig,
-    ) -> Result<RemoteAcmeAccountCredentials, String> {
-        panic!("existing remote serve state must reuse its ACME account")
-    }
-
-    fn renew_certificate(
+#[async_trait]
+impl RemoteAcmeAutomaticRenewalIssuer for ConcurrentRenewalIssuer {
+    async fn renew_certificate_automatically(
         &self,
         _request: &RemoteAcmeRenewalRequest,
     ) -> Result<RemoteCertificateBundle, String> {

--- a/src/daemon/remote_acme_renewal_tests.rs
+++ b/src/daemon/remote_acme_renewal_tests.rs
@@ -199,43 +199,6 @@ async fn remote_acme_renewal_check_reloads_certificate_written_by_manual_renewal
 }
 
 #[tokio::test]
-async fn remote_acme_renewal_check_does_not_overwrite_concurrent_manual_renewal() {
-    let fixture = RenewalFixture::new((2026, 8, 1));
-    let manually_renewed = certificate_bundle((2026, 12, 1));
-    let automatic_result = certificate_bundle((2027, 1, 1));
-    let issuer = ConcurrentRenewalIssuer {
-        db: Arc::clone(&fixture.db),
-        manually_renewed: manually_renewed.clone(),
-        automatic_result,
-    };
-
-    let outcome = run_remote_acme_renewal_check(
-        &fixture.db,
-        &fixture.tls,
-        &issuer,
-        at("2026-07-10T00:00:00Z"),
-    )
-    .await
-    .expect("renewal check");
-
-    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Reloaded);
-    assert_eq!(
-        fixture.tls.certificate_fingerprint(),
-        manually_renewed.fingerprint()
-    );
-    let state = fixture
-        .db
-        .lock()
-        .expect("lock database")
-        .load_remote_acme_state()
-        .expect("load ACME state");
-    assert_eq!(
-        state.certificate_fingerprint.as_deref(),
-        Some(manually_renewed.fingerprint())
-    );
-}
-
-#[tokio::test]
 async fn remote_acme_renewal_loop_checks_immediately_and_stops_on_shutdown() {
     let fixture = RenewalFixture::new((2026, 8, 1));
     let issuer = Arc::new(FakeRenewalIssuer::succeed(certificate_bundle((
@@ -426,28 +389,6 @@ impl Drop for RenewalActivityGuard<'_> {
     }
 }
 
-struct ConcurrentRenewalIssuer {
-    db: Arc<Mutex<DaemonDb>>,
-    manually_renewed: RemoteCertificateBundle,
-    automatic_result: RemoteCertificateBundle,
-}
-
-#[async_trait]
-impl RemoteAcmeAutomaticRenewalIssuer for ConcurrentRenewalIssuer {
-    async fn renew_certificate_automatically(
-        &self,
-        _request: &RemoteAcmeRenewalRequest,
-        _cleanup_tracker: &RemoteAcmeCleanupTracker,
-    ) -> Result<RemoteCertificateBundle, String> {
-        self.db
-            .lock()
-            .map_err(|error| error.to_string())?
-            .record_remote_acme_renewal_success(&self.manually_renewed, "2026-07-10T00:00:00Z")
-            .map_err(|error| error.to_string())?;
-        Ok(self.automatic_result.clone())
-    }
-}
-
 fn certificate_bundle(not_after: (i32, u8, u8)) -> RemoteCertificateBundle {
     let key = KeyPair::generate().expect("generate key");
     let mut params =
@@ -475,3 +416,6 @@ fn at(value: &str) -> DateTime<Utc> {
         .expect("RFC3339 timestamp")
         .with_timezone(&Utc)
 }
+
+#[path = "remote_acme_renewal_race_tests.rs"]
+mod race_tests;

--- a/src/daemon/remote_acme_renewal_tests.rs
+++ b/src/daemon/remote_acme_renewal_tests.rs
@@ -1,0 +1,401 @@
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+use rcgen::{CertificateParams, KeyPair, date_time_ymd};
+use tokio::sync::watch;
+use tokio::time::{Duration, sleep, timeout};
+
+use super::{
+    RemoteAcmeRenewalCheckOutcome, remote_certificate_needs_renewal, run_remote_acme_renewal_check,
+    spawn_remote_acme_renewal_loop_with,
+};
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
+use crate::daemon::remote_acme::{
+    RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
+    RemoteCertificateBundle,
+};
+use crate::daemon::remote_identity::RemoteAuditOutcome;
+use crate::daemon::remote_tls::RemoteTlsConfigHandle;
+
+#[test]
+fn remote_certificate_renewal_becomes_due_exactly_thirty_days_before_expiry() {
+    let bundle = certificate_bundle((2026, 8, 1));
+    let before = at("2026-07-01T23:59:59Z");
+    let due = at("2026-07-02T00:00:00Z");
+
+    assert!(!remote_certificate_needs_renewal(&bundle, before).expect("expiry policy"));
+    assert!(remote_certificate_needs_renewal(&bundle, due).expect("expiry policy"));
+}
+
+#[test]
+fn remote_acme_renewal_check_skips_certificate_outside_renewal_window() {
+    let fixture = RenewalFixture::new((2026, 9, 1));
+    let issuer = FakeRenewalIssuer::succeed(certificate_bundle((2026, 12, 1)));
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:00:00Z"),
+    )
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::NotDue);
+    assert_eq!(issuer.renewal_count(), 0);
+    assert_eq!(fixture.tls.generation(), 1);
+}
+
+#[test]
+fn remote_acme_renewal_check_persists_audits_and_reloads_due_certificate() {
+    let fixture = RenewalFixture::new((2026, 8, 1));
+    let renewed = certificate_bundle((2026, 12, 1));
+    let issuer = FakeRenewalIssuer::succeed(renewed.clone());
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:00:00Z"),
+    )
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Renewed);
+    assert_eq!(issuer.renewal_count(), 1);
+    assert!(issuer.reused_previous_certificate_identity());
+    assert_eq!(fixture.tls.generation(), 2);
+    assert_eq!(fixture.tls.certificate_fingerprint(), renewed.fingerprint());
+    let db = fixture.db.lock().expect("lock database");
+    let state = db.load_remote_acme_state().expect("load ACME state");
+    assert_eq!(state.renewal_status.as_str(), "succeeded");
+    assert_eq!(
+        state.certificate_fingerprint.as_deref(),
+        Some(renewed.fingerprint())
+    );
+    let audits = db.load_remote_audit_events(1).expect("load audit");
+    assert_eq!(audits[0].route_or_method, "remote.acme.renew.automatic");
+    assert_eq!(audits[0].outcome, RemoteAuditOutcome::Success);
+    assert_eq!(audits[0].error_detail, None);
+}
+
+#[test]
+fn remote_acme_renewal_check_keeps_active_certificate_and_redacts_failure() {
+    let fixture = RenewalFixture::new((2026, 8, 1));
+    let issuer =
+        FakeRenewalIssuer::fail("provider token=renewal-secret&retry=1 secret=nested-secret");
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:00:00Z"),
+    )
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Failed);
+    assert_eq!(issuer.renewal_count(), 1);
+    assert_eq!(fixture.tls.generation(), 1);
+    assert_eq!(
+        fixture.tls.certificate_fingerprint(),
+        fixture.initial.fingerprint()
+    );
+    let db = fixture.db.lock().expect("lock database");
+    let state = db.load_remote_acme_state().expect("load ACME state");
+    assert_eq!(state.renewal_status.as_str(), "failed");
+    let report = state.renewal_error.expect("renewal failure report");
+    assert!(report.contains("<redacted>"));
+    assert!(!report.contains("renewal-secret"));
+    assert!(!report.contains("nested-secret"));
+    let audits = db.load_remote_audit_events(1).expect("load audit");
+    assert_eq!(audits[0].outcome, RemoteAuditOutcome::Failure);
+    assert!(
+        !audits[0]
+            .error_detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("renewal-secret")
+    );
+}
+
+#[test]
+fn remote_acme_renewal_check_rejects_mismatched_renewed_key_before_persisting() {
+    let fixture = RenewalFixture::new((2026, 8, 1));
+    let certificate_key = KeyPair::generate().expect("generate certificate key");
+    let wrong_key = KeyPair::generate().expect("generate wrong key");
+    let mut params =
+        CertificateParams::new(["daemon.example.com".to_string()]).expect("certificate params");
+    params.not_before = date_time_ymd(2026, 1, 1);
+    params.not_after = date_time_ymd(2026, 12, 1);
+    let certificate = params
+        .self_signed(&certificate_key)
+        .expect("self-sign certificate");
+    let mismatched =
+        RemoteCertificateBundle::new(certificate.pem().as_str(), &wrong_key.serialize_pem());
+    let issuer = FakeRenewalIssuer::succeed(mismatched);
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:00:00Z"),
+    )
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Failed);
+    assert_eq!(fixture.tls.generation(), 1);
+    let state = fixture
+        .db
+        .lock()
+        .expect("lock database")
+        .load_remote_acme_state()
+        .expect("load ACME state");
+    assert_eq!(
+        state.certificate_fingerprint.as_deref(),
+        Some(fixture.initial.fingerprint())
+    );
+    assert!(
+        state
+            .renewal_error
+            .as_deref()
+            .is_some_and(|error| error.contains("key"))
+    );
+}
+
+#[test]
+fn remote_acme_renewal_check_reloads_certificate_written_by_manual_renewal() {
+    let fixture = RenewalFixture::new((2026, 9, 1));
+    let externally_renewed = certificate_bundle((2026, 12, 1));
+    fixture
+        .db
+        .lock()
+        .expect("lock database")
+        .record_remote_acme_renewal_success(&externally_renewed, "2026-07-10T00:00:00Z")
+        .expect("persist external renewal");
+    let issuer = FakeRenewalIssuer::succeed(certificate_bundle((2027, 1, 1)));
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:01:00Z"),
+    )
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Reloaded);
+    assert_eq!(issuer.renewal_count(), 0);
+    assert_eq!(fixture.tls.generation(), 2);
+    assert_eq!(
+        fixture.tls.certificate_fingerprint(),
+        externally_renewed.fingerprint()
+    );
+}
+
+#[test]
+fn remote_acme_renewal_check_does_not_overwrite_concurrent_manual_renewal() {
+    let fixture = RenewalFixture::new((2026, 8, 1));
+    let manually_renewed = certificate_bundle((2026, 12, 1));
+    let automatic_result = certificate_bundle((2027, 1, 1));
+    let issuer = ConcurrentRenewalIssuer {
+        db: Arc::clone(&fixture.db),
+        manually_renewed: manually_renewed.clone(),
+        automatic_result,
+    };
+
+    let outcome = run_remote_acme_renewal_check(
+        &fixture.db,
+        &fixture.tls,
+        &issuer,
+        at("2026-07-10T00:00:00Z"),
+    )
+    .expect("renewal check");
+
+    assert_eq!(outcome, RemoteAcmeRenewalCheckOutcome::Reloaded);
+    assert_eq!(
+        fixture.tls.certificate_fingerprint(),
+        manually_renewed.fingerprint()
+    );
+    let state = fixture
+        .db
+        .lock()
+        .expect("lock database")
+        .load_remote_acme_state()
+        .expect("load ACME state");
+    assert_eq!(
+        state.certificate_fingerprint.as_deref(),
+        Some(manually_renewed.fingerprint())
+    );
+}
+
+#[tokio::test]
+async fn remote_acme_renewal_loop_checks_immediately_and_stops_on_shutdown() {
+    let fixture = RenewalFixture::new((2026, 8, 1));
+    let issuer = Arc::new(FakeRenewalIssuer::succeed(certificate_bundle((
+        2026, 12, 1,
+    ))));
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let task = spawn_remote_acme_renewal_loop_with(
+        Arc::clone(&fixture.db),
+        fixture.tls.clone(),
+        Arc::clone(&issuer),
+        shutdown_rx,
+        Duration::from_millis(10),
+        || at("2026-07-10T00:00:00Z"),
+    );
+
+    for _ in 0..50 {
+        if issuer.renewal_count() == 1 {
+            break;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(issuer.renewal_count(), 1);
+
+    shutdown_tx.send(true).expect("signal shutdown");
+    timeout(Duration::from_secs(1), task)
+        .await
+        .expect("renewal loop shutdown timeout")
+        .expect("renewal loop join");
+    sleep(Duration::from_millis(30)).await;
+    assert_eq!(issuer.renewal_count(), 1);
+}
+
+struct RenewalFixture {
+    db: Arc<Mutex<DaemonDb>>,
+    tls: RemoteTlsConfigHandle,
+    initial: RemoteCertificateBundle,
+}
+
+impl RenewalFixture {
+    fn new(not_after: (i32, u8, u8)) -> Self {
+        let db = DaemonDb::open_in_memory().expect("open daemon database");
+        let initial = certificate_bundle(not_after);
+        let account = RemoteAcmeAccountCredentials::new(
+            "https://acme.test/acct/1",
+            r#"{"id":"https://acme.test/acct/1","key_pkcs8":"account-secret"}"#,
+        )
+        .expect("ACME account");
+        db.record_remote_acme_serve_config(&serve_config(), "2026-07-01T00:00:00Z")
+            .expect("persist serve config");
+        db.record_remote_acme_account(&account, "2026-07-01T00:00:00Z")
+            .expect("persist ACME account");
+        db.record_remote_acme_renewal_success(&initial, "2026-07-01T00:00:00Z")
+            .expect("persist initial certificate");
+        let tls = RemoteTlsConfigHandle::new(initial.clone()).expect("TLS config");
+        Self {
+            db: Arc::new(Mutex::new(db)),
+            tls,
+            initial,
+        }
+    }
+}
+
+struct FakeRenewalIssuer {
+    renewals: AtomicUsize,
+    reused_previous_certificate_identity: AtomicBool,
+    result: Mutex<Result<RemoteCertificateBundle, String>>,
+}
+
+impl FakeRenewalIssuer {
+    fn succeed(bundle: RemoteCertificateBundle) -> Self {
+        Self {
+            renewals: AtomicUsize::new(0),
+            reused_previous_certificate_identity: AtomicBool::new(false),
+            result: Mutex::new(Ok(bundle)),
+        }
+    }
+
+    fn fail(detail: &str) -> Self {
+        Self {
+            renewals: AtomicUsize::new(0),
+            reused_previous_certificate_identity: AtomicBool::new(false),
+            result: Mutex::new(Err(detail.to_string())),
+        }
+    }
+
+    fn renewal_count(&self) -> usize {
+        self.renewals.load(Ordering::SeqCst)
+    }
+
+    fn reused_previous_certificate_identity(&self) -> bool {
+        self.reused_previous_certificate_identity
+            .load(Ordering::SeqCst)
+    }
+}
+
+impl RemoteAcmeRenewalIssuer for FakeRenewalIssuer {
+    fn create_account(
+        &self,
+        _config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        panic!("existing remote serve state must reuse its ACME account")
+    }
+
+    fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        self.renewals.fetch_add(1, Ordering::SeqCst);
+        self.reused_previous_certificate_identity.store(
+            request.previous_certificate_fingerprint().is_some()
+                && request.previous_private_key_pem().is_some(),
+            Ordering::SeqCst,
+        );
+        self.result.lock().expect("lock issuer result").clone()
+    }
+}
+
+struct ConcurrentRenewalIssuer {
+    db: Arc<Mutex<DaemonDb>>,
+    manually_renewed: RemoteCertificateBundle,
+    automatic_result: RemoteCertificateBundle,
+}
+
+impl RemoteAcmeRenewalIssuer for ConcurrentRenewalIssuer {
+    fn create_account(
+        &self,
+        _config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        panic!("existing remote serve state must reuse its ACME account")
+    }
+
+    fn renew_certificate(
+        &self,
+        _request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        self.db
+            .lock()
+            .map_err(|error| error.to_string())?
+            .record_remote_acme_renewal_success(&self.manually_renewed, "2026-07-10T00:00:00Z")
+            .map_err(|error| error.to_string())?;
+        Ok(self.automatic_result.clone())
+    }
+}
+
+fn certificate_bundle(not_after: (i32, u8, u8)) -> RemoteCertificateBundle {
+    let key = KeyPair::generate().expect("generate key");
+    let mut params =
+        CertificateParams::new(["daemon.example.com".to_string()]).expect("certificate params");
+    params.not_before = date_time_ymd(2026, 1, 1);
+    params.not_after = date_time_ymd(not_after.0, not_after.1, not_after.2);
+    let certificate = params.self_signed(&key).expect("self-sign certificate");
+    RemoteCertificateBundle::new(certificate.pem().as_str(), &key.serialize_pem())
+}
+
+fn serve_config() -> RemoteDaemonServeConfig {
+    RemoteDaemonServeConfig {
+        domain: "daemon.example.com".to_string(),
+        host: "0.0.0.0".to_string(),
+        https_port: 443,
+        http_port: 80,
+        acme_email: "ops@example.com".to_string(),
+        acme_challenge: RemoteAcmeChallenge::TlsAlpn,
+        acme_dns_provider: None,
+    }
+}
+
+fn at(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .expect("RFC3339 timestamp")
+        .with_timezone(&Utc)
+}

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -8,8 +8,7 @@ use sha2::{Digest, Sha256};
 use super::{
     AcmeHttp01ChallengeStore, Dns01ChangeOperation, Dns01ExecHookOperation, Dns01ProviderAction,
     RemoteAcmeAccountCredentials, RemoteAcmeRenewalRequest, RemoteAcmeRuntimeState,
-    RemoteCertificateBundle, RemoteCertificateSlot, RemoteRenewalOutcome,
-    build_remote_acme_runtime_plan,
+    RemoteCertificateBundle, RemoteRenewalOutcome, build_remote_acme_runtime_plan,
 };
 use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
 
@@ -383,18 +382,6 @@ fn remote_dns01_exec_hook_redacts_runner_failure_detail() {
 
     assert!(error.to_string().contains("dns hook failed"));
     assert!(!error.to_string().contains("super-secret"));
-}
-
-#[test]
-fn remote_certificate_reload_tracks_generation_and_noops_unchanged_bundle() {
-    let mut slot =
-        RemoteCertificateSlot::new(RemoteCertificateBundle::new_for_tests("cert-a", "key-a"));
-
-    assert_eq!(slot.generation(), 1);
-    assert!(!slot.reload(RemoteCertificateBundle::new_for_tests("cert-a", "key-a")));
-    assert_eq!(slot.generation(), 1);
-    assert!(slot.reload(RemoteCertificateBundle::new_for_tests("cert-b", "key-b")));
-    assert_eq!(slot.generation(), 2);
 }
 
 #[test]

--- a/src/daemon/remote_certificate_identity.rs
+++ b/src/daemon/remote_certificate_identity.rs
@@ -3,9 +3,11 @@ use std::fmt;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
+use chrono::{DateTime, Utc};
 use rustls::pki_types::CertificateDer;
 use rustls::pki_types::pem::PemObject as _;
 use sha2::{Digest, Sha256};
+use x509_parser::certificate::X509Certificate;
 use x509_parser::parse_x509_certificate;
 
 use super::remote_acme::RemoteCertificateBundle;
@@ -57,6 +59,34 @@ impl Error for RemoteCertificateIdentityError {}
 pub(crate) fn spki_sha256_pin(
     bundle: &RemoteCertificateBundle,
 ) -> Result<String, RemoteCertificateIdentityError> {
+    inspect_leaf_certificate(bundle, |certificate| {
+        let digest = Sha256::digest(certificate.public_key().raw);
+        format!("sha256/{}", STANDARD.encode(digest))
+    })
+}
+
+pub(crate) fn certificate_not_after(
+    bundle: &RemoteCertificateBundle,
+) -> Result<DateTime<Utc>, RemoteCertificateIdentityError> {
+    inspect_leaf_certificate(bundle, |certificate| {
+        certificate.validity().not_after.timestamp()
+    })
+    .and_then(|timestamp| {
+        DateTime::from_timestamp(timestamp, 0).ok_or_else(|| {
+            RemoteCertificateIdentityError::InvalidCertificateDer(
+                "certificate expiry is outside the supported time range".to_string(),
+            )
+        })
+    })
+}
+
+fn inspect_leaf_certificate<T, Inspect>(
+    bundle: &RemoteCertificateBundle,
+    inspect: Inspect,
+) -> Result<T, RemoteCertificateIdentityError>
+where
+    Inspect: FnOnce(&X509Certificate<'_>) -> T,
+{
     let certificate = CertificateDer::pem_slice_iter(bundle.certificate_pem().as_bytes())
         .next()
         .ok_or(RemoteCertificateIdentityError::MissingCertificatePem)?
@@ -72,6 +102,5 @@ pub(crate) fn spki_sha256_pin(
             "trailing certificate data".to_string(),
         ));
     }
-    let digest = Sha256::digest(certificate.public_key().raw);
-    Ok(format!("sha256/{}", STANDARD.encode(digest)))
+    Ok(inspect(&certificate))
 }

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -2,16 +2,21 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use axum::extract::connect_info::Connected;
 use axum::serve::IncomingStream;
 use axum::serve::Listener;
+use rcgen::{CertificateParams, CustomExtension, DistinguishedName, KeyPair};
 use rustls::ServerConfig;
 use rustls::crypto::ring::default_provider;
+use rustls::crypto::ring::sign::any_supported_type;
 use rustls::pki_types::pem::PemObject as _;
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
 use tokio::task::yield_now;
 use tokio::time::sleep;
@@ -21,6 +26,9 @@ use tokio_rustls::server::TlsStream;
 use super::http::DaemonConnectInfo;
 use super::remote_acme::RemoteCertificateBundle;
 
+#[cfg(test)]
+#[path = "remote_tls_live_tests.rs"]
+mod live_tests;
 #[cfg(test)]
 #[path = "remote_tls_tests.rs"]
 mod tests;
@@ -34,6 +42,7 @@ pub enum RemoteTlsConfigError {
     InvalidCertificatePem(String),
     InvalidPrivateKeyPem(String),
     InvalidServerConfig(String),
+    InvalidAcmeChallenge(String),
 }
 
 impl fmt::Display for RemoteTlsConfigError {
@@ -50,6 +59,9 @@ impl fmt::Display for RemoteTlsConfigError {
             Self::InvalidServerConfig(error) => {
                 write!(f, "remote TLS server config is invalid: {error}")
             }
+            Self::InvalidAcmeChallenge(error) => {
+                write!(f, "remote TLS ACME challenge is invalid: {error}")
+            }
         }
     }
 }
@@ -64,20 +76,248 @@ impl Error for RemoteTlsConfigError {}
 pub fn build_remote_tls_server_config(
     bundle: &RemoteCertificateBundle,
 ) -> Result<Arc<ServerConfig>, RemoteTlsConfigError> {
+    build_remote_tls_server_config_with_challenge(bundle, None)
+}
+
+fn build_remote_tls_server_config_with_challenge(
+    bundle: &RemoteCertificateBundle,
+    challenge: Option<&ActiveRemoteTlsAlpnChallenge>,
+) -> Result<Arc<ServerConfig>, RemoteTlsConfigError> {
     ensure_rustls_provider();
-    let cert_chain = parse_certificate_chain(bundle.certificate_pem())?;
-    let private_key = parse_private_key(bundle.private_key_pem())?;
+    let normal = certified_key_from_bundle(bundle)?;
+    let resolver = RemoteTlsCertificateResolver {
+        normal,
+        challenge: challenge.cloned(),
+    };
     let mut config = ServerConfig::builder()
         .with_no_client_auth()
-        .with_single_cert(cert_chain, private_key)
-        .map_err(|error| RemoteTlsConfigError::InvalidServerConfig(error.to_string()))?;
+        .with_cert_resolver(Arc::new(resolver));
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    if challenge.is_some() {
+        config.alpn_protocols.insert(0, b"acme-tls/1".to_vec());
+    }
     Ok(Arc::new(config))
+}
+
+fn certified_key_from_bundle(
+    bundle: &RemoteCertificateBundle,
+) -> Result<Arc<CertifiedKey>, RemoteTlsConfigError> {
+    let cert_chain = parse_certificate_chain(bundle.certificate_pem())?;
+    let private_key = parse_private_key(bundle.private_key_pem())?;
+    let certified_key = CertifiedKey::from_der(cert_chain, private_key, &default_provider())
+        .map_err(|error| RemoteTlsConfigError::InvalidServerConfig(error.to_string()))?;
+    Ok(Arc::new(certified_key))
+}
+
+struct RemoteTlsConfigState {
+    bundle: RemoteCertificateBundle,
+    generation: u64,
+    challenge: Option<ActiveRemoteTlsAlpnChallenge>,
+    next_challenge_id: u64,
+}
+
+#[derive(Clone)]
+struct ActiveRemoteTlsAlpnChallenge {
+    id: u64,
+    domain: String,
+    certified_key: Arc<CertifiedKey>,
+}
+
+impl fmt::Debug for ActiveRemoteTlsAlpnChallenge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ActiveRemoteTlsAlpnChallenge")
+            .field("id", &self.id)
+            .field("domain", &self.domain)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+struct RemoteTlsCertificateResolver {
+    normal: Arc<CertifiedKey>,
+    challenge: Option<ActiveRemoteTlsAlpnChallenge>,
+}
+
+impl ResolvesServerCert for RemoteTlsCertificateResolver {
+    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        let offers_acme_alpn = client_hello
+            .alpn()
+            .is_some_and(|mut protocols| protocols.any(|protocol| protocol == b"acme-tls/1"));
+        if offers_acme_alpn {
+            return self.challenge.as_ref().and_then(|challenge| {
+                (client_hello.server_name() == Some(challenge.domain.as_str()))
+                    .then(|| Arc::clone(&challenge.certified_key))
+            });
+        }
+        Some(Arc::clone(&self.normal))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RemoteTlsAlpnChallengeLease {
+    id: u64,
+}
+
+pub(crate) struct RemoteTlsAlpnChallengeCertificate {
+    certified_key: Arc<CertifiedKey>,
+    certificate_der: Vec<u8>,
+}
+
+impl RemoteTlsAlpnChallengeCertificate {
+    pub(crate) fn certified_key(&self) -> Arc<CertifiedKey> {
+        Arc::clone(&self.certified_key)
+    }
+
+    pub(crate) fn certificate_der(&self) -> Vec<u8> {
+        self.certificate_der.clone()
+    }
+}
+
+pub(crate) fn build_remote_tls_alpn_challenge(
+    domain: &str,
+    digest: &[u8],
+) -> Result<RemoteTlsAlpnChallengeCertificate, String> {
+    let domain = domain.trim();
+    if domain.is_empty() {
+        return Err("remote ACME TLS-ALPN-01 domain is required".to_string());
+    }
+    if digest.len() != 32 {
+        return Err("remote ACME TLS-ALPN-01 digest must contain 32 bytes".to_string());
+    }
+    ensure_rustls_provider();
+    let key = KeyPair::generate()
+        .map_err(|error| format!("generate remote ACME TLS-ALPN-01 key: {error}"))?;
+    let mut params = CertificateParams::new([domain.to_string()])
+        .map_err(|error| format!("build remote ACME TLS-ALPN-01 certificate: {error}"))?;
+    params.distinguished_name = DistinguishedName::new();
+    params
+        .custom_extensions
+        .push(CustomExtension::new_acme_identifier(digest));
+    let certificate = params
+        .self_signed(&key)
+        .map_err(|error| format!("sign remote ACME TLS-ALPN-01 certificate: {error}"))?;
+    let certificate_der = certificate.der().to_vec();
+    let private_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key.serialize_der()));
+    let signing_key = any_supported_type(&private_key)
+        .map_err(|error| format!("load remote ACME TLS-ALPN-01 key: {error}"))?;
+    Ok(RemoteTlsAlpnChallengeCertificate {
+        certified_key: Arc::new(CertifiedKey::new(
+            vec![CertificateDer::from(certificate_der.clone())],
+            signing_key,
+        )),
+        certificate_der,
+    })
+}
+
+#[derive(Clone)]
+pub(crate) struct RemoteTlsConfigHandle {
+    config: Arc<ArcSwap<ServerConfig>>,
+    state: Arc<Mutex<RemoteTlsConfigState>>,
+}
+
+impl RemoteTlsConfigHandle {
+    pub(crate) fn new(bundle: RemoteCertificateBundle) -> Result<Self, RemoteTlsConfigError> {
+        let config = build_remote_tls_server_config(&bundle)?;
+        Ok(Self {
+            config: Arc::new(ArcSwap::from(config)),
+            state: Arc::new(Mutex::new(RemoteTlsConfigState {
+                bundle,
+                generation: 1,
+                challenge: None,
+                next_challenge_id: 1,
+            })),
+        })
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.lock_state().generation
+    }
+
+    pub(crate) fn certificate_fingerprint(&self) -> String {
+        self.lock_state().bundle.fingerprint().to_string()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tls_alpn_challenge_active(&self) -> bool {
+        self.lock_state().challenge.is_some()
+    }
+
+    pub(crate) fn reload(
+        &self,
+        bundle: RemoteCertificateBundle,
+    ) -> Result<bool, RemoteTlsConfigError> {
+        let mut state = self.lock_state();
+        if state.bundle.fingerprint() == bundle.fingerprint() {
+            return Ok(false);
+        }
+        let config =
+            build_remote_tls_server_config_with_challenge(&bundle, state.challenge.as_ref())?;
+        state.bundle = bundle;
+        state.generation += 1;
+        self.config.store(config);
+        Ok(true)
+    }
+
+    pub(crate) fn present_tls_alpn_challenge(
+        &self,
+        domain: &str,
+        digest: &[u8],
+    ) -> Result<RemoteTlsAlpnChallengeLease, RemoteTlsConfigError> {
+        let certificate = build_remote_tls_alpn_challenge(domain, digest)
+            .map_err(RemoteTlsConfigError::InvalidAcmeChallenge)?;
+        let mut state = self.lock_state();
+        if state.challenge.is_some() {
+            return Err(RemoteTlsConfigError::InvalidAcmeChallenge(
+                "another TLS-ALPN-01 challenge is already active".to_string(),
+            ));
+        }
+        let lease = RemoteTlsAlpnChallengeLease {
+            id: state.next_challenge_id,
+        };
+        let challenge = ActiveRemoteTlsAlpnChallenge {
+            id: lease.id,
+            domain: domain.trim().to_string(),
+            certified_key: certificate.certified_key(),
+        };
+        let config =
+            build_remote_tls_server_config_with_challenge(&state.bundle, Some(&challenge))?;
+        state.next_challenge_id = state.next_challenge_id.saturating_add(1);
+        state.challenge = Some(challenge);
+        self.config.store(config);
+        Ok(lease)
+    }
+
+    pub(crate) fn clear_tls_alpn_challenge(
+        &self,
+        lease: RemoteTlsAlpnChallengeLease,
+    ) -> Result<(), RemoteTlsConfigError> {
+        let mut state = self.lock_state();
+        let Some(challenge) = state.challenge.as_ref() else {
+            return Ok(());
+        };
+        if challenge.id != lease.id {
+            return Err(RemoteTlsConfigError::InvalidAcmeChallenge(
+                "TLS-ALPN-01 challenge lease does not match the active challenge".to_string(),
+            ));
+        }
+        let config = build_remote_tls_server_config_with_challenge(&state.bundle, None)?;
+        state.challenge = None;
+        self.config.store(config);
+        Ok(())
+    }
+
+    fn config_source(&self) -> Arc<ArcSwap<ServerConfig>> {
+        Arc::clone(&self.config)
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, RemoteTlsConfigState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
 }
 
 pub struct RemoteTlsListener {
     listener: TcpListener,
-    acceptor: TlsAcceptor,
+    config: Arc<ArcSwap<ServerConfig>>,
 }
 
 impl RemoteTlsListener {
@@ -91,7 +331,20 @@ impl RemoteTlsListener {
     {
         Ok(Self {
             listener: TcpListener::bind(addr).await?,
-            acceptor: TlsAcceptor::from(config),
+            config: Arc::new(ArcSwap::from(config)),
+        })
+    }
+
+    pub(crate) async fn bind_reloadable<A>(
+        addr: A,
+        config: &RemoteTlsConfigHandle,
+    ) -> io::Result<Self>
+    where
+        A: ToSocketAddrs,
+    {
+        Ok(Self {
+            listener: TcpListener::bind(addr).await?,
+            config: config.config_source(),
         })
     }
 }
@@ -109,7 +362,8 @@ impl Listener for RemoteTlsListener {
                     continue;
                 }
             };
-            match self.acceptor.accept(stream).await {
+            let acceptor = TlsAcceptor::from(self.config.load_full());
+            match acceptor.accept(stream).await {
                 Ok(tls_stream) => return (tls_stream, addr),
                 Err(error) => handle_tls_handshake_error(addr, &error),
             }

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -145,12 +145,16 @@ impl ResolvesServerCert for RemoteTlsCertificateResolver {
             .is_some_and(|mut protocols| protocols.any(|protocol| protocol == b"acme-tls/1"));
         if offers_acme_alpn {
             return self.challenge.as_ref().and_then(|challenge| {
-                (client_hello.server_name() == Some(challenge.domain.as_str()))
+                remote_tls_server_name_matches(client_hello.server_name(), &challenge.domain)
                     .then(|| Arc::clone(&challenge.certified_key))
             });
         }
         Some(Arc::clone(&self.normal))
     }
+}
+
+fn remote_tls_server_name_matches(server_name: Option<&str>, expected_domain: &str) -> bool {
+    server_name.is_some_and(|name| name.eq_ignore_ascii_case(expected_domain))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -143,11 +143,11 @@ impl ResolvesServerCert for RemoteTlsCertificateResolver {
         let offers_acme_alpn = client_hello
             .alpn()
             .is_some_and(|mut protocols| protocols.any(|protocol| protocol == b"acme-tls/1"));
-        if offers_acme_alpn {
-            return self.challenge.as_ref().and_then(|challenge| {
-                remote_tls_server_name_matches(client_hello.server_name(), &challenge.domain)
-                    .then(|| Arc::clone(&challenge.certified_key))
-            });
+        if offers_acme_alpn
+            && let Some(challenge) = self.challenge.as_ref()
+            && remote_tls_server_name_matches(client_hello.server_name(), &challenge.domain)
+        {
+            return Some(Arc::clone(&challenge.certified_key));
         }
         Some(Arc::clone(&self.normal))
     }

--- a/src/daemon/remote_tls_live_tests.rs
+++ b/src/daemon/remote_tls_live_tests.rs
@@ -1,0 +1,186 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::serve::Listener as _;
+use rcgen::{CertificateParams, KeyPair};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, Error as TlsError, SignatureScheme};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use x509_parser::parse_x509_certificate;
+
+use super::{RemoteTlsConfigHandle, RemoteTlsListener};
+use crate::daemon::remote_acme::RemoteCertificateBundle;
+
+#[tokio::test]
+async fn remote_tls_listener_uses_reloaded_certificate_on_new_handshakes() {
+    let (initial, initial_der) = generated_bundle("daemon.example.com");
+    let (renewed, renewed_der) = generated_bundle("daemon.example.com");
+    let handle = RemoteTlsConfigHandle::new(initial).expect("initial TLS config");
+    let mut listener = RemoteTlsListener::bind_reloadable(("127.0.0.1", 0), &handle)
+        .await
+        .expect("bind reloadable TLS listener");
+    let address = listener.local_addr().expect("TLS listener address");
+
+    let first = connect_once(&mut listener, address, b"h2").await;
+    assert_eq!(first.certificate_der, initial_der);
+
+    assert!(handle.reload(renewed).expect("reload renewed certificate"));
+    let second = connect_once(&mut listener, address, b"h2").await;
+    assert_eq!(second.certificate_der, renewed_der);
+    assert_ne!(second.certificate_der, first.certificate_der);
+}
+
+#[tokio::test]
+async fn remote_tls_listener_serves_acme_alpn_challenge_without_disrupting_https() {
+    let (normal, normal_der) = generated_bundle("daemon.example.com");
+    let handle = RemoteTlsConfigHandle::new(normal).expect("initial TLS config");
+    let mut listener = RemoteTlsListener::bind_reloadable(("127.0.0.1", 0), &handle)
+        .await
+        .expect("bind reloadable TLS listener");
+    let address = listener.local_addr().expect("TLS listener address");
+    let digest = [7_u8; 32];
+
+    let lease = handle
+        .present_tls_alpn_challenge("daemon.example.com", &digest)
+        .expect("publish TLS-ALPN-01 challenge");
+    let challenge = connect_once(&mut listener, address, b"acme-tls/1").await;
+    assert_eq!(
+        challenge.negotiated_alpn.as_deref(),
+        Some(b"acme-tls/1".as_slice())
+    );
+    assert_ne!(challenge.certificate_der, normal_der);
+    assert_acme_identifier(&challenge.certificate_der, &digest);
+
+    let normal_during_challenge = connect_once(&mut listener, address, b"h2").await;
+    assert_eq!(
+        normal_during_challenge.negotiated_alpn.as_deref(),
+        Some(b"h2".as_slice())
+    );
+    assert_eq!(normal_during_challenge.certificate_der, normal_der);
+
+    handle
+        .clear_tls_alpn_challenge(lease)
+        .expect("clear TLS-ALPN-01 challenge");
+    let normal_after_cleanup = connect_once(&mut listener, address, b"h2").await;
+    assert_eq!(normal_after_cleanup.certificate_der, normal_der);
+}
+
+struct ClientHandshake {
+    certificate_der: Vec<u8>,
+    negotiated_alpn: Option<Vec<u8>>,
+}
+
+async fn connect_once(
+    listener: &mut RemoteTlsListener,
+    address: SocketAddr,
+    alpn: &[u8],
+) -> ClientHandshake {
+    let server = listener.accept();
+    let client = connect_client(address, alpn);
+    let ((server_stream, _), client_stream) = tokio::join!(server, client);
+    let client_stream = client_stream.expect("complete client TLS handshake");
+    let certificate_der = client_stream
+        .get_ref()
+        .1
+        .peer_certificates()
+        .and_then(|certificates| certificates.first())
+        .expect("server leaf certificate")
+        .to_vec();
+    let negotiated_alpn = client_stream
+        .get_ref()
+        .1
+        .alpn_protocol()
+        .map(<[u8]>::to_vec);
+    drop(client_stream);
+    drop(server_stream);
+    ClientHandshake {
+        certificate_der,
+        negotiated_alpn,
+    }
+}
+
+async fn connect_client(
+    address: SocketAddr,
+    alpn: &[u8],
+) -> Result<tokio_rustls::client::TlsStream<TcpStream>, std::io::Error> {
+    let mut config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+        .with_no_client_auth();
+    config.alpn_protocols = vec![alpn.to_vec()];
+    let connector = TlsConnector::from(Arc::new(config));
+    let stream = TcpStream::connect(address).await?;
+    let server_name =
+        ServerName::try_from("daemon.example.com".to_string()).expect("valid TLS server name");
+    connector.connect(server_name, stream).await
+}
+
+fn generated_bundle(domain: &str) -> (RemoteCertificateBundle, Vec<u8>) {
+    let key = KeyPair::generate().expect("generate key");
+    let certificate = CertificateParams::new([domain.to_string()])
+        .expect("certificate params")
+        .self_signed(&key)
+        .expect("self-sign certificate");
+    (
+        RemoteCertificateBundle::new(certificate.pem().as_str(), &key.serialize_pem()),
+        certificate.der().to_vec(),
+    )
+}
+
+fn assert_acme_identifier(certificate_der: &[u8], digest: &[u8]) {
+    let (_, certificate) = parse_x509_certificate(certificate_der).expect("parse challenge cert");
+    let extension = certificate
+        .extensions()
+        .iter()
+        .find(|extension| extension.oid.to_id_string() == "1.3.6.1.5.5.7.1.31")
+        .expect("acmeIdentifier extension");
+    assert!(extension.critical);
+    assert_eq!(
+        extension.value,
+        [vec![0x04, 0x20], digest.to_vec()].concat()
+    );
+}
+
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, TlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _certificate: &CertificateDer<'_>,
+        _signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _certificate: &CertificateDer<'_>,
+        _signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::ED25519,
+        ]
+    }
+}

--- a/src/daemon/remote_tls_live_tests.rs
+++ b/src/daemon/remote_tls_live_tests.rs
@@ -7,6 +7,7 @@ use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, Server
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{ClientConfig, DigitallySignedStruct, Error as TlsError, SignatureScheme};
 use tokio::net::TcpStream;
+use tokio::time::{Duration, timeout};
 use tokio_rustls::TlsConnector;
 use x509_parser::parse_x509_certificate;
 
@@ -67,6 +68,56 @@ async fn remote_tls_listener_serves_acme_alpn_challenge_without_disrupting_https
     assert_eq!(normal_after_cleanup.certificate_der, normal_der);
 }
 
+#[tokio::test]
+async fn remote_tls_listener_falls_back_without_an_active_acme_challenge() {
+    let (normal, normal_der) = generated_bundle("daemon.example.com");
+    let handle = RemoteTlsConfigHandle::new(normal).expect("initial TLS config");
+    let mut listener = RemoteTlsListener::bind_reloadable(("127.0.0.1", 0), &handle)
+        .await
+        .expect("bind reloadable TLS listener");
+    let address = listener.local_addr().expect("TLS listener address");
+
+    let handshake = timeout(
+        Duration::from_secs(5),
+        connect_once_for_server_name_with_alpns(
+            &mut listener,
+            address,
+            &[b"acme-tls/1".as_slice(), b"h2".as_slice()],
+            "daemon.example.com",
+        ),
+    )
+    .await
+    .expect("normal TLS fallback handshake timeout");
+
+    assert_eq!(handshake.certificate_der, normal_der);
+    assert_eq!(handshake.negotiated_alpn.as_deref(), Some(b"h2".as_slice()));
+}
+
+#[tokio::test]
+async fn remote_tls_listener_falls_back_when_acme_challenge_sni_does_not_match() {
+    let (normal, normal_der) = generated_bundle("daemon.example.com");
+    let handle = RemoteTlsConfigHandle::new(normal).expect("initial TLS config");
+    let mut listener = RemoteTlsListener::bind_reloadable(("127.0.0.1", 0), &handle)
+        .await
+        .expect("bind reloadable TLS listener");
+    let address = listener.local_addr().expect("TLS listener address");
+    let lease = handle
+        .present_tls_alpn_challenge("challenge.example.com", &[7_u8; 32])
+        .expect("publish TLS-ALPN-01 challenge");
+
+    let handshake = timeout(
+        Duration::from_secs(5),
+        connect_once_for_server_name(&mut listener, address, b"acme-tls/1", "daemon.example.com"),
+    )
+    .await
+    .expect("normal TLS fallback handshake timeout");
+
+    assert_eq!(handshake.certificate_der, normal_der);
+    handle
+        .clear_tls_alpn_challenge(lease)
+        .expect("clear TLS-ALPN-01 challenge");
+}
+
 struct ClientHandshake {
     certificate_der: Vec<u8>,
     negotiated_alpn: Option<Vec<u8>>,
@@ -77,8 +128,26 @@ async fn connect_once(
     address: SocketAddr,
     alpn: &[u8],
 ) -> ClientHandshake {
+    connect_once_for_server_name(listener, address, alpn, "daemon.example.com").await
+}
+
+async fn connect_once_for_server_name(
+    listener: &mut RemoteTlsListener,
+    address: SocketAddr,
+    alpn: &[u8],
+    server_name: &str,
+) -> ClientHandshake {
+    connect_once_for_server_name_with_alpns(listener, address, &[alpn], server_name).await
+}
+
+async fn connect_once_for_server_name_with_alpns(
+    listener: &mut RemoteTlsListener,
+    address: SocketAddr,
+    alpn_protocols: &[&[u8]],
+    server_name: &str,
+) -> ClientHandshake {
     let server = listener.accept();
-    let client = connect_client(address, alpn);
+    let client = connect_client(address, alpn_protocols, server_name);
     let ((server_stream, _), client_stream) = tokio::join!(server, client);
     let client_stream = client_stream.expect("complete client TLS handshake");
     let certificate_der = client_stream
@@ -103,17 +172,20 @@ async fn connect_once(
 
 async fn connect_client(
     address: SocketAddr,
-    alpn: &[u8],
+    alpn_protocols: &[&[u8]],
+    server_name: &str,
 ) -> Result<tokio_rustls::client::TlsStream<TcpStream>, std::io::Error> {
     let mut config = ClientConfig::builder()
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
         .with_no_client_auth();
-    config.alpn_protocols = vec![alpn.to_vec()];
+    config.alpn_protocols = alpn_protocols
+        .iter()
+        .map(|protocol| (*protocol).to_vec())
+        .collect();
     let connector = TlsConnector::from(Arc::new(config));
     let stream = TcpStream::connect(address).await?;
-    let server_name =
-        ServerName::try_from("daemon.example.com".to_string()).expect("valid TLS server name");
+    let server_name = ServerName::try_from(server_name.to_string()).expect("valid TLS server name");
     connector.connect(server_name, stream).await
 }
 

--- a/src/daemon/remote_tls_tests.rs
+++ b/src/daemon/remote_tls_tests.rs
@@ -2,8 +2,8 @@ use std::io;
 use std::net::SocketAddr;
 
 use super::{
-    RemoteTlsConfigError, build_remote_tls_server_config, handle_tcp_accept_error,
-    handle_tls_handshake_error, is_transient_accept_error,
+    RemoteTlsConfigError, RemoteTlsConfigHandle, build_remote_tls_server_config,
+    handle_tcp_accept_error, handle_tls_handshake_error, is_transient_accept_error,
 };
 use crate::daemon::remote_acme::RemoteCertificateBundle;
 
@@ -37,6 +37,62 @@ fn remote_tls_server_config_builds_http_alpn_from_pem_material() {
 }
 
 #[test]
+fn remote_tls_config_handle_atomically_reloads_changed_certificate_material() {
+    let initial = generated_bundle("daemon.example.com");
+    let renewed = generated_bundle("daemon.example.com");
+    let handle = RemoteTlsConfigHandle::new(initial.clone()).expect("initial TLS config");
+
+    assert_eq!(handle.generation(), 1);
+    assert_eq!(handle.certificate_fingerprint(), initial.fingerprint());
+    assert!(!handle.reload(initial).expect("unchanged reload"));
+    assert_eq!(handle.generation(), 1);
+
+    assert!(handle.reload(renewed.clone()).expect("changed reload"));
+    assert_eq!(handle.generation(), 2);
+    assert_eq!(handle.certificate_fingerprint(), renewed.fingerprint());
+}
+
+#[test]
+fn remote_tls_config_handle_rejects_invalid_reload_without_losing_active_certificate() {
+    let initial = generated_bundle("daemon.example.com");
+    let handle = RemoteTlsConfigHandle::new(initial.clone()).expect("initial TLS config");
+    let invalid = RemoteCertificateBundle::new_for_tests("not-a-certificate", "not-a-key");
+
+    let error = handle
+        .reload(invalid)
+        .expect_err("invalid renewed material must fail");
+
+    assert!(matches!(
+        error,
+        RemoteTlsConfigError::InvalidCertificatePem(_)
+    ));
+    assert_eq!(handle.generation(), 1);
+    assert_eq!(handle.certificate_fingerprint(), initial.fingerprint());
+}
+
+#[test]
+fn remote_tls_config_rejects_certificate_with_mismatched_private_key() {
+    let certificate_key = rcgen::KeyPair::generate().expect("generate certificate key");
+    let wrong_key = rcgen::KeyPair::generate().expect("generate wrong key");
+    let certificate = rcgen::CertificateParams::new(["daemon.example.com".to_string()])
+        .expect("certificate params")
+        .self_signed(&certificate_key)
+        .expect("self-sign certificate");
+    let bundle =
+        RemoteCertificateBundle::new(certificate.pem().as_str(), &wrong_key.serialize_pem());
+
+    let error = RemoteTlsConfigHandle::new(bundle)
+        .err()
+        .expect("mismatched certificate and private key must fail closed");
+
+    assert!(matches!(
+        error,
+        RemoteTlsConfigError::InvalidServerConfig(_)
+    ));
+    assert!(error.to_string().contains("key"));
+}
+
+#[test]
 fn remote_tls_accept_retries_transient_tcp_errors_without_backoff() {
     for kind in [
         io::ErrorKind::ConnectionRefused,
@@ -57,10 +113,16 @@ async fn remote_tls_accept_transient_errors_do_not_backoff() {
 #[test]
 fn remote_tls_handshake_failures_do_not_delay_accept_loop() {
     let error = io::Error::from(io::ErrorKind::InvalidData);
-    handle_tls_handshake_error(
-        SocketAddr::from(([127, 0, 0, 1], 443)),
-        &error,
-    );
+    handle_tls_handshake_error(SocketAddr::from(([127, 0, 0, 1], 443)), &error);
+}
+
+fn generated_bundle(domain: &str) -> RemoteCertificateBundle {
+    let key = rcgen::KeyPair::generate().expect("generate key");
+    let certificate = rcgen::CertificateParams::new([domain.to_string()])
+        .expect("certificate params")
+        .self_signed(&key)
+        .expect("self-sign certificate");
+    RemoteCertificateBundle::new(certificate.pem().as_str(), &key.serialize_pem())
 }
 
 const TEST_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----

--- a/src/daemon/remote_tls_tests.rs
+++ b/src/daemon/remote_tls_tests.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use super::{
     RemoteTlsConfigError, RemoteTlsConfigHandle, build_remote_tls_server_config,
     handle_tcp_accept_error, handle_tls_handshake_error, is_transient_accept_error,
+    remote_tls_server_name_matches,
 };
 use crate::daemon::remote_acme::RemoteCertificateBundle;
 
@@ -90,6 +91,18 @@ fn remote_tls_config_rejects_certificate_with_mismatched_private_key() {
         RemoteTlsConfigError::InvalidServerConfig(_)
     ));
     assert!(error.to_string().contains("key"));
+}
+
+#[test]
+fn remote_tls_acme_server_name_matching_is_case_insensitive() {
+    assert!(remote_tls_server_name_matches(
+        Some("DAEMON.EXAMPLE.COM"),
+        "daemon.example.com"
+    ));
+    assert!(!remote_tls_server_name_matches(
+        Some("other.example.com"),
+        "daemon.example.com"
+    ));
 }
 
 #[test]

--- a/src/daemon/service/serve/remote.rs
+++ b/src/daemon/service/serve/remote.rs
@@ -2,6 +2,7 @@ use std::process::id as process_id;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use tokio::sync::{broadcast, watch as tokio_watch};
+use tokio::task::JoinHandle;
 
 use crate::agents::acp::probe::schedule_probe_cache_refresh;
 use crate::daemon::agent_acp::AcpAgentManagerHandle;
@@ -10,9 +11,8 @@ use crate::daemon::codex_controller::CodexControllerHandle;
 use crate::daemon::db::{AsyncDaemonDb, DaemonDb};
 use crate::daemon::http::{self, AsyncDaemonDbSlot, DaemonHttpAuthMode, DaemonHttpState};
 use crate::daemon::remote_acme::RemoteAcmeRuntimePlan;
-use crate::daemon::remote_tls::{
-    RemoteTlsConfigError, RemoteTlsListener, build_remote_tls_server_config,
-};
+use crate::daemon::remote_acme_renewal::spawn_remote_acme_renewal_loop;
+use crate::daemon::remote_tls::{RemoteTlsConfigError, RemoteTlsConfigHandle, RemoteTlsListener};
 use crate::daemon::state::{self, DaemonManifest, HostBridgeManifest};
 use crate::daemon::voice::cleanup_abandoned_sessions;
 use crate::daemon::websocket::ReplayBuffer;
@@ -50,13 +50,19 @@ pub async fn serve_remote_https(
     cleanup_abandoned_sessions()?;
     let daemon_lock = state::acquire_singleton_lock()?;
 
-    let tls_config = build_remote_tls_server_config(acme_plan.certificate())
+    let tls_config = RemoteTlsConfigHandle::new(acme_plan.certificate().clone())
         .map_err(|error| remote_tls_config_cli_error(&error))?;
-    let listener = RemoteTlsListener::bind((config.host.as_str(), config.port), tls_config)
-        .await
-        .map_err(|error| {
-            CliErrorKind::workflow_io(format!("bind remote HTTPS listener: {error}"))
-        })?;
+    tracing::info!(
+        tls_generation = tls_config.generation(),
+        certificate_fingerprint = %tls_config.certificate_fingerprint(),
+        "remote TLS certificate loaded",
+    );
+    let listener =
+        RemoteTlsListener::bind_reloadable((config.host.as_str(), config.port), &tls_config)
+            .await
+            .map_err(|error| {
+                CliErrorKind::workflow_io(format!("bind remote HTTPS listener: {error}"))
+            })?;
     let endpoint = acme_plan.public_https_origin();
     let manifest = remote_daemon_manifest(&endpoint, config.sandboxed);
     state::append_event("info", &remote_bound_event_message(&endpoint))?;
@@ -82,6 +88,7 @@ pub async fn serve_remote_https(
     initialize_startup_state(&db, &async_db, sender.clone(), config.poll_interval).await?;
     super::audit::record_remote_daemon_bound(async_db.get(), &endpoint, config.sandboxed).await;
     schedule_probe_cache_refresh();
+    let remote_acme_renewal = start_remote_acme_renewal(&db, tls_config, shutdown_rx.clone())?;
 
     let codex_controller = CodexControllerHandle::new_with_async_db(
         sender.clone(),
@@ -119,6 +126,12 @@ pub async fn serve_remote_https(
     let _background = spawn_background_tasks(&app_state, config.poll_interval, shutdown_rx.clone());
 
     let serve_result = http::serve(listener, app_state, shutdown_rx).await;
+    let _ = shutdown_tx.send(true);
+    let renewal_result = remote_acme_renewal.await.map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "join remote ACME renewal loop: {error}"
+        )))
+    });
     super::audit::record_daemon_stopped(async_db_slot_for_audit.get(), &serve_result).await;
     let stop_event_result = if serve_result.is_ok() {
         state::append_event("info", "remote daemon stopped")
@@ -127,10 +140,23 @@ pub async fn serve_remote_https(
     };
     drop(daemon_lock);
 
-    match (serve_result, stop_event_result) {
-        (Err(error), _) | (Ok(()), Err(error)) => Err(error),
-        (Ok(()), Ok(())) => Ok(()),
+    match (serve_result, renewal_result, stop_event_result) {
+        (Err(error), _, _) | (Ok(()), Err(error), _) | (Ok(()), Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(()), Ok(())) => Ok(()),
     }
+}
+
+fn start_remote_acme_renewal(
+    db: &Arc<OnceLock<Arc<Mutex<DaemonDb>>>>,
+    tls: RemoteTlsConfigHandle,
+    shutdown_rx: tokio_watch::Receiver<bool>,
+) -> Result<JoinHandle<()>, CliError> {
+    let renewal_db = db.get().cloned().ok_or_else(|| {
+        CliError::from(CliErrorKind::workflow_io(
+            "remote ACME renewal database was not initialized",
+        ))
+    })?;
+    Ok(spawn_remote_acme_renewal_loop(renewal_db, tls, shutdown_rx))
 }
 
 fn validate_remote_https_config(config: &DaemonServeConfig) -> Result<(), CliError> {


### PR DESCRIPTION
## Motivation
Remote serve loaded its ACME certificate once, so expiry or manual renewal still required a restart. TLS-ALPN-01 also could not renew while the daemon owned port 443. This follows the remote client slice in #199.

## Implementation
- Run an hourly, shutdown-aware renewal check beginning 30 days before expiry, with redacted persisted status and audit events.
- Hot reload rustls for new HTTPS/WSS handshakes and serve TLS-ALPN-01 on the existing listener while preserving HTTP-01 and DNS-01 behavior.
- Reject mismatched key material and prevent stale background orders from overwriting concurrent manual renewals.
- Add real TLS handshake, challenge, persistence, race, retry, and lifecycle tests.