### PR TITLE
feat(remote): connect mobile clients

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorCloudKit/CloudKitContainer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCloudKit/CloudKitContainer.swift
@@ -20,28 +20,32 @@ public enum CloudKitContainer {
   }
 
   public static func hasCloudKitEntitlement() -> Bool {
-    var code: SecCode?
-    guard SecCodeCopySelf(SecCSFlags(), &code) == errSecSuccess, let code else {
-      return false
-    }
-    var staticCode: SecStaticCode?
-    guard SecCodeCopyStaticCode(code, SecCSFlags(), &staticCode) == errSecSuccess,
-      let staticCode
-    else {
-      return false
-    }
-    var signingInfo: CFDictionary?
-    let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
-    guard SecCodeCopySigningInformation(staticCode, flags, &signingInfo) == errSecSuccess,
-      let info = signingInfo as? [String: Any],
-      let entitlements = info[kSecCodeInfoEntitlementsDict as String] as? [String: Any],
-      let containers = entitlements[
-        "com.apple.developer.icloud-container-identifiers"
-      ] as? [String]
-    else {
-      return false
-    }
-    return containers.contains(identifier)
+    #if os(macOS)
+      var code: SecCode?
+      guard SecCodeCopySelf(SecCSFlags(), &code) == errSecSuccess, let code else {
+        return false
+      }
+      var staticCode: SecStaticCode?
+      guard SecCodeCopyStaticCode(code, SecCSFlags(), &staticCode) == errSecSuccess,
+        let staticCode
+      else {
+        return false
+      }
+      var signingInfo: CFDictionary?
+      let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
+      guard SecCodeCopySigningInformation(staticCode, flags, &signingInfo) == errSecSuccess,
+        let info = signingInfo as? [String: Any],
+        let entitlements = info[kSecCodeInfoEntitlementsDict as String] as? [String: Any],
+        let containers = entitlements[
+          "com.apple.developer.icloud-container-identifiers"
+        ] as? [String]
+      else {
+        return false
+      }
+      return containers.contains(identifier)
+    #else
+      true
+    #endif
   }
 
   public static var singletonRecordID: CKRecord.ID {

--- a/apps/harness-monitor/Sources/HarnessMonitorCloudKit/CloudKitContainer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCloudKit/CloudKitContainer.swift
@@ -44,7 +44,9 @@ public enum CloudKitContainer {
       }
       return containers.contains(identifier)
     #else
-      true
+      // Public iOS/watchOS Security APIs cannot inspect code-signing entitlements.
+      // This macOS preflight has no mobile call site, so fail closed if one is added.
+      false
     #endif
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorCore/RemoteDaemonAuthentication.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCore/RemoteDaemonAuthentication.swift
@@ -1,0 +1,3 @@
+public enum RemoteDaemonAuthentication {
+  public static let clientIDHeader = "x-harness-remote-client-id"
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobilePairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobilePairing.swift
@@ -172,6 +172,7 @@ public struct MobilePairedStationCredential: Codable, Equatable, Identifiable, S
   public var pairedAt: Date
   public var lastUsedAt: Date?
   public var defaultStation: Bool
+  public var remoteDaemonAccess: MobileRemoteDaemonAccess?
 
   public init(
     stationID: String,
@@ -184,7 +185,8 @@ public struct MobilePairedStationCredential: Codable, Equatable, Identifiable, S
     symmetricKeyRawRepresentation: Data,
     pairedAt: Date,
     lastUsedAt: Date? = nil,
-    defaultStation: Bool = false
+    defaultStation: Bool = false,
+    remoteDaemonAccess: MobileRemoteDaemonAccess? = nil
   ) {
     self.stationID = stationID
     self.stationName = stationName
@@ -197,6 +199,12 @@ public struct MobilePairedStationCredential: Codable, Equatable, Identifiable, S
     self.pairedAt = pairedAt
     self.lastUsedAt = lastUsedAt
     self.defaultStation = defaultStation
+    self.remoteDaemonAccess = remoteDaemonAccess
+  }
+
+  public var hasCloudMirrorAccess: Bool {
+    !snapshotKeyID.isEmpty
+      && !symmetricKeyRawRepresentation.isEmpty
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
@@ -1,0 +1,245 @@
+import Foundation
+import HarnessMonitorCore
+
+public enum MobileRemoteDaemonRole: String, Codable, CaseIterable, Sendable {
+  case admin
+  case `operator`
+  case viewer
+}
+
+public enum MobileRemoteDaemonProfileError: Error, Equatable, Sendable {
+  case invalidEndpoint
+  case invalidInvitation
+  case invalidPin
+  case expired
+  case unsupportedVersion(Int)
+}
+
+public struct MobileRemoteDaemonSPKIPin: Codable, Equatable, Hashable, Sendable {
+  public let value: String
+  public let digest: Data
+
+  public init(validating value: String) throws {
+    let prefix = "sha256/"
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.hasPrefix(prefix) else {
+      throw MobileRemoteDaemonProfileError.invalidPin
+    }
+    let compact = String(trimmed.dropFirst(prefix.count).filter { !$0.isWhitespace })
+    let remainder = compact.count % 4
+    guard remainder != 1 else {
+      throw MobileRemoteDaemonProfileError.invalidPin
+    }
+    let padded = compact + String(repeating: "=", count: (4 - remainder) % 4)
+    guard let digest = Data(base64Encoded: padded), digest.count == 32 else {
+      throw MobileRemoteDaemonProfileError.invalidPin
+    }
+    self.value = prefix + digest.base64EncodedString()
+    self.digest = digest
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    try self.init(validating: container.decode(String.self))
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(value)
+  }
+}
+
+public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStringConvertible {
+  public var endpoint: URL
+  public var clientID: String
+  public var displayName: String
+  public var platform: String
+  public var role: MobileRemoteDaemonRole
+  public var scopes: [String]
+  public var bearerToken: String
+  public var tokenHint: String
+  public var serverSPKISHA256: MobileRemoteDaemonSPKIPin
+  public var pairedAt: Date
+
+  public init(
+    endpoint: URL,
+    clientID: String,
+    displayName: String,
+    platform: String,
+    role: MobileRemoteDaemonRole,
+    scopes: [String],
+    bearerToken: String,
+    tokenHint: String,
+    serverSPKISHA256: MobileRemoteDaemonSPKIPin,
+    pairedAt: Date
+  ) {
+    self.endpoint = endpoint
+    self.clientID = clientID
+    self.displayName = displayName
+    self.platform = platform
+    self.role = role
+    self.scopes = scopes
+    self.bearerToken = bearerToken
+    self.tokenHint = tokenHint
+    self.serverSPKISHA256 = serverSPKISHA256
+    self.pairedAt = pairedAt
+  }
+
+  public var description: String {
+    "MobileRemoteDaemonAccess(endpoint: \(endpoint.absoluteString), clientID: \(clientID), "
+      + "platform: \(platform), role: \(role.rawValue), scopes: \(scopes), "
+      + "tokenHint: \(tokenHint), bearerToken: <redacted>)"
+  }
+
+  public var canRead: Bool {
+    scopes.contains("read") || scopes.contains("admin")
+  }
+}
+
+public struct MobileRemoteDaemonPairingInvitation: Codable, Equatable, Sendable {
+  public let version: Int
+  public let endpoint: URL
+  public let code: String
+  public let serverSPKISHA256: MobileRemoteDaemonSPKIPin
+  public let role: MobileRemoteDaemonRole
+  public let scopes: [String]
+  public let expiresAt: Date
+
+  public static func decode(_ url: URL, now: Date = .now) throws -> Self {
+    guard MobilePairingLink.supports(url), url.host?.lowercased() == "remote-pair" else {
+      throw MobileRemoteDaemonProfileError.invalidInvitation
+    }
+    let payloads =
+      URLComponents(url: url, resolvingAgainstBaseURL: false)?
+      .queryItems?
+      .filter { $0.name == "payload" } ?? []
+    guard payloads.count == 1,
+      let payload = payloads.first?.value,
+      let data = Data(base64URLEncoded: payload)
+    else {
+      throw MobileRemoteDaemonProfileError.invalidInvitation
+    }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let invitation: Self
+    do {
+      invitation = try decoder.decode(Self.self, from: data)
+    } catch {
+      throw MobileRemoteDaemonProfileError.invalidInvitation
+    }
+    try invitation.validate(now: now)
+    return invitation
+  }
+
+  private func validate(now: Date) throws {
+    guard version == 1 else {
+      throw MobileRemoteDaemonProfileError.unsupportedVersion(version)
+    }
+    try MobileRemoteDaemonEndpoint.validate(endpoint)
+    guard !code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+      !scopes.isEmpty,
+      scopes.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+    else {
+      throw MobileRemoteDaemonProfileError.invalidInvitation
+    }
+    guard expiresAt > now else {
+      throw MobileRemoteDaemonProfileError.expired
+    }
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case version
+    case endpoint
+    case code
+    case serverSPKISHA256 = "server_spki_sha256"
+    case role
+    case scopes
+    case expiresAt = "expires_at"
+  }
+}
+
+public enum MobilePairingLink: Equatable, Sendable {
+  case relay(MobilePairingInvitation)
+  case remote(MobileRemoteDaemonPairingInvitation)
+
+  public static func supports(_ url: URL) -> Bool {
+    guard url.scheme?.lowercased() == MobilePairingInvitationCodec.urlScheme,
+      let host = url.host?.lowercased()
+    else {
+      return false
+    }
+    return [MobilePairingInvitationCodec.urlHost, "remote-pair"].contains(host)
+  }
+
+  public static func decode(_ url: URL, now: Date = .now) throws -> Self {
+    switch url.host?.lowercased() {
+    case MobilePairingInvitationCodec.urlHost:
+      return .relay(try MobilePairingInvitationCodec.decode(url, now: now))
+    case "remote-pair":
+      return .remote(try MobileRemoteDaemonPairingInvitation.decode(url, now: now))
+    default:
+      throw MobilePairingError.unsupportedURL(url.absoluteString)
+    }
+  }
+
+  public static func normalizedURL(from value: String, now: Date = .now) throws -> URL {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let url = URL(string: trimmed), url.scheme != nil {
+      _ = try decode(url, now: now)
+      return url
+    }
+    guard let data = Data(base64URLEncoded: trimmed),
+      let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      throw MobileRemoteDaemonProfileError.invalidInvitation
+    }
+    if payload["server_spki_sha256"] != nil {
+      var components = URLComponents()
+      components.scheme = MobilePairingInvitationCodec.urlScheme
+      components.host = "remote-pair"
+      components.queryItems = [URLQueryItem(name: "payload", value: trimmed)]
+      guard let url = components.url else {
+        throw MobileRemoteDaemonProfileError.invalidInvitation
+      }
+      _ = try decode(url, now: now)
+      return url
+    }
+    let invitation = try MobilePairingInvitationCodec.decode(trimmed, now: now)
+    return try MobilePairingInvitationCodec.encode(invitation)
+  }
+
+  public var stationName: String {
+    switch self {
+    case .relay(let invitation):
+      invitation.stationName
+    case .remote(let invitation):
+      invitation.endpoint.host ?? invitation.endpoint.absoluteString
+    }
+  }
+}
+
+public enum MobileRemoteDaemonStationID {
+  public static func make(endpoint: URL) -> String {
+    let host = endpoint.host?.lowercased() ?? "remote"
+    let authority = endpoint.port.map { "\(host)-\($0)" } ?? host
+    let normalized = authority.map { character in
+      character.isLetter || character.isNumber ? character : "-"
+    }
+    return "remote-" + String(normalized)
+  }
+}
+
+enum MobileRemoteDaemonEndpoint {
+  static func validate(_ endpoint: URL) throws {
+    guard endpoint.scheme?.lowercased() == "https",
+      endpoint.host?.isEmpty == false,
+      endpoint.user == nil,
+      endpoint.password == nil,
+      endpoint.query == nil,
+      endpoint.fragment == nil,
+      endpoint.path.isEmpty || endpoint.path == "/"
+    else {
+      throw MobileRemoteDaemonProfileError.invalidEndpoint
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
@@ -92,7 +92,7 @@ public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStri
   }
 
   public var canRead: Bool {
-    scopes.contains("read") || scopes.contains("admin")
+    role == .admin || scopes.contains("read")
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
@@ -1,0 +1,254 @@
+import Foundation
+
+public struct MobileRemoteDaemonPairingClaim: Equatable, Sendable {
+  public var clientID: String
+  public var displayName: String
+  public var platform: String
+  public var role: MobileRemoteDaemonRole
+  public var scopes: [String]
+  public var token: String
+  public var tokenHint: String
+  public var pairedAt: Date
+
+  public init(
+    clientID: String,
+    displayName: String,
+    platform: String,
+    role: MobileRemoteDaemonRole,
+    scopes: [String],
+    token: String,
+    tokenHint: String,
+    pairedAt: Date
+  ) {
+    self.clientID = clientID
+    self.displayName = displayName
+    self.platform = platform
+    self.role = role
+    self.scopes = scopes
+    self.token = token
+    self.tokenHint = tokenHint
+    self.pairedAt = pairedAt
+  }
+}
+
+public protocol MobileRemoteDaemonPairingTransport: Sendable {
+  func claim(
+    invitation: MobileRemoteDaemonPairingInvitation,
+    clientID: String,
+    displayName: String,
+    platform: String
+  ) async throws -> MobileRemoteDaemonPairingClaim
+}
+
+public enum MobileRemoteDaemonPairingError: Error, Equatable, Sendable {
+  case invalidResponse
+  case serverStatus(Int)
+  case claimMismatch
+}
+
+public struct URLSessionMobileRemoteDaemonPairingTransport:
+  MobileRemoteDaemonPairingTransport, Sendable
+{
+  public typealias SessionFactory = @Sendable (MobileRemoteDaemonSPKIPin) -> URLSession
+
+  private let sessionFactory: SessionFactory
+
+  public init() {
+    self.init(sessionFactory: Self.defaultSession)
+  }
+
+  public init(sessionFactory: @escaping SessionFactory) {
+    self.sessionFactory = sessionFactory
+  }
+
+  public func claim(
+    invitation: MobileRemoteDaemonPairingInvitation,
+    clientID: String,
+    displayName: String,
+    platform: String
+  ) async throws -> MobileRemoteDaemonPairingClaim {
+    let url = invitation.endpoint.appending(path: "/v1/remote/pair/claim")
+    let body = MobileRemoteDaemonPairingClaimRequest(
+      code: invitation.code,
+      domain: invitation.endpoint.host ?? "",
+      clientID: clientID,
+      displayName: displayName,
+      platform: platform
+    )
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = try JSONEncoder().encode(body)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    let session = sessionFactory(invitation.serverSPKISHA256)
+    defer { session.finishTasksAndInvalidate() }
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw MobileRemoteDaemonPairingError.invalidResponse
+    }
+    guard (200..<300).contains(response.statusCode) else {
+      throw MobileRemoteDaemonPairingError.serverStatus(response.statusCode)
+    }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let wire = try decoder.decode(MobileRemoteDaemonPairingClaimResponse.self, from: data)
+    guard wire.clientID == clientID,
+      wire.displayName == displayName,
+      wire.platform == platform,
+      !wire.token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      throw MobileRemoteDaemonPairingError.claimMismatch
+    }
+    return wire.claim
+  }
+
+  private static func defaultSession(pin: MobileRemoteDaemonSPKIPin) -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.waitsForConnectivity = true
+    configuration.timeoutIntervalForRequest = 15
+    configuration.timeoutIntervalForResource = 30
+    return MobileRemoteDaemonURLSessionFactory.make(configuration: configuration, pin: pin)
+  }
+}
+
+public actor MobileRemoteDaemonPairingCoordinator<Transport: MobileRemoteDaemonPairingTransport> {
+  public static var identityID: String { "default-mobile-device" }
+
+  private let identityStore: any MobileDeviceIdentityStore
+  private let credentialStore: any MobilePairedStationCredentialStore
+  private let transport: Transport
+  private let platform: String
+
+  public init(
+    identityStore: any MobileDeviceIdentityStore,
+    credentialStore: any MobilePairedStationCredentialStore,
+    transport: Transport,
+    platform: String
+  ) {
+    self.identityStore = identityStore
+    self.credentialStore = credentialStore
+    self.transport = transport
+    self.platform = platform
+  }
+
+  public func pair(
+    invitationURL: URL,
+    deviceName: String,
+    now: Date = .now
+  ) async throws -> MobilePairedStationCredential {
+    let invitation = try MobileRemoteDaemonPairingInvitation.decode(invitationURL, now: now)
+    let identity = try await loadOrCreateIdentity(deviceName: deviceName, now: now)
+    let clientID = try makeClientID(identity: identity)
+    let claim = try await transport.claim(
+      invitation: invitation,
+      clientID: clientID,
+      displayName: deviceName,
+      platform: platform
+    )
+    let access = MobileRemoteDaemonAccess(
+      endpoint: invitation.endpoint,
+      clientID: claim.clientID,
+      displayName: claim.displayName,
+      platform: claim.platform,
+      role: claim.role,
+      scopes: claim.scopes,
+      bearerToken: claim.token,
+      tokenHint: claim.tokenHint,
+      serverSPKISHA256: invitation.serverSPKISHA256,
+      pairedAt: claim.pairedAt
+    )
+    let stationID = MobileRemoteDaemonStationID.make(endpoint: invitation.endpoint)
+    let existing = try await credentialStore.loadAll()
+    let existingCredential = existing.first { $0.stationID == stationID }
+    let credential = MobilePairedStationCredential(
+      stationID: stationID,
+      stationName: invitation.endpoint.host ?? invitation.endpoint.absoluteString,
+      endpoint: invitation.endpoint,
+      stationPublicKeyFingerprint: invitation.serverSPKISHA256.value,
+      deviceIdentityID: identity.id,
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: claim.pairedAt,
+      lastUsedAt: now,
+      defaultStation: existingCredential?.defaultStation ?? existing.isEmpty,
+      remoteDaemonAccess: access
+    )
+    try await credentialStore.save(credential)
+    return credential
+  }
+
+  private func loadOrCreateIdentity(
+    deviceName: String,
+    now: Date
+  ) async throws -> MobileDeviceIdentity {
+    if let identity = try await identityStore.load(id: Self.identityID) {
+      return identity
+    }
+    let identity = MobileDeviceIdentity(
+      id: Self.identityID,
+      displayName: deviceName,
+      createdAt: now
+    )
+    try await identityStore.save(identity)
+    return identity
+  }
+
+  private func makeClientID(identity: MobileDeviceIdentity) throws -> String {
+    let fingerprint = try identity.signingKeyFingerprint()
+    let suffix = fingerprint.filter(\.isHexDigit).lowercased().prefix(24)
+    let normalizedPlatform = platform.lowercased().filter { $0.isLetter || $0.isNumber }
+    return "\(normalizedPlatform)-\(suffix)"
+  }
+}
+
+private struct MobileRemoteDaemonPairingClaimRequest: Encodable {
+  var code: String
+  var domain: String
+  var clientID: String
+  var displayName: String
+  var platform: String
+
+  enum CodingKeys: String, CodingKey {
+    case code
+    case domain
+    case clientID = "client_id"
+    case displayName = "display_name"
+    case platform
+  }
+}
+
+private struct MobileRemoteDaemonPairingClaimResponse: Decodable {
+  var clientID: String
+  var displayName: String
+  var platform: String
+  var role: MobileRemoteDaemonRole
+  var scopes: [String]
+  var token: String
+  var tokenHint: String
+  var pairedAt: Date
+
+  var claim: MobileRemoteDaemonPairingClaim {
+    MobileRemoteDaemonPairingClaim(
+      clientID: clientID,
+      displayName: displayName,
+      platform: platform,
+      role: role,
+      scopes: scopes,
+      token: token,
+      tokenHint: tokenHint,
+      pairedAt: pairedAt
+    )
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case clientID = "client_id"
+    case displayName = "display_name"
+    case platform
+    case role
+    case scopes
+    case token
+    case tokenHint = "token_hint"
+    case pairedAt = "paired_at"
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonTransportSecurity.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonTransportSecurity.swift
@@ -1,0 +1,159 @@
+import CryptoKit
+import Foundation
+import Security
+
+enum MobileRemoteDaemonSPKIDERError: Error {
+  case malformedCertificate
+}
+
+enum MobileRemoteDaemonSPKIDERExtractor {
+  static func extract(from certificateDER: Data) throws -> Data {
+    let bytes = [UInt8](certificateDER)
+    var certificateCursor = MobileRemoteDERCursor(bytes: bytes)
+    let certificate = try certificateCursor.read(expectedTag: 0x30)
+    guard certificateCursor.isAtEnd else {
+      throw MobileRemoteDaemonSPKIDERError.malformedCertificate
+    }
+    var outerCursor = MobileRemoteDERCursor(bytes: bytes, range: certificate.contentRange)
+    let tbsCertificate = try outerCursor.read(expectedTag: 0x30)
+    var tbsCursor = MobileRemoteDERCursor(bytes: bytes, range: tbsCertificate.contentRange)
+    if tbsCursor.nextTag == 0xA0 {
+      _ = try tbsCursor.read(expectedTag: 0xA0)
+    }
+    _ = try tbsCursor.read(expectedTag: 0x02)
+    for _ in 0..<4 {
+      _ = try tbsCursor.read(expectedTag: 0x30)
+    }
+    let subjectPublicKeyInfo = try tbsCursor.read(expectedTag: 0x30)
+    return Data(bytes[subjectPublicKeyInfo.fullRange])
+  }
+}
+
+private struct MobileRemoteDERElement {
+  let fullRange: Range<Int>
+  let contentRange: Range<Int>
+}
+
+private struct MobileRemoteDERCursor {
+  let bytes: [UInt8]
+  let endIndex: Int
+  var index: Int
+
+  init(bytes: [UInt8], range: Range<Int>? = nil) {
+    self.bytes = bytes
+    let range = range ?? bytes.indices
+    index = range.lowerBound
+    endIndex = range.upperBound
+  }
+
+  var isAtEnd: Bool { index == endIndex }
+  var nextTag: UInt8? { index < endIndex ? bytes[index] : nil }
+
+  mutating func read(expectedTag: UInt8) throws -> MobileRemoteDERElement {
+    let start = index
+    guard index < endIndex, bytes[index] == expectedTag else {
+      throw MobileRemoteDaemonSPKIDERError.malformedCertificate
+    }
+    index += 1
+    let length = try readLength()
+    let contentStart = index
+    let contentEnd = contentStart + length
+    guard contentEnd >= contentStart, contentEnd <= endIndex else {
+      throw MobileRemoteDaemonSPKIDERError.malformedCertificate
+    }
+    index = contentEnd
+    return MobileRemoteDERElement(
+      fullRange: start..<contentEnd,
+      contentRange: contentStart..<contentEnd
+    )
+  }
+
+  private mutating func readLength() throws -> Int {
+    guard index < endIndex else {
+      throw MobileRemoteDaemonSPKIDERError.malformedCertificate
+    }
+    let first = Int(bytes[index])
+    index += 1
+    if first & 0x80 == 0 {
+      return first
+    }
+    let count = first & 0x7F
+    guard count > 0, count <= 4, index + count <= endIndex else {
+      throw MobileRemoteDaemonSPKIDERError.malformedCertificate
+    }
+    var length = 0
+    for _ in 0..<count {
+      length = (length << 8) | Int(bytes[index])
+      index += 1
+    }
+    return length
+  }
+}
+
+struct MobileRemoteDaemonServerTrustEvaluator: Sendable {
+  let pin: MobileRemoteDaemonSPKIPin
+
+  func evaluate(_ trust: SecTrust) -> Bool {
+    var trustError: CFError?
+    guard SecTrustEvaluateWithError(trust, &trustError),
+      let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+      let leaf = chain.first
+    else {
+      return false
+    }
+    let certificateDER = SecCertificateCopyData(leaf) as Data
+    guard let spkiDER = try? MobileRemoteDaemonSPKIDERExtractor.extract(from: certificateDER) else {
+      return false
+    }
+    let digest = Data(SHA256.hash(data: spkiDER))
+    return constantTimeEqual(digest, pin.digest)
+  }
+
+  private func constantTimeEqual(_ lhs: Data, _ rhs: Data) -> Bool {
+    guard lhs.count == rhs.count else { return false }
+    return zip(lhs, rhs).reduce(UInt8(0)) { difference, pair in
+      difference | (pair.0 ^ pair.1)
+    } == 0
+  }
+}
+
+final class MobileRemoteDaemonURLSessionDelegate:
+  NSObject, URLSessionDelegate, @unchecked Sendable
+{
+  private let evaluator: MobileRemoteDaemonServerTrustEvaluator
+
+  init(pin: MobileRemoteDaemonSPKIPin) {
+    evaluator = MobileRemoteDaemonServerTrustEvaluator(pin: pin)
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {
+    guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+      let trust = challenge.protectionSpace.serverTrust
+    else {
+      completionHandler(.performDefaultHandling, nil)
+      return
+    }
+    guard evaluator.evaluate(trust) else {
+      completionHandler(.cancelAuthenticationChallenge, nil)
+      return
+    }
+    completionHandler(.useCredential, URLCredential(trust: trust))
+  }
+}
+
+public enum MobileRemoteDaemonURLSessionFactory {
+  public static func make(
+    configuration: URLSessionConfiguration,
+    pin: MobileRemoteDaemonSPKIPin
+  ) -> URLSession {
+    URLSession(
+      configuration: configuration,
+      delegate: MobileRemoteDaemonURLSessionDelegate(pin: pin),
+      delegateQueue: nil
+    )
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/API/HarnessMonitorAPIClient+Transport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/API/HarnessMonitorAPIClient+Transport.swift
@@ -376,7 +376,7 @@ extension HarnessMonitorAPIClient {
     }
 
     var request = URLRequest(url: url)
-    request.setValue("Bearer \(connection.token)", forHTTPHeaderField: "Authorization")
+    connection.applyAuthenticationHeaders(to: &request)
     request.setValue("application/json", forHTTPHeaderField: "Accept")
     return request
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/API/HarnessMonitorClientProtocol+Support.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/API/HarnessMonitorClientProtocol+Support.swift
@@ -39,7 +39,11 @@ public struct HarnessMonitorConnection: Equatable, Sendable {
 
   func applyAuthenticationHeaders(to request: inout URLRequest) {
     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-    guard let remoteClientID = remoteClientID?.trimmingCharacters(in: .whitespacesAndNewlines),
+    guard
+      isRemote,
+      let remoteClientID = remoteClientID?.trimmingCharacters(
+        in: .whitespacesAndNewlines
+      ),
       !remoteClientID.isEmpty
     else {
       return

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/API/HarnessMonitorClientProtocol+Support.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/API/HarnessMonitorClientProtocol+Support.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HarnessMonitorCore
 
 public enum HarnessMonitorServerTrust: Equatable, Sendable {
   case system
@@ -13,17 +14,20 @@ public enum HarnessMonitorConnectionSource: Equatable, Sendable {
 public struct HarnessMonitorConnection: Equatable, Sendable {
   public let endpoint: URL
   public let token: String
+  public let remoteClientID: String?
   public let serverTrust: HarnessMonitorServerTrust
   public let source: HarnessMonitorConnectionSource
 
   public init(
     endpoint: URL,
     token: String,
+    remoteClientID: String? = nil,
     serverTrust: HarnessMonitorServerTrust = .system,
     source: HarnessMonitorConnectionSource = .local
   ) {
     self.endpoint = endpoint
     self.token = token
+    self.remoteClientID = remoteClientID
     self.serverTrust = serverTrust
     self.source = source
   }
@@ -31,6 +35,19 @@ public struct HarnessMonitorConnection: Equatable, Sendable {
   public var isRemote: Bool {
     if case .remote = source { return true }
     return false
+  }
+
+  func applyAuthenticationHeaders(to request: inout URLRequest) {
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    guard let remoteClientID = remoteClientID?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !remoteClientID.isEmpty
+    else {
+      return
+    }
+    request.setValue(
+      remoteClientID,
+      forHTTPHeaderField: RemoteDaemonAuthentication.clientIDHeader
+    )
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/API/RemoteDaemonConnectionSource.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/API/RemoteDaemonConnectionSource.swift
@@ -55,6 +55,7 @@ public struct StoredRemoteDaemonConnectionSource: RemoteDaemonConnectionSourcing
     return HarnessMonitorConnection(
       endpoint: profile.endpoint,
       token: token,
+      remoteClientID: profile.clientID,
       serverTrust: .spkiSHA256(profile.serverSPKISHA256),
       source: .remote(profileID: profile.id)
     )

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/API/WebSocketTransportInternal+Support.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/API/WebSocketTransportInternal+Support.swift
@@ -87,7 +87,7 @@ extension WebSocketTransport {
   }
 
   func applyHandshakeHeaders(to request: inout URLRequest) {
-    request.setValue("Bearer \(connection.token)", forHTTPHeaderField: "Authorization")
+    connection.applyAuthenticationHeaders(to: &request)
     for (field, value) in currentClientHandshakeMetadata().headers {
       request.setValue(value, forHTTPHeaderField: field)
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/API/WebSocketTransportInternal+Telemetry.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/API/WebSocketTransportInternal+Telemetry.swift
@@ -25,7 +25,7 @@ extension WebSocketTransport {
       var request = URLRequest(url: url)
       request.httpMethod = "POST"
       request.timeoutInterval = DaemonTelemetrySupport.requestTimeoutInterval
-      request.setValue("Bearer \(connection.token)", forHTTPHeaderField: "Authorization")
+      connection.applyAuthenticationHeaders(to: &request)
       request.setValue("application/json", forHTTPHeaderField: "Content-Type")
       request.setValue("application/json", forHTTPHeaderField: "Accept")
       request.httpBody = try encoder.encode(AnyEncodable(telemetryRequest))

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/DirectFirstMobileMonitorSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/DirectFirstMobileMonitorSyncClient.swift
@@ -1,0 +1,57 @@
+import Foundation
+import HarnessMonitorCloudMirror
+import HarnessMonitorCore
+
+public struct DirectFirstMobileMonitorSyncClient: MobileMonitorSyncClient, Sendable {
+  private let direct: any MobileMonitorSyncClient
+  private let cloudFallback: any MobileMonitorSyncClient
+
+  public init(
+    direct: any MobileMonitorSyncClient,
+    cloudFallback: any MobileMonitorSyncClient
+  ) {
+    self.direct = direct
+    self.cloudFallback = cloudFallback
+  }
+
+  public var supportsCommands: Bool {
+    false
+  }
+
+  public func fetchLatestSnapshot(
+    stationID: String,
+    now: Date
+  ) async throws -> MobileMirrorSnapshot? {
+    do {
+      return try await direct.fetchLatestSnapshot(stationID: stationID, now: now)
+    } catch {
+      guard Self.allowsCloudFallback(error) else {
+        throw error
+      }
+      return try await cloudFallback.fetchLatestSnapshot(stationID: stationID, now: now)
+    }
+  }
+
+  public func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileQueuedCommand {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  public func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  private static func allowsCloudFallback(_ error: any Error) -> Bool {
+    if error is URLError {
+      return true
+    }
+    return (error as? MobileRemoteDaemonSyncError)?.allowsCloudFallback == true
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Commands.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Commands.swift
@@ -74,6 +74,10 @@ extension MirrorStore {
       syncStatus = .unpaired
       return
     }
+    guard syncClient.supportsCommands else {
+      syncStatus = .commandFailed("Commands are unavailable for this connection.")
+      return
+    }
     do {
       let queued = try await syncClient.queueCommand(
         command,
@@ -127,6 +131,10 @@ extension MirrorStore {
     }
     guard let syncClient = syncClient(for: command.stationID) else {
       syncStatus = .unpaired
+      return
+    }
+    guard syncClient.supportsCommands else {
+      syncStatus = .commandFailed("Commands are unavailable for this connection.")
       return
     }
     do {

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
@@ -197,9 +197,7 @@ extension MirrorStore {
   }
 
   public func handleOpenURL(_ url: URL, deviceName: String) async {
-    guard url.scheme == MobilePairingInvitationCodec.urlScheme,
-      url.host == MobilePairingInvitationCodec.urlHost
-    else {
+    guard MobilePairingLink.supports(url) else {
       return
     }
     await pair(invitationURL: url, deviceName: deviceName)
@@ -211,18 +209,19 @@ extension MirrorStore {
       return
     }
     do {
-      let invitation = try MobilePairingInvitationCodec.decode(invitationURL, now: .now)
+      let now = Date()
+      let pairingLink = try MobilePairingLink.decode(invitationURL, now: now)
       let wasDemoModeEnabled = demoModeEnabled
       demoModeEnabled = false
       if wasDemoModeEnabled {
         snapshot = .empty()
         selectedStationID = ""
       }
-      syncStatus = .pairing(invitation.stationName)
+      syncStatus = .pairing(pairingLink.stationName)
       let credential = try await pairer.pair(
         invitationURL: invitationURL,
         deviceName: deviceName,
-        now: .now
+        now: now
       )
       try await rebuildSyncClients(preferredStationID: credential.stationID)
       syncStatus = .paired(credential.stationName)

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
@@ -142,7 +142,7 @@ public final class MirrorStore {
   }
 
   public var canQueueCommands: Bool {
-    demoModeEnabled || syncClient(for: selectedStationID) != nil
+    demoModeEnabled || syncClient(for: selectedStationID)?.supportsCommands == true
   }
 
   public var mirroredPrivacyStationCount: Int {
@@ -154,7 +154,7 @@ public final class MirrorStore {
   }
 
   public func canQueueCommand(stationID: String) -> Bool {
-    demoModeEnabled || syncClient(for: stationID) != nil
+    demoModeEnabled || syncClient(for: stationID)?.supportsCommands == true
   }
 
   public func setDemoMode(_ enabled: Bool) {

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileMonitorSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileMonitorSyncClient.swift
@@ -94,6 +94,7 @@ public struct LiveMobileMonitorSyncClientFactory: MobileMonitorSyncClientFactory
       access: access,
       stationID: credential.stationID,
       stationName: credential.stationName,
+      defaultStation: credential.defaultStation,
       session: remoteSessionFactory(access.serverSPKISHA256)
     )
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileMonitorSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileMonitorSyncClient.swift
@@ -3,10 +3,10 @@ import HarnessMonitorCloudMirror
 import HarnessMonitorCore
 import HarnessMonitorCrypto
 
-/// The mobile sync operations the shared store depends on. Kept as a protocol
-/// so tests can inject fakes; the live implementation is the CloudMirror sync
-/// client, which conforms directly below.
+/// The mobile sync operations the shared store depends on. Tests inject fakes;
+/// live credentials select direct remote access, CloudMirror, or both.
 public protocol MobileMonitorSyncClient: Sendable {
+  var supportsCommands: Bool { get }
   func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot?
   func queueCommand(
     _ command: MobileCommandRecord,
@@ -20,6 +20,10 @@ public protocol MobileMonitorSyncClient: Sendable {
   ) async throws -> MobileCommandReceipt
 }
 
+extension MobileMonitorSyncClient {
+  public var supportsCommands: Bool { true }
+}
+
 extension MobileCloudMirrorSyncClient: MobileMonitorSyncClient {}
 
 public protocol MobileMonitorSyncClientFactory: Sendable {
@@ -29,28 +33,100 @@ public protocol MobileMonitorSyncClientFactory: Sendable {
   ) -> any MobileMonitorSyncClient
 }
 
-/// Builds live CloudMirror sync clients. The optional `actorDeviceID` transform
-/// lets the watch stamp commands with its own actor id; the phone leaves it nil
-/// so the client falls back to the device identity id.
+/// Builds live direct and CloudMirror sync clients. The optional `actorDeviceID`
+/// transform lets the watch stamp relay commands with its own actor id.
 public struct LiveMobileMonitorSyncClientFactory: MobileMonitorSyncClientFactory {
+  public typealias RemoteSessionFactory =
+    @Sendable (MobileRemoteDaemonSPKIPin) -> URLSession
+
   private let actorDeviceID: @Sendable (MobileDeviceIdentity) -> String?
+  private let remoteSessionFactory: RemoteSessionFactory
 
   public init(
-    actorDeviceID: @escaping @Sendable (MobileDeviceIdentity) -> String? = { _ in nil }
+    actorDeviceID: @escaping @Sendable (MobileDeviceIdentity) -> String? = { _ in nil },
+    remoteSessionFactory: RemoteSessionFactory? = nil
   ) {
     self.actorDeviceID = actorDeviceID
+    self.remoteSessionFactory = remoteSessionFactory ?? Self.defaultRemoteSession
   }
 
   public func makeSyncClient(
     credential: MobilePairedStationCredential,
     identity: MobileDeviceIdentity
   ) -> any MobileMonitorSyncClient {
-    MobileCloudMirrorSyncClient(
+    let cloud = makeCloudClient(credential: credential, identity: identity)
+    let direct = makeDirectClient(credential: credential)
+    switch (direct, cloud) {
+    case (.some(let direct), .some(let cloud)):
+      return DirectFirstMobileMonitorSyncClient(direct: direct, cloudFallback: cloud)
+    case (.some(let direct), .none):
+      return direct
+    case (.none, .some(let cloud)):
+      return cloud
+    case (.none, .none):
+      return UnavailableMobileMonitorSyncClient()
+    }
+  }
+
+  private func makeCloudClient(
+    credential: MobilePairedStationCredential,
+    identity: MobileDeviceIdentity
+  ) -> MobileCloudMirrorSyncClient? {
+    guard credential.hasCloudMirrorAccess else {
+      return nil
+    }
+    return MobileCloudMirrorSyncClient(
       database: LiveMobileCloudMirrorDatabase(),
       cipher: MobilePayloadCipher(rawKey: credential.symmetricKeyRawRepresentation),
       deviceIdentity: identity,
       actorDeviceID: actorDeviceID(identity),
       commandKeyID: credential.commandKeyID
     )
+  }
+
+  private func makeDirectClient(
+    credential: MobilePairedStationCredential
+  ) -> MobileRemoteDaemonSyncClient? {
+    guard let access = credential.remoteDaemonAccess, access.canRead else {
+      return nil
+    }
+    return MobileRemoteDaemonSyncClient(
+      access: access,
+      stationID: credential.stationID,
+      stationName: credential.stationName,
+      session: remoteSessionFactory(access.serverSPKISHA256)
+    )
+  }
+
+  private static func defaultRemoteSession(pin: MobileRemoteDaemonSPKIPin) -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.waitsForConnectivity = true
+    configuration.timeoutIntervalForRequest = 15
+    configuration.timeoutIntervalForResource = 30
+    return MobileRemoteDaemonURLSessionFactory.make(configuration: configuration, pin: pin)
+  }
+}
+
+private struct UnavailableMobileMonitorSyncClient: MobileMonitorSyncClient {
+  var supportsCommands: Bool { false }
+
+  func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot? {
+    nil
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileQueuedCommand {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
@@ -1,0 +1,210 @@
+import Foundation
+import HarnessMonitorCloudMirror
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+
+public enum MobileRemoteDaemonSyncError: Error, Equatable, Sendable {
+  case invalidResponse
+  case stationMismatch
+  case unauthorized
+  case forbidden
+  case serverStatus(Int)
+  case commandsUnavailable
+
+  var allowsCloudFallback: Bool {
+    if case .serverStatus(let statusCode) = self {
+      return statusCode >= 500
+    }
+    return false
+  }
+}
+
+public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
+  public let supportsCommands = false
+
+  private let access: MobileRemoteDaemonAccess
+  private let stationID: String
+  private let stationName: String
+  private let session: URLSession
+
+  public init(
+    access: MobileRemoteDaemonAccess,
+    stationID: String,
+    stationName: String,
+    session: URLSession
+  ) {
+    self.access = access
+    self.stationID = stationID
+    self.stationName = stationName
+    self.session = session
+  }
+
+  public func fetchLatestSnapshot(
+    stationID: String,
+    now: Date
+  ) async throws -> MobileMirrorSnapshot? {
+    guard stationID == self.stationID else {
+      throw MobileRemoteDaemonSyncError.stationMismatch
+    }
+    var request = URLRequest(url: access.endpoint.appending(path: "/v1/sessions"))
+    request.httpMethod = "GET"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("Bearer \(access.bearerToken)", forHTTPHeaderField: "Authorization")
+    request.setValue(
+      access.clientID,
+      forHTTPHeaderField: RemoteDaemonAuthentication.clientIDHeader
+    )
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+    try validate(response)
+    let sessions = try JSONDecoder().decode([MobileRemoteSessionWire].self, from: data)
+    return makeSnapshot(sessions: sessions, now: now)
+  }
+
+  public func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileQueuedCommand {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  public func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  private func validate(_ response: HTTPURLResponse) throws {
+    switch response.statusCode {
+    case 200..<300:
+      return
+    case 401:
+      throw MobileRemoteDaemonSyncError.unauthorized
+    case 403:
+      throw MobileRemoteDaemonSyncError.forbidden
+    default:
+      throw MobileRemoteDaemonSyncError.serverStatus(response.statusCode)
+    }
+  }
+
+  private func makeSnapshot(
+    sessions: [MobileRemoteSessionWire],
+    now: Date
+  ) -> MobileMirrorSnapshot {
+    let mobileSessions = sessions.map { $0.mobileSummary(stationID: stationID, now: now) }
+    let activeSessions = sessions.filter { $0.status != "ended" }
+    let needsYouCount = sessions.reduce(0) { count, session in
+      count + session.metrics.awaitingReviewAgentCount
+    }
+    let station = MobileStationSummary(
+      id: stationID,
+      displayName: stationName,
+      state: .online,
+      lastSeenAt: now,
+      activeSessionCount: activeSessions.count,
+      needsYouCount: needsYouCount,
+      commandQueueCount: 0,
+      defaultStation: true
+    )
+    let revision = Int64((now.timeIntervalSince1970 * 1_000).rounded(.down))
+    return MobileMirrorSnapshot(
+      revision: revision,
+      generatedAt: now,
+      expiresAt: now.addingTimeInterval(60),
+      stations: [station],
+      attention: [],
+      sessions: mobileSessions,
+      reviews: [],
+      taskBoardItems: [],
+      commands: [],
+      trustedDevices: []
+    )
+  }
+}
+
+private struct MobileRemoteSessionWire: Decodable, Sendable {
+  var projectName: String
+  var sessionID: String
+  var title: String
+  var branchRef: String
+  var status: String
+  var updatedAt: String
+  var lastActivityAt: String?
+  var metrics: MobileRemoteSessionMetricsWire
+
+  func mobileSummary(stationID: String, now: Date) -> MobileSessionSummary {
+    MobileSessionSummary(
+      id: sessionID,
+      stationID: stationID,
+      projectName: projectName,
+      title: title.isEmpty ? "(untitled)" : title,
+      branch: branchRef,
+      status: MobileRemoteSessionStatus.title(for: status),
+      activeAgentCount: metrics.activeAgentCount,
+      blockedAgentCount: metrics.awaitingReviewAgentCount,
+      lastActivityAt: MobileRemoteSessionDate.parse(lastActivityAt ?? updatedAt) ?? now,
+      summary: MobileRemoteSessionSummaryText.make(metrics: metrics)
+    )
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case projectName = "project_name"
+    case sessionID = "session_id"
+    case title
+    case branchRef = "branch_ref"
+    case status
+    case updatedAt = "updated_at"
+    case lastActivityAt = "last_activity_at"
+    case metrics
+  }
+}
+
+private struct MobileRemoteSessionMetricsWire: Decodable, Sendable {
+  var activeAgentCount: Int
+  var awaitingReviewAgentCount: Int
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    activeAgentCount = try container.decodeIfPresent(Int.self, forKey: .activeAgentCount) ?? 0
+    awaitingReviewAgentCount =
+      try container.decodeIfPresent(Int.self, forKey: .awaitingReviewAgentCount) ?? 0
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case activeAgentCount = "active_agent_count"
+    case awaitingReviewAgentCount = "awaiting_review_agent_count"
+  }
+}
+
+private enum MobileRemoteSessionStatus {
+  static func title(for status: String) -> String {
+    switch status {
+    case "awaiting_leader": "Awaiting leader"
+    case "active": "Active"
+    case "paused": "Paused"
+    case "leaderless_degraded": "Leaderless degraded"
+    case "ended": "Ended"
+    default: status.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+  }
+}
+
+private enum MobileRemoteSessionDate {
+  static func parse(_ value: String) -> Date? {
+    let fractional = ISO8601DateFormatter()
+    fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+  }
+}
+
+private enum MobileRemoteSessionSummaryText {
+  static func make(metrics: MobileRemoteSessionMetricsWire) -> String {
+    "\(metrics.activeAgentCount) active agents, "
+      + "\(metrics.awaitingReviewAgentCount) awaiting review"
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
@@ -111,9 +111,8 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
       commandQueueCount: 0,
       defaultStation: true
     )
-    let revision = Int64((now.timeIntervalSince1970 * 1_000).rounded(.down))
     return MobileMirrorSnapshot(
-      revision: revision,
+      revision: 0,
       generatedAt: now,
       expiresAt: now.addingTimeInterval(60),
       stations: [station],

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
@@ -25,17 +25,20 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
   private let access: MobileRemoteDaemonAccess
   private let stationID: String
   private let stationName: String
+  private let defaultStation: Bool
   private let session: URLSession
 
   public init(
     access: MobileRemoteDaemonAccess,
     stationID: String,
     stationName: String,
+    defaultStation: Bool,
     session: URLSession
   ) {
     self.access = access
     self.stationID = stationID
     self.stationName = stationName
+    self.defaultStation = defaultStation
     self.session = session
   }
 
@@ -109,7 +112,7 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
       activeSessionCount: activeSessions.count,
       needsYouCount: needsYouCount,
       commandQueueCount: 0,
-      defaultStation: true
+      defaultStation: defaultStation
     )
     return MobileMirrorSnapshot(
       revision: 0,
@@ -194,10 +197,14 @@ private enum MobileRemoteSessionStatus {
 }
 
 private enum MobileRemoteSessionDate {
+  private static let fractional =
+    Date.ISO8601FormatStyle().year().month().day()
+    .timeZone(separator: .omitted)
+    .time(includingFractionalSeconds: true)
+  private static let standard = Date.ISO8601FormatStyle()
+
   static func parse(_ value: String) -> Date? {
-    let fractional = ISO8601DateFormatter()
-    fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+    (try? fractional.parse(value)) ?? (try? standard.parse(value))
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/HarnessMonitorMobileApp.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/HarnessMonitorMobileApp.swift
@@ -58,9 +58,7 @@ struct HarnessMonitorMobileApp: App {
       MobileRootView(selectedTab: $selectedTab)
         .environment(store)
         .onOpenURL { url in
-          guard url.scheme == MobilePairingInvitationCodec.urlScheme,
-            url.host == MobilePairingInvitationCodec.urlHost
-          else {
+          guard MobilePairingLink.supports(url) else {
             if let tab = MobileRootTab(url: url) {
               routeToTab(tab)
             }

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/LiveMobileMonitorCredentialPairer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/LiveMobileMonitorCredentialPairer.swift
@@ -4,16 +4,24 @@ import HarnessMonitorCrypto
 import HarnessMonitorMirrorStore
 
 actor LiveMobileMonitorCredentialPairer: MobileMonitorCredentialPairer {
-  private let coordinator: MobilePairingCoordinator<URLSessionMobilePairingTransport>
+  private let relayCoordinator: MobilePairingCoordinator<URLSessionMobilePairingTransport>
+  private let remoteCoordinator:
+    MobileRemoteDaemonPairingCoordinator<URLSessionMobileRemoteDaemonPairingTransport>
 
   init(
     identityStore: any MobileDeviceIdentityStore,
     credentialStore: any MobilePairedStationCredentialStore
   ) {
-    coordinator = MobilePairingCoordinator(
+    relayCoordinator = MobilePairingCoordinator(
       identityStore: identityStore,
       credentialStore: credentialStore,
       transport: URLSessionMobilePairingTransport()
+    )
+    remoteCoordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      transport: URLSessionMobileRemoteDaemonPairingTransport(),
+      platform: "ios"
     )
   }
 
@@ -22,6 +30,19 @@ actor LiveMobileMonitorCredentialPairer: MobileMonitorCredentialPairer {
     deviceName: String,
     now: Date
   ) async throws -> MobilePairedStationCredential {
-    try await coordinator.pair(invitationURL: invitationURL, deviceName: deviceName, now: now)
+    switch try MobilePairingLink.decode(invitationURL, now: now) {
+    case .relay:
+      return try await relayCoordinator.pair(
+        invitationURL: invitationURL,
+        deviceName: deviceName,
+        now: now
+      )
+    case .remote:
+      return try await remoteCoordinator.pair(
+        invitationURL: invitationURL,
+        deviceName: deviceName,
+        now: now
+      )
+    }
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/MobilePairingScannerView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/MobilePairingScannerView.swift
@@ -55,8 +55,8 @@ struct MobilePairingScannerView: View {
             }
           }
         }
-        Section("Paste pairing link") {
-          TextField("harness://pair...", text: $manualEntry, axis: .vertical)
+        Section("Paste pairing link or code") {
+          TextField("Pairing link or code", text: $manualEntry, axis: .vertical)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
             .lineLimit(2...4)
@@ -69,7 +69,7 @@ struct MobilePairingScannerView: View {
           .disabled(parsedManualURL == nil)
         }
       }
-      .navigationTitle("Pair Mac")
+      .navigationTitle("Pair Station")
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Cancel") {
@@ -109,14 +109,7 @@ struct MobilePairingScannerView: View {
   }
 
   static func pairingURL(from text: String) -> URL? {
-    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard let url = URL(string: trimmed),
-      url.scheme == MobilePairingInvitationCodec.urlScheme,
-      url.host == MobilePairingInvitationCodec.urlHost
-    else {
-      return nil
-    }
-    return url
+    try? MobilePairingLink.normalizedURL(from: text)
   }
 }
 
@@ -163,15 +156,15 @@ private struct MobilePairingScannerNotice: View {
     switch availability {
     case .needsPermission:
       String(
-        localized: "Allow camera access to scan the Mac pairing QR code, or paste the link below")
+        localized: "Allow camera access to scan a pairing QR code, or paste the link below")
     case .denied:
       String(
         localized:
-          "Enable camera access in iOS Settings to scan the pairing QR code, or paste the link below"
+          "Enable camera access in iOS Settings to scan a pairing QR code, or paste the link below"
       )
     case .unsupported:
       String(
-        localized: "This device cannot scan QR codes. Paste the pairing link from the Mac below")
+        localized: "This device cannot scan QR codes. Paste the pairing link below")
     case .scanning:
       ""
     }

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
@@ -1,0 +1,333 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+import XCTest
+
+final class MobileRemoteDaemonPairingTests: XCTestCase {
+  func testPairingLinkDecodesRemoteInvitation() throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+
+    let link = try MobilePairingLink.decode(remoteInvitationURL(now: now), now: now)
+    guard case .remote(let invitation) = link else {
+      return XCTFail("expected remote daemon invitation")
+    }
+
+    XCTAssertEqual(invitation.endpoint.absoluteString, "https://daemon.example.com")
+    XCTAssertEqual(invitation.code, "one-time-code")
+    XCTAssertEqual(invitation.role, .operator)
+    XCTAssertEqual(invitation.scopes, ["read", "write"])
+    XCTAssertEqual(link.stationName, "daemon.example.com")
+  }
+
+  func testManualPayloadNormalizesRemoteAndRelayInvitations() throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let remoteURL = try remoteInvitationURL(now: now)
+    let relayInvitation = makePairingInvitation(now: now)
+    let relayURL = try MobilePairingInvitationCodec.encode(relayInvitation)
+
+    let normalizedRemote = try MobilePairingLink.normalizedURL(
+      from: pairingPayload(from: remoteURL),
+      now: now
+    )
+    let normalizedRelay = try MobilePairingLink.normalizedURL(
+      from: pairingPayload(from: relayURL),
+      now: now
+    )
+
+    XCTAssertEqual(
+      try MobilePairingLink.decode(normalizedRemote, now: now),
+      try MobilePairingLink.decode(remoteURL, now: now)
+    )
+    XCTAssertEqual(
+      try MobilePairingLink.decode(normalizedRelay, now: now),
+      .relay(relayInvitation)
+    )
+  }
+
+  func testCoordinatorPersistsRemoteBearerCredential() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identityStore = InMemoryMobileDeviceIdentityStore()
+    let credentialStore = InMemoryMobilePairedStationCredentialStore()
+    let transport = RecordingRemotePairingTransport(
+      claim: MobileRemoteDaemonPairingClaim(
+        clientID: "ios-identity-fingerprint",
+        displayName: "Bart's iPhone",
+        platform: "ios",
+        role: .operator,
+        scopes: ["read", "write"],
+        token: "server-issued-token",
+        tokenHint: "abcd1234",
+        pairedAt: now.addingTimeInterval(5)
+      )
+    )
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      transport: transport,
+      platform: "ios"
+    )
+
+    let credential = try await coordinator.pair(
+      invitationURL: remoteInvitationURL(now: now),
+      deviceName: "Bart's iPhone",
+      now: now
+    )
+
+    let capturedRequest = await transport.lastRequest()
+    let request = try XCTUnwrap(capturedRequest)
+    XCTAssertEqual(request.displayName, "Bart's iPhone")
+    XCTAssertEqual(request.platform, "ios")
+    XCTAssertTrue(request.clientID.hasPrefix("ios-"))
+    XCTAssertEqual(credential.remoteDaemonAccess?.bearerToken, "server-issued-token")
+    XCTAssertEqual(credential.remoteDaemonAccess?.serverSPKISHA256.value, testSPKIPin)
+    XCTAssertTrue(credential.symmetricKeyRawRepresentation.isEmpty)
+    XCTAssertTrue(credential.snapshotKeyID.isEmpty)
+    let storedCredential = try await credentialStore.load(stationID: credential.stationID)
+    XCTAssertEqual(storedCredential, credential)
+    let storedIdentity = try await identityStore.load(
+      id: MobileRemoteDaemonPairingCoordinator<RecordingRemotePairingTransport>.identityID
+    )
+    XCTAssertNotNil(storedIdentity)
+  }
+
+  func testRepairingRemoteStationPreservesDefaultSelection() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let existingRemote = MobilePairedStationCredential(
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      endpoint: URL(string: "https://daemon.example.com")!,
+      stationPublicKeyFingerprint: testSPKIPin,
+      deviceIdentityID: "default-mobile-device",
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: now.addingTimeInterval(-600),
+      defaultStation: true,
+      remoteDaemonAccess: try remoteAccess()
+    )
+    let otherStation = makePairedStationCredential(
+      stationID: "station-other",
+      deviceIdentityID: "default-mobile-device",
+      now: now
+    )
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [existingRemote, otherStation]
+    )
+    let transport = RecordingRemotePairingTransport(
+      claim: MobileRemoteDaemonPairingClaim(
+        clientID: "ios-new-fingerprint",
+        displayName: "Bart's iPhone",
+        platform: "ios",
+        role: .operator,
+        scopes: ["read", "write"],
+        token: "rotated-server-token",
+        tokenHint: "dcba4321",
+        pairedAt: now
+      )
+    )
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: InMemoryMobileDeviceIdentityStore(),
+      credentialStore: credentialStore,
+      transport: transport,
+      platform: "ios"
+    )
+
+    let credential = try await coordinator.pair(
+      invitationURL: remoteInvitationURL(now: now),
+      deviceName: "Bart's iPhone",
+      now: now
+    )
+
+    XCTAssertTrue(credential.defaultStation)
+    XCTAssertEqual(credential.remoteDaemonAccess?.bearerToken, "rotated-server-token")
+  }
+
+  func testRemoteAccessDebugDescriptionRedactsBearerToken() throws {
+    let access = try remoteAccess()
+
+    let description = String(describing: access)
+
+    XCTAssertFalse(description.contains("server-issued-token"))
+    XCTAssertTrue(description.contains("abcd1234"))
+  }
+
+  func testCredentialDebugDescriptionRedactsRemoteBearerToken() throws {
+    let credential = MobilePairedStationCredential(
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      endpoint: URL(string: "https://daemon.example.com")!,
+      stationPublicKeyFingerprint: testSPKIPin,
+      deviceIdentityID: "default-mobile-device",
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: Date(timeIntervalSince1970: 1_752_124_405),
+      remoteDaemonAccess: try remoteAccess()
+    )
+
+    XCTAssertFalse(String(describing: credential).contains("server-issued-token"))
+  }
+
+  func testKeychainRoundTripsAndRotatesRemoteBearerToken() async throws {
+    let stationID = "remote-keychain-\(UUID().uuidString)"
+    let store = KeychainMobilePairedStationCredentialStore(
+      service: "io.harnessmonitor.tests.remote-mobile.\(UUID().uuidString)"
+    )
+    addTeardownBlock {
+      try await store.delete(stationID: stationID)
+    }
+    var credential = MobilePairedStationCredential(
+      stationID: stationID,
+      stationName: "daemon.example.com",
+      endpoint: URL(string: "https://daemon.example.com")!,
+      stationPublicKeyFingerprint: testSPKIPin,
+      deviceIdentityID: "default-mobile-device",
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: Date(timeIntervalSince1970: 1_752_124_405),
+      remoteDaemonAccess: try remoteAccess()
+    )
+
+    try await store.save(credential)
+    let stored = try await store.load(stationID: stationID)
+    XCTAssertEqual(stored?.remoteDaemonAccess?.bearerToken, "server-issued-token")
+
+    credential.remoteDaemonAccess?.bearerToken = "rotated-server-token"
+    try await store.save(credential)
+    let rotated = try await store.load(stationID: stationID)
+    XCTAssertEqual(rotated?.remoteDaemonAccess?.bearerToken, "rotated-server-token")
+  }
+
+  func testInvitationRejectsExpiredAndNonHTTPSProfiles() throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+
+    XCTAssertThrowsError(
+      try MobileRemoteDaemonPairingInvitation.decode(
+        remoteInvitationURL(now: now, endpoint: "https://daemon.example.com", ttl: -1),
+        now: now
+      )
+    ) { error in
+      XCTAssertEqual(error as? MobileRemoteDaemonProfileError, .expired)
+    }
+    XCTAssertThrowsError(
+      try MobileRemoteDaemonPairingInvitation.decode(
+        remoteInvitationURL(now: now, endpoint: "http://daemon.example.com"),
+        now: now
+      )
+    ) { error in
+      XCTAssertEqual(error as? MobileRemoteDaemonProfileError, .invalidEndpoint)
+    }
+  }
+
+  func testWatchTransferRoundTripsRemoteDaemonAccess() throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identity = MobileDeviceIdentity(
+      id: "default-mobile-device",
+      displayName: "Bart's iPhone",
+      signingPrivateKeyRawRepresentation: Data(repeating: 1, count: 32),
+      agreementPrivateKeyRawRepresentation: Data(repeating: 2, count: 32),
+      createdAt: now
+    )
+    let credential = MobilePairedStationCredential(
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      endpoint: URL(string: "https://daemon.example.com")!,
+      stationPublicKeyFingerprint: testSPKIPin,
+      deviceIdentityID: identity.id,
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: now,
+      defaultStation: true,
+      remoteDaemonAccess: try remoteAccess()
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [identity],
+      credentials: [credential],
+      exportedAt: now.addingTimeInterval(10)
+    )
+
+    let decoded = try MobileWatchPairingTransfer.decode(try transfer.encodedData())
+
+    XCTAssertEqual(decoded.credentials.first?.remoteDaemonAccess, credential.remoteDaemonAccess)
+    XCTAssertEqual(decoded, transfer)
+  }
+}
+
+private actor RecordingRemotePairingTransport: MobileRemoteDaemonPairingTransport {
+  struct Request: Sendable {
+    var clientID: String
+    var displayName: String
+    var platform: String
+  }
+
+  private let claim: MobileRemoteDaemonPairingClaim
+  private var request: Request?
+
+  init(claim: MobileRemoteDaemonPairingClaim) {
+    self.claim = claim
+  }
+
+  func claim(
+    invitation: MobileRemoteDaemonPairingInvitation,
+    clientID: String,
+    displayName: String,
+    platform: String
+  ) async throws -> MobileRemoteDaemonPairingClaim {
+    request = Request(clientID: clientID, displayName: displayName, platform: platform)
+    return claim
+  }
+
+  func lastRequest() -> Request? {
+    request
+  }
+}
+
+private let testSPKIPin = "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+
+private func remoteInvitationURL(
+  now: Date,
+  endpoint: String = "https://daemon.example.com",
+  ttl: TimeInterval = 600
+) throws -> URL {
+  let payload: [String: Any] = [
+    "version": 1,
+    "endpoint": endpoint,
+    "code": "one-time-code",
+    "server_spki_sha256": testSPKIPin,
+    "role": "operator",
+    "scopes": ["read", "write"],
+    "expires_at": ISO8601DateFormatter().string(from: now.addingTimeInterval(ttl)),
+  ]
+  let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+  let encoded =
+    data.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+  return try XCTUnwrap(URL(string: "harness://remote-pair?payload=\(encoded)"))
+}
+
+private func remoteAccess() throws -> MobileRemoteDaemonAccess {
+  MobileRemoteDaemonAccess(
+    endpoint: URL(string: "https://daemon.example.com")!,
+    clientID: "ios-identity-fingerprint",
+    displayName: "Bart's iPhone",
+    platform: "ios",
+    role: .operator,
+    scopes: ["read", "write"],
+    bearerToken: "server-issued-token",
+    tokenHint: "abcd1234",
+    serverSPKISHA256: try MobileRemoteDaemonSPKIPin(validating: testSPKIPin),
+    pairedAt: Date(timeIntervalSince1970: 1_752_124_405)
+  )
+}
+
+private func pairingPayload(from url: URL) throws -> String {
+  let payload = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+    .queryItems?
+    .first { $0.name == "payload" }?
+    .value
+  return try XCTUnwrap(payload)
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
@@ -151,6 +151,14 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
     XCTAssertTrue(description.contains("abcd1234"))
   }
 
+  func testAdminRoleCanReadBeforeScopeExpansion() throws {
+    var access = try remoteAccess()
+    access.role = .admin
+    access.scopes = []
+
+    XCTAssertTrue(access.canRead)
+  }
+
   func testCredentialDebugDescriptionRedactsRemoteBearerToken() throws {
     let credential = MobilePairedStationCredential(
       stationID: "remote-daemon-example-com",

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTransportTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTransportTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import HarnessMonitorCrypto
+import XCTest
+
+final class MobileRemoteDaemonPairingTransportTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    RemotePairingURLProtocol.reset()
+  }
+
+  override func tearDown() {
+    RemotePairingURLProtocol.reset()
+    super.tearDown()
+  }
+
+  func testClaimPostsOneTimeCodeAndClientIdentity() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    RemotePairingURLProtocol.respond(
+      statusCode: 201,
+      body: """
+        {
+          "client_id": "ios-device-fingerprint",
+          "display_name": "Bart's iPhone",
+          "platform": "ios",
+          "role": "operator",
+          "scopes": ["read", "write"],
+          "token": "server-issued-token",
+          "token_hint": "abcd1234",
+          "paired_at": "2025-07-10T14:33:25Z"
+        }
+        """
+    )
+    let session = makeSession()
+    let transport = URLSessionMobileRemoteDaemonPairingTransport { _ in session }
+    let invitation = try MobileRemoteDaemonPairingInvitation.decode(
+      remoteInvitationURL(now: now),
+      now: now
+    )
+
+    let claim = try await transport.claim(
+      invitation: invitation,
+      clientID: "ios-device-fingerprint",
+      displayName: "Bart's iPhone",
+      platform: "ios"
+    )
+
+    let request = try XCTUnwrap(RemotePairingURLProtocol.lastRequest)
+    XCTAssertEqual(
+      request.url?.absoluteString,
+      "https://daemon.example.com/v1/remote/pair/claim"
+    )
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    let body = try XCTUnwrap(RemotePairingURLProtocol.lastRequestBody)
+    let object = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: body) as? [String: String]
+    )
+    XCTAssertEqual(object["code"], "one-time-code")
+    XCTAssertEqual(object["domain"], "daemon.example.com")
+    XCTAssertEqual(object["client_id"], "ios-device-fingerprint")
+    XCTAssertEqual(object["display_name"], "Bart's iPhone")
+    XCTAssertEqual(object["platform"], "ios")
+    XCTAssertEqual(claim.token, "server-issued-token")
+    XCTAssertEqual(claim.role, .operator)
+    XCTAssertEqual(claim.scopes, ["read", "write"])
+  }
+
+  func testClaimRejectsServerIdentityMismatch() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    RemotePairingURLProtocol.respond(
+      statusCode: 200,
+      body: """
+        {
+          "client_id": "different-client",
+          "display_name": "Bart's iPhone",
+          "platform": "ios",
+          "role": "viewer",
+          "scopes": ["read"],
+          "token": "server-issued-token",
+          "token_hint": "abcd1234",
+          "paired_at": "2025-07-10T14:33:25Z"
+        }
+        """
+    )
+    let session = makeSession()
+    let transport = URLSessionMobileRemoteDaemonPairingTransport { _ in session }
+    let invitation = try MobileRemoteDaemonPairingInvitation.decode(
+      remoteInvitationURL(now: now),
+      now: now
+    )
+
+    do {
+      _ = try await transport.claim(
+        invitation: invitation,
+        clientID: "ios-device-fingerprint",
+        displayName: "Bart's iPhone",
+        platform: "ios"
+      )
+      XCTFail("expected claim mismatch")
+    } catch let error as MobileRemoteDaemonPairingError {
+      XCTAssertEqual(error, .claimMismatch)
+    }
+  }
+
+  private func makeSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [RemotePairingURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+
+  private func remoteInvitationURL(now: Date) throws -> URL {
+    let payload: [String: Any] = [
+      "version": 1,
+      "endpoint": "https://daemon.example.com",
+      "code": "one-time-code",
+      "server_spki_sha256": "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY=",
+      "role": "operator",
+      "scopes": ["read", "write"],
+      "expires_at": ISO8601DateFormatter().string(from: now.addingTimeInterval(600)),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+    let encoded =
+      data.base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+    return try XCTUnwrap(
+      URL(string: "harness://remote-pair?payload=\(encoded)")
+    )
+  }
+}
+
+private final class RemotePairingURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var responseStatusCode = 200
+  nonisolated(unsafe) private static var responseBody = Data()
+  nonisolated(unsafe) private static var capturedRequest: URLRequest?
+  nonisolated(unsafe) private static var capturedRequestBody: Data?
+
+  static var lastRequest: URLRequest? {
+    lock.withLock { capturedRequest }
+  }
+
+  static var lastRequestBody: Data? {
+    lock.withLock { capturedRequestBody }
+  }
+
+  static func reset() {
+    lock.withLock {
+      responseStatusCode = 200
+      responseBody = Data()
+      capturedRequest = nil
+      capturedRequestBody = nil
+    }
+  }
+
+  static func respond(statusCode: Int, body: String) {
+    lock.withLock {
+      responseStatusCode = statusCode
+      responseBody = Data(body.utf8)
+    }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let requestBody = request.httpBody ?? request.httpBodyStream.flatMap(Self.readBodyStream)
+    let state = Self.lock.withLock { () -> (Int, Data) in
+      Self.capturedRequest = request
+      Self.capturedRequestBody = requestBody
+      return (Self.responseStatusCode, Self.responseBody)
+    }
+    guard let url = request.url,
+      let response = HTTPURLResponse(
+        url: url,
+        statusCode: state.0,
+        httpVersion: "HTTP/1.1",
+        headerFields: ["Content-Type": "application/json"]
+      )
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: state.1)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+
+  private static func readBodyStream(_ stream: InputStream) -> Data? {
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 1_024)
+    while stream.hasBytesAvailable {
+      let count = stream.read(&buffer, maxLength: buffer.count)
+      guard count >= 0 else { return nil }
+      if count == 0 { break }
+      data.append(buffer, count: count)
+    }
+    return data
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonTransportSecurityTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonTransportSecurityTests.swift
@@ -1,0 +1,88 @@
+import CryptoKit
+import Foundation
+import Security
+import XCTest
+
+@testable import HarnessMonitorCrypto
+
+final class MobileRemoteDaemonTransportSecurityTests: XCTestCase {
+  func testExtractorMatchesDaemonSPKIPin() throws {
+    let certificateDER = try XCTUnwrap(Data(base64Encoded: Self.certificateBase64))
+
+    let spkiDER = try MobileRemoteDaemonSPKIDERExtractor.extract(from: certificateDER)
+    let pin = "sha256/\(Data(SHA256.hash(data: spkiDER)).base64EncodedString())"
+
+    XCTAssertEqual(pin, Self.validPin)
+  }
+
+  func testTrustEvaluatorAcceptsMatchingPinAndRejectsMismatch() throws {
+    let trust = try makeTrust()
+    let matching = MobileRemoteDaemonServerTrustEvaluator(
+      pin: try MobileRemoteDaemonSPKIPin(validating: Self.validPin)
+    )
+    let mismatched = MobileRemoteDaemonServerTrustEvaluator(
+      pin: try MobileRemoteDaemonSPKIPin(
+        validating: "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      )
+    )
+
+    XCTAssertTrue(matching.evaluate(trust))
+    XCTAssertFalse(mismatched.evaluate(trust))
+  }
+
+  func testURLSessionFactoryInstallsPinningDelegate() throws {
+    let pin = try MobileRemoteDaemonSPKIPin(validating: Self.validPin)
+
+    let session = MobileRemoteDaemonURLSessionFactory.make(
+      configuration: .ephemeral,
+      pin: pin
+    )
+    defer { session.invalidateAndCancel() }
+
+    XCTAssertTrue(session.delegate is MobileRemoteDaemonURLSessionDelegate)
+  }
+
+  private func makeTrust() throws -> SecTrust {
+    let certificateData = try XCTUnwrap(Data(base64Encoded: Self.certificateBase64))
+    let certificate = try XCTUnwrap(
+      SecCertificateCreateWithData(nil, certificateData as CFData)
+    )
+    var trust: SecTrust?
+    XCTAssertEqual(
+      SecTrustCreateWithCertificates(certificate, SecPolicyCreateBasicX509(), &trust),
+      errSecSuccess
+    )
+    let resolvedTrust = try XCTUnwrap(trust)
+    XCTAssertEqual(
+      SecTrustSetAnchorCertificates(resolvedTrust, [certificate] as CFArray),
+      errSecSuccess
+    )
+    XCTAssertEqual(SecTrustSetAnchorCertificatesOnly(resolvedTrust, true), errSecSuccess)
+    let verifyDate = try XCTUnwrap(
+      ISO8601DateFormatter().date(from: "2026-07-10T04:00:00Z")
+    )
+    XCTAssertEqual(SecTrustSetVerifyDate(resolvedTrust, verifyDate as CFDate), errSecSuccess)
+    return resolvedTrust
+  }
+
+  private static let validPin = "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+  private static let certificateBase64 = """
+    MIIDGzCCAgOgAwIBAgIUO6qbgSSvho2GLuSvxiWE6x7/H+wwDQYJKoZIhvcNAQEL
+    BQAwHTEbMBkGA1UEAwwSZGFlbW9uLmV4YW1wbGUuY29tMB4XDTI2MDcwOTExNTAx
+    MloXDTI2MDcxMDExNTAxMlowHTEbMBkGA1UEAwwSZGFlbW9uLmV4YW1wbGUuY29t
+    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApCKXa4o1OtABLolsV/fs
+    E1njTM+x0qBJFKYVW+3Pi8MCAnnQZ+yYzQ4D8Wfv1zjOy1Y/UYdIiqxBFLNp0erD
+    xW+b4kuHSKuGDb15ZAys6iRA5bcTKnz8QGKVzmFIwAbS4dPJNzRb7AuDqpOE0Hxh
+    E6kF/sa/GFz+aW1adDvZZkYrszUPn/3C2DvBjZFEwQgmEX4CUuNySw43tHh+EjFP
+    nt+Bl5yRazZ/WNfDM3pjjnJcxaYNgP8wv1Hf4AAZqnVi17sH9Z7e3ChJZQF/fNgJ
+    0+IOd5z9Q9QTlmDgeVgTIn4cgPFs9VKmCsjByek0bIRlybwl4jhuut6KhvrnXCFY
+    DwIDAQABo1MwUTAdBgNVHQ4EFgQUEQWSux09fVAsGngLhkNIpOgPzj0wHwYDVR0j
+    BBgwFoAUEQWSux09fVAsGngLhkNIpOgPzj0wDwYDVR0TAQH/BAUwAwEB/zANBgkq
+    hkiG9w0BAQsFAAOCAQEAEPjbUJyM/J/wBxMIK4JrAJEX2hmkhpHGCp88OKavf6W/
+    IalWjl70Df+FSc5yBePFKjUUo6S96r5Q4CXBx+DNfRgN26HDk2w55eivYnmi1nNc
+    VHs+G7SrVjiNijOgozt45HQR4CvAgPxcZoGu1U4lmprrx7HaWIC+56y6MFghb4Kg
+    +InZkMWy6ySoFbYjMSsPBifaKnuF1NUTPjL0VE8oNyNftIvFjjZuctvHjhlK+FMP
+    Tys9LeCcV0h6PMHH+/hQLJC4R3RuS2uu55KtmTnhHMjNB3M56XfWb/y18n3GVkys
+    yy4u0xXmF216ZT32j2SxkTQxQOVG9EqmwaZUcuACYQ==
+    """.filter { !$0.isWhitespace }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonAuthenticationHeaderTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonAuthenticationHeaderTests.swift
@@ -43,7 +43,8 @@ struct RemoteDaemonAuthenticationHeaderTests {
   func localRequestsOmitClientID() throws {
     let connection = HarnessMonitorConnection(
       endpoint: URL(string: "http://127.0.0.1:7777")!,
-      token: "local-token"
+      token: "local-token",
+      remoteClientID: "must-not-leak"
     )
     let client = HarnessMonitorAPIClient(
       connection: connection,

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonAuthenticationHeaderTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonAuthenticationHeaderTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import HarnessMonitorKit
+
+@Suite("Remote daemon authentication headers")
+struct RemoteDaemonAuthenticationHeaderTests {
+  @Test("HTTP and WebSocket requests bind the remote client id")
+  func remoteRequestsIncludeClientID() async throws {
+    let connection = HarnessMonitorConnection(
+      endpoint: URL(string: "https://daemon.example.com")!,
+      token: "opaque-token",
+      remoteClientID: "macos-client-1",
+      source: .remote(profileID: UUID())
+    )
+    let client = HarnessMonitorAPIClient(
+      connection: connection,
+      session: URLSession(configuration: .ephemeral)
+    )
+    let httpRequest = try client.makeRequest(path: "/v1/sessions")
+    var webSocketRequest = URLRequest(url: URL(string: "wss://daemon.example.com/v1/ws")!)
+    let webSocket = WebSocketTransport(connection: connection)
+    await webSocket.applyHandshakeHeaders(to: &webSocketRequest)
+
+    #expect(
+      httpRequest.value(forHTTPHeaderField: "x-harness-remote-client-id")
+        == "macos-client-1"
+    )
+    #expect(
+      webSocketRequest.value(forHTTPHeaderField: "x-harness-remote-client-id")
+        == "macos-client-1"
+    )
+    #expect(httpRequest.value(forHTTPHeaderField: "Authorization") == "Bearer opaque-token")
+    #expect(
+      webSocketRequest.value(forHTTPHeaderField: "Authorization") == "Bearer opaque-token"
+    )
+
+    await client.shutdown()
+    await webSocket.shutdown()
+  }
+
+  @Test("Local requests omit the remote client id")
+  func localRequestsOmitClientID() throws {
+    let connection = HarnessMonitorConnection(
+      endpoint: URL(string: "http://127.0.0.1:7777")!,
+      token: "local-token"
+    )
+    let client = HarnessMonitorAPIClient(
+      connection: connection,
+      session: URLSession(configuration: .ephemeral)
+    )
+
+    let request = try client.makeRequest(path: "/v1/sessions")
+
+    #expect(request.value(forHTTPHeaderField: "x-harness-remote-client-id") == nil)
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonProfilePersistenceTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonProfilePersistenceTests.swift
@@ -66,6 +66,7 @@ struct RemoteDaemonProfilePersistenceTests {
 
     #expect(connection.endpoint == profile.endpoint)
     #expect(connection.token == "opaque-bearer-secret")
+    #expect(connection.remoteClientID == profile.clientID)
     #expect(connection.serverTrust == .spkiSHA256(profile.serverSPKISHA256))
     #expect(connection.source == .remote(profileID: profile.id))
   }

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
@@ -1,0 +1,372 @@
+import Foundation
+import HarnessMonitorCloudMirror
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+import XCTest
+
+final class MobileRemoteDaemonSyncClientTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    RemoteDaemonSessionsURLProtocol.reset()
+  }
+
+  override func tearDown() {
+    RemoteDaemonSessionsURLProtocol.reset()
+    super.tearDown()
+  }
+
+  func testFetchBuildsAuthenticatedRemoteSessionsSnapshot() async throws {
+    RemoteDaemonSessionsURLProtocol.respond(statusCode: 200, body: sessionsResponse)
+    let client = MobileRemoteDaemonSyncClient(
+      access: try remoteAccess(),
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      session: makeSession()
+    )
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+
+    let fetchedSnapshot = try await client.fetchLatestSnapshot(
+      stationID: "remote-daemon-example-com",
+      now: now
+    )
+    let snapshot = try XCTUnwrap(fetchedSnapshot)
+
+    let request = try XCTUnwrap(RemoteDaemonSessionsURLProtocol.lastRequest)
+    XCTAssertEqual(request.url?.absoluteString, "https://daemon.example.com/v1/sessions")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer server-token")
+    XCTAssertEqual(
+      request.value(forHTTPHeaderField: "x-harness-remote-client-id"),
+      "ios-device"
+    )
+    XCTAssertEqual(snapshot.generatedAt, now)
+    XCTAssertEqual(snapshot.expiresAt, now.addingTimeInterval(60))
+    XCTAssertEqual(snapshot.stations.first?.state, .online)
+    XCTAssertEqual(snapshot.stations.first?.activeSessionCount, 1)
+    XCTAssertEqual(snapshot.sessions.first?.id, "session-1")
+    XCTAssertEqual(snapshot.sessions.first?.status, "Active")
+    XCTAssertEqual(snapshot.sessions.first?.activeAgentCount, 2)
+    XCTAssertEqual(snapshot.sessions.first?.blockedAgentCount, 1)
+    XCTAssertFalse(snapshot.sessions.first?.summary.contains("super-secret") ?? true)
+    XCTAssertFalse(client.supportsCommands)
+  }
+
+  func testUnauthorizedDirectResponseDoesNotUseCloudFallback() async throws {
+    let fallback = RecordingSyncClient(snapshot: snapshotFixture())
+    let client = DirectFirstMobileMonitorSyncClient(
+      direct: ThrowingSyncClient(error: MobileRemoteDaemonSyncError.unauthorized),
+      cloudFallback: fallback
+    )
+
+    do {
+      _ = try await client.fetchLatestSnapshot(stationID: "station-1", now: .now)
+      XCTFail("expected unauthorized error")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .unauthorized)
+    }
+
+    let fetchCount = await fallback.fetchCount()
+    XCTAssertEqual(fetchCount, 0)
+  }
+
+  func testReachabilityFailureUsesCloudFallback() async throws {
+    let expected = snapshotFixture()
+    let fallback = RecordingSyncClient(snapshot: expected)
+    let client = DirectFirstMobileMonitorSyncClient(
+      direct: ThrowingSyncClient(error: URLError(.timedOut)),
+      cloudFallback: fallback
+    )
+
+    let snapshot = try await client.fetchLatestSnapshot(stationID: "station-1", now: .now)
+
+    XCTAssertEqual(snapshot, expected)
+    let fetchCount = await fallback.fetchCount()
+    XCTAssertEqual(fetchCount, 1)
+    XCTAssertFalse(client.supportsCommands)
+  }
+
+  func testRemoteServerFailureUsesCloudFallback() async throws {
+    let expected = snapshotFixture()
+    let fallback = RecordingSyncClient(snapshot: expected)
+    let client = DirectFirstMobileMonitorSyncClient(
+      direct: ThrowingSyncClient(error: MobileRemoteDaemonSyncError.serverStatus(503)),
+      cloudFallback: fallback
+    )
+
+    let snapshot = try await client.fetchLatestSnapshot(stationID: "station-1", now: .now)
+
+    XCTAssertEqual(snapshot, expected)
+    let fetchCount = await fallback.fetchCount()
+    XCTAssertEqual(fetchCount, 1)
+  }
+
+  func testForbiddenDirectResponseDoesNotUseCloudFallback() async throws {
+    let fallback = RecordingSyncClient(snapshot: snapshotFixture())
+    let client = DirectFirstMobileMonitorSyncClient(
+      direct: ThrowingSyncClient(error: MobileRemoteDaemonSyncError.forbidden),
+      cloudFallback: fallback
+    )
+
+    do {
+      _ = try await client.fetchLatestSnapshot(stationID: "station-1", now: .now)
+      XCTFail("expected forbidden error")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .forbidden)
+    }
+
+    let fetchCount = await fallback.fetchCount()
+    XCTAssertEqual(fetchCount, 0)
+  }
+
+  func testHybridClientRejectsCommandsWithoutUsingCloudRevision() async throws {
+    let cloud = RecordingSyncClient(snapshot: snapshotFixture())
+    let client = DirectFirstMobileMonitorSyncClient(
+      direct: ThrowingSyncClient(error: URLError(.timedOut)),
+      cloudFallback: cloud
+    )
+
+    do {
+      _ = try await client.queueCommand(
+        commandFixture(),
+        currentRevision: 99,
+        now: .now
+      )
+      XCTFail("expected commands unavailable")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .commandsUnavailable)
+    }
+
+    let commandAttempts = await cloud.commandAttemptCount()
+    XCTAssertEqual(commandAttempts, 0)
+  }
+
+  func testFactoryBuildsDirectOnlyClientForRemoteCredential() throws {
+    let credential = MobilePairedStationCredential(
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      endpoint: URL(string: "https://daemon.example.com")!,
+      stationPublicKeyFingerprint: testSPKIPin,
+      deviceIdentityID: "default-mobile-device",
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: .now,
+      defaultStation: true,
+      remoteDaemonAccess: try remoteAccess()
+    )
+    let identity = MobileDeviceIdentity(
+      id: "default-mobile-device",
+      displayName: "Phone",
+      createdAt: .now
+    )
+
+    let client = LiveMobileMonitorSyncClientFactory().makeSyncClient(
+      credential: credential,
+      identity: identity
+    )
+
+    XCTAssertFalse(client.supportsCommands)
+  }
+
+  private func makeSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [RemoteDaemonSessionsURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+}
+
+private struct ThrowingSyncClient: MobileMonitorSyncClient {
+  let error: any Error
+  var supportsCommands: Bool { false }
+
+  func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot? {
+    throw error
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileQueuedCommand {
+    throw error
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw error
+  }
+}
+
+private actor RecordingSyncClient: MobileMonitorSyncClient {
+  private let snapshot: MobileMirrorSnapshot?
+  private var fetches = 0
+  private var commandAttempts = 0
+
+  init(snapshot: MobileMirrorSnapshot?) {
+    self.snapshot = snapshot
+  }
+
+  func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot? {
+    fetches += 1
+    return snapshot
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileQueuedCommand {
+    commandAttempts += 1
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    commandAttempts += 1
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func fetchCount() -> Int {
+    fetches
+  }
+
+  func commandAttemptCount() -> Int {
+    commandAttempts
+  }
+}
+
+private final class RemoteDaemonSessionsURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var responseStatusCode = 200
+  nonisolated(unsafe) private static var responseBody = Data()
+  nonisolated(unsafe) private static var recordedRequest: URLRequest?
+
+  static var lastRequest: URLRequest? {
+    lock.withLock { recordedRequest }
+  }
+
+  static func reset() {
+    lock.withLock {
+      responseStatusCode = 200
+      responseBody = Data()
+      recordedRequest = nil
+    }
+  }
+
+  static func respond(statusCode: Int, body: String) {
+    lock.withLock {
+      responseStatusCode = statusCode
+      responseBody = Data(body.utf8)
+    }
+  }
+
+  override static func canInit(with request: URLRequest) -> Bool { true }
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let response: (Int, Data) = Self.lock.withLock {
+      Self.recordedRequest = request
+      return (Self.responseStatusCode, Self.responseBody)
+    }
+    guard let url = request.url,
+      let httpResponse = HTTPURLResponse(
+        url: url,
+        statusCode: response.0,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )
+    else {
+      return
+    }
+    client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: response.1)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
+private let testSPKIPin = "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+
+private let sessionsResponse = """
+  [
+    {
+      "project_name": "Harness",
+      "session_id": "session-1",
+      "title": "Remote work",
+      "branch_ref": "main",
+      "status": "active",
+      "context": "api_key=super-secret",
+      "updated_at": "2026-07-10T13:00:00Z",
+      "last_activity_at": "2026-07-10T13:01:00Z",
+      "metrics": {
+        "active_agent_count": 2,
+        "awaiting_review_agent_count": 1
+      }
+    },
+    {
+      "project_name": "Harness",
+      "session_id": "session-2",
+      "title": "Finished work",
+      "branch_ref": "feature/done",
+      "status": "ended",
+      "context": "done",
+      "updated_at": "2026-07-09T13:00:00Z",
+      "metrics": {}
+    }
+  ]
+  """
+
+private func remoteAccess() throws -> MobileRemoteDaemonAccess {
+  MobileRemoteDaemonAccess(
+    endpoint: URL(string: "https://daemon.example.com")!,
+    clientID: "ios-device",
+    displayName: "Phone",
+    platform: "ios",
+    role: .viewer,
+    scopes: ["read"],
+    bearerToken: "server-token",
+    tokenHint: "abcd1234",
+    serverSPKISHA256: try MobileRemoteDaemonSPKIPin(validating: testSPKIPin),
+    pairedAt: .now
+  )
+}
+
+private func commandFixture() -> MobileCommandRecord {
+  let now = Date(timeIntervalSince1970: 1_752_124_400)
+  return MobileCommandRecord(
+    id: "command-1",
+    stationID: "station-1",
+    kind: .refresh,
+    risk: .low,
+    status: .draft,
+    title: "Refresh",
+    confirmationText: "Refresh station",
+    target: MobileCommandTarget(stationID: "station-1", targetRevision: 99),
+    actorDeviceID: "ios-device-fingerprint",
+    createdAt: now,
+    expiresAt: now.addingTimeInterval(600),
+    updatedAt: now
+  )
+}
+
+private func snapshotFixture() -> MobileMirrorSnapshot {
+  let now = Date(timeIntervalSince1970: 1_752_124_400)
+  return MobileMirrorSnapshot(
+    revision: 7,
+    generatedAt: now,
+    expiresAt: now.addingTimeInterval(60),
+    stations: [],
+    attention: [],
+    sessions: [],
+    reviews: [],
+    commands: [],
+    trustedDevices: []
+  )
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
@@ -290,6 +290,7 @@ private final class RemoteDaemonSessionsURLProtocol: URLProtocol, @unchecked Sen
         headerFields: ["Content-Type": "application/json"]
       )
     else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
       return
     }
     client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
@@ -22,6 +22,7 @@ final class MobileRemoteDaemonSyncClientTests: XCTestCase {
       access: try remoteAccess(),
       stationID: "remote-daemon-example-com",
       stationName: "daemon.example.com",
+      defaultStation: false,
       session: makeSession()
     )
     let now = Date(timeIntervalSince1970: 1_752_124_400)
@@ -44,10 +45,16 @@ final class MobileRemoteDaemonSyncClientTests: XCTestCase {
     XCTAssertEqual(snapshot.revision, 0)
     XCTAssertEqual(snapshot.stations.first?.state, .online)
     XCTAssertEqual(snapshot.stations.first?.activeSessionCount, 1)
+    XCTAssertEqual(snapshot.stations.first?.defaultStation, false)
     XCTAssertEqual(snapshot.sessions.first?.id, "session-1")
     XCTAssertEqual(snapshot.sessions.first?.status, "Active")
     XCTAssertEqual(snapshot.sessions.first?.activeAgentCount, 2)
     XCTAssertEqual(snapshot.sessions.first?.blockedAgentCount, 1)
+    let expectedActivity = try Date.ISO8601FormatStyle().year().month().day()
+      .timeZone(separator: .omitted)
+      .time(includingFractionalSeconds: true)
+      .parse("2026-07-10T13:01:00.250Z")
+    XCTAssertEqual(snapshot.sessions.first?.lastActivityAt, expectedActivity)
     XCTAssertFalse(snapshot.sessions.first?.summary.contains("super-secret") ?? true)
     XCTAssertFalse(client.supportsCommands)
   }
@@ -305,7 +312,7 @@ private let sessionsResponse = """
       "status": "active",
       "context": "api_key=super-secret",
       "updated_at": "2026-07-10T13:00:00Z",
-      "last_activity_at": "2026-07-10T13:01:00Z",
+      "last_activity_at": "2026-07-10T13:01:00.250Z",
       "metrics": {
         "active_agent_count": 2,
         "awaiting_review_agent_count": 1

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
@@ -41,6 +41,7 @@ final class MobileRemoteDaemonSyncClientTests: XCTestCase {
     )
     XCTAssertEqual(snapshot.generatedAt, now)
     XCTAssertEqual(snapshot.expiresAt, now.addingTimeInterval(60))
+    XCTAssertEqual(snapshot.revision, 0)
     XCTAssertEqual(snapshot.stations.first?.state, .online)
     XCTAssertEqual(snapshot.stations.first?.activeSessionCount, 1)
     XCTAssertEqual(snapshot.sessions.first?.id, "session-1")

--- a/docs/agent-guides/monitor-mobile-reference.md
+++ b/docs/agent-guides/monitor-mobile-reference.md
@@ -6,13 +6,12 @@ The macOS app itself is covered by `apps/harness-monitor/AGENTS.md` and `monitor
 
 ## Product shape
 
-Harness Monitor on the phone and watch is a read-mostly mirror of the Mac's live monitor state with a narrow, audited write path back. There is no direct phone-to-daemon connection over the internet. Everything flows through three stages:
+Harness Monitor on the phone and watch is a read-mostly view of monitor state with two credential-driven transports:
 
-1. The Mac (`HarnessMonitorMacRelay`, embedded in the macOS app) reads live state from the harness daemon, redacts secrets, encrypts a snapshot, and publishes it.
-2. CloudKit (`HarnessMonitorCloudMirror`) carries opaque encrypted records between devices. Apple's servers only ever see ciphertext plus cleartext routing metadata.
-3. The phone and watch fetch and decrypt the mirror, render it, and can queue signed commands that travel back the same way for the Mac to validate and execute.
+1. A remote-daemon profile connects directly over pinned HTTPS. The phone claims a one-time remote pairing invitation, stores the bearer credential in its Keychain, and fetches authenticated session snapshots. The watch can use the same direct path after the phone transfers that profile through WatchConnectivity.
+2. A local-relay profile uses `HarnessMonitorMacRelay` and `HarnessMonitorCloudMirror`. The Mac redacts and encrypts a full snapshot, CloudKit carries only encrypted records plus routing metadata, and the phone/watch decrypt the mirror. Signed commands return through the same relay for the Mac to validate and execute.
 
-The phone is the pairing hub. You pair a phone to a Mac once over the local network, then the phone hands the resulting trust material to the watch over WatchConnectivity. The watch never runs the local-network pairing handshake itself.
+When a credential has both transports, direct access is tried first. CloudMirror is used only for reachability/TLS failures or remote 5xx responses; remote `401` and `403` responses fail closed. The phone remains the pairing hub for the watch. The watch does not run either pairing claim itself.
 
 ## Target and framework map
 
@@ -40,7 +39,9 @@ The macOS app, the iOS app, and the watch app all share the same iCloud containe
 
 `MobileMacRelayService.publishSnapshot()` runs the snapshot through a `MobileMirrorSecretRedactor`, folds in the current pending-command queue and per-station command counts, then writes it to the `MobileMirrorSnapshotSink`. The live sink (`MobileCloudMirrorRelaySnapshotSink`) encrypts the payload into a `MobileEncryptedEnvelope` and upserts it as a CloudKit record. Large snapshots are split into chunk records referenced by `chunkIDs`.
 
-On the device, `MobileCloudMirrorSyncClient.fetchLatestSnapshot(stationID:now:)` fetches the record(s), checks the `expiresAt` TTL (a stale record raises `MobileCloudMirrorSyncError.staleSnapshot`), decrypts and verifies the envelope with the per-station symmetric key, reassembles chunks, and returns a `MobileMirrorSnapshot`. The iOS `MobileMonitorStore.refresh()` aggregates across every paired station, merging each station's snapshot into one combined view via `mergingStationSnapshot`.
+On a relay-paired device, `MobileCloudMirrorSyncClient.fetchLatestSnapshot(stationID:now:)` fetches the record(s), checks the `expiresAt` TTL (a stale record raises `MobileCloudMirrorSyncError.staleSnapshot`), decrypts and verifies the envelope with the per-station symmetric key, reassembles chunks, and returns a `MobileMirrorSnapshot`.
+
+On a remote-paired device, `MobileRemoteDaemonSyncClient.fetchLatestSnapshot(stationID:now:)` sends an authenticated `GET /v1/sessions` to the pinned endpoint and maps the daemon's secret-free session fields into the shared snapshot model. `DirectFirstMobileMonitorSyncClient` applies the fail-closed fallback policy described above. The shared `MirrorStore.refresh()` aggregates every paired station through the same `MobileMonitorSyncClient` protocol.
 
 ### Device to Mac (command)
 
@@ -49,6 +50,8 @@ A command authored on the phone or watch is a `MobileCommandRecord` whose `kind`
 On the Mac, `MobileMacRelayService.executePendingCommands()` walks the pending queue. For each command it: validates the queue envelope (`validatingForQueue`), validates fresh state (`validatingFreshState` rejects a command whose authored revision no longer matches the current one), records an `accepted` then `running` receipt, runs the `MobileRelayCommandExecutor`, and records a terminal receipt (`succeeded`, `failed`, `expired`). Executor output is run back through the secret redactor. Receipts flow to the device through the same encrypted mirror, so the command tab reflects accepted → running → terminal transitions.
 
 Commands are idempotent on the Mac: `executedCommandIDs` guards against re-running a command if a duplicate mirror pass sees it again before its terminal receipt has propagated.
+
+Direct and direct-first profiles currently expose snapshots only because the daemon snapshot has no relay revision for fresh-state validation. A CloudMirror-only relay credential still carries commands; other profiles report commands unavailable instead of queuing against an invented revision.
 
 ## Pairing
 
@@ -60,9 +63,15 @@ The phone scans the QR with `MobilePairingScannerView` (VisionKit). `LiveMobileM
 
 Because the handshake uses the local network, the iOS app surfaces a dedicated `localNetworkDenied` sync state: if iOS has blocked Local Network access the QR scan cannot reach the Mac, and the app deep-links the user to Settings to grant it.
 
+### Phone to remote daemon (internet)
+
+`harness daemon remote pair create` produces a short-lived `harness://remote-pair` invitation containing the HTTPS endpoint, one-time code, requested role/scopes, expiry, and the daemon certificate's SPKI SHA-256 pin. The phone accepts the same QR, deep-link, and manual-entry flows as local pairing. `URLSessionMobileRemoteDaemonPairingTransport` claims `POST /v1/remote/pair/claim` through a pinning URLSession and binds the claim to a stable client id derived from the phone identity.
+
+The daemon returns an opaque per-client bearer token. `MobileRemoteDaemonPairingCoordinator` stores it only inside the existing Keychain-backed `MobilePairedStationCredential`, together with the endpoint, client id, role/scopes, token hint, paired time, and SPKI pin. Invitation endpoints must be plain HTTPS origins with no credentials, query, fragment, or path.
+
 ### Phone to watch (WatchConnectivity)
 
-The watch does not run the HTTP handshake. After the phone pairs, `MobileWatchPairingSessionBridge` serializes the device identities, station credentials, and an optional latest snapshot into a `MobileWatchPairingTransfer` and pushes it to the watch over WatchConnectivity. It uses all three delivery mechanisms for resilience: `sendMessage` when reachable, plus `updateApplicationContext` and `transferUserInfo` for background delivery. The watch can also pull on demand by sending a request payload, which the bridge answers from its cached or stored pairings. Payloads are capped at 60 KB. On the watch, `WatchPairingSessionReceiver` ingests the transfer and writes the same credential/identity material into the watch Keychain, so the watch can then talk to CloudMirror directly.
+The watch does not run a pairing claim. After the phone pairs, `MobileWatchPairingSessionBridge` serializes the device identities, station credentials, and an optional latest snapshot into a `MobileWatchPairingTransfer` and pushes it to the watch over WatchConnectivity. It uses all three delivery mechanisms for resilience: `sendMessage` when reachable, plus `updateApplicationContext` and `transferUserInfo` for background delivery. The watch can also pull on demand by sending a request payload, which the bridge answers from its cached or stored pairings. Payloads are capped at 60 KB. On the watch, `WatchPairingSessionReceiver` ingests the transfer and writes the same credential/identity material into the watch Keychain. Relay credentials select CloudMirror; remote credentials select the pinned direct client.
 
 ## CloudKit schema
 
@@ -92,6 +101,8 @@ The CloudKit schema must be deployed to the Production environment before TestFl
 ## Security model
 
 - End-to-end encryption. Payloads are sealed with `MobilePayloadCipher` (AEAD) under a per-station symmetric key that exists only on the paired Mac and the devices it trusts. CloudKit never holds the key.
+- Remote TLS pinning. Remote pairing and snapshots require HTTPS and validate both platform trust and the invitation's SPKI SHA-256 pin. A mismatched or untrusted certificate fails the request.
+- Remote bearer isolation. Each remote client has its own opaque token and client id. The token is persisted only in the device Keychain and redacted from debug descriptions. Authentication and authorization failures never trigger CloudMirror fallback.
 - Secret redaction. The Mac redacts secrets twice: once while building the snapshot (`+Redaction`) and again on command-execution output, via `MobileMirrorSecretRedactor`. Redaction runs before encryption, so a key compromise still does not expose un-redacted secrets that were never put in the payload.
 - Command signing + fresh-state validation. Commands are signed with a command-signing key distinct from the snapshot key, and the Mac rejects any command whose authored `revision` no longer matches current state. This prevents a stale or replayed command from acting on a board that has moved on.
 - Trust is per device. Each phone/watch has its own `MobileDeviceIdentity`; unpairing one device deletes only its credential and, if no sibling credential shares the identity, its identity too.
@@ -102,7 +113,7 @@ The CloudKit schema must be deployed to the Production environment before TestFl
 
 Entry point `HarnessMonitorMobileApp` installs a `MobileAppDelegate` (UIKit adaptor) and constructs a single `MobileMonitorStore` with Keychain-backed identity and credential stores, the live pairer, and the WatchConnectivity bridge.
 
-- State. `MobileMonitorStore` is a `@MainActor @Observable` class holding the aggregate `snapshot`, `selectedStationID`, `syncStatus`, paired credentials, and notification settings. It builds one `MobileMonitorSyncClient` per paired station through a factory, so the live path and tests can swap transports. Its extensions split by concern: `+Sync` (refresh/pairing/unpair), `+Commands`, `+Privacy`, `+Internals`.
+- State. `MobileMonitorStore` is a `@MainActor @Observable` class holding the aggregate `snapshot`, `selectedStationID`, `syncStatus`, paired credentials, and notification settings. It builds one `MobileMonitorSyncClient` per paired station through a factory, selecting direct, CloudMirror, or direct-first-with-fallback from the credential. Its extensions split by concern: `+Sync` (refresh/pairing/unpair), `+Commands`, `+Privacy`, `+Internals`.
 - Tabs. `MobileRootView` is a `TabView`: Today, Sessions, Reviews, Commands, Settings. `MobileRootTab` also parses `harness://` deep links to a tab.
 - Sync status. `MobileMonitorSyncStatus` is the single source of UI truth for connection state: `unpaired`, `demo`, `pairing`, `syncing`, `live`, `stale`, `localNetworkDenied`, `paired`, `privacy`, and the command outcomes. Each case carries a title, subtitle, and SF Symbol.
 - Demo mode. On by default in the Simulator (App Review and screenshots get `MobileDemoFixtures` data with no real Mac), off on device. Pairing a real Mac clears demo mode.
@@ -113,7 +124,7 @@ Entry point `HarnessMonitorMobileApp` installs a `MobileAppDelegate` (UIKit adap
 
 ## Watch app structure
 
-The watch app is a separate watchOS product embedded in the iOS app, not a macOS extension. It has its own `WatchMonitorStore` (do not confuse it with the iOS `MobileMonitorStore`) that builds `MobileCloudMirrorSyncClient`s directly from the credentials the phone transferred. `RootView`, `WatchCommandComposerView`, and `WatchMonitorStoreRefresh` make up the UI and refresh loop; `WatchPairingSessionReceiver` ingests the WatchConnectivity transfer.
+The watch app is a separate watchOS product embedded in the iOS app, not a macOS extension. It has its own `WatchMonitorStore` (do not confuse it with the iOS `MobileMonitorStore`) that builds direct and/or CloudMirror clients from credentials transferred by the phone. `RootView`, `WatchCommandComposerView`, and `WatchMonitorStoreRefresh` make up the UI and refresh loop; `WatchPairingSessionReceiver` ingests the WatchConnectivity transfer.
 
 ### NeedsMe vs CloudMirror
 
@@ -134,9 +145,9 @@ Shared schemes (in `Project.swift`):
 
 - `HarnessMonitorMobile` — builds the iOS app + widgets + Core/Crypto/CloudMirror; run on an iOS Simulator or device.
 - `HarnessMonitorWatch` — builds and runs the watch app on a watchOS Simulator or device.
-- `HarnessMonitorMobileFoundationTests` — runs the four shared-framework test targets together with coverage: `HarnessMonitorCoreTests`, `HarnessMonitorCryptoTests`, `HarnessMonitorCloudMirrorTests`, `HarnessMonitorMacRelayTests`. There are also per-framework test schemes (`HarnessMonitorCryptoTests`, `HarnessMonitorCloudMirrorTests`, `HarnessMonitorMacRelayTests`).
+- `HarnessMonitorMobileFoundationTests` — runs the five shared-framework test targets together with coverage: `HarnessMonitorCoreTests`, `HarnessMonitorMirrorStoreTests`, `HarnessMonitorCryptoTests`, `HarnessMonitorCloudMirrorTests`, and `HarnessMonitorMacRelayTests`. There are also per-framework test schemes.
 
-Where the logic is tested: the iOS app and watch app targets have no unit tests of their own — they are thin SwiftUI shells over the shared frameworks. The behavior lives in (and is tested through) the four framework test targets, all of which run on the macOS destination. That is why the mobile/watch test gate is a macOS test run, not a Simulator run.
+Where the logic is tested: the iOS app and watch app targets have no unit tests of their own — they are thin SwiftUI shells over the shared frameworks. The behavior lives in (and is tested through) the five framework test targets, all of which run on the macOS destination. That is why the mobile/watch test gate is a macOS test run, not a Simulator run.
 
 Run the shared-framework tests (macOS, no Simulator needed) through the xcodebuild lane wrapper from the repo root, in a dedicated build lane so you do not stomp the user's Cmd+R DerivedData:
 


### PR DESCRIPTION
## Motivation
Remote daemons are internet-reachable, but iPhone and watch still depend on the CloudKit relay. The macOS remote transport also omitted the daemon-required client id header.

## Implementation
- Add remote pairing profiles with Keychain bearer storage and SPKI-pinned HTTPS
- Fetch authenticated session snapshots directly on iPhone and watch, with fail-closed CloudMirror fallback rules
- Transfer remote profiles to watch through the existing WatchConnectivity bundle
- Bind macOS and mobile HTTP/WSS requests to the authenticated remote client id
- Add red-green tests for pairing, pinning, Keychain rotation, auth, fallback, and platform builds

Follows the automatic ACME renewal work in #200.