### PR TITLE
feat(remote): enable secure mobile commands

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
@@ -94,6 +94,10 @@ public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStri
   public var canRead: Bool {
     role == .admin || scopes.contains("read")
   }
+
+  public var canWrite: Bool {
+    role == .admin || scopes.contains("write")
+  }
 }
 
 public struct MobileRemoteDaemonPairingInvitation: Codable, Equatable, Sendable {

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/DirectFirstMobileMonitorSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/DirectFirstMobileMonitorSyncClient.swift
@@ -15,7 +15,7 @@ public struct DirectFirstMobileMonitorSyncClient: MobileMonitorSyncClient, Senda
   }
 
   public var supportsCommands: Bool {
-    false
+    direct.supportsCommands || cloudFallback.supportsCommands
   }
 
   public func fetchLatestSnapshot(
@@ -36,7 +36,21 @@ public struct DirectFirstMobileMonitorSyncClient: MobileMonitorSyncClient, Senda
     _ command: MobileCommandRecord,
     currentRevision: Int64,
     now: Date
-  ) async throws -> MobileQueuedCommand {
+  ) async throws -> MobileCommandSubmission {
+    if direct.supportsCommands {
+      return try await direct.queueCommand(
+        command,
+        currentRevision: currentRevision,
+        now: now
+      )
+    }
+    if cloudFallback.supportsCommands {
+      return try await cloudFallback.queueCommand(
+        command,
+        currentRevision: currentRevision,
+        now: now
+      )
+    }
     throw MobileRemoteDaemonSyncError.commandsUnavailable
   }
 
@@ -45,6 +59,16 @@ public struct DirectFirstMobileMonitorSyncClient: MobileMonitorSyncClient, Senda
     currentRevision: Int64,
     now: Date
   ) async throws -> MobileCommandReceipt {
+    guard !direct.supportsCommands else {
+      throw MobileRemoteDaemonSyncError.commandsUnavailable
+    }
+    if cloudFallback.supportsCommands {
+      return try await cloudFallback.cancelCommand(
+        command,
+        currentRevision: currentRevision,
+        now: now
+      )
+    }
     throw MobileRemoteDaemonSyncError.commandsUnavailable
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Commands.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Commands.swift
@@ -79,16 +79,21 @@ extension MirrorStore {
       return
     }
     do {
-      let queued = try await syncClient.queueCommand(
+      let submission = try await syncClient.queueCommand(
         command,
         currentRevision: snapshot.revision,
         now: now
       )
-      snapshot.commands.insert(queued.signedCommand.command, at: 0)
+      snapshot.commands.insert(submission.command, at: 0)
       selectedStationID = command.stationID
       persistSharedSnapshot(snapshot)
       reconcileLiveActivity(snapshot)
-      syncStatus = .commandQueued(now)
+      let submissionStatus: MirrorSyncStatus
+      switch submission.disposition {
+      case .queued: submissionStatus = .commandQueued(now)
+      case .completed: submissionStatus = .commandCompleted(now)
+      }
+      syncStatus = submissionStatus
     } catch {
       syncStatus = .commandFailed(String(describing: error))
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorSyncStatus.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorSyncStatus.swift
@@ -20,6 +20,7 @@ public enum MirrorSyncStatus: Equatable, Sendable {
   case paired(String)
   case privacy(String)
   case commandQueued(Date)
+  case commandCompleted(Date)
   case commandCancelled(Date)
   case commandFailed(String)
 
@@ -36,6 +37,7 @@ public enum MirrorSyncStatus: Equatable, Sendable {
     case .paired: "key.horizontal"
     case .privacy: "checkmark.shield"
     case .commandQueued: "checkmark.seal"
+    case .commandCompleted: "checkmark.circle"
     case .commandCancelled: "xmark.seal"
     case .commandFailed: "xmark.octagon"
     }
@@ -57,7 +59,7 @@ public enum MirrorSyncStatus: Equatable, Sendable {
     case .stale, .localNetworkDenied, .iCloudAccountUnavailable:
       true
     case .unpaired, .demo, .pairing, .syncing, .live, .paired, .privacy,
-      .commandQueued, .commandCancelled, .commandFailed:
+      .commandQueued, .commandCompleted, .commandCancelled, .commandFailed:
       false
     }
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileMonitorSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileMonitorSyncClient.swift
@@ -3,6 +3,24 @@ import HarnessMonitorCloudMirror
 import HarnessMonitorCore
 import HarnessMonitorCrypto
 
+public enum MobileCommandSubmissionDisposition: Equatable, Sendable {
+  case queued
+  case completed
+}
+
+public struct MobileCommandSubmission: Equatable, Sendable {
+  public var command: MobileCommandRecord
+  public var disposition: MobileCommandSubmissionDisposition
+
+  public init(
+    command: MobileCommandRecord,
+    disposition: MobileCommandSubmissionDisposition = .queued
+  ) {
+    self.command = command
+    self.disposition = disposition
+  }
+}
+
 /// The mobile sync operations the shared store depends on. Tests inject fakes;
 /// live credentials select direct remote access, CloudMirror, or both.
 public protocol MobileMonitorSyncClient: Sendable {
@@ -12,7 +30,7 @@ public protocol MobileMonitorSyncClient: Sendable {
     _ command: MobileCommandRecord,
     currentRevision: Int64,
     now: Date
-  ) async throws -> MobileQueuedCommand
+  ) async throws -> MobileCommandSubmission
   func cancelCommand(
     _ command: MobileCommandRecord,
     currentRevision: Int64,
@@ -21,10 +39,8 @@ public protocol MobileMonitorSyncClient: Sendable {
 }
 
 extension MobileMonitorSyncClient {
-  public var supportsCommands: Bool { true }
+  public var supportsCommands: Bool { false }
 }
-
-extension MobileCloudMirrorSyncClient: MobileMonitorSyncClient {}
 
 public protocol MobileMonitorSyncClientFactory: Sendable {
   func makeSyncClient(
@@ -71,16 +87,18 @@ public struct LiveMobileMonitorSyncClientFactory: MobileMonitorSyncClientFactory
   private func makeCloudClient(
     credential: MobilePairedStationCredential,
     identity: MobileDeviceIdentity
-  ) -> MobileCloudMirrorSyncClient? {
+  ) -> CloudMirrorMobileMonitorSyncClient? {
     guard credential.hasCloudMirrorAccess else {
       return nil
     }
-    return MobileCloudMirrorSyncClient(
-      database: LiveMobileCloudMirrorDatabase(),
-      cipher: MobilePayloadCipher(rawKey: credential.symmetricKeyRawRepresentation),
-      deviceIdentity: identity,
-      actorDeviceID: actorDeviceID(identity),
-      commandKeyID: credential.commandKeyID
+    return CloudMirrorMobileMonitorSyncClient(
+      client: MobileCloudMirrorSyncClient(
+        database: LiveMobileCloudMirrorDatabase(),
+        cipher: MobilePayloadCipher(rawKey: credential.symmetricKeyRawRepresentation),
+        deviceIdentity: identity,
+        actorDeviceID: actorDeviceID(identity),
+        commandKeyID: credential.commandKeyID
+      )
     )
   }
 
@@ -119,7 +137,7 @@ private struct UnavailableMobileMonitorSyncClient: MobileMonitorSyncClient {
     _ command: MobileCommandRecord,
     currentRevision: Int64,
     now: Date
-  ) async throws -> MobileQueuedCommand {
+  ) async throws -> MobileCommandSubmission {
     throw MobileRemoteDaemonSyncError.commandsUnavailable
   }
 
@@ -129,5 +147,38 @@ private struct UnavailableMobileMonitorSyncClient: MobileMonitorSyncClient {
     now: Date
   ) async throws -> MobileCommandReceipt {
     throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+}
+
+private struct CloudMirrorMobileMonitorSyncClient: MobileMonitorSyncClient {
+  let client: MobileCloudMirrorSyncClient
+  let supportsCommands = true
+
+  func fetchLatestSnapshot(
+    stationID: String,
+    now: Date
+  ) async throws -> MobileMirrorSnapshot? {
+    try await client.fetchLatestSnapshot(stationID: stationID, now: now)
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    let queued = try await client.queueCommand(
+      command,
+      currentRevision: currentRevision,
+      now: now
+    )
+    return MobileCommandSubmission(command: queued.signedCommand.command)
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    try await client.cancelCommand(command, currentRevision: currentRevision, now: now)
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonAgentCommandRequest.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonAgentCommandRequest.swift
@@ -1,0 +1,179 @@
+import Foundation
+import HarnessMonitorCore
+
+extension MobileRemoteDaemonCommandRequestBuilder {
+  static func agentRequest(
+    _ command: MobileCommandRecord,
+    agentKind: String?
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    switch command.kind {
+    case .agentStart:
+      try agentStartRequest(command)
+    case .agentStop:
+      try agentStopRequest(command, agentKind: agentKind)
+    case .agentPrompt:
+      try agentPromptRequest(command, agentKind: agentKind)
+    default:
+      throw MobileRemoteDaemonSyncError.invalidCommand("not an agent command")
+    }
+  }
+
+  private static func agentStartRequest(
+    _ command: MobileCommandRecord
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    let sessionID = try command.remoteRequiredSessionID().remotePathComponent()
+    let agent = try command.remoteRequiredPayload("agent")
+    let family = try agentFamily(command, agent: agent)
+    var body = try commonAgentStartBody(command)
+    let path: String
+    switch family {
+    case "terminal":
+      body["runtime"] = terminalRuntime(command, agent: agent)
+      body["argv"] = command.remoteCSVPayload("argv")
+      body["rows"] = try command.remotePositiveIntPayload("rows") ?? 32
+      body["cols"] = try command.remotePositiveIntPayload("cols") ?? 120
+      path = "/v1/sessions/\(sessionID)/managed-agents/terminal"
+    case "codex":
+      body["prompt"] = try command.remoteRequiredPayload("prompt")
+      body["actor"] = command.actorDeviceID
+      body["mode"] = command.remoteOptionalPayload("mode") ?? "workspace_write"
+      path = "/v1/sessions/\(sessionID)/managed-agents/codex"
+    case "acp":
+      let descriptorID =
+        agent.lowercased().hasPrefix("acp:")
+        ? String(agent.dropFirst(4)) : agent
+      guard let descriptorID = descriptorID.remoteTrimmed else {
+        throw MobileRemoteDaemonSyncError.invalidCommand("agent is required")
+      }
+      body["descriptor_id"] = descriptorID
+      body["record_permissions"] = try command.remoteBoolPayload("recordPermissions") ?? true
+      path = "/v1/sessions/\(sessionID)/managed-agents/acp"
+    default:
+      throw MobileRemoteDaemonSyncError.invalidCommand("unknown agent family: \(family)")
+    }
+    return try request(
+      path: path,
+      body: body,
+      successMessage: "Started the managed agent directly."
+    )
+  }
+
+  private static func agentStopRequest(
+    _ command: MobileCommandRecord,
+    agentKind: String?
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    let agentID = try command.remoteRequiredAgentID().remotePathComponent()
+    switch agentKind {
+    case "terminal":
+      return try request(
+        path: "/v1/managed-agents/\(agentID)/stop",
+        body: [:],
+        successMessage: "Stopped the terminal agent directly."
+      )
+    case "codex":
+      return try request(
+        path: "/v1/managed-agents/\(agentID)/interrupt",
+        body: [:],
+        successMessage: "Interrupted the Codex agent directly."
+      )
+    case "acp":
+      return try request(
+        method: "DELETE",
+        path: "/v1/managed-agents/\(agentID)",
+        successMessage: "Stopped the ACP agent directly."
+      )
+    case let kind?:
+      throw MobileRemoteDaemonSyncError.unsupportedAgentKind(kind)
+    case nil:
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+  }
+
+  private static func agentPromptRequest(
+    _ command: MobileCommandRecord,
+    agentKind: String?
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    let agentID = try command.remoteRequiredAgentID().remotePathComponent()
+    let prompt = try command.remoteRequiredPayload("prompt")
+    switch agentKind {
+    case "terminal":
+      let submittedPrompt = prompt.hasSuffix("\n") ? prompt : "\(prompt)\n"
+      return try request(
+        path: "/v1/managed-agents/\(agentID)/input",
+        body: ["input": ["type": "text", "text": submittedPrompt]],
+        successMessage: "Prompted the terminal agent directly."
+      )
+    case "codex":
+      return try request(
+        path: "/v1/managed-agents/\(agentID)/steer",
+        body: ["prompt": prompt],
+        successMessage: "Steered the Codex agent directly."
+      )
+    case "acp":
+      return try request(
+        path: "/v1/managed-agents/\(agentID)/prompt",
+        body: ["prompt": prompt],
+        successMessage: "Prompted the ACP agent directly."
+      )
+    case let kind?:
+      throw MobileRemoteDaemonSyncError.unsupportedAgentKind(kind)
+    case nil:
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+  }
+
+  private static func commonAgentStartBody(
+    _ command: MobileCommandRecord
+  ) throws -> [String: Any] {
+    var body: [String: Any] = [
+      "role": command.remoteOptionalPayload("role") ?? "worker",
+      "capabilities": command.remoteCSVPayload("capabilities"),
+      "allow_custom_model": try command.remoteBoolPayload("allowCustomModel") ?? false,
+    ]
+    body.add("fallback_role", command.remoteOptionalPayload("fallbackRole"))
+    body.add("name", command.remoteOptionalPayload("name"))
+    body.add("prompt", command.remoteOptionalPayload("prompt"))
+    body.add("project_dir", command.remoteOptionalPayload("projectDir"))
+    body.add("persona", command.remoteOptionalPayload("persona"))
+    body.add("task_id", command.target.taskID?.remoteTrimmed)
+    body.add("board_item_id", command.remoteOptionalPayload("boardItemID"))
+    body.add("workflow_execution_id", command.remoteOptionalPayload("workflowExecutionID"))
+    body.add("model", command.remoteOptionalPayload("model"))
+    body.add("effort", command.remoteOptionalPayload("effort"))
+    return body
+  }
+
+  private static func agentFamily(_ command: MobileCommandRecord, agent: String) throws -> String {
+    if let family = command.remoteOptionalPayload("family") {
+      guard ["terminal", "codex", "acp"].contains(family.lowercased()) else {
+        throw MobileRemoteDaemonSyncError.invalidCommand("unknown agent family: \(family)")
+      }
+      return family.lowercased()
+    }
+    let normalized = agent.lowercased()
+    if normalized.hasPrefix("terminal:") || normalized.hasPrefix("tui:") {
+      return "terminal"
+    }
+    if normalized.hasPrefix("acp:") {
+      return "acp"
+    }
+    if ["codex", "codex-native", "codex-run"].contains(normalized) {
+      return "codex"
+    }
+    if ["claude", "codex", "gemini", "copilot", "vibe", "opencode"].contains(normalized) {
+      return "terminal"
+    }
+    return "acp"
+  }
+
+  private static func terminalRuntime(_ command: MobileCommandRecord, agent: String) -> String {
+    if let runtime = command.remoteOptionalPayload("runtime") {
+      return runtime
+    }
+    let normalized = agent.lowercased()
+    for prefix in ["terminal:", "tui:"] where normalized.hasPrefix(prefix) {
+      return String(normalized.dropFirst(prefix.count))
+    }
+    return normalized
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonCommandClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonCommandClient.swift
@@ -1,0 +1,120 @@
+import Foundation
+import HarnessMonitorCore
+
+extension MobileRemoteDaemonSyncClient {
+  public func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    guard supportsCommands else {
+      throw MobileRemoteDaemonSyncError.commandsUnavailable
+    }
+    guard command.stationID == stationID, command.target.stationID == stationID else {
+      throw MobileRemoteDaemonSyncError.stationMismatch
+    }
+    guard command.expiresAt > now else {
+      throw MobileRemoteDaemonSyncError.commandExpired
+    }
+
+    let reviewTarget = try await resolvedReviewTarget(for: command)
+    let agentKind = try await resolvedAgentKind(for: command)
+    let route = try MobileRemoteDaemonCommandRequestBuilder.make(
+      command: command,
+      agentKind: agentKind,
+      clientID: access.clientID,
+      reviewTarget: reviewTarget
+    )
+    var request = try authenticatedRequest(path: route.path, method: route.method)
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    if let body = route.body {
+      request.httpBody = body
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    }
+    let (_, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+    try validate(response)
+    return succeededSubmission(
+      command,
+      currentRevision: currentRevision,
+      now: now,
+      message: route.successMessage
+    )
+  }
+
+  public func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func authenticatedRequest(path: String, method: String) throws -> URLRequest {
+    guard
+      var components = URLComponents(
+        url: access.endpoint,
+        resolvingAgainstBaseURL: false
+      )
+    else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("invalid remote endpoint")
+    }
+    components.percentEncodedPath = path
+    guard let url = components.url else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("invalid remote command path")
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = method
+    request.setValue("Bearer \(access.bearerToken)", forHTTPHeaderField: "Authorization")
+    request.setValue(
+      access.clientID,
+      forHTTPHeaderField: RemoteDaemonAuthentication.clientIDHeader
+    )
+    return request
+  }
+
+  private func resolvedAgentKind(for command: MobileCommandRecord) async throws -> String? {
+    guard [.agentStop, .agentPrompt].contains(command.kind) else {
+      return nil
+    }
+    let agentID = try command.remoteRequiredAgentID()
+    var request = try authenticatedRequest(
+      path: "/v1/managed-agents/\(try agentID.remotePathComponent())",
+      method: "GET"
+    )
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+    try validate(response)
+    return try JSONDecoder().decode(MobileRemoteDaemonAgentKindResponse.self, from: data).kind
+  }
+
+  private func succeededSubmission(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date,
+    message: String
+  ) -> MobileCommandSubmission {
+    var command = command
+    command.status = .succeeded
+    command.updatedAt = now
+    command.receipt = MobileCommandReceipt(
+      commandID: command.id,
+      stationID: command.stationID,
+      status: .succeeded,
+      message: message,
+      receivedAt: now,
+      completedAt: now,
+      executionRevision: currentRevision
+    )
+    return MobileCommandSubmission(command: command, disposition: .completed)
+  }
+}
+
+private struct MobileRemoteDaemonAgentKindResponse: Decodable {
+  let kind: String
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonCommandRecord+Payload.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonCommandRecord+Payload.swift
@@ -1,0 +1,82 @@
+import Foundation
+import HarnessMonitorCore
+
+extension MobileCommandRecord {
+  func remoteRequiredPayload(_ key: String) throws -> String {
+    guard let value = remoteOptionalPayload(key) else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("\(key) is required")
+    }
+    return value
+  }
+
+  func remoteOptionalPayload(_ key: String) -> String? {
+    payload[key]?.remoteTrimmed
+  }
+
+  func remoteRequiredSessionID() throws -> String {
+    try remoteRequiredTarget(target.sessionID, name: "sessionID")
+  }
+
+  func remoteRequiredAgentID() throws -> String {
+    try remoteRequiredTarget(target.agentID, name: "agentID")
+  }
+
+  func remoteRequiredTaskID() throws -> String {
+    try remoteRequiredTarget(target.taskID, name: "taskID")
+  }
+
+  func remoteBoolPayload(_ key: String) throws -> Bool? {
+    guard let value = remoteOptionalPayload(key)?.lowercased() else {
+      return nil
+    }
+    switch value {
+    case "1", "true", "yes": return true
+    case "0", "false", "no": return false
+    default: throw MobileRemoteDaemonSyncError.invalidCommand("\(key) must be a boolean")
+    }
+  }
+
+  func remotePositiveIntPayload(_ key: String) throws -> Int? {
+    guard let value = remoteOptionalPayload(key) else { return nil }
+    guard let result = Int(value), result > 0 else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("\(key) must be a positive integer")
+    }
+    return result
+  }
+
+  func remoteCSVPayload(_ key: String) -> [String] {
+    remoteOptionalPayload(key)?
+      .split(separator: ",")
+      .compactMap { String($0).remoteTrimmed } ?? []
+  }
+
+  private func remoteRequiredTarget(_ value: String?, name: String) throws -> String {
+    guard let value = value?.remoteTrimmed else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("\(name) is required")
+    }
+    return value
+  }
+}
+
+extension String {
+  var remoteTrimmed: String? {
+    let value = trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
+  }
+
+  func remotePathComponent() throws -> String {
+    let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+    guard let encoded = addingPercentEncoding(withAllowedCharacters: allowed) else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("invalid path component")
+    }
+    return encoded
+  }
+}
+
+extension Dictionary where Key == String, Value == Any {
+  mutating func add(_ key: String, _ value: Any?) {
+    if let value {
+      self[key] = value
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonCommandRequest.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonCommandRequest.swift
@@ -1,0 +1,156 @@
+import Foundation
+import HarnessMonitorCore
+
+struct MobileRemoteDaemonCommandRequest {
+  let method: String
+  let path: String
+  let body: Data?
+  let successMessage: String
+}
+
+enum MobileRemoteDaemonCommandRequestBuilder {
+  static func make(
+    command: MobileCommandRecord,
+    agentKind: String?,
+    clientID: String,
+    reviewTarget: MobileRemoteDaemonResolvedReviewTarget?
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    switch command.kind {
+    case .acpPermissionDecision:
+      try permissionRequest(command)
+    case .taskBoardDispatch:
+      try taskBoardDispatchRequest(command)
+    case .taskBoardPlanApproval:
+      try taskBoardPlanApprovalRequest(command, clientID: clientID)
+    case .agentStart, .agentStop, .agentPrompt:
+      try agentRequest(command, agentKind: agentKind)
+    case .pullRequestApprove, .pullRequestLabel, .pullRequestRerunChecks, .pullRequestMerge:
+      try reviewRequest(command, target: try requiredReviewTarget(reviewTarget))
+    case .refresh:
+      try refreshRequest(command, reviewTarget: reviewTarget)
+    }
+  }
+
+  static func request(
+    method: String = "POST",
+    path: String,
+    body: [String: Any]? = nil,
+    successMessage: String
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    MobileRemoteDaemonCommandRequest(
+      method: method,
+      path: path,
+      body: try body.map(jsonBody),
+      successMessage: successMessage
+    )
+  }
+
+  static func jsonBody(_ value: [String: Any]) throws -> Data {
+    guard JSONSerialization.isValidJSONObject(value) else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("request body is not valid JSON")
+    }
+    return try JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+  }
+
+  private static func permissionRequest(
+    _ command: MobileCommandRecord
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    let agentID = try command.remoteRequiredAgentID().remotePathComponent()
+    let batchID = try command.remoteRequiredPayload("batchID").remotePathComponent()
+    let decision = try command.remoteRequiredPayload("decision")
+    var body: [String: Any] = ["decision": decision]
+    switch decision {
+    case "approve_all", "deny_all":
+      break
+    case "approve_some":
+      let requestIDs = command.remoteCSVPayload("requestIDs")
+      guard !requestIDs.isEmpty else {
+        throw MobileRemoteDaemonSyncError.invalidCommand("requestIDs is required")
+      }
+      body["request_ids"] = requestIDs
+    default:
+      throw MobileRemoteDaemonSyncError.invalidCommand("invalid ACP permission decision")
+    }
+    return try request(
+      path: "/v1/managed-agents/\(agentID)/permission-batches/\(batchID)",
+      body: body,
+      successMessage: "Resolved the ACP permission directly."
+    )
+  }
+
+  private static func taskBoardDispatchRequest(
+    _ command: MobileCommandRecord
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    let itemID = command.target.taskID?.remoteTrimmed ?? command.remoteOptionalPayload("itemID")
+    guard let itemID else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("taskID is required")
+    }
+    var body: [String: Any] = [
+      "item_id": itemID,
+      "dry_run": try command.remoteBoolPayload("dryRun") ?? false,
+    ]
+    body.add("status", command.remoteOptionalPayload("status"))
+    body.add("project_dir", command.remoteOptionalPayload("projectDir"))
+    return try request(
+      path: "/v1/task-board/dispatch",
+      body: body,
+      successMessage: "Dispatched the task board item directly."
+    )
+  }
+
+  private static func taskBoardPlanApprovalRequest(
+    _ command: MobileCommandRecord,
+    clientID: String
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    let taskID = try command.remoteRequiredTaskID().remotePathComponent()
+    var body: [String: Any] = ["approved_by": clientID]
+    body.add("approved_at", command.remoteOptionalPayload("approvedAt"))
+    return try request(
+      path: "/v1/task-board/items/\(taskID)/planning/approve",
+      body: body,
+      successMessage: "Approved the task board plan directly."
+    )
+  }
+
+  private static func refreshRequest(
+    _ command: MobileCommandRecord,
+    reviewTarget: MobileRemoteDaemonResolvedReviewTarget?
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    switch command.remoteOptionalPayload("scope") ?? "health" {
+    case "health":
+      return try request(method: "GET", path: "/v1/health", successMessage: "Refreshed health.")
+    case "mobileMirror":
+      return try request(method: "GET", path: "/v1/sessions", successMessage: "Refreshed sessions.")
+    case "reviews":
+      return try request(
+        path: "/v1/reviews/refresh",
+        body: ["targets": [try requiredReviewTarget(reviewTarget).actionTarget]],
+        successMessage: "Refreshed the pull request."
+      )
+    case "taskBoard":
+      return try request(
+        path: "/v1/task-board/sync",
+        body: ["direction": "both", "dry_run": true],
+        successMessage: "Refreshed the task board."
+      )
+    case "sessionTasks":
+      let sessionID = try command.remoteRequiredSessionID().remotePathComponent()
+      return try request(
+        method: "GET",
+        path: "/v1/sessions/\(sessionID)",
+        successMessage: "Refreshed the session tasks."
+      )
+    case let scope:
+      throw MobileRemoteDaemonSyncError.invalidCommand("unknown refresh scope: \(scope)")
+    }
+  }
+
+  private static func requiredReviewTarget(
+    _ target: MobileRemoteDaemonResolvedReviewTarget?
+  ) throws -> MobileRemoteDaemonResolvedReviewTarget {
+    guard let target else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("review target was not resolved")
+    }
+    return target
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewCommandRequest.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewCommandRequest.swift
@@ -1,0 +1,82 @@
+import Foundation
+import HarnessMonitorCore
+
+extension MobileRemoteDaemonCommandRequestBuilder {
+  static func reviewRequest(
+    _ command: MobileCommandRecord,
+    target: MobileRemoteDaemonResolvedReviewTarget
+  ) throws -> MobileRemoteDaemonCommandRequest {
+    let actionTarget = target.actionTarget
+    switch command.kind {
+    case .pullRequestApprove:
+      return try request(
+        path: "/v1/reviews/approve",
+        body: ["targets": [actionTarget]],
+        successMessage: "Approved the pull request directly."
+      )
+    case .pullRequestLabel:
+      return try request(
+        path: "/v1/reviews/labels",
+        body: [
+          "targets": [actionTarget],
+          "label": try command.remoteRequiredPayload("label"),
+        ],
+        successMessage: "Labeled the pull request directly."
+      )
+    case .pullRequestRerunChecks:
+      return try request(
+        path: "/v1/reviews/rerun-checks",
+        body: ["targets": [actionTarget]],
+        successMessage: "Reran pull request checks directly."
+      )
+    case .pullRequestMerge:
+      return try request(
+        path: "/v1/reviews/merge",
+        body: [
+          "targets": [actionTarget],
+          "method": try mergeMethod(command),
+        ],
+        successMessage: "Merged the pull request directly."
+      )
+    default:
+      throw MobileRemoteDaemonSyncError.invalidCommand("not a review command")
+    }
+  }
+
+  static func reviewReference(
+    _ command: MobileCommandRecord
+  ) throws -> MobileRemoteDaemonReviewReference? {
+    let needsReview: Bool
+    switch command.kind {
+    case .pullRequestApprove, .pullRequestLabel, .pullRequestRerunChecks, .pullRequestMerge:
+      needsReview = true
+    case .refresh:
+      needsReview = command.remoteOptionalPayload("scope") == "reviews"
+    default:
+      needsReview = false
+    }
+    guard needsReview else { return nil }
+
+    let repository = try command.remoteRequiredPayload("repository")
+    let number = try positiveReviewNumber(command)
+    return MobileRemoteDaemonReviewReference(repository: repository, number: number)
+  }
+
+  private static func positiveReviewNumber(_ command: MobileCommandRecord) throws -> Int {
+    guard let raw = command.remoteOptionalPayload("number"),
+      let number = Int(raw),
+      number > 0
+    else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("number must be a positive integer")
+    }
+    return number
+  }
+
+  private static func mergeMethod(_ command: MobileCommandRecord) throws -> String {
+    let method = command.remoteOptionalPayload("method") ?? "squash"
+    guard ["merge", "squash", "rebase"].contains(method) else {
+      throw MobileRemoteDaemonSyncError.invalidCommand("invalid merge method: \(method)")
+    }
+    return method
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewResolution.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewResolution.swift
@@ -1,0 +1,143 @@
+import Foundation
+import HarnessMonitorCore
+
+struct MobileRemoteDaemonReviewReference: Equatable, Sendable {
+  let repository: String
+  let number: Int
+}
+
+struct MobileRemoteDaemonResolvedReviewTarget: Decodable, Sendable {
+  private let pullRequestID: String
+  private let repositoryID: String
+  private let repository: String
+  private let number: Int
+  private let url: String
+  private let state: String
+  private let headSHA: String
+  private let mergeable: String
+  private let reviewStatus: String
+  private let checkStatus: String
+  private let isDraft: Bool?
+  private let policyBlocked: Bool?
+  private let viewerCanUpdate: Bool?
+  private let viewerCanMergeAsAdmin: Bool?
+  private let requiredFailedCheckNames: [String]?
+  private let checks: [Check]?
+  private let hasConflictMarkers: Bool?
+  private let viewerHasActiveApproval: Bool?
+  private let autoMergeEnabled: Bool?
+  private let approvalSatisfiedAfterViewerApproval: Bool?
+
+  var actionTarget: [String: Any] {
+    var target: [String: Any] = [
+      "pull_request_id": pullRequestID,
+      "repository_id": repositoryID,
+      "repository": repository,
+      "number": number,
+      "url": url,
+      "state": state,
+      "head_sha": headSHA,
+      "mergeable": mergeable,
+      "review_status": reviewStatus,
+      "check_status": checkStatus,
+      "is_draft": isDraft ?? false,
+      "policy_blocked": policyBlocked ?? false,
+      "viewer_can_update": viewerCanUpdate ?? true,
+      "viewer_can_merge_as_admin": viewerCanMergeAsAdmin ?? false,
+      "required_failed_check_names": requiredFailedCheckNames ?? [],
+      "check_suite_ids": checkSuiteIDs,
+    ]
+    target.add("has_conflict_markers", hasConflictMarkers)
+    target.add("viewer_has_active_approval", viewerHasActiveApproval)
+    target.add("auto_merge_enabled", autoMergeEnabled)
+    target.add(
+      "approval_requirement_satisfied_after_viewer_approval",
+      approvalSatisfiedAfterViewerApproval
+    )
+    return target
+  }
+
+  func matches(_ reference: MobileRemoteDaemonReviewReference) -> Bool {
+    number == reference.number
+      && repository.caseInsensitiveCompare(reference.repository) == .orderedSame
+  }
+
+  private var checkSuiteIDs: [String] {
+    var seen = Set<String>()
+    return (checks ?? []).compactMap(\.checkSuiteID).filter { seen.insert($0).inserted }
+  }
+
+  private struct Check: Decodable, Sendable {
+    let checkSuiteID: String?
+
+    enum CodingKeys: String, CodingKey {
+      case checkSuiteID = "check_suite_id"
+    }
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case pullRequestID = "pull_request_id"
+    case repositoryID = "repository_id"
+    case repository
+    case number
+    case url
+    case state
+    case headSHA = "head_sha"
+    case mergeable
+    case reviewStatus = "review_status"
+    case checkStatus = "check_status"
+    case isDraft = "is_draft"
+    case policyBlocked = "policy_blocked"
+    case viewerCanUpdate = "viewer_can_update"
+    case viewerCanMergeAsAdmin = "viewer_can_merge_as_admin"
+    case requiredFailedCheckNames = "required_failed_check_names"
+    case checks
+    case hasConflictMarkers = "has_conflict_markers"
+    case viewerHasActiveApproval = "viewer_has_active_approval"
+    case autoMergeEnabled = "auto_merge_enabled"
+    case approvalSatisfiedAfterViewerApproval =
+      "approval_requirement_satisfied_after_viewer_approval"
+  }
+}
+
+extension MobileRemoteDaemonSyncClient {
+  func resolvedReviewTarget(
+    for command: MobileCommandRecord
+  ) async throws -> MobileRemoteDaemonResolvedReviewTarget? {
+    guard
+      let reference = try MobileRemoteDaemonCommandRequestBuilder.reviewReference(command)
+    else {
+      return nil
+    }
+    let body = try MobileRemoteDaemonCommandRequestBuilder.jsonBody([
+      "references": [["repository": reference.repository, "number": reference.number]],
+      "backport_detection_enabled": true,
+    ])
+    var request = try authenticatedRequest(
+      path: "/v1/reviews/pull-requests/resolve",
+      method: "POST"
+    )
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+    try validate(response)
+    guard let result = try? JSONDecoder().decode(ResolveResponse.self, from: data) else {
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+    guard let target = result.items.first(where: { $0.matches(reference) }) else {
+      throw MobileRemoteDaemonSyncError.invalidCommand(
+        "remote daemon did not resolve \(reference.repository)#\(reference.number)"
+      )
+    }
+    return target
+  }
+}
+
+private struct ResolveResponse: Decodable {
+  let items: [MobileRemoteDaemonResolvedReviewTarget]
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
@@ -10,6 +10,9 @@ public enum MobileRemoteDaemonSyncError: Error, Equatable, Sendable {
   case forbidden
   case serverStatus(Int)
   case commandsUnavailable
+  case commandExpired
+  case invalidCommand(String)
+  case unsupportedAgentKind(String)
 
   var allowsCloudFallback: Bool {
     if case .serverStatus(let statusCode) = self {
@@ -20,13 +23,13 @@ public enum MobileRemoteDaemonSyncError: Error, Equatable, Sendable {
 }
 
 public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
-  public let supportsCommands = false
+  public var supportsCommands: Bool { access.canWrite }
 
-  private let access: MobileRemoteDaemonAccess
-  private let stationID: String
+  let access: MobileRemoteDaemonAccess
+  let stationID: String
   private let stationName: String
   private let defaultStation: Bool
-  private let session: URLSession
+  let session: URLSession
 
   public init(
     access: MobileRemoteDaemonAccess,
@@ -66,23 +69,7 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
     return makeSnapshot(sessions: sessions, now: now)
   }
 
-  public func queueCommand(
-    _ command: MobileCommandRecord,
-    currentRevision: Int64,
-    now: Date
-  ) async throws -> MobileQueuedCommand {
-    throw MobileRemoteDaemonSyncError.commandsUnavailable
-  }
-
-  public func cancelCommand(
-    _ command: MobileCommandRecord,
-    currentRevision: Int64,
-    now: Date
-  ) async throws -> MobileCommandReceipt {
-    throw MobileRemoteDaemonSyncError.commandsUnavailable
-  }
-
-  private func validate(_ response: HTTPURLResponse) throws {
+  func validate(_ response: HTTPURLResponse) throws {
     switch response.statusCode {
     case 200..<300:
       return

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/MirrorSyncStatus+MobileDisplay.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/MirrorSyncStatus+MobileDisplay.swift
@@ -17,6 +17,7 @@ extension MirrorSyncStatus {
     case .paired: String(localized: "Mac paired")
     case .privacy: String(localized: "Privacy updated")
     case .commandQueued: String(localized: "Command queued")
+    case .commandCompleted: String(localized: "Command completed")
     case .commandCancelled: String(localized: "Command cancelled")
     case .commandFailed: String(localized: "Command failed")
     }
@@ -47,6 +48,8 @@ extension MirrorSyncStatus {
       message
     case .commandQueued(let date):
       String(localized: "Signed at \(date.formatted(.dateTime.hour().minute().second()))")
+    case .commandCompleted(let date):
+      String(localized: "Completed at \(date.formatted(.dateTime.hour().minute().second()))")
     case .commandCancelled(let date):
       String(localized: "Cancelled at \(date.formatted(.dateTime.hour().minute().second()))")
     case .commandFailed(let reason):

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/MirrorSyncStatus+WatchDisplay.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/MirrorSyncStatus+WatchDisplay.swift
@@ -18,6 +18,7 @@ extension MirrorSyncStatus {
     case .paired: String(localized: "Mac paired")
     case .privacy: String(localized: "Privacy")
     case .commandQueued: String(localized: "Command queued")
+    case .commandCompleted: String(localized: "Command completed")
     case .commandCancelled: String(localized: "Command cancelled")
     case .commandFailed: String(localized: "Command failed")
     }
@@ -47,6 +48,8 @@ extension MirrorSyncStatus {
       message
     case .commandQueued(let date):
       String(localized: "Signed \(date.formatted(.dateTime.hour().minute()))")
+    case .commandCompleted(let date):
+      String(localized: "Completed \(date.formatted(.dateTime.hour().minute()))")
     case .commandCancelled(let date):
       String(localized: "Cancelled \(date.formatted(.dateTime.hour().minute()))")
     }

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStoreTests.swift
@@ -26,7 +26,7 @@ private struct StubSyncClient: MobileMonitorSyncClient {
     _ command: MobileCommandRecord,
     currentRevision: Int64,
     now: Date
-  ) async throws -> MobileQueuedCommand {
+  ) async throws -> MobileCommandSubmission {
     throw StubFetchError()
   }
 
@@ -96,7 +96,7 @@ private final class GatedSyncClient: MobileMonitorSyncClient, @unchecked Sendabl
     _ command: MobileCommandRecord,
     currentRevision: Int64,
     now: Date
-  ) async throws -> MobileQueuedCommand {
+  ) async throws -> MobileCommandSubmission {
     throw StubFetchError()
   }
 
@@ -240,6 +240,38 @@ final class MirrorStoreCommandTests: XCTestCase {
     await store.queueCommand(makeRefreshDraft())
     XCTAssertTrue(store.snapshot.commands.isEmpty)
     XCTAssertTrue(store.lastAuthenticationFailed)
+  }
+
+  func testLiveDirectSubmissionReportsCompletion() async {
+    let store = MirrorStore(
+      snapshot: .empty(),
+      syncClient: RecordingCommandSyncClient(disposition: .completed),
+      demoModeEnabled: false,
+      sharedSnapshotStore: nil,
+      authenticator: StubAuthenticator(result: true)
+    )
+
+    await store.queueCommand(makeRefreshDraft())
+
+    guard case .commandCompleted = store.syncStatus else {
+      return XCTFail("expected direct command completion, got \(store.syncStatus)")
+    }
+  }
+
+  func testLiveCloudSubmissionReportsQueued() async {
+    let store = MirrorStore(
+      snapshot: .empty(),
+      syncClient: RecordingCommandSyncClient(disposition: .queued),
+      demoModeEnabled: false,
+      sharedSnapshotStore: nil,
+      authenticator: StubAuthenticator(result: true)
+    )
+
+    await store.queueCommand(makeRefreshDraft())
+
+    guard case .commandQueued = store.syncStatus else {
+      return XCTFail("expected queued command status, got \(store.syncStatus)")
+    }
   }
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorSyncStatusTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorSyncStatusTests.swift
@@ -16,6 +16,7 @@ final class MirrorSyncStatusTests: XCTestCase {
       (.paired("Studio"), "key.horizontal"),
       (.privacy("done"), "checkmark.shield"),
       (.commandQueued(.distantPast), "checkmark.seal"),
+      (.commandCompleted(.distantPast), "checkmark.circle"),
       (.commandCancelled(.distantPast), "xmark.seal"),
       (.commandFailed("boom"), "xmark.octagon"),
     ]
@@ -33,8 +34,8 @@ final class MirrorSyncStatusTests: XCTestCase {
     }
     let nonFailures: [MirrorSyncStatus] = [
       .unpaired, .demo, .pairing("S"), .syncing, .live(.distantPast), .paired("S"),
-      .privacy("p"), .commandQueued(.distantPast), .commandCancelled(.distantPast),
-      .commandFailed("boom"),
+      .privacy("p"), .commandQueued(.distantPast), .commandCompleted(.distantPast),
+      .commandCancelled(.distantPast), .commandFailed("boom"),
     ]
     for status in nonFailures {
       XCTAssertFalse(status.indicatesSyncFailure, "\(status) is not a sync failure")
@@ -46,7 +47,8 @@ final class MirrorSyncStatusTests: XCTestCase {
     let others: [MirrorSyncStatus] = [
       .unpaired, .demo, .pairing("S"), .syncing, .live(.distantPast), .stale("e"),
       .iCloudAccountUnavailable, .paired("S"), .privacy("p"),
-      .commandQueued(.distantPast), .commandCancelled(.distantPast), .commandFailed("b"),
+      .commandQueued(.distantPast), .commandCompleted(.distantPast),
+      .commandCancelled(.distantPast), .commandFailed("b"),
     ]
     for status in others {
       XCTAssertFalse(status.opensAppSettingsForRecovery, "\(status) stays in-app")

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandRouteTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandRouteTests.swift
@@ -1,0 +1,320 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorMirrorStore
+import XCTest
+
+final class MobileRemoteDaemonCommandRouteTests: XCTestCase {
+  override func tearDown() {
+    RemoteDaemonCommandURLProtocol.reset()
+    super.tearDown()
+  }
+
+  func testPermissionAndTaskBoardCommandsUseWriteRoutes() async throws {
+    var requests = try await submit(
+      makeRemoteDaemonCommand(
+        kind: .acpPermissionDecision,
+        agentID: "agent-1",
+        payload: ["batchID": "batch-1", "decision": "approve_all"]
+      )
+    )
+    var request = try XCTUnwrap(requests.last)
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.url?.path, "/v1/managed-agents/agent-1/permission-batches/batch-1")
+    XCTAssertEqual(try commandRequestJSON(request)["decision"] as? String, "approve_all")
+
+    requests = try await submit(
+      makeRemoteDaemonCommand(
+        kind: .taskBoardDispatch,
+        taskID: "task-1",
+        payload: [
+          "status": "todo",
+          "dryRun": "false",
+          "projectDir": "/workspace/project",
+        ]
+      )
+    )
+    request = try XCTUnwrap(requests.last)
+    let dispatch = try commandRequestJSON(request)
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.url?.path, "/v1/task-board/dispatch")
+    XCTAssertEqual(dispatch["item_id"] as? String, "task-1")
+    XCTAssertEqual(dispatch["status"] as? String, "todo")
+    XCTAssertEqual(dispatch["dry_run"] as? Bool, false)
+    XCTAssertEqual(dispatch["project_dir"] as? String, "/workspace/project")
+
+    requests = try await submit(
+      makeRemoteDaemonCommand(kind: .taskBoardPlanApproval, taskID: "task-1")
+    )
+    request = try XCTUnwrap(requests.last)
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.url?.path, "/v1/task-board/items/task-1/planning/approve")
+    XCTAssertEqual(try commandRequestJSON(request)["approved_by"] as? String, "ios-device")
+  }
+
+  func testAgentStartCommandsRouteEveryRuntimeFamily() async throws {
+    var requests = try await submit(
+      makeRemoteDaemonCommand(
+        kind: .agentStart,
+        sessionID: "session-1",
+        payload: ["agent": "codex", "role": "worker", "prompt": "continue"]
+      )
+    )
+    var request = try XCTUnwrap(requests.last)
+    var body = try commandRequestJSON(request)
+    XCTAssertEqual(request.url?.path, "/v1/sessions/session-1/managed-agents/codex")
+    XCTAssertEqual(body["prompt"] as? String, "continue")
+    XCTAssertEqual(body["mode"] as? String, "workspace_write")
+
+    requests = try await submit(
+      makeRemoteDaemonCommand(
+        kind: .agentStart,
+        sessionID: "session-1",
+        payload: [
+          "agent": "terminal:claude",
+          "role": "reviewer",
+          "prompt": "inspect",
+          "rows": "40",
+          "cols": "100",
+        ]
+      )
+    )
+    request = try XCTUnwrap(requests.last)
+    body = try commandRequestJSON(request)
+    XCTAssertEqual(request.url?.path, "/v1/sessions/session-1/managed-agents/terminal")
+    XCTAssertEqual(body["runtime"] as? String, "claude")
+    XCTAssertEqual(body["role"] as? String, "reviewer")
+    XCTAssertEqual(body["rows"] as? Int, 40)
+    XCTAssertEqual(body["cols"] as? Int, 100)
+
+    requests = try await submit(
+      makeRemoteDaemonCommand(
+        kind: .agentStart,
+        sessionID: "session-1",
+        payload: [
+          "agent": "acp:copilot",
+          "role": "worker",
+          "recordPermissions": "true",
+        ]
+      )
+    )
+    request = try XCTUnwrap(requests.last)
+    body = try commandRequestJSON(request)
+    XCTAssertEqual(request.url?.path, "/v1/sessions/session-1/managed-agents/acp")
+    XCTAssertEqual(body["descriptor_id"] as? String, "copilot")
+    XCTAssertEqual(body["record_permissions"] as? Bool, true)
+  }
+
+  func testAgentStopCommandsResolveRuntimeBeforeMutation() async throws {
+    let routes: [(String, String, String)] = [
+      ("terminal", "POST", "/v1/managed-agents/agent-1/stop"),
+      ("codex", "POST", "/v1/managed-agents/agent-1/interrupt"),
+      ("acp", "DELETE", "/v1/managed-agents/agent-1"),
+    ]
+    for (kind, method, path) in routes {
+      let requests = try await submit(
+        makeRemoteDaemonCommand(kind: .agentStop, agentID: "agent-1"),
+        responseBodies: [#"{"kind":"\#(kind)"}"#, "{}"]
+      )
+
+      XCTAssertEqual(requests.map(\.url?.path), ["/v1/managed-agents/agent-1", path])
+      XCTAssertEqual(requests.last?.httpMethod, method)
+    }
+  }
+
+  func testAgentPromptCommandsResolveRuntimeBeforeMutation() async throws {
+    let routes: [(String, String)] = [
+      ("terminal", "/v1/managed-agents/agent-1/input"),
+      ("codex", "/v1/managed-agents/agent-1/steer"),
+      ("acp", "/v1/managed-agents/agent-1/prompt"),
+    ]
+    for (kind, path) in routes {
+      let requests = try await submit(
+        makeRemoteDaemonCommand(
+          kind: .agentPrompt,
+          agentID: "agent-1",
+          payload: ["prompt": "continue"]
+        ),
+        responseBodies: [#"{"kind":"\#(kind)"}"#, "{}"]
+      )
+      let request = try XCTUnwrap(requests.last)
+      let body = try commandRequestJSON(request)
+
+      XCTAssertEqual(request.url?.path, path)
+      if kind == "terminal" {
+        let input = try XCTUnwrap(body["input"] as? [String: Any])
+        XCTAssertEqual(input["type"] as? String, "text")
+        XCTAssertEqual(input["text"] as? String, "continue\n")
+      } else {
+        XCTAssertEqual(body["prompt"] as? String, "continue")
+      }
+    }
+  }
+
+  func testPullRequestCommandsUseReviewMutationRoutes() async throws {
+    let routes: [(MobileCommandKind, String, [String: String])] = [
+      (.pullRequestApprove, "/v1/reviews/approve", [:]),
+      (.pullRequestLabel, "/v1/reviews/labels", ["label": "ready"]),
+      (.pullRequestRerunChecks, "/v1/reviews/rerun-checks", [:]),
+      (.pullRequestMerge, "/v1/reviews/merge", ["method": "squash"]),
+    ]
+    for (kind, path, extraPayload) in routes {
+      var payload = [
+        "repository": "owner/repo",
+        "number": "42",
+        "pullRequestID": "stale-pr",
+        "repositoryID": "stale-repo",
+        "headSha": "stale-sha",
+        "mergeable": "unknown",
+      ]
+      payload.merge(extraPayload) { _, new in new }
+      let requests = try await submit(
+        makeRemoteDaemonCommand(
+          kind: kind,
+          reviewID: "owner/repo#42",
+          payload: payload
+        ),
+        responseBodies: [remoteResolvedReviewResponse, "{}"]
+      )
+      XCTAssertEqual(
+        requests.map(\.url?.path),
+        ["/v1/reviews/pull-requests/resolve", path]
+      )
+
+      let resolveBody = try commandRequestJSON(try XCTUnwrap(requests.first))
+      let references = try XCTUnwrap(resolveBody["references"] as? [[String: Any]])
+      XCTAssertEqual(references.first?["repository"] as? String, "owner/repo")
+      XCTAssertEqual(references.first?["number"] as? Int, 42)
+      XCTAssertEqual(resolveBody["backport_detection_enabled"] as? Bool, true)
+      XCTAssertNil(resolveBody["backport_patterns"])
+
+      let request = try XCTUnwrap(requests.last)
+      let body = try commandRequestJSON(request)
+      let targets = try XCTUnwrap(body["targets"] as? [[String: Any]])
+      let target = try XCTUnwrap(targets.first)
+
+      XCTAssertEqual(request.url?.path, path)
+      XCTAssertEqual(target["repository"] as? String, "owner/repo")
+      XCTAssertEqual(target["number"] as? Int, 42)
+      XCTAssertEqual(target["pull_request_id"] as? String, "fresh-pr")
+      XCTAssertEqual(target["repository_id"] as? String, "fresh-repo")
+      XCTAssertEqual(target["head_sha"] as? String, "fresh-sha")
+      XCTAssertEqual(target["mergeable"] as? String, "mergeable")
+      XCTAssertEqual(target["review_status"] as? String, "approved")
+      XCTAssertEqual(target["check_status"] as? String, "failure")
+      XCTAssertEqual(target["policy_blocked"] as? Bool, true)
+      XCTAssertEqual(target["viewer_can_update"] as? Bool, false)
+      XCTAssertEqual(target["viewer_can_merge_as_admin"] as? Bool, true)
+      XCTAssertEqual(target["required_failed_check_names"] as? [String], ["required/ci"])
+      XCTAssertEqual(target["check_suite_ids"] as? [String], ["suite-fresh"])
+      XCTAssertEqual(target["has_conflict_markers"] as? Bool, true)
+      XCTAssertEqual(target["viewer_has_active_approval"] as? Bool, true)
+      XCTAssertEqual(target["auto_merge_enabled"] as? Bool, false)
+      XCTAssertEqual(
+        target["approval_requirement_satisfied_after_viewer_approval"] as? Bool,
+        true
+      )
+      if let (key, value) = extraPayload.first {
+        XCTAssertEqual(body[key] as? String, value)
+      }
+    }
+  }
+
+  func testPullRequestCommandFailsClosedWhenReviewCannotBeResolved() async throws {
+    RemoteDaemonCommandURLProtocol.reset()
+    RemoteDaemonCommandURLProtocol.enqueue(
+      body: #"{"fetched_at":"2026-07-10T12:00:00Z","items":[],"missing_references":[]}"#
+    )
+    let client = try makeRemoteDaemonCommandClient()
+    let command = makeRemoteDaemonCommand(
+      kind: .pullRequestApprove,
+      reviewID: "owner/repo#42",
+      payload: ["repository": "owner/repo", "number": "42"]
+    )
+
+    do {
+      _ = try await client.queueCommand(command, currentRevision: 42, now: command.createdAt)
+      XCTFail("unresolved review command should fail")
+    } catch {
+      XCTAssertEqual(
+        error as? MobileRemoteDaemonSyncError,
+        .invalidCommand("remote daemon did not resolve owner/repo#42")
+      )
+    }
+    XCTAssertEqual(
+      RemoteDaemonCommandURLProtocol.requests.map(\.url?.path),
+      ["/v1/reviews/pull-requests/resolve"]
+    )
+  }
+
+  func testRefreshCommandsUseScopeSpecificReadOrSyncRoutes() async throws {
+    let routes: [(String, String, String, [String: String])] = [
+      ("health", "GET", "/v1/health", [:]),
+      ("mobileMirror", "GET", "/v1/sessions", [:]),
+      ("reviews", "POST", "/v1/reviews/refresh", ["repository": "owner/repo", "number": "42"]),
+      ("taskBoard", "POST", "/v1/task-board/sync", [:]),
+      ("sessionTasks", "GET", "/v1/sessions/session-1", [:]),
+    ]
+    for (scope, method, path, extraPayload) in routes {
+      var payload = ["scope": scope]
+      payload.merge(extraPayload) { _, new in new }
+      let requests = try await submit(
+        makeRemoteDaemonCommand(
+          kind: .refresh,
+          sessionID: scope == "sessionTasks" ? "session-1" : nil,
+          reviewID: scope == "reviews" ? "owner/repo#42" : nil,
+          payload: payload
+        ),
+        responseBodies: scope == "reviews" ? [remoteResolvedReviewResponse, "{}"] : ["{}"]
+      )
+
+      XCTAssertEqual(requests.last?.httpMethod, method)
+      XCTAssertEqual(requests.last?.url?.path, path)
+      if scope == "reviews" {
+        XCTAssertEqual(
+          requests.map(\.url?.path),
+          ["/v1/reviews/pull-requests/resolve", "/v1/reviews/refresh"]
+        )
+        let body = try commandRequestJSON(try XCTUnwrap(requests.last))
+        let targets = try XCTUnwrap(body["targets"] as? [[String: Any]])
+        XCTAssertEqual(targets.first?["pull_request_id"] as? String, "fresh-pr")
+        XCTAssertEqual(targets.first?["head_sha"] as? String, "fresh-sha")
+      }
+    }
+  }
+
+  func testCommandIdentifiersAreEncodedAsSinglePathComponents() async throws {
+    let requests = try await submit(
+      makeRemoteDaemonCommand(
+        kind: .acpPermissionDecision,
+        agentID: "agent/one",
+        payload: ["batchID": "batch/two", "decision": "deny_all"]
+      )
+    )
+
+    XCTAssertEqual(
+      requests.last?.url?.absoluteString,
+      "https://daemon.example.com/v1/managed-agents/agent%2Fone/permission-batches/batch%2Ftwo"
+    )
+  }
+
+  private func submit(
+    _ command: MobileCommandRecord,
+    responseBodies: [String] = ["{}"]
+  ) async throws -> [URLRequest] {
+    RemoteDaemonCommandURLProtocol.reset()
+    for body in responseBodies {
+      RemoteDaemonCommandURLProtocol.enqueue(body: body)
+    }
+    let client = try makeRemoteDaemonCommandClient()
+    _ = try await client.queueCommand(command, currentRevision: 42, now: command.createdAt)
+    let requests = RemoteDaemonCommandURLProtocol.requests
+    for request in requests {
+      XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer server-token")
+      XCTAssertEqual(
+        request.value(forHTTPHeaderField: "x-harness-remote-client-id"),
+        "ios-device"
+      )
+    }
+    return requests
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandTestSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandTestSupport.swift
@@ -1,0 +1,246 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+
+final class RemoteDaemonCommandURLProtocol: URLProtocol, @unchecked Sendable {
+  private struct StubResponse {
+    let statusCode: Int
+    let body: Data
+  }
+
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var queuedResponses: [StubResponse] = []
+  nonisolated(unsafe) private static var recordedRequests: [URLRequest] = []
+
+  static var requests: [URLRequest] {
+    lock.withLock { recordedRequests }
+  }
+
+  static func reset() {
+    lock.withLock {
+      queuedResponses = []
+      recordedRequests = []
+    }
+  }
+
+  static func respond(statusCode: Int, body: String) {
+    lock.withLock {
+      queuedResponses = [StubResponse(statusCode: statusCode, body: Data(body.utf8))]
+    }
+  }
+
+  static func enqueue(statusCode: Int = 200, body: String = "{}") {
+    lock.withLock {
+      queuedResponses.append(StubResponse(statusCode: statusCode, body: Data(body.utf8)))
+    }
+  }
+
+  override static func canInit(with request: URLRequest) -> Bool { true }
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let response: StubResponse = Self.lock.withLock {
+      var recordedRequest = request
+      let body = request.httpBody ?? request.httpBodyStream.flatMap(Self.readBody)
+      recordedRequest.httpBodyStream = nil
+      recordedRequest.httpBody = body
+      Self.recordedRequests.append(recordedRequest)
+      guard !Self.queuedResponses.isEmpty else {
+        return StubResponse(statusCode: 200, body: Data("{}".utf8))
+      }
+      return Self.queuedResponses.removeFirst()
+    }
+    guard let url = request.url,
+      let httpResponse = HTTPURLResponse(
+        url: url,
+        statusCode: response.statusCode,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+    client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: response.body)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+
+  private static func readBody(_ stream: InputStream) -> Data? {
+    stream.open()
+    defer { stream.close() }
+    var result = Data()
+    var buffer = [UInt8](repeating: 0, count: 1_024)
+    while stream.hasBytesAvailable {
+      let count = stream.read(&buffer, maxLength: buffer.count)
+      guard count >= 0 else { return nil }
+      guard count > 0 else { break }
+      result.append(buffer, count: count)
+    }
+    return result
+  }
+}
+
+func makeRemoteDaemonCommandClient(
+  role: MobileRemoteDaemonRole = .operator,
+  scopes: [String] = ["read", "write"]
+) throws -> MobileRemoteDaemonSyncClient {
+  let configuration = URLSessionConfiguration.ephemeral
+  configuration.protocolClasses = [RemoteDaemonCommandURLProtocol.self]
+  return MobileRemoteDaemonSyncClient(
+    access: try makeRemoteDaemonCommandAccess(role: role, scopes: scopes),
+    stationID: "station-1",
+    stationName: "daemon.example.com",
+    defaultStation: true,
+    session: URLSession(configuration: configuration)
+  )
+}
+
+func makeRemoteDaemonCommandAccess(
+  role: MobileRemoteDaemonRole,
+  scopes: [String]
+) throws -> MobileRemoteDaemonAccess {
+  MobileRemoteDaemonAccess(
+    endpoint: URL(string: "https://daemon.example.com")!,
+    clientID: "ios-device",
+    displayName: "Phone",
+    platform: "ios",
+    role: role,
+    scopes: scopes,
+    bearerToken: "server-token",
+    tokenHint: "abcd1234",
+    serverSPKISHA256: try MobileRemoteDaemonSPKIPin(
+      validating: "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+    ),
+    pairedAt: .now
+  )
+}
+
+func makeRemoteDaemonCommand(
+  kind: MobileCommandKind,
+  sessionID: String? = nil,
+  agentID: String? = nil,
+  reviewID: String? = nil,
+  taskID: String? = nil,
+  payload: [String: String] = [:],
+  now: Date = Date(timeIntervalSince1970: 1_752_124_400)
+) -> MobileCommandRecord {
+  MobileCommandRecord(
+    id: "command-1",
+    stationID: "station-1",
+    kind: kind,
+    risk: kind.risk,
+    status: .draft,
+    title: kind.title,
+    confirmationText: "Run \(kind.title)",
+    target: MobileCommandTarget(
+      stationID: "station-1",
+      sessionID: sessionID,
+      agentID: agentID,
+      reviewID: reviewID,
+      taskID: taskID,
+      targetRevision: 42
+    ),
+    payload: payload,
+    actorDeviceID: "phone-identity",
+    createdAt: now,
+    expiresAt: now.addingTimeInterval(600),
+    updatedAt: now
+  )
+}
+
+func commandRequestJSON(_ request: URLRequest) throws -> [String: Any] {
+  guard let body = request.httpBody else { return [:] }
+  return try JSONSerialization.jsonObject(with: body) as? [String: Any] ?? [:]
+}
+
+let remoteResolvedReviewResponse =
+  #"""
+  {
+    "fetched_at": "2026-07-10T12:00:00Z",
+    "items": [{
+      "pull_request_id": "fresh-pr",
+      "repository_id": "fresh-repo",
+      "repository": "owner/repo",
+      "number": 42,
+      "title": "Fresh review",
+      "url": "https://github.com/owner/repo/pull/42",
+      "author_login": "octocat",
+      "author_association": "member",
+      "state": "open",
+      "mergeable": "mergeable",
+      "review_status": "approved",
+      "check_status": "failure",
+      "is_draft": false,
+      "policy_blocked": true,
+      "viewer_can_update": false,
+      "viewer_can_merge_as_admin": true,
+      "head_sha": "fresh-sha",
+      "labels": [],
+      "checks": [{
+        "name": "required/ci",
+        "status": "completed",
+        "conclusion": "failure",
+        "check_suite_id": "suite-fresh"
+      }],
+      "reviews": [],
+      "additions": 1,
+      "deletions": 1,
+      "created_at": "2026-07-10T10:00:00Z",
+      "updated_at": "2026-07-10T11:00:00Z",
+      "required_failed_check_names": ["required/ci"],
+      "has_conflict_markers": true,
+      "viewer_has_active_approval": true,
+      "auto_merge_enabled": false,
+      "approval_requirement_satisfied_after_viewer_approval": true
+    }],
+    "missing_references": []
+  }
+  """#
+
+actor RecordingCommandSyncClient: MobileMonitorSyncClient {
+  nonisolated let supportsCommands = true
+  private let disposition: MobileCommandSubmissionDisposition
+  private var submissions = 0
+  private var cancellations = 0
+
+  init(disposition: MobileCommandSubmissionDisposition = .queued) {
+    self.disposition = disposition
+  }
+
+  func fetchLatestSnapshot(
+    stationID: String,
+    now: Date
+  ) async throws -> MobileMirrorSnapshot? {
+    nil
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    submissions += 1
+    return MobileCommandSubmission(command: command, disposition: disposition)
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    cancellations += 1
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func submissionCount() -> Int {
+    submissions
+  }
+
+  func cancellationCount() -> Int {
+    cancellations
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandTestSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandTestSupport.swift
@@ -40,16 +40,20 @@ final class RemoteDaemonCommandURLProtocol: URLProtocol, @unchecked Sendable {
   override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
   override func startLoading() {
-    let response: StubResponse = Self.lock.withLock {
+    let response: StubResponse? = Self.lock.withLock {
       var recordedRequest = request
       let body = request.httpBody ?? request.httpBodyStream.flatMap(Self.readBody)
       recordedRequest.httpBodyStream = nil
       recordedRequest.httpBody = body
       Self.recordedRequests.append(recordedRequest)
       guard !Self.queuedResponses.isEmpty else {
-        return StubResponse(statusCode: 200, body: Data("{}".utf8))
+        return nil
       }
       return Self.queuedResponses.removeFirst()
+    }
+    guard let response else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
     }
     guard let url = request.url,
       let httpResponse = HTTPURLResponse(

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandTests.swift
@@ -46,6 +46,22 @@ final class MobileRemoteDaemonCommandTests: XCTestCase {
     )
   }
 
+  func testMissingNetworkStubFailsClosed() async throws {
+    let client = try makeClient(role: .operator, scopes: ["read", "write"])
+    let command = makeRemoteDaemonCommand(kind: .refresh, payload: ["scope": "health"])
+
+    do {
+      _ = try await client.queueCommand(
+        command,
+        currentRevision: 42,
+        now: command.createdAt
+      )
+      XCTFail("missing response stub should fail")
+    } catch let error as URLError {
+      XCTAssertEqual(error.code, .badServerResponse)
+    }
+  }
+
   func testDirectSubmissionReturnsTerminalReceipt() async throws {
     RemoteDaemonCommandURLProtocol.respond(statusCode: 200, body: #"{"status":"ok"}"#)
     let client = try makeClient(role: .operator, scopes: ["read", "write"])

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonCommandTests.swift
@@ -1,0 +1,269 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+import XCTest
+
+final class MobileRemoteDaemonCommandTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    RemoteDaemonCommandURLProtocol.reset()
+  }
+
+  override func tearDown() {
+    RemoteDaemonCommandURLProtocol.reset()
+    super.tearDown()
+  }
+
+  func testOperatorDirectClientSupportsCommands() throws {
+    let client = try makeClient(role: .operator, scopes: ["read", "write"])
+
+    XCTAssertTrue(client.supportsCommands)
+  }
+
+  func testSyncClientsDefaultToCommandsUnavailable() {
+    XCTAssertFalse(SnapshotOnlyCommandSyncClient().supportsCommands)
+  }
+
+  func testRefreshCommandUsesAuthenticatedDirectRoute() async throws {
+    RemoteDaemonCommandURLProtocol.respond(statusCode: 200, body: #"{"status":"ok"}"#)
+    let client = try makeClient(role: .operator, scopes: ["read", "write"])
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+
+    _ = try await client.queueCommand(
+      makeRemoteDaemonCommand(kind: .refresh, payload: ["scope": "health"], now: now),
+      currentRevision: 42,
+      now: now
+    )
+
+    let request = try XCTUnwrap(RemoteDaemonCommandURLProtocol.requests.first)
+    XCTAssertEqual(request.httpMethod, "GET")
+    XCTAssertEqual(request.url?.absoluteString, "https://daemon.example.com/v1/health")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer server-token")
+    XCTAssertEqual(
+      request.value(forHTTPHeaderField: "x-harness-remote-client-id"),
+      "ios-device"
+    )
+  }
+
+  func testDirectSubmissionReturnsTerminalReceipt() async throws {
+    RemoteDaemonCommandURLProtocol.respond(statusCode: 200, body: #"{"status":"ok"}"#)
+    let client = try makeClient(role: .operator, scopes: ["read", "write"])
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let command = makeRemoteDaemonCommand(
+      kind: .refresh,
+      payload: ["scope": "health"],
+      now: now
+    )
+
+    let submission = try await client.queueCommand(
+      command,
+      currentRevision: 42,
+      now: now
+    )
+
+    XCTAssertEqual(submission.disposition, .completed)
+    XCTAssertEqual(submission.command.status, .succeeded)
+    XCTAssertEqual(submission.command.updatedAt, now)
+    XCTAssertEqual(submission.command.receipt?.status, .succeeded)
+    XCTAssertEqual(submission.command.receipt?.receivedAt, now)
+    XCTAssertEqual(submission.command.receipt?.completedAt, now)
+    XCTAssertEqual(submission.command.receipt?.executionRevision, 42)
+  }
+
+  func testViewerCannotSubmitDirectCommands() async throws {
+    let client = try makeClient(role: .viewer, scopes: ["read"])
+
+    XCTAssertFalse(client.supportsCommands)
+    do {
+      _ = try await client.queueCommand(
+        makeRemoteDaemonCommand(kind: .refresh, payload: ["scope": "health"]),
+        currentRevision: 42,
+        now: Date(timeIntervalSince1970: 1_752_124_400)
+      )
+      XCTFail("expected commands unavailable")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .commandsUnavailable)
+    }
+    XCTAssertTrue(RemoteDaemonCommandURLProtocol.requests.isEmpty)
+  }
+
+  func testAdminCanSubmitBeforeScopeExpansion() throws {
+    let client = try makeClient(role: .admin, scopes: [])
+
+    XCTAssertTrue(client.supportsCommands)
+  }
+
+  func testLiveFactoryEnablesCommandsForRemoteOperatorCredential() throws {
+    let access = try makeRemoteDaemonCommandAccess(
+      role: .operator,
+      scopes: ["read", "write"]
+    )
+    let credential = MobilePairedStationCredential(
+      stationID: "station-1",
+      stationName: "daemon.example.com",
+      endpoint: access.endpoint,
+      stationPublicKeyFingerprint: access.serverSPKISHA256.value,
+      deviceIdentityID: "phone-identity",
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: access.pairedAt,
+      defaultStation: true,
+      remoteDaemonAccess: access
+    )
+    let identity = MobileDeviceIdentity(
+      id: "phone-identity",
+      displayName: "Phone",
+      createdAt: access.pairedAt
+    )
+
+    let client = LiveMobileMonitorSyncClientFactory().makeSyncClient(
+      credential: credential,
+      identity: identity
+    )
+
+    XCTAssertTrue(client.supportsCommands)
+  }
+
+  func testExpiredCommandIsRejectedBeforeNetwork() async throws {
+    let client = try makeClient(role: .operator, scopes: ["read", "write"])
+    let createdAt = Date(timeIntervalSince1970: 1_752_124_400)
+    let now = createdAt.addingTimeInterval(601)
+
+    do {
+      _ = try await client.queueCommand(
+        makeRemoteDaemonCommand(
+          kind: .refresh,
+          payload: ["scope": "health"],
+          now: createdAt
+        ),
+        currentRevision: 42,
+        now: now
+      )
+      XCTFail("expected command expiry")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .commandExpired)
+    }
+    XCTAssertTrue(RemoteDaemonCommandURLProtocol.requests.isEmpty)
+  }
+
+  func testRemoteAuthorizationFailuresRemainFailClosed() async throws {
+    let client = try makeClient(role: .operator, scopes: ["read", "write"])
+    let command = makeRemoteDaemonCommand(kind: .refresh, payload: ["scope": "health"])
+    for (statusCode, expectedError) in [
+      (401, MobileRemoteDaemonSyncError.unauthorized),
+      (403, MobileRemoteDaemonSyncError.forbidden),
+    ] {
+      RemoteDaemonCommandURLProtocol.respond(statusCode: statusCode, body: "{}")
+      do {
+        _ = try await client.queueCommand(
+          command,
+          currentRevision: 42,
+          now: command.createdAt
+        )
+        XCTFail("expected authorization failure")
+      } catch let error as MobileRemoteDaemonSyncError {
+        XCTAssertEqual(error, expectedError)
+      }
+    }
+  }
+
+  func testDirectMutationFailureDoesNotFallBackToCloud() async throws {
+    RemoteDaemonCommandURLProtocol.respond(statusCode: 503, body: "{}")
+    let cloud = RecordingCommandSyncClient()
+    let client = DirectFirstMobileMonitorSyncClient(
+      direct: try makeClient(role: .operator, scopes: ["read", "write"]),
+      cloudFallback: cloud
+    )
+    let command = makeRemoteDaemonCommand(kind: .refresh, payload: ["scope": "health"])
+
+    do {
+      _ = try await client.queueCommand(
+        command,
+        currentRevision: 42,
+        now: command.createdAt
+      )
+      XCTFail("expected server failure")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .serverStatus(503))
+    }
+    let submissionCount = await cloud.submissionCount()
+    XCTAssertEqual(submissionCount, 0)
+  }
+
+  func testHybridViewerUsesCloudCommandTransport() async throws {
+    let cloud = RecordingCommandSyncClient()
+    let client = DirectFirstMobileMonitorSyncClient(
+      direct: try makeClient(role: .viewer, scopes: ["read"]),
+      cloudFallback: cloud
+    )
+    let command = makeRemoteDaemonCommand(kind: .refresh, payload: ["scope": "health"])
+
+    let submission = try await client.queueCommand(
+      command,
+      currentRevision: 42,
+      now: command.createdAt
+    )
+
+    XCTAssertEqual(submission.disposition, .queued)
+    XCTAssertEqual(submission.command.id, command.id)
+    let submissionCount = await cloud.submissionCount()
+    XCTAssertEqual(submissionCount, 1)
+    XCTAssertTrue(RemoteDaemonCommandURLProtocol.requests.isEmpty)
+  }
+
+  func testHybridDirectCommandDoesNotCancelThroughCloud() async throws {
+    let cloud = RecordingCommandSyncClient()
+    let client = DirectFirstMobileMonitorSyncClient(
+      direct: try makeClient(role: .operator, scopes: ["read", "write"]),
+      cloudFallback: cloud
+    )
+    let command = makeRemoteDaemonCommand(kind: .refresh, payload: ["scope": "health"])
+
+    do {
+      _ = try await client.cancelCommand(
+        command,
+        currentRevision: 42,
+        now: command.createdAt
+      )
+      XCTFail("direct commands do not have a CloudMirror cancellation")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .commandsUnavailable)
+    }
+    let cancellationCount = await cloud.cancellationCount()
+    XCTAssertEqual(cancellationCount, 0)
+  }
+
+  private func makeClient(
+    role: MobileRemoteDaemonRole,
+    scopes: [String]
+  ) throws -> MobileRemoteDaemonSyncClient {
+    try makeRemoteDaemonCommandClient(role: role, scopes: scopes)
+  }
+}
+
+private struct SnapshotOnlyCommandSyncClient: MobileMonitorSyncClient {
+  func fetchLatestSnapshot(
+    stationID: String,
+    now: Date
+  ) async throws -> MobileMirrorSnapshot? {
+    nil
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
@@ -90,7 +90,7 @@ final class MobileRemoteDaemonSyncClientTests: XCTestCase {
     XCTAssertEqual(snapshot, expected)
     let fetchCount = await fallback.fetchCount()
     XCTAssertEqual(fetchCount, 1)
-    XCTAssertFalse(client.supportsCommands)
+    XCTAssertTrue(client.supportsCommands)
   }
 
   func testRemoteServerFailureUsesCloudFallback() async throws {
@@ -126,26 +126,22 @@ final class MobileRemoteDaemonSyncClientTests: XCTestCase {
     XCTAssertEqual(fetchCount, 0)
   }
 
-  func testHybridClientRejectsCommandsWithoutUsingCloudRevision() async throws {
+  func testHybridClientUsesCloudCommandsWhenDirectWriteIsUnavailable() async throws {
     let cloud = RecordingSyncClient(snapshot: snapshotFixture())
     let client = DirectFirstMobileMonitorSyncClient(
       direct: ThrowingSyncClient(error: URLError(.timedOut)),
       cloudFallback: cloud
     )
 
-    do {
-      _ = try await client.queueCommand(
-        commandFixture(),
-        currentRevision: 99,
-        now: .now
-      )
-      XCTFail("expected commands unavailable")
-    } catch let error as MobileRemoteDaemonSyncError {
-      XCTAssertEqual(error, .commandsUnavailable)
-    }
+    let submission = try await client.queueCommand(
+      commandFixture(),
+      currentRevision: 99,
+      now: .now
+    )
 
+    XCTAssertEqual(submission.command.id, "command-1")
     let commandAttempts = await cloud.commandAttemptCount()
-    XCTAssertEqual(commandAttempts, 0)
+    XCTAssertEqual(commandAttempts, 1)
   }
 
   func testFactoryBuildsDirectOnlyClientForRemoteCredential() throws {
@@ -195,7 +191,7 @@ private struct ThrowingSyncClient: MobileMonitorSyncClient {
     _ command: MobileCommandRecord,
     currentRevision: Int64,
     now: Date
-  ) async throws -> MobileQueuedCommand {
+  ) async throws -> MobileCommandSubmission {
     throw error
   }
 
@@ -209,6 +205,7 @@ private struct ThrowingSyncClient: MobileMonitorSyncClient {
 }
 
 private actor RecordingSyncClient: MobileMonitorSyncClient {
+  nonisolated let supportsCommands = true
   private let snapshot: MobileMirrorSnapshot?
   private var fetches = 0
   private var commandAttempts = 0
@@ -226,9 +223,9 @@ private actor RecordingSyncClient: MobileMonitorSyncClient {
     _ command: MobileCommandRecord,
     currentRevision: Int64,
     now: Date
-  ) async throws -> MobileQueuedCommand {
+  ) async throws -> MobileCommandSubmission {
     commandAttempts += 1
-    throw MobileRemoteDaemonSyncError.commandsUnavailable
+    return MobileCommandSubmission(command: command)
   }
 
   func cancelCommand(

--- a/docs/agent-guides/monitor-mobile-reference.md
+++ b/docs/agent-guides/monitor-mobile-reference.md
@@ -6,12 +6,12 @@ The macOS app itself is covered by `apps/harness-monitor/AGENTS.md` and `monitor
 
 ## Product shape
 
-Harness Monitor on the phone and watch is a read-mostly view of monitor state with two credential-driven transports:
+Harness Monitor on the phone and watch is a mobile control surface with two credential-driven transports:
 
-1. A remote-daemon profile connects directly over pinned HTTPS. The phone claims a one-time remote pairing invitation, stores the bearer credential in its Keychain, and fetches authenticated session snapshots. The watch can use the same direct path after the phone transfers that profile through WatchConnectivity.
+1. A remote-daemon profile connects directly over pinned HTTPS. The phone claims a one-time remote pairing invitation, stores the bearer credential in its Keychain, fetches authenticated session snapshots, and executes role-scoped commands against daemon HTTP routes. The watch can use the same direct path after the phone transfers that profile through WatchConnectivity.
 2. A local-relay profile uses `HarnessMonitorMacRelay` and `HarnessMonitorCloudMirror`. The Mac redacts and encrypts a full snapshot, CloudKit carries only encrypted records plus routing metadata, and the phone/watch decrypt the mirror. Signed commands return through the same relay for the Mac to validate and execute.
 
-When a credential has both transports, direct access is tried first. CloudMirror is used only for reachability/TLS failures or remote 5xx responses; remote `401` and `403` responses fail closed. The phone remains the pairing hub for the watch. The watch does not run either pairing claim itself.
+When a credential has both transports, direct snapshot access is tried first. CloudMirror snapshot fallback is used only for reachability/TLS failures or remote 5xx responses; remote `401` and `403` responses fail closed. Commands use direct execution whenever the remote profile has write scope and never fall back after a direct attempt, avoiding duplicate side effects after an ambiguous network failure. A read-only direct profile may still use an independently configured CloudMirror command channel. The phone remains the pairing hub for the watch. The watch does not run either pairing claim itself.
 
 ## Target and framework map
 
@@ -43,7 +43,7 @@ On a relay-paired device, `MobileCloudMirrorSyncClient.fetchLatestSnapshot(stati
 
 On a remote-paired device, `MobileRemoteDaemonSyncClient.fetchLatestSnapshot(stationID:now:)` sends an authenticated `GET /v1/sessions` to the pinned endpoint and maps the daemon's secret-free session fields into the shared snapshot model. `DirectFirstMobileMonitorSyncClient` applies the fail-closed fallback policy described above. The shared `MirrorStore.refresh()` aggregates every paired station through the same `MobileMonitorSyncClient` protocol.
 
-### Device to Mac (command)
+### Device command paths
 
 A command authored on the phone or watch is a `MobileCommandRecord` whose `kind` is one of a fixed `MobileCommandKind` set: resolve an ACP permission, start/stop/prompt an agent, dispatch a task or approve a task-board plan, approve/label/merge a pull request or rerun its checks, or a plain refresh. The device encrypts and signs it with the command-signing key established at pairing, then `MobileCloudMirrorSyncClient.queueCommand(_:currentRevision:now:)` writes it to the queue with the snapshot `revision` it was authored against (optimistic concurrency).
 
@@ -51,7 +51,9 @@ On the Mac, `MobileMacRelayService.executePendingCommands()` walks the pending q
 
 Commands are idempotent on the Mac: `executedCommandIDs` guards against re-running a command if a duplicate mirror pass sees it again before its terminal receipt has propagated.
 
-Direct and direct-first profiles currently expose snapshots only because the daemon snapshot has no relay revision for fresh-state validation. A CloudMirror-only relay credential still carries commands; other profiles report commands unavailable instead of queuing against an invented revision.
+For a write-scoped remote profile, `MobileRemoteDaemonSyncClient.queueCommand` executes the command immediately against the corresponding authenticated daemon route. ACP permission, task-board dispatch/plan approval, terminal/Codex/ACP start-stop-prompt, pull-request actions, and refresh scopes all use the same pinned URLSession and per-client bearer headers as snapshots. Stop and prompt first resolve the managed-agent kind so the client chooses the correct terminal, Codex, or ACP mutation. Review actions first resolve the referenced pull request through the daemon and build the mutation target from that fresh response; stale target IDs, policy flags, checks, and head SHA values from the mobile command are never trusted. A successful response becomes a terminal local receipt instead of a relay queue record, so no invented relay revision or cancellation window is needed.
+
+Remote mutation requests are attributed to a token-free structured actor principal containing the authenticated client id, platform, role, and scopes. Caller-supplied actor values are replaced for both HTTP and WebSocket mutations, including review workflow requests that preserve local agent actors. Viewer/read-only profiles do not expose direct commands. Admin profiles retain write access before local scope expansion, while operator profiles require the returned `write` scope.
 
 ## Pairing
 
@@ -104,7 +106,7 @@ The CloudKit schema must be deployed to the Production environment before TestFl
 - Remote TLS pinning. Remote pairing and snapshots require HTTPS and validate both platform trust and the invitation's SPKI SHA-256 pin. A mismatched or untrusted certificate fails the request.
 - Remote bearer isolation. Each remote client has its own opaque token and client id. The token is persisted only in the device Keychain and redacted from debug descriptions. Authentication and authorization failures never trigger CloudMirror fallback.
 - Secret redaction. The Mac redacts secrets twice: once while building the snapshot (`+Redaction`) and again on command-execution output, via `MobileMirrorSecretRedactor`. Redaction runs before encryption, so a key compromise still does not expose un-redacted secrets that were never put in the payload.
-- Command signing + fresh-state validation. Commands are signed with a command-signing key distinct from the snapshot key, and the Mac rejects any command whose authored `revision` no longer matches current state. This prevents a stale or replayed command from acting on a board that has moved on.
+- Command integrity. CloudMirror commands are signed with a command-signing key distinct from the snapshot key, and the Mac rejects any command whose authored `revision` no longer matches current state. Direct commands use pinned TLS, per-client bearer authentication, route authorization, and authenticated actor rebinding; they execute immediately and never retry through CloudMirror after a direct mutation attempt.
 - Trust is per device. Each phone/watch has its own `MobileDeviceIdentity`; unpairing one device deletes only its credential and, if no sibling credential shares the identity, its identity too.
 - Biometric gate. Both apps link `LocalAuthentication` to gate sensitive command actions behind Face ID / Touch ID / wrist-detection.
 - Privacy controls. `MobileCloudMirrorPrivacyService` lets the user inventory and delete the records mirrored for their devices; the iOS Settings tab exposes this when at least one station is mirrored.

--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -7,6 +7,7 @@ use axum::response::{IntoResponse, Response};
 
 use crate::daemon::protocol::{
     ControlPlaneActorRequest, HTTP_API_CONTRACT, HttpApiRouteContract, http_paths,
+    with_control_plane_actor,
 };
 use crate::daemon::remote_auth::{
     RemoteAuthError, RemoteBearerCredentials, authorize_remote_http_route,
@@ -106,7 +107,12 @@ pub(crate) async fn authorize_remote_http_request(
         return remote_auth_error_response(RemoteAuthError::MissingScopeContract);
     };
     match verify_and_authorize_http_route(request.headers(), &state, route) {
-        Ok(client) => REMOTE_HTTP_CLIENT.scope(client, next.run(request)).await,
+        Ok(client) => {
+            let actor = client.control_plane_actor_id();
+            REMOTE_HTTP_CLIENT
+                .scope(client, with_control_plane_actor(actor, next.run(request)))
+                .await
+        }
         Err(response) => *response,
     }
 }

--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -40,6 +40,7 @@ mod async_reads;
 mod async_signal_mutations;
 mod async_stream;
 mod decode_failure_telemetry;
+mod remote_actor;
 mod remote_authz;
 mod remote_pairing;
 mod reviews_policy_writes;

--- a/src/daemon/http/tests/remote_actor.rs
+++ b/src/daemon/http/tests/remote_actor.rs
@@ -1,0 +1,72 @@
+use axum::http::StatusCode;
+use axum::{Router, middleware, routing::get};
+use tokio::net::TcpListener;
+
+use crate::daemon::http::auth::DaemonHttpAuthMode;
+use crate::daemon::protocol::{current_control_plane_actor_id, http_paths};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_auth::REMOTE_CLIENT_ID_HEADER;
+use crate::daemon::remote_identity::RemoteClientRegistration;
+
+use super::test_http_state_with_db;
+
+#[tokio::test]
+async fn remote_http_authz_scopes_authenticated_actor_identity() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_operator(&state);
+    let app = Router::new()
+        .route(http_paths::HEALTH, get(current_actor))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            super::super::auth::authorize_remote_http_request,
+        ))
+        .with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let address = listener.local_addr().expect("listener address");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve router");
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{address}{}", http_paths::HEALTH))
+        .header(REMOTE_CLIENT_ID_HEADER, "operator")
+        .bearer_auth(remote_token())
+        .send()
+        .await
+        .expect("send health request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.text().await.expect("actor response"),
+        r#"{"client_id":"operator","platform":"ios","role":"operator","scopes":["read","write"]}"#
+    );
+    server.abort();
+    let _ = server.await;
+}
+
+fn register_operator(state: &crate::daemon::http::DaemonHttpState) {
+    let registration = RemoteClientRegistration::new_for_tests(
+        "operator",
+        "Phone",
+        "ios",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        &remote_token(),
+        "2026-06-21T16:00:00Z",
+    )
+    .expect("remote registration");
+    let db = state.db.get().expect("db slot").lock().expect("db lock");
+    db.register_remote_client(&registration)
+        .expect("register remote client");
+}
+
+fn remote_token() -> String {
+    "remote-token-secret-operator".to_string()
+}
+
+async fn current_actor() -> String {
+    current_control_plane_actor_id()
+}

--- a/src/daemon/protocol/binding.rs
+++ b/src/daemon/protocol/binding.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use serde_json::Value;
 
 use crate::session::types::CONTROL_PLANE_ACTOR_ID;
@@ -20,25 +22,44 @@ pub trait ControlPlaneActorRequest {
     fn bind_control_plane_actor(&mut self);
 }
 
+tokio::task_local! {
+    static CONTROL_PLANE_ACTOR_OVERRIDE: String;
+}
+
+pub async fn with_control_plane_actor<T>(actor: String, future: impl Future<Output = T>) -> T {
+    CONTROL_PLANE_ACTOR_OVERRIDE.scope(actor, future).await
+}
+
+#[must_use]
+pub fn current_control_plane_actor_id() -> String {
+    CONTROL_PLANE_ACTOR_OVERRIDE
+        .try_with(Clone::clone)
+        .unwrap_or_else(|_| CONTROL_PLANE_ACTOR_ID.to_string())
+}
+
 pub fn bind_control_plane_actor_value(params: &mut Value) {
     let Some(object) = params.as_object_mut() else {
         return;
     };
     object.insert(
         "actor".into(),
-        Value::String(CONTROL_PLANE_ACTOR_ID.to_string()),
+        Value::String(current_control_plane_actor_id()),
     );
 }
 
 fn bind_required_control_plane_actor(actor: &mut String) {
-    *actor = CONTROL_PLANE_ACTOR_ID.to_string();
+    *actor = current_control_plane_actor_id();
 }
 
 fn bind_optional_control_plane_actor(actor: &mut Option<String>) {
-    *actor = Some(CONTROL_PLANE_ACTOR_ID.to_string());
+    *actor = Some(current_control_plane_actor_id());
 }
 
-fn preserve_required_actor(_actor: &mut String) {}
+fn preserve_required_actor(actor: &mut String) {
+    if let Ok(remote_actor) = CONTROL_PLANE_ACTOR_OVERRIDE.try_with(Clone::clone) {
+        *actor = remote_actor;
+    }
+}
 
 impl ControlPlaneActorRequest for CodexRunRequest {
     fn bind_control_plane_actor(&mut self) {
@@ -277,5 +298,51 @@ mod tests {
         };
         request.bind_control_plane_actor();
         assert_eq!(request.actor.as_deref(), Some(CONTROL_PLANE_ACTOR_ID));
+    }
+
+    #[tokio::test]
+    async fn actor_binding_uses_scoped_remote_principal() {
+        let principal = r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["read","write"]}"#;
+
+        with_control_plane_actor(principal.to_string(), async {
+            let mut request = TaskBoardDispatchRequest {
+                actor: Some("imposter".into()),
+                ..Default::default()
+            };
+            request.bind_control_plane_actor();
+
+            assert_eq!(request.actor.as_deref(), Some(principal));
+        })
+        .await;
+    }
+
+    #[test]
+    fn actor_binding_preserves_local_review_actor() {
+        let mut request = TaskSubmitForReviewRequest {
+            actor: "worker-1".into(),
+            summary: None,
+            suggested_persona: None,
+        };
+
+        request.bind_control_plane_actor();
+
+        assert_eq!(request.actor, "worker-1");
+    }
+
+    #[tokio::test]
+    async fn actor_binding_replaces_remote_review_actor() {
+        let principal = r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["read","write"]}"#;
+
+        with_control_plane_actor(principal.to_string(), async {
+            let mut request = TaskSubmitForReviewRequest {
+                actor: "spoofed-worker".into(),
+                summary: None,
+                suggested_persona: None,
+            };
+            request.bind_control_plane_actor();
+
+            assert_eq!(request.actor, principal);
+        })
+        .await;
     }
 }

--- a/src/daemon/protocol/mod.rs
+++ b/src/daemon/protocol/mod.rs
@@ -15,7 +15,10 @@ mod websocket;
 
 pub use api_contract::*;
 pub use audit::*;
-pub use binding::{ControlPlaneActorRequest, bind_control_plane_actor_value};
+pub use binding::{
+    ControlPlaneActorRequest, bind_control_plane_actor_value, current_control_plane_actor_id,
+    with_control_plane_actor,
+};
 pub use codex::*;
 pub use managed_agents::*;
 pub use openrouter_models::*;

--- a/src/daemon/remote_identity.rs
+++ b/src/daemon/remote_identity.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use rand_core06::{OsRng, RngCore};
+use serde::Serialize;
 
 use super::remote::{RemoteAccessScope, RemoteRole, scopes_for_role};
 use super::remote_crypto::{
@@ -227,6 +228,31 @@ pub struct RemoteStoredClient {
     pub last_seen_at: Option<String>,
     pub revoked_at: Option<String>,
     pub rotated_at: Option<String>,
+}
+
+#[derive(Serialize)]
+struct RemoteControlPlaneActor<'a> {
+    client_id: &'a str,
+    platform: &'a str,
+    role: &'static str,
+    scopes: Vec<&'static str>,
+}
+
+impl RemoteStoredClient {
+    #[must_use]
+    /// Serialize the authenticated, token-free actor identity for mutation attribution.
+    ///
+    /// # Panics
+    /// Panics only if `serde_json` cannot serialize the string-only identity fields.
+    pub fn control_plane_actor_id(&self) -> String {
+        let actor = RemoteControlPlaneActor {
+            client_id: &self.client_id,
+            platform: &self.platform,
+            role: self.role.as_str(),
+            scopes: self.scopes.iter().map(|scope| scope.as_str()).collect(),
+        };
+        serde_json::to_string(&actor).expect("remote control-plane actor serialization")
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -4,13 +4,16 @@ use super::frames::{
     serialize_response_frames,
 };
 use crate::daemon::http::{DaemonHttpAuthMode, DaemonHttpState};
-use crate::daemon::protocol::{WsErrorPayload, WsRequest, WsResponse, ws_methods};
+use crate::daemon::protocol::{
+    WsErrorPayload, WsRequest, WsResponse, with_control_plane_actor, ws_methods,
+};
 use crate::daemon::remote_auth::{RemoteAuthError, authorize_remote_ws_method};
 use crate::daemon::remote_identity::RemoteStoredClient;
 use crate::telemetry::{
     TelemetryBaggage, apply_parent_context_from_text_map, current_trace_id, with_active_baggage,
 };
 use axum::extract::ws::Message;
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 use tracing::Instrument as _;
@@ -122,7 +125,13 @@ async fn dispatch_inner(
     if let Some(response) = authorize_remote_ws_request(request, state, connection) {
         return response;
     }
-    if let Some(response) = routing::dispatch_known_method(request, state, connection).await {
+    let response = Box::pin(with_connection_actor(
+        state,
+        connection,
+        routing::dispatch_known_method(request, state, connection),
+    ))
+    .await;
+    if let Some(response) = response {
         return response;
     }
     error_response(
@@ -130,6 +139,22 @@ async fn dispatch_inner(
         "UNKNOWN_METHOD",
         &format!("unknown method: {}", request.method),
     )
+}
+
+async fn with_connection_actor<T>(
+    state: &DaemonHttpState,
+    connection: &Arc<Mutex<ConnectionState>>,
+    future: impl Future<Output = T>,
+) -> T {
+    let actor = (state.auth_mode == DaemonHttpAuthMode::Remote)
+        .then(|| remote_client_for_connection(connection))
+        .flatten()
+        .map(|client| client.control_plane_actor_id());
+    if let Some(actor) = actor {
+        with_control_plane_actor(actor, future).await
+    } else {
+        future.await
+    }
 }
 
 fn authorize_remote_ws_request(

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -117,6 +117,10 @@ pub(crate) const fn ws_activity_log_level() -> tracing::Level {
     crate::DAEMON_ACTIVITY_LOG_LEVEL
 }
 
+#[expect(
+    clippy::large_futures,
+    reason = "boxing dispatch would allocate for every websocket message"
+)]
 async fn dispatch_inner(
     request: &WsRequest,
     state: &DaemonHttpState,
@@ -125,13 +129,13 @@ async fn dispatch_inner(
     if let Some(response) = authorize_remote_ws_request(request, state, connection) {
         return response;
     }
-    let response = Box::pin(with_connection_actor(
+    if let Some(response) = with_connection_actor(
         state,
         connection,
         routing::dispatch_known_method(request, state, connection),
-    ))
-    .await;
-    if let Some(response) = response {
+    )
+    .await
+    {
         return response;
     }
     error_response(

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::daemon::http::DaemonHttpAuthMode;
-use crate::daemon::protocol::WsRequest;
 use crate::daemon::protocol::ws_methods;
+use crate::daemon::protocol::{WsRequest, current_control_plane_actor_id};
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 use crate::daemon::remote_identity::{RemoteStoredClient, RemoteTokenHash};
 use std::sync::{Arc, Mutex};
@@ -94,6 +94,27 @@ async fn remote_ws_dispatch_preserves_unknown_method_errors() {
     assert_eq!(error.code, "UNKNOWN_METHOD");
     assert!(error.message.contains("remote.unscoped"));
     assert_eq!(error.status_code, None);
+}
+
+#[tokio::test]
+async fn remote_ws_dispatch_scopes_authenticated_actor_identity() {
+    let mut state = super::super::test_support::test_ws_state();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
+        "operator",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+    ))));
+
+    let actor = with_connection_actor(&state, &connection, async {
+        current_control_plane_actor_id()
+    })
+    .await;
+
+    assert_eq!(
+        actor,
+        r#"{"client_id":"operator","platform":"macos","role":"operator","scopes":["read","write"]}"#
+    );
 }
 
 #[test]

--- a/src/session/service/session_helpers.rs
+++ b/src/session/service/session_helpers.rs
@@ -173,15 +173,16 @@ pub(crate) fn require_permission(
     actor_id: &str,
     action: SessionAction,
 ) -> Result<(), CliError> {
-    if is_control_plane_actor_id(actor_id) {
-        return Ok(());
-    }
-    let agent = state.agents.get(actor_id).ok_or_else(|| {
-        CliError::from(CliErrorKind::session_agent_conflict(format!(
+    let Some(agent) = state.agents.get(actor_id) else {
+        if is_control_plane_actor_id(actor_id) {
+            return Ok(());
+        }
+        return Err(CliErrorKind::session_agent_conflict(format!(
             "agent '{actor_id}' not registered in session '{}'",
             state.session_id
-        )))
-    })?;
+        ))
+        .into());
+    };
     if !agent.status.is_alive() {
         return Err(CliErrorKind::session_permission_denied(format!(
             "agent '{actor_id}' is {} in session '{}'",
@@ -375,6 +376,39 @@ mod remote_actor_tests {
         let actor = r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["read","write"]}"#;
 
         assert!(require_permission(&state, actor, SessionAction::CreateTask).is_ok());
+    }
+
+    #[test]
+    fn registered_agent_matching_remote_actor_keeps_agent_permissions() {
+        let mut state = build_initial_state(
+            "remote session",
+            "Remote session",
+            "remote-session",
+            "2026-07-10T12:00:00Z",
+            None,
+        );
+        let actor = r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["read","write"]}"#;
+        state.agents.insert(
+            actor.to_string(),
+            AgentRegistration {
+                agent_id: actor.to_string(),
+                name: "Colliding worker".to_string(),
+                runtime: crate::agents::kind::RuntimeKind::from("codex"),
+                role: SessionRole::Worker,
+                capabilities: Vec::new(),
+                joined_at: "2026-07-10T12:00:00Z".to_string(),
+                updated_at: "2026-07-10T12:00:00Z".to_string(),
+                status: crate::session::types::AgentStatus::Active,
+                agent_session_id: None,
+                managed_agent: None,
+                last_activity_at: None,
+                current_task_id: None,
+                runtime_capabilities: Default::default(),
+                persona: None,
+            },
+        );
+
+        assert!(require_permission(&state, actor, SessionAction::EndSession).is_err());
     }
 
     #[test]

--- a/src/session/service/session_helpers.rs
+++ b/src/session/service/session_helpers.rs
@@ -1,12 +1,14 @@
 use std::path::PathBuf;
 
 use super::{
-    BTreeMap, CONTROL_PLANE_ACTOR_ID, CURRENT_VERSION, CliError, CliErrorKind,
-    LEAVE_SESSION_SIGNAL_COMMAND, LeaveSignalRecord, Path, SessionAction, SessionMetrics,
-    SessionState, SessionStatus, TaskStatus, agent_status_label, build_signal, fmt,
-    generate_session_id, is_permitted, promote_or_degrade, refresh_session, runtime, storage,
+    BTreeMap, CURRENT_VERSION, CliError, CliErrorKind, LEAVE_SESSION_SIGNAL_COMMAND,
+    LeaveSignalRecord, Path, SessionAction, SessionMetrics, SessionState, SessionStatus,
+    TaskStatus, agent_status_label, build_signal, fmt, generate_session_id, is_permitted,
+    promote_or_degrade, refresh_session, runtime, storage,
 };
-use crate::session::types::{AgentRegistration, SessionPolicy, SessionRole};
+use crate::session::types::{
+    AgentRegistration, SessionPolicy, SessionRole, is_control_plane_actor_id,
+};
 
 pub(crate) fn create_initial_session(
     context: &str,
@@ -171,7 +173,7 @@ pub(crate) fn require_permission(
     actor_id: &str,
     action: SessionAction,
 ) -> Result<(), CliError> {
-    if actor_id == CONTROL_PLANE_ACTOR_ID {
+    if is_control_plane_actor_id(actor_id) {
         return Ok(());
     }
     let agent = state.agents.get(actor_id).ok_or_else(|| {
@@ -355,4 +357,48 @@ pub(crate) fn require_active_worker_target_agent(
         .into());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod remote_actor_tests {
+    use super::*;
+
+    #[test]
+    fn remote_control_plane_actor_can_mutate_without_agent_registration() {
+        let state = build_initial_state(
+            "remote session",
+            "Remote session",
+            "remote-session",
+            "2026-07-10T12:00:00Z",
+            None,
+        );
+        let actor = r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["read","write"]}"#;
+
+        assert!(require_permission(&state, actor, SessionAction::CreateTask).is_ok());
+    }
+
+    #[test]
+    fn invalid_remote_actors_cannot_gain_control_plane_permission() {
+        let state = build_initial_state(
+            "remote session",
+            "Remote session",
+            "remote-session",
+            "2026-07-10T12:00:00Z",
+            None,
+        );
+        let invalid_actors = [
+            r#"{"client_id":"phone-1","platform":"ios","role":"viewer","scopes":["read"]}"#,
+            r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["read"]}"#,
+            r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["write","unknown"]}"#,
+            r#"{"client_id":"","platform":"ios","role":"operator","scopes":["write"]}"#,
+            "not-json",
+        ];
+
+        for actor in invalid_actors {
+            assert!(
+                require_permission(&state, actor, SessionAction::CreateTask).is_err(),
+                "invalid remote actor should not gain permission: {actor}"
+            );
+        }
+    }
 }

--- a/src/session/service/session_helpers.rs
+++ b/src/session/service/session_helpers.rs
@@ -379,6 +379,20 @@ mod remote_actor_tests {
     }
 
     #[test]
+    fn remote_admin_actor_can_mutate_with_admin_scope() {
+        let state = build_initial_state(
+            "remote session",
+            "Remote session",
+            "remote-session",
+            "2026-07-10T12:00:00Z",
+            None,
+        );
+        let actor = r#"{"client_id":"phone-1","platform":"ios","role":"admin","scopes":["admin"]}"#;
+
+        assert!(require_permission(&state, actor, SessionAction::EndSession).is_ok());
+    }
+
+    #[test]
     fn registered_agent_matching_remote_actor_keeps_agent_permissions() {
         let mut state = build_initial_state(
             "remote session",
@@ -423,6 +437,7 @@ mod remote_actor_tests {
         let invalid_actors = [
             r#"{"client_id":"phone-1","platform":"ios","role":"viewer","scopes":["read"]}"#,
             r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["read"]}"#,
+            r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["admin"]}"#,
             r#"{"client_id":"phone-1","platform":"ios","role":"operator","scopes":["write","unknown"]}"#,
             r#"{"client_id":"","platform":"ios","role":"operator","scopes":["write"]}"#,
             "not-json",

--- a/src/session/types/mod.rs
+++ b/src/session/types/mod.rs
@@ -26,6 +26,7 @@ pub use identity::{
     AgentDescriptorId, HarnessSessionId, ManagedAgentId, RuntimeSessionId, SessionAgentId,
 };
 pub use policy::{AutoPromotionPolicy, LeaderJoinPolicy, LeaderRecoveryPolicy, SessionPolicy};
+pub(crate) use state::is_control_plane_actor_id;
 pub use state::{
     CONTROL_PLANE_ACTOR_ID, CURRENT_VERSION, SessionMetrics, SessionState, SessionStatus,
 };

--- a/src/session/types/state.rs
+++ b/src/session/types/state.rs
@@ -35,6 +35,9 @@ pub(crate) fn is_control_plane_actor_id(actor_id: &str) -> bool {
     if actor_id == CONTROL_PLANE_ACTOR_ID {
         return true;
     }
+    if !actor_id.starts_with('{') || !actor_id.ends_with('}') {
+        return false;
+    }
     serde_json::from_str::<RemoteControlPlaneActor>(actor_id).is_ok_and(|actor| {
         let has_control_scope = match actor.role.as_str() {
             "admin" => actor

--- a/src/session/types/state.rs
+++ b/src/session/types/state.rs
@@ -36,10 +36,17 @@ pub(crate) fn is_control_plane_actor_id(actor_id: &str) -> bool {
         return true;
     }
     serde_json::from_str::<RemoteControlPlaneActor>(actor_id).is_ok_and(|actor| {
+        let has_control_scope = match actor.role.as_str() {
+            "admin" => actor
+                .scopes
+                .iter()
+                .any(|scope| matches!(scope.as_str(), "write" | "admin")),
+            "operator" => actor.scopes.iter().any(|scope| scope == "write"),
+            _ => false,
+        };
         !actor.client_id.trim().is_empty()
             && !actor.platform.trim().is_empty()
-            && matches!(actor.role.as_str(), "admin" | "operator")
-            && actor.scopes.iter().any(|scope| scope == "write")
+            && has_control_scope
             && actor
                 .scopes
                 .iter()

--- a/src/session/types/state.rs
+++ b/src/session/types/state.rs
@@ -13,11 +13,39 @@ pub const CURRENT_VERSION: u32 = 14;
 
 /// Server-derived principal for daemon-authenticated control-plane mutations.
 ///
-/// The monitor daemon authenticates a shared bearer token, so HTTP and
-/// websocket request payloads must not treat client-supplied actor IDs as an
-/// authenticated identity. Daemon transports rebind actor-bearing mutations to
-/// this control-plane principal server-side.
+/// Local monitor clients authenticate with a shared bearer token, while remote
+/// clients authenticate with per-client credentials. HTTP and websocket
+/// request payloads must not treat client-supplied actor IDs as authenticated.
+/// Daemon transports rebind actor-bearing mutations server-side.
 pub const CONTROL_PLANE_ACTOR_ID: &str = "harness-app";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteControlPlaneActor {
+    client_id: String,
+    platform: String,
+    role: String,
+    scopes: Vec<String>,
+}
+
+/// Recognize a transport-bound local or write-capable remote control-plane actor.
+/// Untrusted payload actors must be rebound before reaching this check.
+#[must_use]
+pub(crate) fn is_control_plane_actor_id(actor_id: &str) -> bool {
+    if actor_id == CONTROL_PLANE_ACTOR_ID {
+        return true;
+    }
+    serde_json::from_str::<RemoteControlPlaneActor>(actor_id).is_ok_and(|actor| {
+        !actor.client_id.trim().is_empty()
+            && !actor.platform.trim().is_empty()
+            && matches!(actor.role.as_str(), "admin" | "operator")
+            && actor.scopes.iter().any(|scope| scope == "write")
+            && actor
+                .scopes
+                .iter()
+                .all(|scope| matches!(scope.as_str(), "read" | "write" | "admin"))
+    })
+}
 
 /// Main versioned state document for a multi-agent orchestration session.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Motivation

The remote daemon is internet-reachable, but iPhone and watch profiles still cannot execute app workflows directly. Remote mutations also lose the authenticated client identity when they enter actor-bearing service requests.

## Implementation

- Execute role-scoped mobile and watch commands over pinned HTTPS, with direct-first transport selection and terminal receipts.
- Resolve fresh pull-request targets before review mutations and use CloudMirror commands only when direct write access is unavailable.
- Bind HTTP and WebSocket mutations to the authenticated client principal and recognize validated write principals in session authorization.
- Cover route shapes, auth failures, fallback rules, actor rebinding, and fail-closed defaults with focused tests, lint, codegen, and iOS/watchOS builds.