### PR TITLE
fix(remote): prove ACME daemon startup

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -152,6 +152,10 @@ run = "./scripts/cargo-local.sh test --quiet --test integration -- --test-thread
 description = "Run ignored slow tests (fake toolchain, ENV_LOCK)"
 run = "./scripts/cargo-local.sh test --quiet --test integration -- --ignored --test-threads=1 --format terse"
 
+[tasks."remote-daemon:e2e"]
+description = "Run the real remote daemon ACME, HTTPS, WSS, pairing, and revocation proof"
+run = "./scripts/cargo-local.sh test --quiet --test remote_daemon_e2e -- --ignored --test-threads=1 --format terse"
+
 [tasks.codegen]
 description = "Regenerate every Rust -> Swift wire-type module from the Rust sources"
 run = "./scripts/cargo-local.sh run --quiet --example policy-codegen"

--- a/src/daemon/remote_acme_issuer.rs
+++ b/src/daemon/remote_acme_issuer.rs
@@ -24,6 +24,7 @@ use super::remote_acme_challenge::SystemRemoteAcmeChallengeProvisioner;
 use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use super::remote_acme_lease_guard::RemoteAcmeChallengeLeaseGuard;
 use super::remote_redaction::redact_secret_detail;
+use super::remote_tls::ensure_rustls_provider;
 
 type AccountBuilderFactory = dyn Fn() -> Result<AccountBuilder, String> + Send + Sync + 'static;
 
@@ -137,6 +138,7 @@ where
     }
 
     pub(crate) fn production(provisioner: P) -> Self {
+        ensure_rustls_provider();
         let directory_url = env::var("HARNESS_REMOTE_ACME_DIRECTORY_URL")
             .ok()
             .filter(|value| !value.trim().is_empty())

--- a/src/daemon/remote_acme_issuer_tests.rs
+++ b/src/daemon/remote_acme_issuer_tests.rs
@@ -19,6 +19,13 @@ use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, Remote
 use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use crate::daemon::remote_tls::build_remote_tls_server_config;
 
+#[test]
+fn production_acme_issuer_installs_rustls_provider_before_client_creation() {
+    let _issuer = InstantAcmeIssuer::production(RecordingProvisioner::default());
+
+    assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+}
+
 #[tokio::test]
 async fn instant_acme_issuer_completes_account_order_and_http01_issuance() {
     let http = ScriptedAcmeHttp::new(acme_happy_path());

--- a/src/daemon/remote_acme_issuer_tests.rs
+++ b/src/daemon/remote_acme_issuer_tests.rs
@@ -1,3 +1,5 @@
+use std::env;
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -19,8 +21,28 @@ use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, Remote
 use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use crate::daemon::remote_tls::build_remote_tls_server_config;
 
+const PRODUCTION_PROVIDER_CHILD_ENV: &str = "HARNESS_TEST_REMOTE_ACME_PROVIDER_CHILD";
+const PRODUCTION_PROVIDER_TEST: &str =
+    "daemon::remote_acme_issuer::tests::production_acme_issuer_installs_rustls_provider_before_client_creation";
+
 #[test]
 fn production_acme_issuer_installs_rustls_provider_before_client_creation() {
+    if env::var_os(PRODUCTION_PROVIDER_CHILD_ENV).is_none() {
+        let output = Command::new(env::current_exe().expect("current unit test executable"))
+            .args(["--exact", PRODUCTION_PROVIDER_TEST, "--nocapture"])
+            .env(PRODUCTION_PROVIDER_CHILD_ENV, "1")
+            .output()
+            .expect("run isolated ACME provider test");
+        assert!(
+            output.status.success(),
+            "isolated ACME provider test failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        return;
+    }
+
+    assert!(rustls::crypto::CryptoProvider::get_default().is_none());
     let _issuer = InstantAcmeIssuer::production(RecordingProvisioner::default());
 
     assert!(rustls::crypto::CryptoProvider::get_default().is_some());

--- a/src/daemon/remote_tls.rs
+++ b/src/daemon/remote_tls.rs
@@ -446,7 +446,7 @@ fn handle_tls_handshake_error(addr: SocketAddr, error: &io::Error) {
     );
 }
 
-fn ensure_rustls_provider() {
+pub(crate) fn ensure_rustls_provider() {
     RUSTLS_PROVIDER.get_or_init(install_remote_tls_rustls_provider);
 }
 

--- a/tests/remote_daemon_e2e.rs
+++ b/tests/remote_daemon_e2e.rs
@@ -1,0 +1,101 @@
+#![allow(
+    clippy::absolute_paths,
+    reason = "the isolated e2e binary keeps system-bound collaborators explicit"
+)]
+#![allow(
+    clippy::cognitive_complexity,
+    reason = "the top-level scenario keeps the complete remote contract visible"
+)]
+
+#[path = "remote_daemon_e2e/acme/mod.rs"]
+mod acme;
+#[path = "remote_daemon_e2e/client.rs"]
+mod client;
+#[path = "remote_daemon_e2e/process.rs"]
+mod process;
+
+use acme::{AcmeChallenge, AcmeChallengeConfig, FakeAcmeServer};
+use client::RemoteDaemonClient;
+use process::{RemoteDaemonEnvironment, RemoteDaemonProcess};
+use serde_json::Value;
+
+const DOMAIN: &str = "daemon.example.com";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "run with mise run remote-daemon:e2e"]
+async fn remote_daemon_e2e_proves_acme_https_wss_pairing_and_revocation() {
+    for challenge in AcmeChallenge::ALL {
+        run_remote_daemon_case(challenge)
+            .await
+            .unwrap_or_else(|error| panic!("{} e2e failed: {error}", challenge.cli_name()));
+    }
+}
+
+async fn run_remote_daemon_case(challenge: AcmeChallenge) -> Result<(), String> {
+    let environment = RemoteDaemonEnvironment::new(challenge)?;
+    let acme = FakeAcmeServer::start(AcmeChallengeConfig {
+        challenge,
+        domain: DOMAIN.to_string(),
+        http_port: environment.http_port(),
+        https_port: environment.https_port(),
+        dns_log: environment.dns_log().to_path_buf(),
+        ca_root: environment.acme_ca_root().to_path_buf(),
+    })
+    .await?;
+    let mut daemon = RemoteDaemonProcess::spawn(&environment, challenge, acme.directory_url())?;
+    let client = RemoteDaemonClient::new(DOMAIN, environment.https_port(), acme.ca_pem())?;
+
+    client
+        .wait_until_listening()
+        .await
+        .map_err(|error| format!("{error}; daemon output: {}", daemon.diagnostics()))?;
+    daemon.ensure_running()?;
+
+    let viewer = pair_client(&daemon, &client, "viewer", "viewer-e2e").await?;
+    client.expect_health(&viewer, 200).await?;
+    client.expect_telemetry(&viewer, 403).await?;
+
+    let operator = pair_client(&daemon, &client, "operator", "operator-e2e").await?;
+    client.expect_telemetry(&operator, 200).await?;
+    client.expect_log_level_update(&operator, 403).await?;
+    client
+        .expect_websocket_health_and_admin_denial(&operator)
+        .await?;
+
+    let admin = pair_client(&daemon, &client, "admin", "admin-e2e").await?;
+    client.expect_log_level_update(&admin, 200).await?;
+
+    daemon.revoke_client(&operator.client_id)?;
+    client.expect_health(&operator, 401).await?;
+    acme.assert_complete().await?;
+
+    client.stop(&admin).await?;
+    daemon.wait_for_exit().await?;
+    acme.shutdown().await?;
+    Ok(())
+}
+
+async fn pair_client(
+    daemon: &RemoteDaemonProcess,
+    client: &RemoteDaemonClient,
+    role: &str,
+    client_id: &str,
+) -> Result<client::RemoteCredentials, String> {
+    let invitation = daemon.create_pairing(role)?;
+    let code = required_string(&invitation, "code")?;
+    let credentials = client.claim_pairing(code, client_id, role).await?;
+    if credentials.role != role {
+        return Err(format!(
+            "pairing role mismatch: expected {role}, received {}",
+            credentials.role
+        ));
+    }
+    Ok(credentials)
+}
+
+fn required_string<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
+    value[field]
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("pairing response omitted {field}: {value}"))
+}

--- a/tests/remote_daemon_e2e/acme/mod.rs
+++ b/tests/remote_daemon_e2e/acme/mod.rs
@@ -1,0 +1,265 @@
+mod protocol;
+mod validation;
+
+use std::io;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::Router;
+use axum::serve::Listener;
+use rcgen::{
+    BasicConstraints, CertificateParams, CertifiedIssuer, DistinguishedName, DnType, IsCa, KeyPair,
+    KeyUsagePurpose,
+};
+use rustls::ServerConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::server::TlsStream;
+
+pub(super) const HTTP_TOKEN: &str = "remote-e2e-http-token";
+pub(super) const DNS_TOKEN: &str = "remote-e2e-dns-token";
+pub(super) const TLS_TOKEN: &str = "remote-e2e-tls-token";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcmeChallenge {
+    TlsAlpn,
+    Http,
+    Dns,
+}
+
+impl AcmeChallenge {
+    pub const ALL: [Self; 3] = [Self::TlsAlpn, Self::Http, Self::Dns];
+
+    pub const fn cli_name(self) -> &'static str {
+        match self {
+            Self::TlsAlpn => "tls-alpn",
+            Self::Http => "http",
+            Self::Dns => "dns",
+        }
+    }
+
+    pub(super) fn challenge_path(self) -> &'static str {
+        match self {
+            Self::TlsAlpn => "/challenge/tls/1",
+            Self::Http => "/challenge/http/1",
+            Self::Dns => "/challenge/dns/1",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AcmeChallengeConfig {
+    pub challenge: AcmeChallenge,
+    pub domain: String,
+    pub http_port: u16,
+    pub https_port: u16,
+    pub dns_log: PathBuf,
+    pub ca_root: PathBuf,
+}
+
+pub struct FakeAcmeServer {
+    state: Arc<FakeAcmeState>,
+    directory_url: String,
+    ca_pem: String,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: JoinHandle<Result<(), std::io::Error>>,
+}
+
+impl FakeAcmeServer {
+    pub async fn start(config: AcmeChallengeConfig) -> Result<Self, String> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .map_err(|error| format!("bind fake ACME server: {error}"))?;
+        let address = listener
+            .local_addr()
+            .map_err(|error| format!("read fake ACME address: {error}"))?;
+        let (issuer, ca_pem) = fake_ca()?;
+        std::fs::write(&config.ca_root, ca_pem.as_bytes())
+            .map_err(|error| format!("write fake ACME CA root: {error}"))?;
+        let tls_config = fake_acme_server_tls_config(&issuer)?;
+        let listener = FakeAcmeTlsListener::new(listener, tls_config);
+        let origin = format!("https://localhost:{}", address.port());
+        let state = Arc::new(FakeAcmeState {
+            origin: origin.clone(),
+            config,
+            issuer,
+            progress: Mutex::new(FakeAcmeProgress::default()),
+        });
+        let app = Router::new()
+            .fallback(protocol::handle_acme_request)
+            .with_state(Arc::clone(&state));
+        let (shutdown, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+        });
+        Ok(Self {
+            state,
+            directory_url: format!("{origin}/directory"),
+            ca_pem,
+            shutdown: Some(shutdown),
+            task,
+        })
+    }
+
+    pub fn directory_url(&self) -> &str {
+        &self.directory_url
+    }
+
+    pub fn ca_pem(&self) -> &str {
+        &self.ca_pem
+    }
+
+    pub async fn assert_complete(&self) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let (protocol_complete, validation_error) = {
+                let progress = self
+                    .state
+                    .progress
+                    .lock()
+                    .map_err(|_| "fake ACME progress lock poisoned".to_string())?;
+                (
+                    progress.challenge_validated && progress.certificate_downloaded,
+                    progress.validation_error.clone(),
+                )
+            };
+            if let Some(error) = validation_error {
+                return Err(format!("fake ACME validation failed: {error}"));
+            }
+            let dns_complete = self.state.config.challenge != AcmeChallenge::Dns
+                || validation::dns_lifecycle_complete(&self.state.config.dns_log)?;
+            if protocol_complete && dns_complete {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(
+                    "fake ACME flow did not finish challenge, issuance, and cleanup".to_string(),
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    pub async fn shutdown(mut self) -> Result<(), String> {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        (&mut self.task)
+            .await
+            .map_err(|error| format!("join fake ACME server: {error}"))?
+            .map_err(|error| format!("serve fake ACME server: {error}"))
+    }
+}
+
+impl Drop for FakeAcmeServer {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        self.task.abort();
+    }
+}
+
+pub(super) struct FakeAcmeState {
+    pub(super) origin: String,
+    pub(super) config: AcmeChallengeConfig,
+    pub(super) issuer: CertifiedIssuer<'static, KeyPair>,
+    pub(super) progress: Mutex<FakeAcmeProgress>,
+}
+
+#[derive(Default)]
+pub(super) struct FakeAcmeProgress {
+    pub(super) challenge_validated: bool,
+    pub(super) finalized: bool,
+    pub(super) certificate_pem: Option<String>,
+    pub(super) certificate_downloaded: bool,
+    pub(super) validation_error: Option<String>,
+}
+
+fn fake_ca() -> Result<(CertifiedIssuer<'static, KeyPair>, String), String> {
+    let mut params = CertificateParams::default();
+    params.distinguished_name = DistinguishedName::new();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "Harness Remote E2E CA");
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+    ];
+    let issuer = CertifiedIssuer::self_signed(
+        params,
+        KeyPair::generate().map_err(|error| format!("generate fake ACME CA key: {error}"))?,
+    )
+    .map_err(|error| format!("generate fake ACME CA certificate: {error}"))?;
+    let pem = issuer.pem();
+    Ok((issuer, pem))
+}
+
+fn fake_acme_server_tls_config(
+    issuer: &CertifiedIssuer<'static, KeyPair>,
+) -> Result<Arc<ServerConfig>, String> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let signing_key =
+        KeyPair::generate().map_err(|error| format!("generate fake ACME server key: {error}"))?;
+    let certificate = CertificateParams::new(["localhost".to_string()])
+        .map_err(|error| format!("build fake ACME server certificate: {error}"))?
+        .signed_by(&signing_key, issuer)
+        .map_err(|error| format!("sign fake ACME server certificate: {error}"))?;
+    let chain = vec![
+        CertificateDer::from(certificate.der().to_vec()),
+        CertificateDer::from(issuer.der().to_vec()),
+    ];
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
+    let mut config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(chain, key)
+        .map_err(|error| format!("build fake ACME TLS config: {error}"))?;
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    Ok(Arc::new(config))
+}
+
+struct FakeAcmeTlsListener {
+    listener: TcpListener,
+    acceptor: TlsAcceptor,
+}
+
+impl FakeAcmeTlsListener {
+    fn new(listener: TcpListener, config: Arc<ServerConfig>) -> Self {
+        Self {
+            listener,
+            acceptor: TlsAcceptor::from(config),
+        }
+    }
+}
+
+impl Listener for FakeAcmeTlsListener {
+    type Io = TlsStream<TcpStream>;
+    type Addr = SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            let Ok((stream, address)) = self.listener.accept().await else {
+                tokio::task::yield_now().await;
+                continue;
+            };
+            if let Ok(stream) = self.acceptor.accept(stream).await {
+                return (stream, address);
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<Self::Addr> {
+        self.listener.local_addr()
+    }
+}

--- a/tests/remote_daemon_e2e/acme/protocol.rs
+++ b/tests/remote_daemon_e2e/acme/protocol.rs
@@ -1,0 +1,251 @@
+use std::sync::Arc;
+
+use axum::body::{Body, Bytes};
+use axum::extract::State;
+use axum::http::header::{CONTENT_TYPE, LOCATION};
+use axum::http::{HeaderValue, Method, StatusCode, Uri};
+use axum::response::Response;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use rcgen::CertificateSigningRequestParams;
+use rustls::pki_types::CertificateSigningRequestDer;
+use serde_json::{Value, json};
+
+use super::{AcmeChallenge, DNS_TOKEN, FakeAcmeState, HTTP_TOKEN, TLS_TOKEN, validation};
+
+pub(super) async fn handle_acme_request(
+    State(state): State<Arc<FakeAcmeState>>,
+    method: Method,
+    uri: Uri,
+    body: Bytes,
+) -> Response<Body> {
+    match route_acme_request(&state, &method, uri.path(), &body).await {
+        Ok(response) => response,
+        Err(error) => {
+            if let Ok(mut progress) = state.progress.lock() {
+                progress.validation_error = Some(error.clone());
+            }
+            response(StatusCode::INTERNAL_SERVER_ERROR, "text/plain", error)
+        }
+    }
+}
+
+async fn route_acme_request(
+    state: &FakeAcmeState,
+    method: &Method,
+    path: &str,
+    body: &[u8],
+) -> Result<Response<Body>, String> {
+    if *method == Method::GET && path == "/directory" {
+        return Ok(json_response(
+            StatusCode::OK,
+            &directory_body(&state.origin),
+            None,
+        ));
+    }
+    if *method == Method::HEAD && path == "/new-nonce" {
+        return Ok(acme_response(StatusCode::OK, "application/json", "", None));
+    }
+    if *method != Method::POST {
+        return Ok(response(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "text/plain",
+            format!("unsupported fake ACME method {method} for {path}"),
+        ));
+    }
+    match path {
+        "/new-account" => Ok(json_response(
+            StatusCode::CREATED,
+            &json!({}),
+            Some(format!("{}/acct/1", state.origin)),
+        )),
+        "/new-order" => Ok(json_response(
+            StatusCode::CREATED,
+            &order_body(state, "pending", false),
+            Some(format!("{}/order/1", state.origin)),
+        )),
+        "/authz/1" => Ok(json_response(
+            StatusCode::OK,
+            &authorization_body(state),
+            None,
+        )),
+        "/order/1" => order_status(state),
+        "/order/1/finalize" => finalize_order(state, body),
+        "/cert/1" => download_certificate(state),
+        path if path == state.config.challenge.challenge_path() => {
+            validation::verify_challenge(&state.config).await?;
+            state
+                .progress
+                .lock()
+                .map_err(|_| "fake ACME progress lock poisoned".to_string())?
+                .challenge_validated = true;
+            Ok(json_response(StatusCode::OK, &challenge_body(state), None))
+        }
+        _ => Ok(response(
+            StatusCode::NOT_FOUND,
+            "text/plain",
+            format!("unknown fake ACME path {path}"),
+        )),
+    }
+}
+
+fn order_status(state: &FakeAcmeState) -> Result<Response<Body>, String> {
+    let finalized = state
+        .progress
+        .lock()
+        .map_err(|_| "fake ACME progress lock poisoned".to_string())?
+        .finalized;
+    Ok(json_response(
+        StatusCode::OK,
+        &order_body(state, if finalized { "valid" } else { "ready" }, finalized),
+        None,
+    ))
+}
+
+fn finalize_order(state: &FakeAcmeState, body: &[u8]) -> Result<Response<Body>, String> {
+    let payload = jws_payload(body)?;
+    let csr = payload["csr"]
+        .as_str()
+        .ok_or_else(|| "fake ACME finalize request omitted CSR".to_string())?;
+    let csr = URL_SAFE_NO_PAD
+        .decode(csr)
+        .map_err(|error| format!("decode fake ACME CSR: {error}"))?;
+    let csr = CertificateSigningRequestDer::from(csr);
+    let request = CertificateSigningRequestParams::from_der(&csr)
+        .map_err(|error| format!("parse fake ACME CSR: {error}"))?;
+    let certificate = request
+        .signed_by(&state.issuer)
+        .map_err(|error| format!("sign fake ACME CSR: {error}"))?;
+    let chain = format!("{}\n{}", certificate.pem(), state.issuer.pem());
+    let mut progress = state
+        .progress
+        .lock()
+        .map_err(|_| "fake ACME progress lock poisoned".to_string())?;
+    progress.finalized = true;
+    progress.certificate_pem = Some(chain);
+    Ok(json_response(
+        StatusCode::OK,
+        &order_body(state, "processing", false),
+        None,
+    ))
+}
+
+fn download_certificate(state: &FakeAcmeState) -> Result<Response<Body>, String> {
+    let mut progress = state
+        .progress
+        .lock()
+        .map_err(|_| "fake ACME progress lock poisoned".to_string())?;
+    let certificate = progress
+        .certificate_pem
+        .clone()
+        .ok_or_else(|| "fake ACME certificate requested before finalize".to_string())?;
+    progress.certificate_downloaded = true;
+    Ok(acme_response(
+        StatusCode::OK,
+        "application/pem-certificate-chain",
+        certificate,
+        None,
+    ))
+}
+
+fn directory_body(origin: &str) -> Value {
+    json!({
+        "newNonce": format!("{origin}/new-nonce"),
+        "newAccount": format!("{origin}/new-account"),
+        "newOrder": format!("{origin}/new-order"),
+    })
+}
+
+fn authorization_body(state: &FakeAcmeState) -> Value {
+    json!({
+        "identifier": { "type": "dns", "value": state.config.domain },
+        "status": "pending",
+        "challenges": [
+            challenge_descriptor(&state.origin, "http-01", "/challenge/http/1", HTTP_TOKEN),
+            challenge_descriptor(&state.origin, "dns-01", "/challenge/dns/1", DNS_TOKEN),
+            challenge_descriptor(&state.origin, "tls-alpn-01", "/challenge/tls/1", TLS_TOKEN),
+        ],
+    })
+}
+
+fn challenge_descriptor(origin: &str, kind: &str, path: &str, token: &str) -> Value {
+    json!({
+        "type": kind,
+        "url": format!("{origin}{path}"),
+        "token": token,
+        "status": "pending",
+        "error": null,
+    })
+}
+
+fn challenge_body(state: &FakeAcmeState) -> Value {
+    let (kind, token) = match state.config.challenge {
+        AcmeChallenge::Http => ("http-01", HTTP_TOKEN),
+        AcmeChallenge::Dns => ("dns-01", DNS_TOKEN),
+        AcmeChallenge::TlsAlpn => ("tls-alpn-01", TLS_TOKEN),
+    };
+    challenge_descriptor(
+        &state.origin,
+        kind,
+        state.config.challenge.challenge_path(),
+        token,
+    )
+}
+
+fn order_body(state: &FakeAcmeState, status: &str, with_certificate: bool) -> Value {
+    json!({
+        "status": status,
+        "authorizations": [format!("{}/authz/1", state.origin)],
+        "finalize": format!("{}/order/1/finalize", state.origin),
+        "certificate": with_certificate.then(|| format!("{}/cert/1", state.origin)),
+        "error": null,
+    })
+}
+
+fn json_response(status: StatusCode, value: &Value, location: Option<String>) -> Response<Body> {
+    acme_response(status, "application/json", value.to_string(), location)
+}
+
+fn acme_response(
+    status: StatusCode,
+    content_type: &'static str,
+    body: impl Into<String>,
+    location: Option<String>,
+) -> Response<Body> {
+    let mut response = response(status, content_type, body);
+    response
+        .headers_mut()
+        .insert("replay-nonce", HeaderValue::from_static("remote-e2e-nonce"));
+    if let Some(location) = location
+        && let Ok(location) = HeaderValue::from_str(&location)
+    {
+        response.headers_mut().insert(LOCATION, location);
+    }
+    response
+}
+
+fn response(
+    status: StatusCode,
+    content_type: &'static str,
+    body: impl Into<String>,
+) -> Response<Body> {
+    let mut response = Response::new(Body::from(body.into()));
+    *response.status_mut() = status;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static(content_type));
+    response
+}
+
+fn jws_payload(body: &[u8]) -> Result<Value, String> {
+    let envelope = serde_json::from_slice::<Value>(body)
+        .map_err(|error| format!("decode fake ACME JWS envelope: {error}"))?;
+    let payload = envelope["payload"]
+        .as_str()
+        .ok_or_else(|| "fake ACME JWS omitted payload".to_string())?;
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|error| format!("decode fake ACME JWS payload: {error}"))?;
+    serde_json::from_slice(&payload)
+        .map_err(|error| format!("decode fake ACME JWS payload JSON: {error}"))
+}

--- a/tests/remote_daemon_e2e/acme/validation.rs
+++ b/tests/remote_daemon_e2e/acme/validation.rs
@@ -1,0 +1,162 @@
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, Error as TlsError, SignatureScheme};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use x509_parser::parse_x509_certificate;
+
+use super::{AcmeChallenge, AcmeChallengeConfig, HTTP_TOKEN};
+
+pub(super) async fn verify_challenge(config: &AcmeChallengeConfig) -> Result<(), String> {
+    match config.challenge {
+        AcmeChallenge::Http => verify_http_challenge(config).await,
+        AcmeChallenge::TlsAlpn => verify_tls_alpn_challenge(config).await,
+        AcmeChallenge::Dns => verify_dns_challenge(config),
+    }
+}
+
+async fn verify_http_challenge(config: &AcmeChallengeConfig) -> Result<(), String> {
+    let mut stream = TcpStream::connect(("127.0.0.1", config.http_port))
+        .await
+        .map_err(|error| format!("connect HTTP-01 challenge: {error}"))?;
+    let request = format!(
+        "GET /.well-known/acme-challenge/{HTTP_TOKEN} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
+        config.domain
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|error| format!("write HTTP-01 challenge request: {error}"))?;
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .await
+        .map_err(|error| format!("read HTTP-01 challenge response: {error}"))?;
+    let body = response
+        .split_once("\r\n\r\n")
+        .map(|(_, body)| body.trim())
+        .unwrap_or_default();
+    if !response.starts_with("HTTP/1.1 200") || !body.starts_with(&format!("{HTTP_TOKEN}.")) {
+        return Err(format!(
+            "HTTP-01 challenge response was invalid: {response}"
+        ));
+    }
+    Ok(())
+}
+
+async fn verify_tls_alpn_challenge(config: &AcmeChallengeConfig) -> Result<(), String> {
+    let mut tls_config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"acme-tls/1".to_vec()];
+    let stream = TcpStream::connect(("127.0.0.1", config.https_port))
+        .await
+        .map_err(|error| format!("connect TLS-ALPN-01 challenge: {error}"))?;
+    let server_name = ServerName::try_from(config.domain.clone())
+        .map_err(|error| format!("build TLS-ALPN-01 server name: {error}"))?;
+    let stream = TlsConnector::from(Arc::new(tls_config))
+        .connect(server_name, stream)
+        .await
+        .map_err(|error| format!("handshake TLS-ALPN-01 challenge: {error}"))?;
+    if stream.get_ref().1.alpn_protocol() != Some(b"acme-tls/1".as_slice()) {
+        return Err("TLS-ALPN-01 challenge did not negotiate acme-tls/1".to_string());
+    }
+    let certificate = stream
+        .get_ref()
+        .1
+        .peer_certificates()
+        .and_then(|certificates| certificates.first())
+        .ok_or_else(|| "TLS-ALPN-01 challenge omitted certificate".to_string())?;
+    let (_, certificate) = parse_x509_certificate(certificate)
+        .map_err(|error| format!("parse TLS-ALPN-01 certificate: {error}"))?;
+    let extension = certificate
+        .extensions()
+        .iter()
+        .find(|extension| extension.oid.to_id_string() == "1.3.6.1.5.5.7.1.31")
+        .ok_or_else(|| "TLS-ALPN-01 certificate omitted acmeIdentifier".to_string())?;
+    if !extension.critical || extension.value.len() != 34 || extension.value[..2] != [0x04, 0x20] {
+        return Err("TLS-ALPN-01 acmeIdentifier extension was invalid".to_string());
+    }
+    Ok(())
+}
+
+fn verify_dns_challenge(config: &AcmeChallengeConfig) -> Result<(), String> {
+    let log = fs::read_to_string(&config.dns_log)
+        .map_err(|error| format!("read DNS-01 hook log: {error}"))?;
+    let prefix = format!("present|_acme-challenge.{}|", config.domain);
+    if log
+        .lines()
+        .any(|line| line.starts_with(&prefix) && line.len() > prefix.len())
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "DNS-01 hook did not present the TXT value: {log:?}"
+    ))
+}
+
+pub(super) fn dns_lifecycle_complete(path: &Path) -> Result<bool, String> {
+    let log = match fs::read_to_string(path) {
+        Ok(log) => log,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("read DNS-01 lifecycle log: {error}")),
+    };
+    let mut present = None;
+    let mut cleanup = None;
+    for line in log.lines() {
+        if let Some(value) = line.strip_prefix("present|") {
+            present = Some(value);
+        } else if let Some(value) = line.strip_prefix("cleanup|") {
+            cleanup = Some(value);
+        }
+    }
+    Ok(present.is_some() && present == cleanup)
+}
+
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, TlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _certificate: &CertificateDer<'_>,
+        _signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _certificate: &CertificateDer<'_>,
+        _signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::ED25519,
+        ]
+    }
+}

--- a/tests/remote_daemon_e2e/client.rs
+++ b/tests/remote_daemon_e2e/client.rs
@@ -1,0 +1,282 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures_util::{SinkExt as _, StreamExt as _};
+use http::header::{AUTHORIZATION, HeaderValue};
+use reqwest::StatusCode;
+use rustls::pki_types::pem::PemObject as _;
+use rustls::pki_types::{CertificateDer, ServerName};
+use rustls::{ClientConfig, RootCertStore};
+use serde_json::{Value, json};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use tokio_tungstenite::client_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
+
+const REMOTE_CLIENT_ID_HEADER: &str = "x-harness-remote-client-id";
+
+#[derive(Debug, Clone)]
+pub struct RemoteCredentials {
+    pub client_id: String,
+    pub token: String,
+    pub role: String,
+}
+
+pub struct RemoteDaemonClient {
+    domain: String,
+    port: u16,
+    origin: String,
+    ca_pem: String,
+    http: reqwest::Client,
+}
+
+impl RemoteDaemonClient {
+    pub fn new(domain: &str, port: u16, ca_pem: &str) -> Result<Self, String> {
+        let certificate = reqwest::Certificate::from_pem(ca_pem.as_bytes())
+            .map_err(|error| format!("parse fake ACME CA: {error}"))?;
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+        let http = reqwest::Client::builder()
+            .add_root_certificate(certificate)
+            .resolve(domain, address)
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|error| format!("build remote HTTPS client: {error}"))?;
+        Ok(Self {
+            domain: domain.to_string(),
+            port,
+            origin: format!("https://{domain}:{port}"),
+            ca_pem: ca_pem.to_string(),
+            http,
+        })
+    }
+
+    pub async fn wait_until_listening(&self) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let mut last_error = "remote HTTPS listener did not answer".to_string();
+        while Instant::now() < deadline {
+            match self.http.get(self.url("/v1/health")).send().await {
+                Ok(response) if response.status() == StatusCode::UNAUTHORIZED => return Ok(()),
+                Ok(response) => {
+                    last_error = format!("unexpected health status {}", response.status());
+                }
+                Err(error) => last_error = error.to_string(),
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        Err(format!("remote HTTPS listener not ready: {last_error}"))
+    }
+
+    pub async fn claim_pairing(
+        &self,
+        code: &str,
+        client_id: &str,
+        role: &str,
+    ) -> Result<RemoteCredentials, String> {
+        let response = self
+            .http
+            .post(self.url("/v1/remote/pair/claim"))
+            .json(&json!({
+                "code": code,
+                "domain": self.domain,
+                "client_id": client_id,
+                "display_name": format!("Remote E2E {role}"),
+                "platform": "e2e",
+            }))
+            .send()
+            .await
+            .map_err(|error| format!("claim remote pairing: {error}"))?;
+        let status = response.status();
+        let body = response
+            .json::<Value>()
+            .await
+            .map_err(|error| format!("decode pairing response: {error}"))?;
+        if !status.is_success() {
+            return Err(format!("pairing claim returned {status}: {body}"));
+        }
+        Ok(RemoteCredentials {
+            client_id: required_string(&body, "client_id")?.to_string(),
+            token: required_string(&body, "token")?.to_string(),
+            role: required_string(&body, "role")?.to_string(),
+        })
+    }
+
+    pub async fn expect_health(
+        &self,
+        credentials: &RemoteCredentials,
+        expected: u16,
+    ) -> Result<(), String> {
+        let response = Self::authenticated(self.http.get(self.url("/v1/health")), credentials)
+            .send()
+            .await
+            .map_err(|error| format!("send authenticated health request: {error}"))?;
+        expect_status("GET /v1/health", response, expected).await
+    }
+
+    pub async fn expect_telemetry(
+        &self,
+        credentials: &RemoteCredentials,
+        expected: u16,
+    ) -> Result<(), String> {
+        let request = self
+            .http
+            .post(self.url("/v1/daemon/telemetry"))
+            .json(&json!({
+                "kind": "decode_failure",
+                "source": "remote-daemon-e2e",
+                "message": "remote e2e telemetry proof",
+            }));
+        let response = Self::authenticated(request, credentials)
+            .send()
+            .await
+            .map_err(|error| format!("send remote telemetry: {error}"))?;
+        expect_status("POST /v1/daemon/telemetry", response, expected).await
+    }
+
+    pub async fn expect_log_level_update(
+        &self,
+        credentials: &RemoteCredentials,
+        expected: u16,
+    ) -> Result<(), String> {
+        let request = self
+            .http
+            .put(self.url("/v1/daemon/log-level"))
+            .json(&json!({ "level": "debug" }));
+        let response = Self::authenticated(request, credentials)
+            .send()
+            .await
+            .map_err(|error| format!("send remote admin request: {error}"))?;
+        expect_status("PUT /v1/daemon/log-level", response, expected).await
+    }
+
+    pub async fn expect_websocket_health_and_admin_denial(
+        &self,
+        credentials: &RemoteCredentials,
+    ) -> Result<(), String> {
+        let mut roots = RootCertStore::empty();
+        for certificate in CertificateDer::pem_slice_iter(self.ca_pem.as_bytes()) {
+            roots
+                .add(certificate.map_err(|error| format!("parse WSS root CA: {error}"))?)
+                .map_err(|error| format!("add WSS root CA: {error}"))?;
+        }
+        let mut tls_config = ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+        let stream = TcpStream::connect(("127.0.0.1", self.port))
+            .await
+            .map_err(|error| format!("connect WSS TCP stream: {error}"))?;
+        let server_name = ServerName::try_from(self.domain.clone())
+            .map_err(|error| format!("build WSS server name: {error}"))?;
+        let tls = TlsConnector::from(Arc::new(tls_config))
+            .connect(server_name, stream)
+            .await
+            .map_err(|error| format!("connect WSS TLS stream: {error}"))?;
+        let mut request = format!("wss://{}:{}/v1/ws", self.domain, self.port)
+            .into_client_request()
+            .map_err(|error| format!("build WSS request: {error}"))?;
+        request.headers_mut().insert(
+            REMOTE_CLIENT_ID_HEADER,
+            HeaderValue::from_str(&credentials.client_id)
+                .map_err(|error| format!("build WSS client id header: {error}"))?,
+        );
+        request.headers_mut().insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", credentials.token))
+                .map_err(|error| format!("build WSS auth header: {error}"))?,
+        );
+        let (mut socket, _) = client_async(request, tls)
+            .await
+            .map_err(|error| format!("upgrade WSS connection: {error}"))?;
+
+        let health = websocket_rpc(&mut socket, "e2e-health", "health").await?;
+        if !health["error"].is_null() || health["result"].is_null() {
+            return Err(format!("WSS health failed: {health}"));
+        }
+        let denied = websocket_rpc(&mut socket, "e2e-admin-denied", "daemon.stop").await?;
+        if denied["error"]["status_code"].as_u64() != Some(403) {
+            return Err(format!("WSS admin denial missing: {denied}"));
+        }
+        socket
+            .close(None)
+            .await
+            .map_err(|error| format!("close WSS connection: {error}"))
+    }
+
+    pub async fn stop(&self, credentials: &RemoteCredentials) -> Result<(), String> {
+        let response =
+            Self::authenticated(self.http.post(self.url("/v1/daemon/stop")), credentials)
+                .send()
+                .await
+                .map_err(|error| format!("send remote daemon stop: {error}"))?;
+        expect_status("POST /v1/daemon/stop", response, 200).await
+    }
+
+    fn authenticated(
+        request: reqwest::RequestBuilder,
+        credentials: &RemoteCredentials,
+    ) -> reqwest::RequestBuilder {
+        request
+            .header(REMOTE_CLIENT_ID_HEADER, &credentials.client_id)
+            .bearer_auth(&credentials.token)
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.origin)
+    }
+}
+
+async fn websocket_rpc<S>(socket: &mut S, id: &str, method: &str) -> Result<Value, String>
+where
+    S: futures_util::Sink<Message, Error = tokio_tungstenite::tungstenite::Error>
+        + futures_util::Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>>
+        + Unpin,
+{
+    socket
+        .send(Message::Text(
+            json!({ "id": id, "method": method, "params": {} })
+                .to_string()
+                .into(),
+        ))
+        .await
+        .map_err(|error| format!("send WSS {method}: {error}"))?;
+    let response = tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(frame) = socket.next().await {
+            let frame = frame.map_err(|error| format!("read WSS {method}: {error}"))?;
+            if let Message::Text(text) = frame {
+                let value = serde_json::from_str::<Value>(&text)
+                    .map_err(|error| format!("decode WSS {method}: {error}"))?;
+                if value["id"].as_str() == Some(id) {
+                    return Ok(value);
+                }
+            }
+        }
+        Err(format!("WSS closed before {method} response"))
+    })
+    .await
+    .map_err(|_| format!("timed out waiting for WSS {method}"))??;
+    Ok(response)
+}
+
+async fn expect_status(
+    operation: &str,
+    response: reqwest::Response,
+    expected: u16,
+) -> Result<(), String> {
+    let status = response.status();
+    if status.as_u16() == expected {
+        return Ok(());
+    }
+    let body = response.text().await.unwrap_or_default();
+    Err(format!(
+        "{operation} returned {status}, expected {expected}: {body}"
+    ))
+}
+
+fn required_string<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
+    value[field]
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("response omitted {field}: {value}"))
+}

--- a/tests/remote_daemon_e2e/process.rs
+++ b/tests/remote_daemon_e2e/process.rs
@@ -251,11 +251,9 @@ impl RemoteDaemonProcess {
     }
 
     pub fn diagnostics(&self) -> String {
-        format!(
-            "stdout={:?} stderr={:?}",
-            fs::read_to_string(&self.stdout_path).unwrap_or_default(),
-            fs::read_to_string(&self.stderr_path).unwrap_or_default()
-        )
+        let stdout = fs::read_to_string(&self.stdout_path).unwrap_or_default();
+        let stderr = fs::read_to_string(&self.stderr_path).unwrap_or_default();
+        format!("stdout:\n{stdout}\nstderr:\n{stderr}")
     }
 }
 
@@ -276,7 +274,7 @@ fn unused_port() -> Result<u16, String> {
     TcpListener::bind(("127.0.0.1", 0))
         .and_then(|listener| listener.local_addr())
         .map(|address| address.port())
-        .map_err(|error| format!("reserve unused local port: {error}"))
+        .map_err(|error| format!("select unused local port: {error}"))
 }
 
 fn write_dns_hook(path: &Path) -> Result<(), String> {

--- a/tests/remote_daemon_e2e/process.rs
+++ b/tests/remote_daemon_e2e/process.rs
@@ -1,0 +1,294 @@
+use std::fs::{self, File};
+use std::net::TcpListener;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::acme::AcmeChallenge;
+
+pub struct RemoteDaemonEnvironment {
+    temp: TempDir,
+    home: PathBuf,
+    xdg: PathBuf,
+    data_home: PathBuf,
+    dns_hook: PathBuf,
+    dns_log: PathBuf,
+    acme_ca_root: PathBuf,
+    daemon_stdout: PathBuf,
+    daemon_stderr: PathBuf,
+    https_port: u16,
+    http_port: u16,
+}
+
+impl RemoteDaemonEnvironment {
+    pub fn new(challenge: AcmeChallenge) -> Result<Self, String> {
+        let temp = tempfile::Builder::new()
+            .prefix(&format!("harness-remote-e2e-{}-", challenge.cli_name()))
+            .tempdir()
+            .map_err(|error| format!("create remote e2e tempdir: {error}"))?;
+        let home = temp.path().join("home");
+        let xdg = temp.path().join("xdg");
+        let data_home = temp.path().join("daemon-data");
+        for path in [&home, &xdg, &data_home] {
+            fs::create_dir_all(path)
+                .map_err(|error| format!("create {}: {error}", path.display()))?;
+        }
+        let dns_hook = temp.path().join("dns-hook.sh");
+        let dns_log = temp.path().join("dns-hook.log");
+        let acme_ca_root = temp.path().join("fake-acme-ca.pem");
+        write_dns_hook(&dns_hook)?;
+        Ok(Self {
+            temp,
+            home,
+            xdg,
+            data_home,
+            dns_hook,
+            dns_log,
+            acme_ca_root,
+            daemon_stdout: PathBuf::from("daemon.stdout.log"),
+            daemon_stderr: PathBuf::from("daemon.stderr.log"),
+            https_port: unused_port()?,
+            http_port: unused_port()?,
+        }
+        .with_log_paths())
+    }
+
+    fn with_log_paths(mut self) -> Self {
+        self.daemon_stdout = self.temp.path().join(&self.daemon_stdout);
+        self.daemon_stderr = self.temp.path().join(&self.daemon_stderr);
+        self
+    }
+
+    pub const fn https_port(&self) -> u16 {
+        self.https_port
+    }
+
+    pub const fn http_port(&self) -> u16 {
+        self.http_port
+    }
+
+    pub fn dns_log(&self) -> &Path {
+        &self.dns_log
+    }
+
+    pub fn acme_ca_root(&self) -> &Path {
+        &self.acme_ca_root
+    }
+
+    fn apply(&self, command: &mut Command, directory_url: &str) {
+        command
+            .env("HOME", &self.home)
+            .env("HARNESS_HOST_HOME", &self.home)
+            .env("XDG_DATA_HOME", &self.xdg)
+            .env("HARNESS_DAEMON_DATA_HOME", &self.data_home)
+            .env("HARNESS_DAEMON_OWNERSHIP", "external")
+            .env("HARNESS_REMOTE_ACME_DIRECTORY_URL", directory_url)
+            .env("HARNESS_REMOTE_ACME_CA_ROOT", &self.acme_ca_root)
+            .env("HARNESS_REMOTE_ACME_DNS_PROPAGATION_SECONDS", "0")
+            .env("HARNESS_REMOTE_ACME_DNS_EXEC", &self.dns_hook)
+            .env("HARNESS_REMOTE_ACME_DNS_LOG", &self.dns_log)
+            .env("RUST_LOG", "harness=debug");
+    }
+}
+
+pub struct RemoteDaemonProcess {
+    child: Child,
+    directory_url: String,
+    home: PathBuf,
+    xdg: PathBuf,
+    data_home: PathBuf,
+    dns_hook: PathBuf,
+    dns_log: PathBuf,
+    acme_ca_root: PathBuf,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl RemoteDaemonProcess {
+    pub fn spawn(
+        environment: &RemoteDaemonEnvironment,
+        challenge: AcmeChallenge,
+        directory_url: &str,
+    ) -> Result<Self, String> {
+        let stdout = File::create(&environment.daemon_stdout)
+            .map_err(|error| format!("create daemon stdout log: {error}"))?;
+        let stderr = File::create(&environment.daemon_stderr)
+            .map_err(|error| format!("create daemon stderr log: {error}"))?;
+        let mut command = Command::new(harness_binary());
+        command.args([
+            "daemon",
+            "remote",
+            "serve",
+            "--domain",
+            super::DOMAIN,
+            "--host",
+            "127.0.0.1",
+            "--https-port",
+            &environment.https_port.to_string(),
+            "--http-port",
+            &environment.http_port.to_string(),
+            "--acme-email",
+            "remote-e2e@example.com",
+            "--acme-challenge",
+            challenge.cli_name(),
+        ]);
+        if challenge == AcmeChallenge::Dns {
+            command.args(["--acme-dns-provider", "exec"]);
+        }
+        environment.apply(&mut command, directory_url);
+        let child = command
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .map_err(|error| format!("spawn remote daemon: {error}"))?;
+        Ok(Self {
+            child,
+            directory_url: directory_url.to_string(),
+            home: environment.home.clone(),
+            xdg: environment.xdg.clone(),
+            data_home: environment.data_home.clone(),
+            dns_hook: environment.dns_hook.clone(),
+            dns_log: environment.dns_log.clone(),
+            acme_ca_root: environment.acme_ca_root.clone(),
+            stdout_path: environment.daemon_stdout.clone(),
+            stderr_path: environment.daemon_stderr.clone(),
+        })
+    }
+
+    pub fn ensure_running(&mut self) -> Result<(), String> {
+        match self.child.try_wait() {
+            Ok(None) => Ok(()),
+            Ok(Some(status)) => Err(format!(
+                "remote daemon exited with {status}; {}",
+                self.diagnostics()
+            )),
+            Err(error) => Err(format!("poll remote daemon: {error}")),
+        }
+    }
+
+    pub fn create_pairing(&self, role: &str) -> Result<Value, String> {
+        self.run_json(&[
+            "daemon", "remote", "pair", "create", "--role", role, "--ttl", "10m",
+        ])
+    }
+
+    pub fn revoke_client(&self, client_id: &str) -> Result<Value, String> {
+        self.run_json(&[
+            "daemon",
+            "remote",
+            "clients",
+            "revoke",
+            "--client-id",
+            client_id,
+        ])
+    }
+
+    fn run_json(&self, args: &[&str]) -> Result<Value, String> {
+        let mut command = Command::new(harness_binary());
+        command.args(args);
+        self.apply_environment(&mut command);
+        let output = command
+            .output()
+            .map_err(|error| format!("run harness {args:?}: {error}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "harness {args:?} failed with {}: stdout={} stderr={}",
+                output.status,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        serde_json::from_slice(&output.stdout).map_err(|error| {
+            format!(
+                "parse harness {args:?} JSON: {error}; stdout={}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        })
+    }
+
+    fn apply_environment(&self, command: &mut Command) {
+        command
+            .env("HOME", &self.home)
+            .env("HARNESS_HOST_HOME", &self.home)
+            .env("XDG_DATA_HOME", &self.xdg)
+            .env("HARNESS_DAEMON_DATA_HOME", &self.data_home)
+            .env("HARNESS_DAEMON_OWNERSHIP", "external")
+            .env("HARNESS_REMOTE_ACME_DIRECTORY_URL", &self.directory_url)
+            .env("HARNESS_REMOTE_ACME_CA_ROOT", &self.acme_ca_root)
+            .env("HARNESS_REMOTE_ACME_DNS_PROPAGATION_SECONDS", "0")
+            .env("HARNESS_REMOTE_ACME_DNS_EXEC", &self.dns_hook)
+            .env("HARNESS_REMOTE_ACME_DNS_LOG", &self.dns_log);
+    }
+
+    pub async fn wait_for_exit(&mut self) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) if status.success() => return Ok(()),
+                Ok(Some(status)) => {
+                    return Err(format!(
+                        "remote daemon stopped with {status}; {}",
+                        self.diagnostics()
+                    ));
+                }
+                Ok(None) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                Ok(None) => {
+                    return Err(format!(
+                        "remote daemon did not stop; {}",
+                        self.diagnostics()
+                    ));
+                }
+                Err(error) => return Err(format!("wait for remote daemon: {error}")),
+            }
+        }
+    }
+
+    pub fn diagnostics(&self) -> String {
+        format!(
+            "stdout={:?} stderr={:?}",
+            fs::read_to_string(&self.stdout_path).unwrap_or_default(),
+            fs::read_to_string(&self.stderr_path).unwrap_or_default()
+        )
+    }
+}
+
+impl Drop for RemoteDaemonProcess {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn harness_binary() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("harness")
+}
+
+fn unused_port() -> Result<u16, String> {
+    TcpListener::bind(("127.0.0.1", 0))
+        .and_then(|listener| listener.local_addr())
+        .map(|address| address.port())
+        .map_err(|error| format!("reserve unused local port: {error}"))
+}
+
+fn write_dns_hook(path: &Path) -> Result<(), String> {
+    fs::write(
+        path,
+        "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$1\" \"$2\" \"$3\" >> \"$HARNESS_REMOTE_ACME_DNS_LOG\"\n",
+    )
+    .map_err(|error| format!("write DNS hook: {error}"))?;
+    let mut permissions = fs::metadata(path)
+        .map_err(|error| format!("read DNS hook permissions: {error}"))?
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(path, permissions)
+        .map_err(|error| format!("set DNS hook permissions: {error}"))
+}


### PR DESCRIPTION
## Motivation
The remote daemon had focused component tests, but no proof that the real binary could issue a certificate, start HTTPS/WSS, pair clients, enforce roles, and honor revocation. The first black-box run also exposed a Rustls provider panic before ACME could connect.

## Implementation
- Add `mise run remote-daemon:e2e` with a TLS fake ACME authority covering TLS-ALPN-01, HTTP-01, and DNS-01 through the exec provider.
- Start the real remote daemon process and prove HTTPS pairing, viewer/operator/admin scopes, WSS per-message authorization, revocation denial, and admin shutdown.
- Initialize the Ring provider before constructing the production ACME client.
- Pass the remote e2e task, 9 ACME issuer tests, 22 remote TLS tests, package check, scoped test Clippy, and codegen check. `harness:check` reaches a pre-existing `src/reviews/logic.rs` Clippy error after its script checks pass.