### PR TITLE
feat(remote): prove Linux remote deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3645,6 +3651,7 @@ dependencies = [
  "gray_matter",
  "harness-testkit",
  "hex",
+ "hickory-resolver",
  "hmac 0.13.0",
  "http",
  "http-body-util",
@@ -3828,6 +3835,76 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -4320,6 +4397,19 @@ checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4919,6 +5009,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5213,6 +5326,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -5836,6 +5953,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6307,6 +6435,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -7624,6 +7758,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8536,6 +8676,12 @@ name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ libc = "0.2"
 nix = { version = "0.31", features = ["signal"] }
 signal-hook = "0.4"
 agent-client-protocol = { version = "=0.12.1", features = ["unstable_session_model"] }
+hickory-resolver = "0.26.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ serde_yml = "0.0.13"
 thiserror = "2.0.18"
 sha1 = "0.11.0"
 sha2 = "0.11.0"
-security-framework = "3.7.0"
 hex = "0.4.3"
 hmac = "0.13.0"
 chrono = { version = "0.4.44", features = ["serde"] }

--- a/src/app/cli/tests/daemon.rs
+++ b/src/app/cli/tests/daemon.rs
@@ -48,15 +48,41 @@ fn parse_daemon_remote_serve() {
 
     match cli.command {
         Command::Daemon {
-            command: DaemonCommand::Remote { command },
+            command:
+                DaemonCommand::Remote {
+                    command,
+                    systemd_unit,
+                },
         } => match command {
             crate::daemon::transport::DaemonRemoteCommand::Serve(args) => {
+                assert_eq!(systemd_unit, None);
                 assert_eq!(args.domain, "daemon.example.com");
                 assert_eq!(args.host, "0.0.0.0");
                 assert_eq!(args.https_port, 443);
             }
             other => panic!("expected daemon remote serve, got {other:?}"),
         },
+        _ => panic!("expected daemon remote command"),
+    }
+}
+
+#[test]
+fn parse_daemon_remote_systemd_unit_after_nested_command() {
+    let cli = Cli::try_parse_from([
+        "harness",
+        "daemon",
+        "remote",
+        "pair",
+        "create",
+        "--systemd-unit",
+        "harness-remote-proof",
+    ])
+    .expect("parse remote systemd unit");
+
+    match cli.command {
+        Command::Daemon {
+            command: DaemonCommand::Remote { systemd_unit, .. },
+        } => assert_eq!(systemd_unit.as_deref(), Some("harness-remote-proof")),
         _ => panic!("expected daemon remote command"),
     }
 }

--- a/src/daemon/db/remote_acme.rs
+++ b/src/daemon/db/remote_acme.rs
@@ -426,6 +426,7 @@ fn parse_acme_challenge_at_column(
 
 fn parse_dns_provider_at_column(label: &str, column: usize) -> rusqlite::Result<RemoteDnsProvider> {
     match label {
+        "aftermarket" => Ok(RemoteDnsProvider::Aftermarket),
         "cloudflare" => Ok(RemoteDnsProvider::Cloudflare),
         "route53" => Ok(RemoteDnsProvider::Route53),
         "exec" => Ok(RemoteDnsProvider::Exec),

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -18,6 +18,7 @@ mod performance;
 mod projects;
 mod reconcile;
 mod remote_acme;
+mod remote_acme_providers;
 mod remote_identity;
 mod remote_pairing;
 mod runtime;

--- a/src/daemon/db/tests/remote_acme.rs
+++ b/src/daemon/db/tests/remote_acme.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig};
 use crate::daemon::remote_acme::{
     RemoteAcmeAccountCredentials, RemoteCertificateBundle, build_remote_acme_runtime_plan,
 };
@@ -36,47 +36,6 @@ fn remote_acme_state_status_hides_private_key_and_tracks_material() {
         !format!("{state:?}").contains("key-secret"),
         "ACME status debug output must not expose private key material"
     );
-}
-
-#[test]
-fn remote_acme_state_persists_serve_config_for_issuance() {
-    let db = DaemonDb::open_in_memory().expect("open db");
-    let config = RemoteDaemonServeConfig {
-        domain: " daemon.example.com ".to_string(),
-        host: " 0.0.0.0 ".to_string(),
-        https_port: 8443,
-        http_port: 8080,
-        acme_email: " ops@example.com ".to_string(),
-        acme_challenge: RemoteAcmeChallenge::Dns,
-        acme_dns_provider: Some(RemoteDnsProvider::Cloudflare),
-    };
-
-    db.record_remote_acme_serve_config(&config, "2026-06-21T15:03:00Z")
-        .expect("record remote acme serve config");
-
-    let state = db.load_remote_acme_state().expect("load acme state");
-    let stored = state
-        .serve_config
-        .as_ref()
-        .expect("serve config should be stored");
-    assert_eq!(stored.domain, "daemon.example.com");
-    assert_eq!(stored.host, "0.0.0.0");
-    assert_eq!(stored.https_port, 8443);
-    assert_eq!(stored.http_port, 8080);
-    assert_eq!(stored.acme_email, "ops@example.com");
-    assert_eq!(stored.acme_challenge, RemoteAcmeChallenge::Dns);
-    assert_eq!(
-        stored.acme_dns_provider,
-        Some(RemoteDnsProvider::Cloudflare)
-    );
-    assert_eq!(state.updated_at, "2026-06-21T15:03:00Z");
-
-    let loaded = db
-        .load_remote_acme_state()
-        .expect("load remote acme state")
-        .serve_config
-        .expect("stored remote acme serve config");
-    assert_eq!(loaded, *stored);
 }
 
 #[test]

--- a/src/daemon/db/tests/remote_acme_providers.rs
+++ b/src/daemon/db/tests/remote_acme_providers.rs
@@ -1,0 +1,66 @@
+use super::*;
+use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
+
+#[test]
+fn remote_acme_state_persists_serve_config_for_issuance() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let config = remote_serve_config(RemoteDnsProvider::Cloudflare);
+
+    db.record_remote_acme_serve_config(&config, "2026-06-21T15:03:00Z")
+        .expect("record remote acme serve config");
+
+    let state = db.load_remote_acme_state().expect("load acme state");
+    let stored = state
+        .serve_config
+        .as_ref()
+        .expect("serve config should be stored");
+    assert_eq!(stored.domain, "daemon.example.com");
+    assert_eq!(stored.host, "0.0.0.0");
+    assert_eq!(stored.https_port, 8443);
+    assert_eq!(stored.http_port, 8080);
+    assert_eq!(stored.acme_email, "ops@example.com");
+    assert_eq!(stored.acme_challenge, RemoteAcmeChallenge::Dns);
+    assert_eq!(
+        stored.acme_dns_provider,
+        Some(RemoteDnsProvider::Cloudflare)
+    );
+    assert_eq!(state.updated_at, "2026-06-21T15:03:00Z");
+
+    let loaded = db
+        .load_remote_acme_state()
+        .expect("load remote acme state")
+        .serve_config
+        .expect("stored remote acme serve config");
+    assert_eq!(loaded, *stored);
+}
+
+#[test]
+fn remote_acme_state_roundtrips_aftermarket_provider() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let config = remote_serve_config(RemoteDnsProvider::Aftermarket);
+
+    db.record_remote_acme_serve_config(&config, "2026-07-11T07:00:00Z")
+        .expect("record Aftermarket config");
+
+    let stored = db
+        .load_remote_acme_state()
+        .expect("load ACME state")
+        .serve_config
+        .expect("stored serve config");
+    assert_eq!(
+        stored.acme_dns_provider,
+        Some(RemoteDnsProvider::Aftermarket)
+    );
+}
+
+fn remote_serve_config(provider: RemoteDnsProvider) -> RemoteDaemonServeConfig {
+    RemoteDaemonServeConfig {
+        domain: " daemon.example.com ".to_string(),
+        host: " 0.0.0.0 ".to_string(),
+        https_port: 8443,
+        http_port: 8080,
+        acme_email: " ops@example.com ".to_string(),
+        acme_challenge: RemoteAcmeChallenge::Dns,
+        acme_dns_provider: Some(provider),
+    }
+}

--- a/src/daemon/http/sessions_adopt.rs
+++ b/src/daemon/http/sessions_adopt.rs
@@ -11,6 +11,7 @@ use crate::daemon::db::{DaemonDb, ensure_shared_db};
 use crate::daemon::protocol::{AdoptSessionRequest, SessionMutationResponse};
 use crate::daemon::service;
 use crate::errors::{CliError, CliErrorKind};
+#[cfg(target_os = "macos")]
 use crate::sandbox;
 use crate::workspace::adopter::{AdoptionError, AdoptionOutcome, SessionAdopter};
 use crate::workspace::harness_data_root;

--- a/src/daemon/remote.rs
+++ b/src/daemon/remote.rs
@@ -104,6 +104,7 @@ impl RemoteAcmeChallenge {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteDnsProvider {
+    Aftermarket,
     Cloudflare,
     Route53,
     Exec,
@@ -113,6 +114,7 @@ impl RemoteDnsProvider {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::Aftermarket => "aftermarket",
             Self::Cloudflare => "cloudflare",
             Self::Route53 => "route53",
             Self::Exec => "exec",

--- a/src/daemon/remote_acme_challenge.rs
+++ b/src/daemon/remote_acme_challenge.rs
@@ -301,8 +301,14 @@ impl RemoteAcmeChallengeProvisioner for SystemRemoteAcmeChallengeProvisioner {
     }
 
     async fn wait_ready(&self, lease: &Self::Lease) -> Result<(), String> {
-        if matches!(lease, SystemRemoteAcmeChallengeLease::Dns(_)) {
-            sleep(self.dns_propagation_delay).await;
+        if let SystemRemoteAcmeChallengeLease::Dns(lease) = lease {
+            let dns = self
+                .dns
+                .as_ref()
+                .ok_or_else(|| "remote ACME DNS provider is not configured".to_string())?;
+            if !dns.wait_ready(lease).await? {
+                sleep(self.dns_propagation_delay).await;
+            }
         }
         Ok(())
     }

--- a/src/daemon/remote_acme_dns_aftermarket.rs
+++ b/src/daemon/remote_acme_dns_aftermarket.rs
@@ -1,0 +1,231 @@
+use std::fmt;
+use std::sync::Arc;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use http::Method;
+use serde_json::{Value, json};
+
+use super::visibility::{
+    AuthoritativeDnsTxtVisibilityWaiter, DnsTxtRecordState, DnsTxtVisibilityWaiter,
+};
+use super::{RemoteDnsHttpClient, RemoteDnsHttpRequest, RemoteDnsHttpResponse};
+use crate::daemon::remote_redaction::redact_secret_detail;
+
+pub(crate) struct AftermarketDns01Provider<C> {
+    http: C,
+    api_base: String,
+    zone_name: String,
+    public_key: String,
+    secret_key: String,
+    visibility: Arc<dyn DnsTxtVisibilityWaiter>,
+}
+
+impl<C> fmt::Debug for AftermarketDns01Provider<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AftermarketDns01Provider")
+            .field("api_base", &self.api_base)
+            .field("zone_name", &self.zone_name)
+            .field("public_key", &"<redacted>")
+            .field("secret_key", &"<redacted>")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<C> AftermarketDns01Provider<C>
+where
+    C: RemoteDnsHttpClient,
+{
+    pub(crate) fn new(
+        http: C,
+        api_base: &str,
+        zone_name: &str,
+        public_key: &str,
+        secret_key: &str,
+    ) -> Result<Self, String> {
+        let zone_name = required("Aftermarket zone name", zone_name)?
+            .trim_end_matches('.')
+            .to_string();
+        let visibility = Arc::new(AuthoritativeDnsTxtVisibilityWaiter::from_environment(
+            &zone_name,
+        )?);
+        Self::new_with_visibility(
+            http, api_base, &zone_name, public_key, secret_key, visibility,
+        )
+    }
+
+    pub(crate) fn new_with_visibility(
+        http: C,
+        api_base: &str,
+        zone_name: &str,
+        public_key: &str,
+        secret_key: &str,
+        visibility: Arc<dyn DnsTxtVisibilityWaiter>,
+    ) -> Result<Self, String> {
+        let api_base = required("Aftermarket API base URL", api_base)?;
+        let zone_name = required("Aftermarket zone name", zone_name)?
+            .trim_end_matches('.')
+            .to_string();
+        let public_key = required("Aftermarket API key", public_key)?;
+        let secret_key = required("Aftermarket API secret", secret_key)?;
+        Ok(Self {
+            http,
+            api_base: api_base.trim_end_matches('/').to_string(),
+            zone_name,
+            public_key: public_key.to_string(),
+            secret_key: secret_key.to_string(),
+            visibility,
+        })
+    }
+
+    pub(crate) async fn present(
+        &self,
+        record_name: &str,
+        record_value: &str,
+    ) -> Result<AftermarketDns01Lease, String> {
+        let host = validated_record_host(record_name, &self.zone_name)?;
+        let record_value = required("Aftermarket DNS record value", record_value)?;
+        let response = self
+            .send(
+                "/domain/dns/add",
+                json!({
+                    "name": self.zone_name,
+                    "host": host,
+                    "type": "TXT",
+                    "value": record_value,
+                }),
+            )
+            .await?;
+        let entry_id = aftermarket_entry_id(&response)?;
+        Ok(AftermarketDns01Lease {
+            entry_id,
+            record_name: host,
+            record_value: record_value.to_string(),
+        })
+    }
+
+    pub(crate) async fn wait_ready(&self, lease: &AftermarketDns01Lease) -> Result<(), String> {
+        self.visibility
+            .wait_for(
+                &lease.record_name,
+                &lease.record_value,
+                DnsTxtRecordState::Present,
+            )
+            .await
+    }
+
+    pub(crate) async fn cleanup(&self, lease: AftermarketDns01Lease) -> Result<(), String> {
+        let response = self
+            .send(
+                "/domain/dns/remove",
+                json!({
+                    "name": self.zone_name,
+                    "entryId": lease.entry_id,
+                }),
+            )
+            .await?;
+        ensure_aftermarket_removed(&response, lease.entry_id)?;
+        self.visibility
+            .wait_for(
+                &lease.record_name,
+                &lease.record_value,
+                DnsTxtRecordState::Absent,
+            )
+            .await
+    }
+
+    async fn send(&self, path: &str, body: Value) -> Result<RemoteDnsHttpResponse, String> {
+        self.http
+            .send(RemoteDnsHttpRequest::new(
+                Method::POST,
+                format!("{}{path}", self.api_base),
+                self.headers(),
+                body.to_string(),
+            ))
+            .await
+    }
+
+    fn headers(&self) -> Vec<(String, String)> {
+        let credentials =
+            BASE64_STANDARD.encode(format!("{}:{}", self.public_key, self.secret_key));
+        vec![
+            ("authorization".to_string(), format!("Basic {credentials}")),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct AftermarketDns01Lease {
+    entry_id: u64,
+    record_name: String,
+    record_value: String,
+}
+
+fn aftermarket_entry_id(response: &RemoteDnsHttpResponse) -> Result<u64, String> {
+    let body = ensure_aftermarket_success(response)?;
+    body["data"]
+        .as_u64()
+        .or_else(|| body["data"].as_str().and_then(|value| value.parse().ok()))
+        .filter(|entry_id| *entry_id > 0)
+        .ok_or_else(|| "Aftermarket DNS response omitted entry id".to_string())
+}
+
+fn ensure_aftermarket_removed(
+    response: &RemoteDnsHttpResponse,
+    entry_id: u64,
+) -> Result<(), String> {
+    let body = ensure_aftermarket_success(response)?;
+    if body["data"].as_bool() == Some(true) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Aftermarket DNS response did not remove entry {entry_id}"
+        ))
+    }
+}
+
+fn ensure_aftermarket_success(response: &RemoteDnsHttpResponse) -> Result<Value, String> {
+    let body = serde_json::from_str::<Value>(response.body()).map_err(|error| {
+        format!(
+            "parse Aftermarket DNS response with status {}: {error}",
+            response.status()
+        )
+    })?;
+    let ok = body["ok"]
+        .as_bool()
+        .unwrap_or_else(|| body["ok"].as_i64().is_some_and(|value| value != 0));
+    if response.is_success() && ok {
+        return Ok(body);
+    }
+    Err(format!(
+        "Aftermarket DNS request failed with status {}: {}",
+        response.status(),
+        redact_secret_detail(response.body())
+    ))
+}
+
+fn validated_record_host(record_name: &str, zone_name: &str) -> Result<String, String> {
+    let record_name = required("Aftermarket DNS record name", record_name)?.trim_end_matches('.');
+    if record_name.eq_ignore_ascii_case(zone_name) {
+        return Ok(record_name.to_string());
+    }
+    let suffix = format!(".{zone_name}");
+    if record_name.len() <= suffix.len()
+        || !record_name[record_name.len() - suffix.len()..].eq_ignore_ascii_case(&suffix)
+    {
+        return Err(format!(
+            "Aftermarket DNS record {record_name} is outside zone {zone_name}"
+        ));
+    }
+    Ok(record_name.to_string())
+}
+
+fn required<'a>(label: &str, value: &'a str) -> Result<&'a str, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        Err(format!("{label} is required"))
+    } else {
+        Ok(value)
+    }
+}

--- a/src/daemon/remote_acme_dns_provider.rs
+++ b/src/daemon/remote_acme_dns_provider.rs
@@ -4,13 +4,18 @@ use std::fmt;
 use async_trait::async_trait;
 use http::Method;
 
+#[path = "remote_acme_dns_aftermarket.rs"]
+mod aftermarket;
 #[path = "remote_acme_dns_cloudflare.rs"]
 mod cloudflare;
 #[path = "remote_acme_dns_exec.rs"]
 mod exec;
 #[path = "remote_acme_dns_route53.rs"]
 mod route53;
+#[path = "remote_acme_dns_visibility.rs"]
+mod visibility;
 
+pub(crate) use aftermarket::{AftermarketDns01Lease, AftermarketDns01Provider};
 pub(crate) use cloudflare::CloudflareDns01Lease;
 pub(crate) use cloudflare::CloudflareDns01Provider;
 #[cfg(test)]
@@ -18,6 +23,8 @@ pub(crate) use exec::RemoteDnsCommandRunner;
 pub(crate) use exec::{ExecDns01Lease, ExecDns01Provider, TokioRemoteDnsCommandRunner};
 pub(crate) use route53::Route53Dns01Lease;
 pub(crate) use route53::{AwsRoute53Credentials, Route53Dns01Provider};
+#[cfg(test)]
+pub(crate) use visibility::{DnsTxtRecordState, DnsTxtVisibilityWaiter};
 
 use super::remote::RemoteDnsProvider;
 
@@ -158,12 +165,14 @@ impl RemoteDnsHttpClient for ReqwestRemoteDnsHttpClient {
 
 #[derive(Debug)]
 pub(crate) enum SystemDns01Provider {
+    Aftermarket(AftermarketDns01Provider<ReqwestRemoteDnsHttpClient>),
     Cloudflare(CloudflareDns01Provider<ReqwestRemoteDnsHttpClient>),
     Route53(Route53Dns01Provider<ReqwestRemoteDnsHttpClient>),
     Exec(ExecDns01Provider<TokioRemoteDnsCommandRunner>),
 }
 
 pub(crate) enum SystemDns01Lease {
+    Aftermarket(AftermarketDns01Lease),
     Cloudflare(CloudflareDns01Lease),
     Route53(Route53Dns01Lease),
     Exec(ExecDns01Lease),
@@ -172,6 +181,16 @@ pub(crate) enum SystemDns01Lease {
 impl SystemDns01Provider {
     pub(crate) fn from_environment(provider: RemoteDnsProvider) -> Result<Self, String> {
         match provider {
+            RemoteDnsProvider::Aftermarket => Ok(Self::Aftermarket(AftermarketDns01Provider::new(
+                ReqwestRemoteDnsHttpClient::default(),
+                &optional_env(
+                    "HARNESS_REMOTE_ACME_AFTERMARKET_API_BASE",
+                    "https://json.aftermarket.pl",
+                ),
+                &required_env("AFTERMARKET_ZONE_NAME")?,
+                &required_env("AFTERMARKET_API_KEY")?,
+                &required_env("AFTERMARKET_API_SECRET")?,
+            )?)),
             RemoteDnsProvider::Cloudflare => Ok(Self::Cloudflare(CloudflareDns01Provider::new(
                 ReqwestRemoteDnsHttpClient::default(),
                 &optional_env(
@@ -211,6 +230,10 @@ impl SystemDns01Provider {
         record_value: &str,
     ) -> Result<SystemDns01Lease, String> {
         match (self, provider) {
+            (Self::Aftermarket(client), RemoteDnsProvider::Aftermarket) => client
+                .present(record_name, record_value)
+                .await
+                .map(SystemDns01Lease::Aftermarket),
             (Self::Cloudflare(client), RemoteDnsProvider::Cloudflare) => client
                 .present(record_name, record_value)
                 .await
@@ -227,8 +250,24 @@ impl SystemDns01Provider {
         }
     }
 
+    pub(crate) async fn wait_ready(&self, lease: &SystemDns01Lease) -> Result<bool, String> {
+        match (self, lease) {
+            (Self::Aftermarket(client), SystemDns01Lease::Aftermarket(lease)) => {
+                client.wait_ready(lease).await?;
+                Ok(true)
+            }
+            (Self::Cloudflare(_), SystemDns01Lease::Cloudflare(_))
+            | (Self::Route53(_), SystemDns01Lease::Route53(_))
+            | (Self::Exec(_), SystemDns01Lease::Exec(_)) => Ok(false),
+            _ => Err("remote DNS provider lease does not match configured provider".to_string()),
+        }
+    }
+
     pub(crate) async fn cleanup(&self, lease: SystemDns01Lease) -> Result<(), String> {
         match (self, lease) {
+            (Self::Aftermarket(client), SystemDns01Lease::Aftermarket(lease)) => {
+                client.cleanup(lease).await
+            }
             (Self::Cloudflare(client), SystemDns01Lease::Cloudflare(lease)) => {
                 client.cleanup(lease).await
             }

--- a/src/daemon/remote_acme_dns_provider_tests.rs
+++ b/src/daemon/remote_acme_dns_provider_tests.rs
@@ -5,9 +5,163 @@ use async_trait::async_trait;
 use http::Method;
 
 use super::{
-    AwsRoute53Credentials, CloudflareDns01Provider, ExecDns01Provider, RemoteDnsCommandRunner,
-    RemoteDnsHttpClient, RemoteDnsHttpRequest, RemoteDnsHttpResponse, Route53Dns01Provider,
+    AftermarketDns01Provider, AwsRoute53Credentials, CloudflareDns01Provider, DnsTxtRecordState,
+    DnsTxtVisibilityWaiter, ExecDns01Provider, RemoteDnsCommandRunner, RemoteDnsHttpClient,
+    RemoteDnsHttpRequest, RemoteDnsHttpResponse, Route53Dns01Provider,
 };
+
+#[tokio::test]
+async fn aftermarket_dns01_creates_and_deletes_the_issued_record() {
+    let http = RecordingDnsHttpClient::new([
+        RemoteDnsHttpResponse::new(
+            200,
+            r#"{"ok":1,"status":0,"error":"","data":987,"errtype":""}"#,
+        ),
+        RemoteDnsHttpResponse::new(
+            200,
+            r#"{"ok":1,"status":0,"error":"","data":true,"errtype":""}"#,
+        ),
+    ]);
+    let visibility = RecordingDnsTxtVisibility::default();
+    let provider = AftermarketDns01Provider::new_with_visibility(
+        http.clone(),
+        "https://aftermarket.test",
+        "example.com",
+        "public-key",
+        "secret-key",
+        Arc::new(visibility.clone()),
+    )
+    .expect("configure Aftermarket provider");
+
+    let lease = provider
+        .present("_acme-challenge.daemon.example.com.", "dns-proof-value")
+        .await
+        .expect("present Aftermarket challenge");
+    provider
+        .wait_ready(&lease)
+        .await
+        .expect("wait for authoritative Aftermarket challenge");
+    provider
+        .cleanup(lease)
+        .await
+        .expect("cleanup Aftermarket challenge");
+
+    let requests = http.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].method(), Method::POST);
+    assert_eq!(requests[0].url(), "https://aftermarket.test/domain/dns/add");
+    assert_eq!(
+        requests[0].header("authorization"),
+        Some("Basic cHVibGljLWtleTpzZWNyZXQta2V5")
+    );
+    let create_body = requests[0].json_body().expect("Aftermarket create JSON");
+    assert_eq!(create_body["name"], "example.com");
+    assert_eq!(create_body["host"], "_acme-challenge.daemon.example.com");
+    assert_eq!(create_body["type"], "TXT");
+    assert_eq!(create_body["value"], "dns-proof-value");
+    assert_eq!(requests[1].method(), Method::POST);
+    assert_eq!(
+        requests[1].url(),
+        "https://aftermarket.test/domain/dns/remove"
+    );
+    let cleanup_body = requests[1].json_body().expect("Aftermarket cleanup JSON");
+    assert_eq!(cleanup_body["name"], "example.com");
+    assert_eq!(cleanup_body["entryId"], 987);
+    assert_eq!(
+        visibility.calls(),
+        vec![
+            (
+                "_acme-challenge.daemon.example.com".to_string(),
+                "dns-proof-value".to_string(),
+                DnsTxtRecordState::Present,
+            ),
+            (
+                "_acme-challenge.daemon.example.com".to_string(),
+                "dns-proof-value".to_string(),
+                DnsTxtRecordState::Absent,
+            ),
+        ]
+    );
+    assert!(!format!("{provider:?}").contains("secret-key"));
+}
+
+#[tokio::test]
+async fn aftermarket_dns01_rejects_records_outside_the_configured_zone() {
+    let http = RecordingDnsHttpClient::new([]);
+    let provider = AftermarketDns01Provider::new(
+        http.clone(),
+        "https://aftermarket.test",
+        "example.com",
+        "public-key",
+        "secret-key",
+    )
+    .expect("configure Aftermarket provider");
+
+    let error = provider
+        .present("_acme-challenge.example.net", "dns-proof-value")
+        .await
+        .expect_err("reject record outside zone");
+
+    assert!(error.contains("outside zone example.com"));
+    assert!(http.requests().is_empty());
+}
+
+#[tokio::test]
+async fn aftermarket_dns01_redacts_provider_errors() {
+    let http = RecordingDnsHttpClient::new([RemoteDnsHttpResponse::new(
+        200,
+        r#"{"ok":0,"status":500,"error":"token=super-secret failed","data":null}"#,
+    )]);
+    let provider = AftermarketDns01Provider::new(
+        http,
+        "https://aftermarket.test",
+        "example.com",
+        "public-key",
+        "secret-key",
+    )
+    .expect("configure Aftermarket provider");
+
+    let error = provider
+        .present("_acme-challenge.example.com", "dns-proof-value")
+        .await
+        .expect_err("surface provider failure");
+
+    assert!(error.contains("Aftermarket DNS request failed"));
+    assert!(!error.contains("super-secret"));
+}
+
+#[tokio::test]
+async fn aftermarket_dns01_rejects_unsuccessful_cleanup_result() {
+    let http = RecordingDnsHttpClient::new([
+        RemoteDnsHttpResponse::new(
+            200,
+            r#"{"ok":1,"status":0,"error":"","data":987,"errtype":""}"#,
+        ),
+        RemoteDnsHttpResponse::new(
+            200,
+            r#"{"ok":1,"status":0,"error":"","data":false,"errtype":""}"#,
+        ),
+    ]);
+    let provider = AftermarketDns01Provider::new(
+        http,
+        "https://aftermarket.test",
+        "example.com",
+        "public-key",
+        "secret-key",
+    )
+    .expect("configure Aftermarket provider");
+
+    let lease = provider
+        .present("_acme-challenge.example.com", "dns-proof-value")
+        .await
+        .expect("present Aftermarket challenge");
+    let error = provider
+        .cleanup(lease)
+        .await
+        .expect_err("reject unsuccessful cleanup result");
+
+    assert_eq!(error, "Aftermarket DNS response did not remove entry 987");
+}
 
 #[tokio::test]
 async fn cloudflare_dns01_creates_and_deletes_the_issued_record() {
@@ -192,6 +346,34 @@ impl RemoteDnsHttpClient for RecordingDnsHttpClient {
             .responses
             .pop_front()
             .ok_or_else(|| "missing fake DNS HTTP response".to_string())
+    }
+}
+
+#[derive(Clone, Default)]
+struct RecordingDnsTxtVisibility {
+    calls: Arc<Mutex<Vec<(String, String, DnsTxtRecordState)>>>,
+}
+
+impl RecordingDnsTxtVisibility {
+    fn calls(&self) -> Vec<(String, String, DnsTxtRecordState)> {
+        self.calls.lock().expect("lock DNS visibility").clone()
+    }
+}
+
+#[async_trait]
+impl DnsTxtVisibilityWaiter for RecordingDnsTxtVisibility {
+    async fn wait_for(
+        &self,
+        record_name: &str,
+        record_value: &str,
+        state: DnsTxtRecordState,
+    ) -> Result<(), String> {
+        self.calls.lock().map_err(|error| error.to_string())?.push((
+            record_name.to_string(),
+            record_value.to_string(),
+            state,
+        ));
+        Ok(())
     }
 }
 

--- a/src/daemon/remote_acme_dns_runner.rs
+++ b/src/daemon/remote_acme_dns_runner.rs
@@ -11,12 +11,20 @@ use super::remote_redaction::redact_secret_detail;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Dns01ProviderExecutionConfig {
+    Aftermarket { zone_name: String },
     Cloudflare { zone_id: String },
     Route53 { hosted_zone_id: String },
     Exec { hook_program: String },
 }
 
 impl Dns01ProviderExecutionConfig {
+    #[must_use]
+    pub fn aftermarket(zone_name: impl Into<String>) -> Self {
+        Self::Aftermarket {
+            zone_name: zone_name.into(),
+        }
+    }
+
     #[must_use]
     pub fn cloudflare(zone_id: impl Into<String>) -> Self {
         Self::Cloudflare {
@@ -40,6 +48,18 @@ impl Dns01ProviderExecutionConfig {
 }
 
 pub trait Dns01ProviderChangeRunner {
+    /// Apply an Aftermarket DNS-01 TXT record change.
+    ///
+    /// # Errors
+    /// Returns a redaction-ready provider detail when the change fails.
+    fn apply_aftermarket_change(
+        &mut self,
+        zone_name: &str,
+        fqdn: &str,
+        digest: &str,
+        operation: Dns01ChangeOperation,
+    ) -> Result<(), String>;
+
     /// Apply a Cloudflare DNS-01 TXT record change.
     ///
     /// # Errors
@@ -172,6 +192,7 @@ impl Dns01ProviderAction {
     #[must_use]
     pub const fn required_secret_names(&self) -> &'static [&'static str] {
         match self.provider {
+            RemoteDnsProvider::Aftermarket => &["AFTERMARKET_API_KEY", "AFTERMARKET_API_SECRET"],
             RemoteDnsProvider::Cloudflare => &["CLOUDFLARE_API_TOKEN"],
             RemoteDnsProvider::Route53 => &["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
             RemoteDnsProvider::Exec => &["HARNESS_REMOTE_ACME_DNS_EXEC"],
@@ -181,6 +202,9 @@ impl Dns01ProviderAction {
     #[must_use]
     pub fn command_preview(&self) -> String {
         match self.provider {
+            RemoteDnsProvider::Aftermarket => {
+                format!("aftermarket TXT {} {}", self.fqdn, self.digest)
+            }
             RemoteDnsProvider::Cloudflare => {
                 format!("cloudflare TXT {} {}", self.fqdn, self.digest)
             }
@@ -252,6 +276,16 @@ impl Dns01ProviderAction {
         Runner: Dns01ProviderChangeRunner,
     {
         match self.provider {
+            RemoteDnsProvider::Aftermarket => {
+                let Dns01ProviderExecutionConfig::Aftermarket { zone_name } = config else {
+                    return Err(Dns01ProviderExecutionError::WrongProviderConfig(
+                        "aftermarket",
+                    ));
+                };
+                runner
+                    .apply_aftermarket_change(zone_name, &self.fqdn, &self.digest, operation)
+                    .map_err(|detail| Dns01ProviderExecutionError::runner_failed(&detail))
+            }
             RemoteDnsProvider::Cloudflare => {
                 let Dns01ProviderExecutionConfig::Cloudflare { zone_id } = config else {
                     return Err(Dns01ProviderExecutionError::WrongProviderConfig(

--- a/src/daemon/remote_acme_dns_runner_tests.rs
+++ b/src/daemon/remote_acme_dns_runner_tests.rs
@@ -8,6 +8,11 @@ use crate::daemon::remote::RemoteDnsProvider;
 #[test]
 fn remote_dns01_provider_runner_dispatches_native_and_exec_operations() {
     let mut runner = RecordingDns01Runner::default();
+    let aftermarket = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Aftermarket,
+        "_acme-challenge.daemon.example.com",
+        "aftermarket-digest",
+    );
     let cloudflare = Dns01ProviderAction::for_provider(
         RemoteDnsProvider::Cloudflare,
         "_acme-challenge.daemon.example.com",
@@ -24,6 +29,13 @@ fn remote_dns01_provider_runner_dispatches_native_and_exec_operations() {
         "exec-digest",
     );
 
+    aftermarket
+        .run_change_with(
+            &Dns01ProviderExecutionConfig::aftermarket("example.com"),
+            Dns01ChangeOperation::Present,
+            &mut runner,
+        )
+        .expect("Aftermarket present");
     cloudflare
         .run_change_with(
             &Dns01ProviderExecutionConfig::cloudflare("zone-123"),
@@ -48,6 +60,8 @@ fn remote_dns01_provider_runner_dispatches_native_and_exec_operations() {
     assert_eq!(
         runner.events,
         vec![
+            "aftermarket:present:example.com:_acme-challenge.daemon.example.com:aftermarket-digest"
+                .to_string(),
             "cloudflare:present:zone-123:_acme-challenge.daemon.example.com:cloudflare-digest"
                 .to_string(),
             "route53:DELETE:Z123456:_acme-challenge.daemon.example.com.:\"route53-digest\""
@@ -209,6 +223,21 @@ struct RecordingDns01Runner {
 }
 
 impl Dns01ProviderChangeRunner for RecordingDns01Runner {
+    fn apply_aftermarket_change(
+        &mut self,
+        zone_name: &str,
+        fqdn: &str,
+        digest: &str,
+        operation: Dns01ChangeOperation,
+    ) -> Result<(), String> {
+        let is_cleanup = operation == Dns01ChangeOperation::Cleanup;
+        self.events.push(format!(
+            "aftermarket:{}:{zone_name}:{fqdn}:{digest}",
+            operation.as_str()
+        ));
+        self.maybe_fail(is_cleanup)
+    }
+
     fn apply_cloudflare_change(
         &mut self,
         request: &CloudflareDns01ChangeRequest,

--- a/src/daemon/remote_acme_dns_visibility.rs
+++ b/src/daemon/remote_acme_dns_visibility.rs
@@ -1,0 +1,335 @@
+use std::env;
+use std::net::IpAddr;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
+use hickory_resolver::lookup::Lookup;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::proto::rr::{RData, RecordType};
+use hickory_resolver::{Resolver, TokioResolver};
+use tokio::time::{Instant, sleep};
+
+const TIMEOUT_ENV: &str = "HARNESS_REMOTE_ACME_DNS_VISIBILITY_TIMEOUT_SECONDS";
+const POLL_INTERVAL_ENV: &str = "HARNESS_REMOTE_ACME_DNS_VISIBILITY_POLL_SECONDS";
+const DEFAULT_TIMEOUT: Duration = Duration::from_mins(5);
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DnsTxtRecordState {
+    Present,
+    Absent,
+}
+
+impl DnsTxtRecordState {
+    const fn matches(self, present: bool) -> bool {
+        match self {
+            Self::Present => present,
+            Self::Absent => !present,
+        }
+    }
+
+    const fn description(self) -> &'static str {
+        match self {
+            Self::Present => "appear",
+            Self::Absent => "disappear",
+        }
+    }
+}
+
+#[async_trait]
+pub(crate) trait DnsTxtVisibilityWaiter: Send + Sync {
+    async fn wait_for(
+        &self,
+        record_name: &str,
+        record_value: &str,
+        state: DnsTxtRecordState,
+    ) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AuthoritativeDnsTxtVisibilityWaiter {
+    zone_name: String,
+    timeout: Duration,
+    poll_interval: Duration,
+}
+
+impl AuthoritativeDnsTxtVisibilityWaiter {
+    pub(crate) fn from_environment(zone_name: &str) -> Result<Self, String> {
+        Ok(Self {
+            zone_name: zone_name.to_string(),
+            timeout: duration_from_env(TIMEOUT_ENV, DEFAULT_TIMEOUT)?,
+            poll_interval: duration_from_env(POLL_INTERVAL_ENV, DEFAULT_POLL_INTERVAL)?,
+        })
+    }
+}
+
+#[async_trait]
+impl DnsTxtVisibilityWaiter for AuthoritativeDnsTxtVisibilityWaiter {
+    async fn wait_for(
+        &self,
+        record_name: &str,
+        record_value: &str,
+        state: DnsTxtRecordState,
+    ) -> Result<(), String> {
+        let resolvers = authoritative_resolvers(&self.zone_name).await?;
+        let fqdn = format!("{}.", record_name.trim_end_matches('.'));
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            let query_error =
+                match all_authoritative_resolvers_match(&resolvers, &fqdn, record_value, state)
+                    .await
+                {
+                    Ok(true) => return Ok(()),
+                    Ok(_) => None,
+                    Err(error) => Some(error),
+                };
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(visibility_timeout_error(
+                    record_name,
+                    state,
+                    self.timeout,
+                    query_error.as_deref(),
+                ));
+            }
+            sleep(self.poll_interval.min(deadline - now)).await;
+        }
+    }
+}
+
+struct AuthoritativeDnsResolver {
+    name: String,
+    resolver: TokioResolver,
+}
+
+async fn authoritative_resolvers(zone_name: &str) -> Result<Vec<AuthoritativeDnsResolver>, String> {
+    let system = TokioResolver::builder_tokio()
+        .map_err(|error| format!("load system DNS resolver: {error}"))?
+        .build()
+        .map_err(|error| format!("build system DNS resolver: {error}"))?;
+    let zone_fqdn = format!("{}.", zone_name.trim_end_matches('.'));
+    let nameservers = system
+        .ns_lookup(&zone_fqdn)
+        .await
+        .map_err(|error| format!("resolve authoritative DNS servers for {zone_name}: {error}"))?;
+    let mut names = nameservers
+        .answers()
+        .iter()
+        .filter_map(|record| match &record.data {
+            RData::NS(nameserver) => Some(nameserver.to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    names.dedup();
+    if names.is_empty() {
+        return Err(format!(
+            "authoritative DNS lookup for {zone_name} returned no nameservers"
+        ));
+    }
+    let mut resolvers = Vec::with_capacity(names.len());
+    for nameserver in names {
+        let resolved = system
+            .lookup_ip(nameserver.as_str())
+            .await
+            .map_err(|error| format!("resolve authoritative DNS server {nameserver}: {error}"))?;
+        let mut addresses = resolved.iter().collect::<Vec<_>>();
+        addresses.sort_unstable();
+        addresses.dedup();
+        resolvers.push(AuthoritativeDnsResolver {
+            resolver: build_authoritative_resolver(&addresses, &nameserver)?,
+            name: nameserver,
+        });
+    }
+    Ok(resolvers)
+}
+
+fn build_authoritative_resolver(
+    addresses: &[IpAddr],
+    zone_name: &str,
+) -> Result<TokioResolver, String> {
+    if addresses.is_empty() {
+        return Err(format!(
+            "authoritative DNS servers for {zone_name} resolved without addresses"
+        ));
+    }
+    let name_servers = addresses
+        .iter()
+        .copied()
+        .map(|address| {
+            let mut config = NameServerConfig::udp_and_tcp(address);
+            config.trust_negative_responses = false;
+            config
+        })
+        .collect();
+    let mut options = ResolverOpts::default();
+    options.attempts = 2;
+    options.cache_size = 0;
+    options.num_concurrent_reqs = addresses.len().min(2);
+    options.recursion_desired = false;
+    options.timeout = Duration::from_secs(5);
+    options.try_tcp_on_error = true;
+    Resolver::builder_with_config(
+        ResolverConfig::from_parts(None, Vec::new(), name_servers),
+        TokioRuntimeProvider::default(),
+    )
+    .with_options(options)
+    .build()
+    .map_err(|error| format!("build authoritative DNS resolver for {zone_name}: {error}"))
+}
+
+async fn txt_value_present(
+    resolver: &TokioResolver,
+    record_name: &str,
+    record_value: &str,
+) -> Result<bool, String> {
+    match resolver.txt_lookup(record_name).await {
+        Ok(lookup) => Ok(lookup_contains_txt(&lookup, record_value)),
+        Err(error) if error.is_no_records_found() => Ok(false),
+        Err(error) => Err(format!(
+            "query authoritative TXT record {record_name}: {error}"
+        )),
+    }
+}
+
+async fn all_authoritative_resolvers_match(
+    resolvers: &[AuthoritativeDnsResolver],
+    record_name: &str,
+    record_value: &str,
+    state: DnsTxtRecordState,
+) -> Result<bool, String> {
+    let mut states = Vec::with_capacity(resolvers.len());
+    for server in resolvers {
+        server
+            .resolver
+            .clear_lookup_cache(record_name, RecordType::TXT);
+        states.push(
+            txt_value_present(&server.resolver, record_name, record_value)
+                .await
+                .map_err(|error| format!("{error} via {}", server.name))?,
+        );
+    }
+    Ok(all_authoritative_states_match(state, states))
+}
+
+fn all_authoritative_states_match(
+    state: DnsTxtRecordState,
+    states: impl IntoIterator<Item = bool>,
+) -> bool {
+    let mut states = states.into_iter().peekable();
+    states.peek().is_some() && states.all(|present| state.matches(present))
+}
+
+fn lookup_contains_txt(lookup: &Lookup, record_value: &str) -> bool {
+    lookup.answers().iter().any(|record| {
+        let RData::TXT(txt) = &record.data else {
+            return false;
+        };
+        txt.txt_data
+            .iter()
+            .flat_map(|part| part.iter().copied())
+            .eq(record_value.bytes())
+    })
+}
+
+fn duration_from_env(name: &str, default: Duration) -> Result<Duration, String> {
+    let Ok(value) = env::var(name) else {
+        return Ok(default);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(default);
+    }
+    let seconds = value
+        .parse::<u64>()
+        .map_err(|error| format!("parse {name}: {error}"))?;
+    if seconds == 0 {
+        return Err(format!("{name} must be greater than zero"));
+    }
+    Ok(Duration::from_secs(seconds))
+}
+
+fn visibility_timeout_error(
+    record_name: &str,
+    state: DnsTxtRecordState,
+    timeout: Duration,
+    last_error: Option<&str>,
+) -> String {
+    let detail = last_error.map_or_else(String::new, |error| format!("; last query: {error}"));
+    format!(
+        "authoritative DNS TXT record {record_name} did not {} within {} seconds{detail}",
+        state.description(),
+        timeout.as_secs(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use hickory_resolver::lookup::Lookup;
+    use hickory_resolver::proto::op::Query;
+    use hickory_resolver::proto::rr::rdata::TXT;
+    use hickory_resolver::proto::rr::{Name, RData, RecordType};
+
+    use super::*;
+
+    #[test]
+    fn visibility_config_uses_provider_neutral_environment() {
+        temp_env::with_vars(
+            [(TIMEOUT_ENV, Some("17")), (POLL_INTERVAL_ENV, Some("3"))],
+            || {
+                let waiter = AuthoritativeDnsTxtVisibilityWaiter::from_environment("example.com")
+                    .expect("visibility config");
+                assert_eq!(waiter.timeout, Duration::from_secs(17));
+                assert_eq!(waiter.poll_interval, Duration::from_secs(3));
+            },
+        );
+    }
+
+    #[test]
+    fn visibility_config_rejects_zero_duration() {
+        temp_env::with_var(TIMEOUT_ENV, Some("0"), || {
+            let error = AuthoritativeDnsTxtVisibilityWaiter::from_environment("example.com")
+                .expect_err("reject zero timeout");
+            assert_eq!(
+                error,
+                "HARNESS_REMOTE_ACME_DNS_VISIBILITY_TIMEOUT_SECONDS must be greater than zero"
+            );
+        });
+    }
+
+    #[test]
+    fn txt_matching_joins_segments_and_requires_the_exact_value() {
+        let query = Query::query(
+            Name::from_ascii("_acme-challenge.example.com.").expect("record name"),
+            RecordType::TXT,
+        );
+        let lookup = Lookup::from_rdata(
+            query,
+            RData::TXT(TXT::from_bytes(vec![b"dns-proof-", b"value"])),
+        );
+
+        assert!(lookup_contains_txt(&lookup, "dns-proof-value"));
+        assert!(!lookup_contains_txt(&lookup, "dns-proof"));
+    }
+
+    #[test]
+    fn visibility_requires_every_authoritative_server_to_match() {
+        assert!(all_authoritative_states_match(
+            DnsTxtRecordState::Present,
+            [true, true]
+        ));
+        assert!(!all_authoritative_states_match(
+            DnsTxtRecordState::Present,
+            [true, false]
+        ));
+        assert!(all_authoritative_states_match(
+            DnsTxtRecordState::Absent,
+            [false, false]
+        ));
+        assert!(!all_authoritative_states_match(
+            DnsTxtRecordState::Absent,
+            [false, true]
+        ));
+    }
+}

--- a/src/daemon/remote_acme_tests.rs
+++ b/src/daemon/remote_acme_tests.rs
@@ -128,6 +128,11 @@ fn remote_http01_challenge_routes_only_well_known_tokens() {
 
 #[test]
 fn remote_dns01_providers_report_required_operations() {
+    let aftermarket = Dns01ProviderAction::for_provider(
+        RemoteDnsProvider::Aftermarket,
+        "_acme-challenge.daemon.example.com",
+        "digest",
+    );
     let cloudflare = Dns01ProviderAction::for_provider(
         RemoteDnsProvider::Cloudflare,
         "_acme-challenge.daemon.example.com",
@@ -144,6 +149,10 @@ fn remote_dns01_providers_report_required_operations() {
         "digest",
     );
 
+    assert_eq!(
+        aftermarket.required_secret_names(),
+        &["AFTERMARKET_API_KEY", "AFTERMARKET_API_SECRET"]
+    );
     assert_eq!(
         cloudflare.required_secret_names(),
         &["CLOUDFLARE_API_TOKEN"]

--- a/src/daemon/transport/commands.rs
+++ b/src/daemon/transport/commands.rs
@@ -19,6 +19,7 @@ use super::control::{
     restart_daemon, stop_daemon,
 };
 use super::remote::DaemonRemoteCommand;
+use super::remote_systemd::{ensure_linux_systemd, systemd_daemon_root};
 
 /// Local daemon operations and remote-daemon scaffolding.
 #[derive(Debug, Clone, Subcommand)]
@@ -31,6 +32,9 @@ pub enum DaemonCommand {
     Dev(DaemonDevArgs),
     /// Serve and manage an internet-reachable remote daemon.
     Remote {
+        /// Use the private state directory of an installed systemd unit.
+        #[arg(long, global = true)]
+        systemd_unit: Option<String>,
         #[command(subcommand)]
         command: DaemonRemoteCommand,
     },
@@ -55,7 +59,10 @@ impl Execute for DaemonCommand {
         match self {
             Self::Serve(args) => args.execute(context),
             Self::Dev(args) => args.execute(context),
-            Self::Remote { command } => command.execute(context),
+            Self::Remote {
+                command,
+                systemd_unit,
+            } => execute_remote_command(command, systemd_unit.as_deref(), context),
             Self::Status => {
                 adopt_daemon_root_for_transport_command("daemon-status");
                 let report = service::status_report()?;
@@ -77,6 +84,21 @@ impl Execute for DaemonCommand {
             Self::Snapshot(args) => args.execute(context),
         }
     }
+}
+
+fn execute_remote_command(
+    command: &DaemonRemoteCommand,
+    systemd_unit: Option<&str>,
+    context: &AppContext,
+) -> Result<i32, CliError> {
+    let _root_override = systemd_unit
+        .map(|unit| {
+            ensure_linux_systemd()?;
+            systemd_daemon_root(unit)
+        })
+        .transpose()?
+        .map(|root| state::ScopedDaemonRootOverride::set(Some(root)));
+    command.execute(context)
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -331,6 +331,8 @@ impl From<DaemonRemoteAcmeChallenge> for RemoteAcmeChallenge {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum DaemonRemoteDnsProvider {
+    #[value(name = "aftermarket")]
+    Aftermarket,
     #[value(name = "cloudflare")]
     Cloudflare,
     #[value(name = "route53")]
@@ -343,6 +345,7 @@ impl DaemonRemoteDnsProvider {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::Aftermarket => "aftermarket",
             Self::Cloudflare => "cloudflare",
             Self::Route53 => "route53",
             Self::Exec => "exec",
@@ -353,6 +356,7 @@ impl DaemonRemoteDnsProvider {
 impl From<DaemonRemoteDnsProvider> for RemoteDnsProvider {
     fn from(value: DaemonRemoteDnsProvider) -> Self {
         match value {
+            DaemonRemoteDnsProvider::Aftermarket => Self::Aftermarket,
             DaemonRemoteDnsProvider::Cloudflare => Self::Cloudflare,
             DaemonRemoteDnsProvider::Route53 => Self::Route53,
             DaemonRemoteDnsProvider::Exec => Self::Exec,

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -299,6 +299,7 @@ fn render_unit(
          Type=simple\n\
          EnvironmentFile={}\n\
          Environment=HARNESS_DAEMON_DATA_HOME=%S/{unit}\n\
+         Environment=XDG_DATA_HOME=%S/{unit}\n\
          Environment=HARNESS_DAEMON_OWNERSHIP=external\n\
          ExecStart={exec_start}\n\
          Restart=on-failure\n\

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -18,6 +18,7 @@ use super::remote_systemd_lifecycle::{
 const DEFAULT_UNIT: &str = "harness-remote-daemon";
 const SYSTEMD_UNIT_DIR: &str = "/etc/systemd/system";
 const SYSTEMD_ENV_DIR: &str = "/etc/harness";
+const SYSTEMD_PRIVATE_STATE_DIR: &str = "/var/lib/private";
 
 #[derive(Debug, Clone, Args)]
 pub struct DaemonRemoteSystemdUnitArgs {
@@ -432,12 +433,27 @@ fn default_env_path(unit: &str) -> PathBuf {
     Path::new(SYSTEMD_ENV_DIR).join(format!("{unit}.env"))
 }
 
+pub(super) fn systemd_daemon_root(unit: &str) -> Result<PathBuf, CliError> {
+    let unit = normalize_unit_name(unit);
+    validate_unit_name(unit)?;
+    Ok(Path::new(SYSTEMD_PRIVATE_STATE_DIR)
+        .join(unit)
+        .join("harness")
+        .join("daemon")
+        .join("external"))
+}
+
 #[cfg(test)]
 pub(crate) fn default_env_path_for_tests(unit: &str) -> PathBuf {
     default_env_path(unit)
 }
 
-fn ensure_linux_systemd() -> Result<(), CliError> {
+#[cfg(test)]
+pub(crate) fn systemd_daemon_root_for_tests(unit: &str) -> Result<PathBuf, CliError> {
+    systemd_daemon_root(unit)
+}
+
+pub(super) fn ensure_linux_systemd() -> Result<(), CliError> {
     if cfg!(target_os = "linux") {
         Ok(())
     } else {

--- a/src/daemon/transport/remote_systemd_lifecycle.rs
+++ b/src/daemon/transport/remote_systemd_lifecycle.rs
@@ -57,7 +57,7 @@ where
     RunSystemctl: Fn(&[String]) -> Result<RemoteSystemdCommandOutput, CliError>,
 {
     let unit_written = write_if_changed(&plan.unit_path, &plan.unit_contents, 0o644)?;
-    let env_written = write_if_changed(&plan.env_path, &plan.env_contents, 0o600)?;
+    let env_written = write_if_missing(&plan.env_path, &plan.env_contents, 0o600)?;
     run_checked(run_systemctl, &["daemon-reload".to_string()])?;
     run_checked(
         run_systemctl,
@@ -165,6 +165,50 @@ fn write_if_changed(path: &Path, contents: &str, mode: u32) -> Result<bool, CliE
     }
     write_atomic(path, contents, mode)?;
     Ok(true)
+}
+
+fn write_if_missing(path: &Path, contents: &str, mode: u32) -> Result<bool, CliError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            CliError::from(CliErrorKind::workflow_io(format!(
+                "create directory {}: {error}",
+                parent.display()
+            )))
+        })?;
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut temp = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "create temp file for {}: {error}",
+            path.display()
+        )))
+    })?;
+    set_file_mode(temp.path(), mode)?;
+    temp.write_all(contents.as_bytes()).map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "write temp file for {}: {error}",
+            path.display()
+        )))
+    })?;
+    temp.flush().map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "flush temp file for {}: {error}",
+            path.display()
+        )))
+    })?;
+    match temp.persist_noclobber(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.error.kind() == ErrorKind::AlreadyExists => {
+            set_file_mode(path, mode)?;
+            Ok(false)
+        }
+        Err(error) => Err(CliErrorKind::workflow_io(format!(
+            "persist {}: {}",
+            path.display(),
+            error.error
+        ))
+        .into()),
+    }
 }
 
 fn write_atomic(path: &Path, contents: &str, mode: u32) -> Result<(), CliError> {

--- a/src/daemon/transport/remote_systemd_lifecycle.rs
+++ b/src/daemon/transport/remote_systemd_lifecycle.rs
@@ -61,7 +61,11 @@ where
     run_checked(run_systemctl, &["daemon-reload".to_string()])?;
     run_checked(
         run_systemctl,
-        &["enable".to_string(), unit_service_name(&plan.unit)],
+        &[
+            "enable".to_string(),
+            "--now".to_string(),
+            unit_service_name(&plan.unit),
+        ],
     )?;
     Ok(RemoteSystemdInstallReport {
         unit_path: plan.unit_path.clone(),
@@ -70,7 +74,7 @@ where
         env_written,
         daemon_reloaded: true,
         enabled: true,
-        started: false,
+        started: true,
     })
 }
 

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -146,6 +146,28 @@ fn daemon_remote_serve_args_support_dns01_providers() {
 }
 
 #[test]
+fn daemon_remote_serve_args_support_aftermarket_dns01() {
+    let parsed = DaemonRemoteServeArgsTestHarness::try_parse_from([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+        "--acme-challenge",
+        "dns",
+        "--acme-dns-provider",
+        "aftermarket",
+    ])
+    .unwrap();
+
+    let config = parsed.args.contract_config().expect("Aftermarket DNS-01");
+    assert_eq!(
+        config.acme_dns_provider.expect("dns provider").as_str(),
+        "aftermarket"
+    );
+}
+
+#[test]
 fn daemon_remote_serve_args_reject_dns01_without_provider() {
     let parsed = DaemonRemoteServeArgsTestHarness::try_parse_from([
         "test",

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -138,6 +138,10 @@ fn remote_systemd_unit_is_hardened_and_runs_remote_serve() {
     );
     assert!(
         plan.unit_contents
+            .contains("Environment=XDG_DATA_HOME=%S/harness-remote-daemon")
+    );
+    assert!(
+        plan.unit_contents
             .contains("Environment=HARNESS_DAEMON_OWNERSHIP=external")
     );
     assert!(plan.unit_contents.contains("NoNewPrivileges=true"));

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -6,6 +6,7 @@ use tempfile::tempdir;
 use super::super::remote::DaemonRemoteCommand;
 use super::super::remote_systemd::{
     DaemonRemoteSystemdInstallArgs, RemoteSystemdInstallPlan, default_env_path_for_tests,
+    systemd_daemon_root_for_tests,
 };
 use super::super::remote_systemd_lifecycle::{
     RemoteSystemdCommandOutput, install_remote_systemd_with, uninstall_remote_systemd_with,
@@ -15,6 +16,15 @@ use super::super::remote_systemd_lifecycle::{
 struct DaemonRemoteCommandTestHarness {
     #[command(subcommand)]
     command: DaemonRemoteCommand,
+}
+
+#[test]
+fn remote_systemd_management_root_uses_private_state_directory() {
+    assert_eq!(
+        systemd_daemon_root_for_tests("harness-remote-proof").expect("systemd daemon root"),
+        PathBuf::from("/var/lib/private/harness-remote-proof/harness/daemon/external")
+    );
+    assert!(systemd_daemon_root_for_tests("../unsafe").is_err());
 }
 
 #[test]

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -374,7 +374,7 @@ fn remote_systemd_uninstall_reports_disable_failure() {
 }
 
 #[test]
-fn remote_systemd_install_writes_files_with_secret_permissions_idempotently() {
+fn remote_systemd_install_preserves_preprovisioned_environment_idempotently() {
     let temp = tempdir().expect("temp dir");
     let unit_path = temp
         .path()
@@ -384,7 +384,12 @@ fn remote_systemd_install_writes_files_with_secret_permissions_idempotently() {
     std::fs::create_dir_all(unit_path.parent().expect("unit parent")).expect("unit dir");
     std::fs::create_dir_all(env_path.parent().expect("env parent")).expect("env dir");
     std::fs::write(&unit_path, "stale unit").expect("write stale unit");
-    std::fs::write(&env_path, "stale env").expect("write stale env");
+    let provisioned_env = concat!(
+        "HARNESS_REMOTE_ACME_DIRECTORY_URL=",
+        "https://acme-staging-v02.api.letsencrypt.org/directory\n",
+        "HARNESS_REMOTE_ACME_DNS_EXEC=/usr/local/bin/harness-acme-dns\n",
+    );
+    std::fs::write(&env_path, provisioned_env).expect("write provisioned env");
     let args = install_args([
         "test",
         "--domain",
@@ -411,7 +416,7 @@ fn remote_systemd_install_writes_files_with_secret_permissions_idempotently() {
     let second = install_remote_systemd_with(&plan, &runner).expect("second install");
 
     assert!(first.unit_written);
-    assert!(first.env_written);
+    assert!(!first.env_written);
     assert!(!second.unit_written);
     assert!(!second.env_written);
     assert_eq!(
@@ -420,7 +425,7 @@ fn remote_systemd_install_writes_files_with_secret_permissions_idempotently() {
     );
     assert_eq!(
         std::fs::read_to_string(&env_path).expect("env file"),
-        plan.env_contents
+        provisioned_env
     );
     assert_secret_file_mode(&env_path);
 }

--- a/src/daemon/transport/tests/remote_systemd_plan.rs
+++ b/src/daemon/transport/tests/remote_systemd_plan.rs
@@ -59,6 +59,34 @@ fn remote_systemd_install_enables_and_starts_remote_serve() {
 }
 
 #[test]
+fn remote_systemd_plan_runs_aftermarket_dns01() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+        "--acme-challenge",
+        "dns",
+        "--acme-dns-provider",
+        "aftermarket",
+    ]);
+    let plan = RemoteSystemdInstallPlan::for_tests(
+        &args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect("systemd install plan");
+
+    assert!(plan.unit_contents.contains("--acme-challenge dns"));
+    assert!(
+        plan.unit_contents
+            .contains("--acme-dns-provider aftermarket")
+    );
+}
+
+#[test]
 fn remote_systemd_plan_rejects_relative_binary_path() {
     let args = install_args([
         "test",

--- a/src/daemon/transport/tests/remote_systemd_plan.rs
+++ b/src/daemon/transport/tests/remote_systemd_plan.rs
@@ -10,7 +10,7 @@ use super::super::remote_systemd_lifecycle::{
 };
 
 #[test]
-fn remote_systemd_install_enables_without_starting_reserved_serve() {
+fn remote_systemd_install_enables_and_starts_remote_serve() {
     let temp = tempdir().expect("temp dir");
     let unit_path = temp
         .path()
@@ -44,13 +44,14 @@ fn remote_systemd_install_enables_without_starting_reserved_serve() {
     let report = install_remote_systemd_with(&plan, &runner).expect("install systemd");
 
     assert!(report.enabled);
-    assert!(!report.started);
+    assert!(report.started);
     assert_eq!(
         calls.borrow().as_slice(),
         [
             vec!["daemon-reload".to_string()],
             vec![
                 "enable".to_string(),
+                "--now".to_string(),
                 "harness-remote-daemon.service".to_string(),
             ],
         ]

--- a/src/daemon/websocket/parity.rs
+++ b/src/daemon/websocket/parity.rs
@@ -23,6 +23,7 @@ use crate::daemon::voice::{
     append_audio_chunk, append_transcript_async, finish_session_async, start_session_async,
 };
 use crate::errors::{CliError, CliErrorKind};
+#[cfg(target_os = "macos")]
 use crate::sandbox;
 use crate::workspace::adopter::AdoptionOutcome;
 

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -1,5 +1,6 @@
 //! CLI subcommand entry points for `harness mcp ...`.
 
+#[cfg(target_os = "macos")]
 use std::io;
 use std::path::PathBuf;
 
@@ -97,6 +98,7 @@ where
         .map_err(|error| map_io_error(&error))
 }
 
+#[cfg(target_os = "macos")]
 fn map_io_error(error: &io::Error) -> CliError {
     CliError::from(CliErrorKind::workflow_io(format!(
         "mcp stdio serve: {error}"

--- a/src/sandbox/migration.rs
+++ b/src/sandbox/migration.rs
@@ -11,7 +11,9 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::info;
+#[cfg(target_os = "macos")]
+use tracing::warn;
 
 #[must_use]
 #[derive(Debug, PartialEq, Eq)]

--- a/src/setup/secrets.rs
+++ b/src/setup/secrets.rs
@@ -5,25 +5,35 @@
 //! environment variable (precedence in that order), and from there the bytes
 //! ride a `SecKeychainItem*` buffer into `Security.framework` directly.
 
-use std::env;
-use std::fs;
+#[cfg(target_os = "macos")]
 use std::io::{self, Read};
+#[cfg(target_os = "macos")]
+use std::{env, fs};
 
 use clap::{Args, Subcommand, ValueEnum};
+#[cfg(target_os = "macos")]
 use security_framework::base::Error as SecError;
+#[cfg(target_os = "macos")]
 use security_framework::passwords::{
     delete_generic_password, get_generic_password, set_generic_password,
 };
+#[cfg(any(target_os = "macos", test))]
 use sha1::{Digest, Sha1};
 
 use crate::app::command_context::AppContext;
 use crate::errors::{CliError, CliErrorKind};
 
+#[cfg(any(target_os = "macos", test))]
 const SERVICE_GITHUB: &str = "io.harnessmonitor.task-board.github-credentials";
+#[cfg(any(target_os = "macos", test))]
 const SERVICE_TODOIST: &str = "io.harnessmonitor.task-board.todoist-credentials";
+#[cfg(any(target_os = "macos", test))]
 const SERVICE_SSH: &str = "io.harnessmonitor.task-board.ssh-key";
+#[cfg(any(target_os = "macos", test))]
 const SERVICE_SIGNING_SSH: &str = "io.harnessmonitor.task-board.signing-ssh-key";
+#[cfg(any(target_os = "macos", test))]
 const SERVICE_GPG: &str = "io.harnessmonitor.task-board.gpg-key";
+#[cfg(any(target_os = "macos", test))]
 const SERVICE_OPENROUTER: &str = "io.harnessmonitor.task-board.openrouter-credentials";
 
 #[derive(Debug, Clone, Args)]
@@ -38,11 +48,21 @@ impl SecretsArgs {
     /// # Errors
     /// Returns `CliError` only when the underlying subcommand returns one.
     pub fn execute(&self, _ctx: &AppContext) -> Result<i32, CliError> {
-        match &self.command {
-            SecretsCommand::List => Ok(run_list()),
-            SecretsCommand::Set(args) => run_set(args),
-            SecretsCommand::Clear(args) => run_clear(args),
-            SecretsCommand::Test(args) => run_test(args),
+        #[cfg(target_os = "macos")]
+        {
+            match &self.command {
+                SecretsCommand::List => Ok(run_list()),
+                SecretsCommand::Set(args) => run_set(args),
+                SecretsCommand::Clear(args) => run_clear(args),
+                SecretsCommand::Test(args) => run_test(args),
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Err(
+                CliErrorKind::workflow_io("setup secrets requires the macOS Keychain".to_string())
+                    .into(),
+            )
         }
     }
 }
@@ -102,6 +122,7 @@ pub struct SecretMutateArgs {
     pub env_var: Option<String>,
 }
 
+#[cfg(target_os = "macos")]
 fn run_list() -> i32 {
     let entries = [
         ("GitHub token", SERVICE_GITHUB, "default"),
@@ -123,6 +144,7 @@ fn run_list() -> i32 {
     0
 }
 
+#[cfg(target_os = "macos")]
 fn run_set(args: &SecretMutateArgs) -> Result<i32, CliError> {
     let (service, account) = resolve_service_account(&args.scope)?;
     let secret = read_secret(args)?;
@@ -137,6 +159,7 @@ fn run_set(args: &SecretMutateArgs) -> Result<i32, CliError> {
     Ok(0)
 }
 
+#[cfg(target_os = "macos")]
 fn run_clear(args: &SecretScopeArgs) -> Result<i32, CliError> {
     let (service, account) = resolve_service_account(args)?;
     match delete_generic_password(service, account.as_str()) {
@@ -152,6 +175,7 @@ fn run_clear(args: &SecretScopeArgs) -> Result<i32, CliError> {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn run_test(args: &SecretScopeArgs) -> Result<i32, CliError> {
     let (service, account) = resolve_service_account(args)?;
     if keychain_item_present(service, account.as_str()) {
@@ -163,6 +187,7 @@ fn run_test(args: &SecretScopeArgs) -> Result<i32, CliError> {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn keychain_error(action: &str, service: &str, account: &str, error: SecError) -> CliError {
     CliError::from(CliErrorKind::workflow_io(format!(
         "Keychain {action} failed for {service} ({account}): {error}"
@@ -170,12 +195,15 @@ fn keychain_error(action: &str, service: &str, account: &str, error: SecError) -
 }
 
 /// errSecItemNotFound on macOS.
+#[cfg(target_os = "macos")]
 const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
 
+#[cfg(target_os = "macos")]
 fn is_not_found(error: SecError) -> bool {
     error.code() == ERR_SEC_ITEM_NOT_FOUND
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn resolve_service_account(args: &SecretScopeArgs) -> Result<(&'static str, String), CliError> {
     let (service, global_account) = match args.kind {
         SecretKindArg::Github => (SERVICE_GITHUB, "default"),
@@ -194,6 +222,7 @@ fn resolve_service_account(args: &SecretScopeArgs) -> Result<(&'static str, Stri
     Ok((service, account))
 }
 
+#[cfg(target_os = "macos")]
 fn read_secret(args: &SecretMutateArgs) -> Result<String, CliError> {
     if let Some(path) = &args.file {
         fs::read_to_string(path)
@@ -220,6 +249,7 @@ fn read_secret(args: &SecretMutateArgs) -> Result<String, CliError> {
     }
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn normalize_repository_slug(slug: &str) -> Result<String, CliError> {
     let trimmed = slug.trim();
     if trimmed.is_empty() || !trimmed.contains('/') {
@@ -230,12 +260,14 @@ fn normalize_repository_slug(slug: &str) -> Result<String, CliError> {
     Ok(trimmed.to_lowercase())
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn sha1_hex(value: &str) -> String {
     let mut hasher = Sha1::new();
     hasher.update(value.as_bytes());
     hex::encode(hasher.finalize())
 }
 
+#[cfg(target_os = "macos")]
 fn keychain_item_present(service: &str, account: &str) -> bool {
     get_generic_password(service, account).is_ok()
 }


### PR DESCRIPTION
## Motivation
Remote mode could issue certificates in tests, but Linux installation and external DNS automation were not yet proven on a real server. Installed DynamicUser state also lacked a usable management path.

## Implementation
- make the systemd installer start units, preserve provisioned secrets, and provide writable daemon state
- add Aftermarket DNS-01 with authoritative publication and cleanup checks
- add systemd-unit state selection for remote management commands
- prove TLS-ALPN-01, HTTP-01, DNS-01, HTTPS, WSS, restart, revoke, and uninstall on Linux