### PR TITLE
feat(remote): harden systemd deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,6 +3685,7 @@ dependencies = [
  "serde",
  "serde-sarif",
  "serde_json",
+ "serde_urlencoded",
  "serde_yml",
  "sha1 0.11.0",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tokio-rustls = "0.26.4"
 tokio-util = { version = "0.7.18", features = ["compat"] }
 console-subscriber = { version = "0.5", optional = true }
 reqwest = { version = "0.13.2", features = ["json"] }
+serde_urlencoded = "0.7.1"
 rustls = { version = "0.23.37", features = ["ring"] }
 notify = "8.2.0"
 backoff = { version = "0.4.0", features = ["tokio"] }

--- a/src/daemon/remote_acme_cleanup.rs
+++ b/src/daemon/remote_acme_cleanup.rs
@@ -20,6 +20,11 @@ struct RemoteAcmeCleanupState {
 }
 
 impl RemoteAcmeCleanupTracker {
+    #[cfg(test)]
+    pub(crate) fn same_operation(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
+
     pub(crate) fn spawn_cleanup<F>(&self, cleanup: F) -> oneshot::Receiver<Result<(), String>>
     where
         F: Future<Output = Result<(), String>> + Send + 'static,

--- a/src/daemon/remote_acme_dns_aftermarket.rs
+++ b/src/daemon/remote_acme_dns_aftermarket.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use http::Method;
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use super::visibility::{
     AuthoritativeDnsTxtVisibilityWaiter, DnsTxtRecordState, DnsTxtVisibilityWaiter,
@@ -88,12 +88,12 @@ where
         let response = self
             .send(
                 "/domain/dns/add",
-                json!({
-                    "name": self.zone_name,
-                    "host": host,
-                    "type": "TXT",
-                    "value": record_value,
-                }),
+                form_body(&[
+                    ("name", self.zone_name.as_str()),
+                    ("host", host.as_str()),
+                    ("type", "TXT"),
+                    ("value", record_value),
+                ])?,
             )
             .await?;
         let entry_id = aftermarket_entry_id(&response)?;
@@ -115,13 +115,14 @@ where
     }
 
     pub(crate) async fn cleanup(&self, lease: AftermarketDns01Lease) -> Result<(), String> {
+        let entry_id = lease.entry_id.to_string();
         let response = self
             .send(
                 "/domain/dns/remove",
-                json!({
-                    "name": self.zone_name,
-                    "entryId": lease.entry_id,
-                }),
+                form_body(&[
+                    ("name", self.zone_name.as_str()),
+                    ("entryId", entry_id.as_str()),
+                ])?,
             )
             .await?;
         ensure_aftermarket_removed(&response, lease.entry_id)?;
@@ -134,13 +135,13 @@ where
             .await
     }
 
-    async fn send(&self, path: &str, body: Value) -> Result<RemoteDnsHttpResponse, String> {
+    async fn send(&self, path: &str, body: String) -> Result<RemoteDnsHttpResponse, String> {
         self.http
             .send(RemoteDnsHttpRequest::new(
                 Method::POST,
                 format!("{}{path}", self.api_base),
                 self.headers(),
-                body.to_string(),
+                body,
             ))
             .await
     }
@@ -150,7 +151,10 @@ where
             BASE64_STANDARD.encode(format!("{}:{}", self.public_key, self.secret_key));
         vec![
             ("authorization".to_string(), format!("Basic {credentials}")),
-            ("content-type".to_string(), "application/json".to_string()),
+            (
+                "content-type".to_string(),
+                "application/x-www-form-urlencoded".to_string(),
+            ),
         ]
     }
 }
@@ -228,4 +232,9 @@ fn required<'a>(label: &str, value: &'a str) -> Result<&'a str, String> {
     } else {
         Ok(value)
     }
+}
+
+fn form_body(fields: &[(&str, &str)]) -> Result<String, String> {
+    serde_urlencoded::to_string(fields)
+        .map_err(|error| format!("encode Aftermarket DNS request: {error}"))
 }

--- a/src/daemon/remote_acme_dns_provider_tests.rs
+++ b/src/daemon/remote_acme_dns_provider_tests.rs
@@ -54,19 +54,24 @@ async fn aftermarket_dns01_creates_and_deletes_the_issued_record() {
         requests[0].header("authorization"),
         Some("Basic cHVibGljLWtleTpzZWNyZXQta2V5")
     );
-    let create_body = requests[0].json_body().expect("Aftermarket create JSON");
-    assert_eq!(create_body["name"], "example.com");
-    assert_eq!(create_body["host"], "_acme-challenge.daemon.example.com");
-    assert_eq!(create_body["type"], "TXT");
-    assert_eq!(create_body["value"], "dns-proof-value");
+    assert_eq!(
+        requests[0].header("content-type"),
+        Some("application/x-www-form-urlencoded")
+    );
+    assert_eq!(
+        requests[0].body(),
+        "name=example.com&host=_acme-challenge.daemon.example.com&type=TXT&value=dns-proof-value"
+    );
     assert_eq!(requests[1].method(), Method::POST);
     assert_eq!(
         requests[1].url(),
         "https://aftermarket.test/domain/dns/remove"
     );
-    let cleanup_body = requests[1].json_body().expect("Aftermarket cleanup JSON");
-    assert_eq!(cleanup_body["name"], "example.com");
-    assert_eq!(cleanup_body["entryId"], 987);
+    assert_eq!(
+        requests[1].header("content-type"),
+        Some("application/x-www-form-urlencoded")
+    );
+    assert_eq!(requests[1].body(), "name=example.com&entryId=987");
     assert_eq!(
         visibility.calls(),
         vec![
@@ -88,12 +93,13 @@ async fn aftermarket_dns01_creates_and_deletes_the_issued_record() {
 #[tokio::test]
 async fn aftermarket_dns01_rejects_records_outside_the_configured_zone() {
     let http = RecordingDnsHttpClient::new([]);
-    let provider = AftermarketDns01Provider::new(
+    let provider = AftermarketDns01Provider::new_with_visibility(
         http.clone(),
         "https://aftermarket.test",
         "example.com",
         "public-key",
         "secret-key",
+        Arc::new(RecordingDnsTxtVisibility::default()),
     )
     .expect("configure Aftermarket provider");
 
@@ -112,12 +118,13 @@ async fn aftermarket_dns01_redacts_provider_errors() {
         200,
         r#"{"ok":0,"status":500,"error":"token=super-secret failed","data":null}"#,
     )]);
-    let provider = AftermarketDns01Provider::new(
+    let provider = AftermarketDns01Provider::new_with_visibility(
         http,
         "https://aftermarket.test",
         "example.com",
         "public-key",
         "secret-key",
+        Arc::new(RecordingDnsTxtVisibility::default()),
     )
     .expect("configure Aftermarket provider");
 
@@ -142,12 +149,13 @@ async fn aftermarket_dns01_rejects_unsuccessful_cleanup_result() {
             r#"{"ok":1,"status":0,"error":"","data":false,"errtype":""}"#,
         ),
     ]);
-    let provider = AftermarketDns01Provider::new(
+    let provider = AftermarketDns01Provider::new_with_visibility(
         http,
         "https://aftermarket.test",
         "example.com",
         "public-key",
         "secret-key",
+        Arc::new(RecordingDnsTxtVisibility::default()),
     )
     .expect("configure Aftermarket provider");
 

--- a/src/daemon/remote_acme_issuer.rs
+++ b/src/daemon/remote_acme_issuer.rs
@@ -189,6 +189,7 @@ where
         project_account_credentials(&credentials)
     }
 
+    #[cfg(test)]
     pub(crate) async fn issue_certificate(
         &self,
         credentials: &RemoteAcmeAccountCredentials,
@@ -405,28 +406,48 @@ fn redacted_acme_error(error: &instant_acme::Error) -> String {
 
 pub(crate) struct SystemRemoteAcmeIssuer;
 
+impl SystemRemoteAcmeIssuer {
+    pub(crate) async fn create_account_async(
+        &self,
+        config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        let provisioner = SystemRemoteAcmeChallengeProvisioner::from_environment(config)?;
+        InstantAcmeIssuer::production(provisioner)
+            .create_account(config.acme_email.as_str())
+            .await
+    }
+
+    pub(crate) async fn renew_certificate_async(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+        cleanup_tracker: RemoteAcmeCleanupTracker,
+    ) -> Result<RemoteCertificateBundle, String> {
+        let provisioner =
+            SystemRemoteAcmeChallengeProvisioner::from_environment(request.serve_config())?;
+        InstantAcmeIssuer::production(provisioner)
+            .issue_certificate_with_cleanup(
+                request.account(),
+                request.serve_config(),
+                request.previous_private_key_pem(),
+                cleanup_tracker,
+            )
+            .await
+    }
+}
+
 impl RemoteAcmeRenewalIssuer for SystemRemoteAcmeIssuer {
     fn create_account(
         &self,
         config: &RemoteDaemonServeConfig,
     ) -> Result<RemoteAcmeAccountCredentials, String> {
-        let provisioner = SystemRemoteAcmeChallengeProvisioner::from_environment(config)?;
-        let issuer = InstantAcmeIssuer::production(provisioner);
-        run_acme_future(issuer.create_account(config.acme_email.as_str()))
+        run_acme_future(self.create_account_async(config))
     }
 
     fn renew_certificate(
         &self,
         request: &RemoteAcmeRenewalRequest,
     ) -> Result<RemoteCertificateBundle, String> {
-        let provisioner =
-            SystemRemoteAcmeChallengeProvisioner::from_environment(request.serve_config())?;
-        let issuer = InstantAcmeIssuer::production(provisioner);
-        run_acme_future(issuer.issue_certificate(
-            request.account(),
-            request.serve_config(),
-            request.previous_private_key_pem(),
-        ))
+        run_acme_future(self.renew_certificate_async(request, RemoteAcmeCleanupTracker::default()))
     }
 }
 

--- a/src/daemon/service/mod.rs
+++ b/src/daemon/service/mod.rs
@@ -324,7 +324,7 @@ pub use reviews_files::{
 pub use reviews_thread_resolve::set_review_thread_resolved;
 pub use reviews_timeline::{clear_reviews_caches_with_timeline, fetch_review_timeline};
 pub use serve::serve;
-pub(crate) use serve::serve_remote_https;
+pub(crate) use serve::{ShutdownSignalGuard, serve_remote_https};
 pub use sessions::{
     list_projects, list_sessions, session_detail, session_detail_core, session_extensions,
     session_timeline,

--- a/src/daemon/service/serve/mod.rs
+++ b/src/daemon/service/serve/mod.rs
@@ -13,6 +13,8 @@ mod remote;
 mod shutdown_signals;
 mod task_board_orchestrator_loop;
 
+pub(crate) use shutdown_signals::ShutdownSignalGuard;
+
 pub(crate) use config::{http_auth_mode, validate_serve_config};
 pub(crate) use open_db::{open_daemon_async_db, open_daemon_db};
 pub(crate) use remote::serve_remote_https;

--- a/src/daemon/service/serve/remote.rs
+++ b/src/daemon/service/serve/remote.rs
@@ -25,7 +25,6 @@ use super::background_tasks::{self, spawn_background_tasks};
 use super::binary_stamp::current_binary_stamp;
 use super::initialize_startup_state;
 use super::legacy_migration::log_legacy_daemon_root_migration;
-use super::shutdown_signals::ShutdownSignalGuard;
 
 /// Start the remote daemon HTTPS API.
 ///
@@ -39,6 +38,8 @@ use super::shutdown_signals::ShutdownSignalGuard;
 pub async fn serve_remote_https(
     config: DaemonServeConfig,
     acme_plan: RemoteAcmeRuntimePlan,
+    shutdown_tx: tokio_watch::Sender<bool>,
+    shutdown_rx: tokio_watch::Receiver<bool>,
 ) -> Result<(), CliError> {
     validate_remote_https_config(&config)?;
     super::super::log_sandbox_startup(config.sandboxed);
@@ -68,7 +69,6 @@ pub async fn serve_remote_https(
     state::append_event("info", &remote_bound_event_message(&endpoint))?;
 
     let (sender, _) = broadcast::channel(256);
-    let (shutdown_tx, shutdown_rx) = tokio_watch::channel(false);
     let db: Arc<OnceLock<Arc<Mutex<DaemonDb>>>> = Arc::new(OnceLock::new());
     let async_db: Arc<OnceLock<Arc<AsyncDaemonDb>>> = Arc::new(OnceLock::new());
     let _ = OBSERVE_RUNTIME.set(DaemonObserveRuntime {
@@ -79,7 +79,6 @@ pub async fn serve_remote_https(
         async_db: async_db.clone(),
     });
     let _ = SHUTDOWN_SIGNAL.set(shutdown_tx.clone());
-    let _shutdown_signal_guard = ShutdownSignalGuard::install(shutdown_tx.clone())?;
     let replay_buffer = Arc::new(Mutex::new(ReplayBuffer::new(512)));
     let prepared_sender = background_tasks::spawn_broadcast_fanout(&sender, &replay_buffer);
     let daemon_epoch = manifest.started_at.clone();

--- a/src/daemon/service/serve/shutdown_signals.rs
+++ b/src/daemon/service/serve/shutdown_signals.rs
@@ -20,13 +20,13 @@ enum ShutdownSignalAction {
     ForceExit(i32),
 }
 
-pub(super) struct ShutdownSignalGuard {
+pub(crate) struct ShutdownSignalGuard {
     handle: SignalHandle,
     thread: Option<JoinHandle<()>>,
 }
 
 impl ShutdownSignalGuard {
-    pub(super) fn install(shutdown_tx: tokio_watch::Sender<bool>) -> Result<Self, CliError> {
+    pub(crate) fn install(shutdown_tx: tokio_watch::Sender<bool>) -> Result<Self, CliError> {
         ignore_sigpipe()?;
         let mut signals = Signals::new([SIGTERM, SIGINT, SIGHUP]).map_err(|error| {
             CliErrorKind::workflow_io(format!("install daemon signal handlers: {error}"))

--- a/src/daemon/transport/mod.rs
+++ b/src/daemon/transport/mod.rs
@@ -6,6 +6,7 @@ mod remote_clients;
 mod remote_doctor;
 mod remote_pairing_invitation;
 mod remote_serve;
+mod remote_serve_startup;
 mod remote_systemd;
 mod remote_systemd_lifecycle;
 #[cfg(test)]

--- a/src/daemon/transport/remote_acme.rs
+++ b/src/daemon/transport/remote_acme.rs
@@ -256,7 +256,7 @@ where
     }
 }
 
-fn record_remote_acme_audit(
+pub(super) fn record_remote_acme_audit(
     db: &DaemonDb,
     event_id: &str,
     recorded_at: &str,

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -2,17 +2,25 @@ use std::thread;
 
 use crate::daemon::db::DaemonDb;
 use crate::daemon::remote::RemoteDaemonServeConfig;
-use crate::daemon::remote_acme::{
-    RemoteAcmeRenewalIssuer, RemoteAcmeRuntimePlan, build_remote_acme_runtime_plan,
-};
+#[cfg(test)]
+use crate::daemon::remote_acme::RemoteAcmeRenewalIssuer;
+use crate::daemon::remote_acme::{RemoteAcmeRuntimePlan, build_remote_acme_runtime_plan};
+use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use crate::daemon::remote_acme_issuer::SystemRemoteAcmeIssuer;
-use crate::daemon::service::{self, DaemonServeConfig};
+use crate::daemon::service::{self, DaemonServeConfig, ShutdownSignalGuard};
 use crate::errors::{CliError, CliErrorKind};
 use crate::workspace::utc_now;
 use tokio::runtime::{Handle, Runtime};
+use tokio::sync::watch as tokio_watch;
 
 use super::control::adopt_daemon_root_for_transport_command;
-use super::remote::{DaemonRemoteAcmeCommand, DaemonRemoteServeArgs, open_remote_daemon_db};
+#[cfg(test)]
+use super::remote::DaemonRemoteAcmeCommand;
+use super::remote::{DaemonRemoteServeArgs, open_remote_daemon_db};
+use super::remote_serve_startup::{
+    RemoteInitialAcmeControl, ensure_initial_remote_acme, record_initial_acme_shutdown,
+    run_initial_acme_until_shutdown,
+};
 
 #[derive(Clone)]
 pub(crate) struct RemoteDaemonServeExecutionPlan {
@@ -21,9 +29,22 @@ pub(crate) struct RemoteDaemonServeExecutionPlan {
 }
 
 pub(super) fn execute_remote_serve(args: &DaemonRemoteServeArgs) -> Result<i32, CliError> {
-    execute_remote_serve_with(args, open_remote_daemon_db, run_remote_serve_plan)
+    adopt_daemon_root_for_transport_command("daemon-remote-serve");
+    let db = open_remote_daemon_db()?;
+    let remote_config = args.contract_config()?;
+    let certificate_domain_matches = certificate_domain_matches(&db, &remote_config)?;
+    let now = utc_now();
+    db.record_remote_acme_serve_config(&remote_config, now.as_str())?;
+    run_remote_serve_lifecycle(
+        args.clone(),
+        db,
+        remote_config,
+        certificate_domain_matches,
+        now,
+    )
 }
 
+#[cfg(test)]
 pub(crate) fn execute_remote_serve_with<OpenDb, Run>(
     args: &DaemonRemoteServeArgs,
     open_db: OpenDb,
@@ -43,6 +64,7 @@ where
     )
 }
 
+#[cfg(test)]
 pub(crate) fn execute_remote_serve_with_issuer<OpenDb, Run, Issuer>(
     args: &DaemonRemoteServeArgs,
     open_db: OpenDb,
@@ -58,7 +80,18 @@ where
     adopt_daemon_root_for_transport_command("daemon-remote-serve");
     let db = open_db()?;
     let remote_config = args.contract_config()?;
-    let certificate_domain_matches = db
+    let certificate_domain_matches = certificate_domain_matches(&db, &remote_config)?;
+    db.record_remote_acme_serve_config(&remote_config, now)?;
+    ensure_remote_acme_for_serve(&db, issuer, now, certificate_domain_matches)?;
+    let plan = build_remote_serve_execution_plan_from_config(args, &db, &remote_config)?;
+    run_plan(plan)
+}
+
+fn certificate_domain_matches(
+    db: &DaemonDb,
+    remote_config: &RemoteDaemonServeConfig,
+) -> Result<bool, CliError> {
+    Ok(db
         .load_remote_acme_state()?
         .serve_config
         .as_ref()
@@ -67,11 +100,7 @@ where
                 .domain
                 .trim()
                 .eq_ignore_ascii_case(remote_config.domain.trim())
-        });
-    db.record_remote_acme_serve_config(&remote_config, now)?;
-    ensure_remote_acme_for_serve(&db, issuer, now, certificate_domain_matches)?;
-    let plan = build_remote_serve_execution_plan_from_config(args, &db, &remote_config)?;
-    run_plan(plan)
+        }))
 }
 
 /// Build the remote daemon serve execution plan from static CLI config and
@@ -105,6 +134,7 @@ fn build_remote_serve_execution_plan_from_config(
     })
 }
 
+#[cfg(test)]
 fn ensure_remote_acme_for_serve<I>(
     db: &DaemonDb,
     issuer: &I,
@@ -125,13 +155,6 @@ where
         .ensure_success()
 }
 
-fn run_remote_serve_plan(plan: RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
-    match remote_serve_runtime_mode() {
-        RemoteServeRuntimeMode::ExistingTokioRuntime => run_remote_serve_plan_on_thread(plan),
-        RemoteServeRuntimeMode::NewTokioRuntime => run_remote_serve_plan_on_runtime(plan),
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RemoteServeRuntimeMode {
     ExistingTokioRuntime,
@@ -146,32 +169,94 @@ pub(crate) fn remote_serve_runtime_mode() -> RemoteServeRuntimeMode {
     }
 }
 
-fn run_remote_serve_plan_on_thread(plan: RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
-    thread::Builder::new()
-        .name("harness-remote-daemon".to_string())
-        .spawn(move || run_remote_serve_plan_on_runtime(plan))
-        .map_err(|error| {
-            CliError::from(CliErrorKind::workflow_io(format!(
-                "spawn remote daemon runtime thread: {error}"
-            )))
-        })?
-        .join()
-        .map_err(|_| {
-            CliError::from(CliErrorKind::workflow_io(
-                "remote daemon runtime thread panicked",
-            ))
-        })?
+fn run_remote_serve_lifecycle(
+    args: DaemonRemoteServeArgs,
+    db: DaemonDb,
+    remote_config: RemoteDaemonServeConfig,
+    certificate_domain_matches: bool,
+    now: String,
+) -> Result<i32, CliError> {
+    match remote_serve_runtime_mode() {
+        RemoteServeRuntimeMode::ExistingTokioRuntime => thread::scope(|scope| {
+            scope
+                .spawn(move || {
+                    run_remote_serve_lifecycle_on_runtime(
+                        &args,
+                        &db,
+                        &remote_config,
+                        certificate_domain_matches,
+                        &now,
+                    )
+                })
+                .join()
+                .map_err(|_| {
+                    CliError::from(CliErrorKind::workflow_io(
+                        "remote daemon lifecycle thread panicked",
+                    ))
+                })?
+        }),
+        RemoteServeRuntimeMode::NewTokioRuntime => run_remote_serve_lifecycle_on_runtime(
+            &args,
+            &db,
+            &remote_config,
+            certificate_domain_matches,
+            &now,
+        ),
+    }
 }
 
-fn run_remote_serve_plan_on_runtime(plan: RemoteDaemonServeExecutionPlan) -> Result<i32, CliError> {
+fn run_remote_serve_lifecycle_on_runtime(
+    args: &DaemonRemoteServeArgs,
+    db: &DaemonDb,
+    remote_config: &RemoteDaemonServeConfig,
+    certificate_domain_matches: bool,
+    now: &str,
+) -> Result<i32, CliError> {
     let runtime = Runtime::new().map_err(|error| {
         CliError::from(CliErrorKind::workflow_io(format!(
             "create remote daemon tokio runtime: {error}"
         )))
     })?;
-    runtime.block_on(service::serve_remote_https(
+    runtime.block_on(run_remote_serve_lifecycle_async(
+        args,
+        db,
+        remote_config,
+        certificate_domain_matches,
+        now,
+    ))
+}
+
+async fn run_remote_serve_lifecycle_async(
+    args: &DaemonRemoteServeArgs,
+    db: &DaemonDb,
+    remote_config: &RemoteDaemonServeConfig,
+    certificate_domain_matches: bool,
+    now: &str,
+) -> Result<i32, CliError> {
+    let (shutdown_tx, shutdown_rx) = tokio_watch::channel(false);
+    let _shutdown_signal_guard = ShutdownSignalGuard::install(shutdown_tx.clone())?;
+    let cleanup_tracker = RemoteAcmeCleanupTracker::default();
+    let initial_acme = ensure_initial_remote_acme(
+        db,
+        &SystemRemoteAcmeIssuer,
+        now,
+        certificate_domain_matches,
+        &cleanup_tracker,
+    );
+    let control =
+        run_initial_acme_until_shutdown(shutdown_rx.clone(), &cleanup_tracker, initial_acme)
+            .await?;
+    if control == RemoteInitialAcmeControl::Shutdown {
+        record_initial_acme_shutdown(db, utc_now().as_str())?;
+        return Ok(0);
+    }
+    let plan = build_remote_serve_execution_plan_from_config(args, db, remote_config)?;
+    service::serve_remote_https(
         plan.service_config,
         plan.acme_plan,
-    ))?;
+        shutdown_tx,
+        shutdown_rx,
+    )
+    .await?;
     Ok(0)
 }

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -177,23 +177,14 @@ fn run_remote_serve_lifecycle(
     now: String,
 ) -> Result<i32, CliError> {
     match remote_serve_runtime_mode() {
-        RemoteServeRuntimeMode::ExistingTokioRuntime => thread::scope(|scope| {
-            scope
-                .spawn(move || {
-                    run_remote_serve_lifecycle_on_runtime(
-                        &args,
-                        &db,
-                        &remote_config,
-                        certificate_domain_matches,
-                        &now,
-                    )
-                })
-                .join()
-                .map_err(|_| {
-                    CliError::from(CliErrorKind::workflow_io(
-                        "remote daemon lifecycle thread panicked",
-                    ))
-                })?
+        RemoteServeRuntimeMode::ExistingTokioRuntime => run_remote_daemon_thread(move || {
+            run_remote_serve_lifecycle_on_runtime(
+                &args,
+                &db,
+                &remote_config,
+                certificate_domain_matches,
+                &now,
+            )
         }),
         RemoteServeRuntimeMode::NewTokioRuntime => run_remote_serve_lifecycle_on_runtime(
             &args,
@@ -203,6 +194,29 @@ fn run_remote_serve_lifecycle(
             &now,
         ),
     }
+}
+
+pub(crate) fn run_remote_daemon_thread<T, Run>(run: Run) -> Result<T, CliError>
+where
+    T: Send,
+    Run: FnOnce() -> Result<T, CliError> + Send,
+{
+    thread::scope(|scope| {
+        thread::Builder::new()
+            .name("harness-remote-daemon".to_string())
+            .spawn_scoped(scope, run)
+            .map_err(|error| {
+                CliError::from(CliErrorKind::workflow_io(format!(
+                    "spawn remote daemon lifecycle thread: {error}"
+                )))
+            })?
+            .join()
+            .map_err(|_| {
+                CliError::from(CliErrorKind::workflow_io(
+                    "remote daemon lifecycle thread panicked",
+                ))
+            })?
+    })
 }
 
 fn run_remote_serve_lifecycle_on_runtime(
@@ -246,9 +260,13 @@ async fn run_remote_serve_lifecycle_async(
     let control =
         run_initial_acme_until_shutdown(shutdown_rx.clone(), &cleanup_tracker, initial_acme)
             .await?;
-    if control == RemoteInitialAcmeControl::Shutdown {
-        record_initial_acme_shutdown(db, utc_now().as_str())?;
-        return Ok(0);
+    match control {
+        RemoteInitialAcmeControl::Continue => {}
+        RemoteInitialAcmeControl::ShutdownDuringIssuance => {
+            record_initial_acme_shutdown(db, utc_now().as_str())?;
+            return Ok(0);
+        }
+        RemoteInitialAcmeControl::ShutdownAfterIssuance => return Ok(0),
     }
     let plan = build_remote_serve_execution_plan_from_config(args, db, remote_config)?;
     service::serve_remote_https(

--- a/src/daemon/transport/remote_serve_startup.rs
+++ b/src/daemon/transport/remote_serve_startup.rs
@@ -1,0 +1,213 @@
+use std::future::Future;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::watch as tokio_watch;
+use tokio::time::timeout;
+
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote::RemoteDaemonServeConfig;
+use crate::daemon::remote_acme::{
+    RemoteAcmeAccountCredentials, RemoteAcmeRenewalRequest, RemoteCertificateBundle,
+};
+use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
+use crate::daemon::remote_acme_issuer::SystemRemoteAcmeIssuer;
+use crate::daemon::remote_identity::RemoteAuditOutcome;
+use crate::errors::{CliError, CliErrorKind};
+
+use super::remote_acme::record_remote_acme_audit;
+
+const INITIAL_ACME_CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteInitialAcmeControl {
+    Continue,
+    Shutdown,
+}
+
+#[async_trait]
+pub(crate) trait RemoteInitialAcmeIssuer: Sync {
+    async fn create_account(
+        &self,
+        config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String>;
+
+    async fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+        cleanup_tracker: &RemoteAcmeCleanupTracker,
+    ) -> Result<RemoteCertificateBundle, String>;
+}
+
+#[async_trait]
+impl RemoteInitialAcmeIssuer for SystemRemoteAcmeIssuer {
+    async fn create_account(
+        &self,
+        config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        self.create_account_async(config).await
+    }
+
+    async fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+        cleanup_tracker: &RemoteAcmeCleanupTracker,
+    ) -> Result<RemoteCertificateBundle, String> {
+        self.renew_certificate_async(request, cleanup_tracker.clone())
+            .await
+    }
+}
+
+pub(crate) async fn ensure_initial_remote_acme<I>(
+    db: &DaemonDb,
+    issuer: &I,
+    now: &str,
+    certificate_domain_matches: bool,
+    cleanup_tracker: &RemoteAcmeCleanupTracker,
+) -> Result<(), CliError>
+where
+    I: RemoteInitialAcmeIssuer,
+{
+    let state = db.load_remote_acme_state()?;
+    let issuance = db.load_remote_acme_issuance_state()?;
+    if state.certificate_configured && issuance.account.is_some() && certificate_domain_matches {
+        return Ok(());
+    }
+    let audit_event_id = format!("remote-acme-initial-{}", uuid::Uuid::new_v4());
+    let Some(serve_config) = state.serve_config.as_ref() else {
+        return record_initial_acme_failure(
+            db,
+            &audit_event_id,
+            now,
+            "remote daemon requires persisted remote ACME serve config",
+        );
+    };
+    let account = match issuance.account {
+        Some(account) => account,
+        None => match issuer.create_account(serve_config).await {
+            Ok(account) => {
+                db.record_remote_acme_account(&account, now)?;
+                account
+            }
+            Err(detail) => {
+                return record_initial_acme_failure(db, &audit_event_id, now, &detail);
+            }
+        },
+    };
+    let request = RemoteAcmeRenewalRequest::new(
+        &account,
+        state.certificate_fingerprint.as_deref(),
+        issuance.previous_private_key_pem.as_deref(),
+        serve_config,
+    );
+    match issuer.renew_certificate(&request, cleanup_tracker).await {
+        Ok(bundle) => {
+            db.record_remote_acme_renewal_success(&bundle, now)?;
+            record_remote_acme_audit(
+                db,
+                &audit_event_id,
+                now,
+                "remote.acme.renew",
+                RemoteAuditOutcome::Success,
+                None,
+            )
+        }
+        Err(detail) => record_initial_acme_failure(db, &audit_event_id, now, &detail),
+    }
+}
+
+pub(crate) fn record_initial_acme_shutdown(db: &DaemonDb, now: &str) -> Result<(), CliError> {
+    let audit_event_id = format!("remote-acme-initial-{}", uuid::Uuid::new_v4());
+    record_initial_acme_failure_detail(
+        db,
+        &audit_event_id,
+        now,
+        "remote ACME initial issuance cancelled during daemon shutdown",
+    )?;
+    Ok(())
+}
+
+fn record_initial_acme_failure(
+    db: &DaemonDb,
+    audit_event_id: &str,
+    now: &str,
+    detail: &str,
+) -> Result<(), CliError> {
+    let redacted_detail = record_initial_acme_failure_detail(db, audit_event_id, now, detail)?;
+    Err(CliErrorKind::workflow_parse(redacted_detail).into())
+}
+
+fn record_initial_acme_failure_detail(
+    db: &DaemonDb,
+    audit_event_id: &str,
+    now: &str,
+    detail: &str,
+) -> Result<String, CliError> {
+    db.record_remote_acme_renewal_failure(detail, now)?;
+    let state = db.load_remote_acme_state()?;
+    let redacted_detail = state
+        .renewal_error
+        .as_deref()
+        .unwrap_or("remote ACME initial issuance failed")
+        .to_string();
+    record_remote_acme_audit(
+        db,
+        audit_event_id,
+        now,
+        "remote.acme.renew",
+        RemoteAuditOutcome::Failure,
+        Some(&redacted_detail),
+    )?;
+    Ok(redacted_detail)
+}
+
+pub(crate) async fn run_initial_acme_until_shutdown<F>(
+    mut shutdown_rx: tokio_watch::Receiver<bool>,
+    cleanup_tracker: &RemoteAcmeCleanupTracker,
+    initial_acme: F,
+) -> Result<RemoteInitialAcmeControl, CliError>
+where
+    F: Future<Output = Result<(), CliError>>,
+{
+    let outcome = {
+        tokio::pin!(initial_acme);
+        tokio::select! {
+            () = wait_for_shutdown(&mut shutdown_rx) => None,
+            result = &mut initial_acme => Some(result),
+        }
+    };
+    if let Some(result) = outcome {
+        result?;
+        Ok(RemoteInitialAcmeControl::Continue)
+    } else {
+        wait_for_cleanup(cleanup_tracker).await;
+        Ok(RemoteInitialAcmeControl::Shutdown)
+    }
+}
+
+async fn wait_for_shutdown(shutdown_rx: &mut tokio_watch::Receiver<bool>) {
+    if *shutdown_rx.borrow() {
+        return;
+    }
+    while shutdown_rx.changed().await.is_ok() {
+        if *shutdown_rx.borrow() {
+            return;
+        }
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+async fn wait_for_cleanup(cleanup_tracker: &RemoteAcmeCleanupTracker) {
+    if timeout(
+        INITIAL_ACME_CLEANUP_TIMEOUT,
+        cleanup_tracker.wait_for_cleanup(),
+    )
+    .await
+    .is_err()
+    {
+        tracing::warn!("remote ACME challenge cleanup timed out during initial shutdown");
+    }
+}

--- a/src/daemon/transport/remote_serve_startup.rs
+++ b/src/daemon/transport/remote_serve_startup.rs
@@ -22,7 +22,8 @@ const INITIAL_ACME_CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RemoteInitialAcmeControl {
     Continue,
-    Shutdown,
+    ShutdownDuringIssuance,
+    ShutdownAfterIssuance,
 }
 
 #[async_trait]
@@ -176,12 +177,25 @@ where
             result = &mut initial_acme => Some(result),
         }
     };
+    initial_acme_control(outcome, &shutdown_rx, cleanup_tracker).await
+}
+
+async fn initial_acme_control(
+    outcome: Option<Result<(), CliError>>,
+    shutdown_rx: &tokio_watch::Receiver<bool>,
+    cleanup_tracker: &RemoteAcmeCleanupTracker,
+) -> Result<RemoteInitialAcmeControl, CliError> {
     if let Some(result) = outcome {
         result?;
-        Ok(RemoteInitialAcmeControl::Continue)
+        if *shutdown_rx.borrow() {
+            wait_for_cleanup(cleanup_tracker).await;
+            Ok(RemoteInitialAcmeControl::ShutdownAfterIssuance)
+        } else {
+            Ok(RemoteInitialAcmeControl::Continue)
+        }
     } else {
         wait_for_cleanup(cleanup_tracker).await;
-        Ok(RemoteInitialAcmeControl::Shutdown)
+        Ok(RemoteInitialAcmeControl::ShutdownDuringIssuance)
     }
 }
 

--- a/src/daemon/transport/remote_systemd.rs
+++ b/src/daemon/transport/remote_systemd.rs
@@ -308,9 +308,28 @@ fn render_unit(
          NoNewPrivileges=true\n\
          DynamicUser=yes\n\
          PrivateTmp=true\n\
+         PrivateDevices=true\n\
+         PrivateMounts=true\n\
          ProtectSystem=strict\n\
          ProtectHome=true\n\
+         ProtectClock=true\n\
+         ProtectControlGroups=true\n\
+         ProtectHostname=true\n\
+         ProtectKernelLogs=true\n\
+         ProtectKernelModules=true\n\
+         ProtectKernelTunables=true\n\
+         ProtectProc=invisible\n\
+         ProcSubset=pid\n\
+         LockPersonality=true\n\
+         MemoryDenyWriteExecute=true\n\
+         RestrictNamespaces=true\n\
+         RestrictRealtime=true\n\
+         RestrictSUIDSGID=true\n\
          RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX\n\
+         SystemCallArchitectures=native\n\
+         SystemCallFilter=@system-service\n\
+         SystemCallFilter=~@privileged @resources\n\
+         SystemCallErrorNumber=EPERM\n\
          StateDirectory={unit}\n\
          StateDirectoryMode=0700\n\
          UMask=0077\n",
@@ -320,6 +339,11 @@ fn render_unit(
         contents.push_str(
             "AmbientCapabilities=CAP_NET_BIND_SERVICE\n\
              CapabilityBoundingSet=CAP_NET_BIND_SERVICE\n",
+        );
+    } else {
+        contents.push_str(
+            "CapabilityBoundingSet=\n\
+             PrivateUsers=true\n",
         );
     }
     contents.push_str("\n[Install]\nWantedBy=multi-user.target\n");

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -9,6 +9,7 @@ mod remote_serve;
 mod remote_systemd;
 mod remote_systemd_lifecycle;
 mod remote_systemd_plan;
+mod remote_systemd_security;
 
 use std::path::{Path, PathBuf};
 

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -4,6 +4,7 @@ use harness_testkit::with_isolated_harness_env;
 use std::future::pending;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread;
 use std::time::Duration;
 use tokio::sync::{Notify, watch as tokio_watch};
 use tokio::time::{sleep, timeout};
@@ -21,7 +22,7 @@ use crate::errors::CliError;
 use super::super::remote::DaemonRemoteServeArgs;
 use super::super::remote_serve::{
     RemoteServeRuntimeMode, build_remote_serve_execution_plan, execute_remote_serve_with,
-    execute_remote_serve_with_issuer, remote_serve_runtime_mode,
+    execute_remote_serve_with_issuer, remote_serve_runtime_mode, run_remote_daemon_thread,
 };
 use super::super::remote_serve_startup::{
     RemoteInitialAcmeControl, RemoteInitialAcmeIssuer, ensure_initial_remote_acme,
@@ -228,9 +229,36 @@ async fn daemon_remote_initial_acme_shutdown_waits_for_challenge_cleanup() {
     .expect("initial ACME shutdown should succeed");
     shutdown.await.expect("join shutdown request");
 
-    assert_eq!(control, RemoteInitialAcmeControl::Shutdown);
+    assert_eq!(control, RemoteInitialAcmeControl::ShutdownDuringIssuance);
     assert!(cleanup_started.load(Ordering::SeqCst));
     assert!(cleanup_completed.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn daemon_remote_initial_acme_completion_observes_pending_shutdown() {
+    let cleanup_tracker = RemoteAcmeCleanupTracker::default();
+    let (shutdown_tx, shutdown_rx) = tokio_watch::channel(false);
+    let issuance = async move {
+        shutdown_tx
+            .send(true)
+            .expect("request shutdown before issuance completes");
+        Ok(())
+    };
+
+    let control = run_initial_acme_until_shutdown(shutdown_rx, &cleanup_tracker, issuance)
+        .await
+        .expect("observe shutdown after issuance");
+
+    assert_eq!(control, RemoteInitialAcmeControl::ShutdownAfterIssuance);
+}
+
+#[test]
+fn daemon_remote_existing_runtime_thread_has_stable_name() {
+    let name =
+        run_remote_daemon_thread(|| Ok(thread::current().name().unwrap_or_default().to_string()))
+            .expect("run named remote daemon thread");
+
+    assert_eq!(name, "harness-remote-daemon");
 }
 
 #[tokio::test]
@@ -262,7 +290,7 @@ async fn daemon_remote_initial_acme_shutdown_persists_account_cleanup_and_failur
     record_initial_acme_shutdown(&db, "2026-07-11T10:00:01Z")
         .expect("record initial ACME shutdown");
 
-    assert_eq!(control, RemoteInitialAcmeControl::Shutdown);
+    assert_eq!(control, RemoteInitialAcmeControl::ShutdownDuringIssuance);
     assert!(issuer.cleanup_started.load(Ordering::SeqCst));
     assert!(issuer.cleanup_completed.load(Ordering::SeqCst));
     let issuance = db

--- a/src/daemon/transport/tests/remote_serve.rs
+++ b/src/daemon/transport/tests/remote_serve.rs
@@ -1,7 +1,12 @@
+use async_trait::async_trait;
 use clap::Parser;
 use harness_testkit::with_isolated_harness_env;
+use std::future::pending;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::sync::{Notify, watch as tokio_watch};
+use tokio::time::{sleep, timeout};
 
 use crate::daemon::db::DaemonDb;
 use crate::daemon::http::DaemonHttpAuthMode;
@@ -10,11 +15,17 @@ use crate::daemon::remote_acme::{
     RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
     RemoteCertificateBundle,
 };
+use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
+use crate::errors::CliError;
 
 use super::super::remote::DaemonRemoteServeArgs;
 use super::super::remote_serve::{
     RemoteServeRuntimeMode, build_remote_serve_execution_plan, execute_remote_serve_with,
     execute_remote_serve_with_issuer, remote_serve_runtime_mode,
+};
+use super::super::remote_serve_startup::{
+    RemoteInitialAcmeControl, RemoteInitialAcmeIssuer, ensure_initial_remote_acme,
+    record_initial_acme_shutdown, run_initial_acme_until_shutdown,
 };
 
 #[derive(Debug, Parser)]
@@ -181,6 +192,175 @@ fn daemon_remote_serve_runtime_mode_detects_existing_tokio_runtime() {
             RemoteServeRuntimeMode::ExistingTokioRuntime
         );
     });
+}
+
+#[tokio::test]
+async fn daemon_remote_initial_acme_shutdown_waits_for_challenge_cleanup() {
+    let cleanup_tracker = RemoteAcmeCleanupTracker::default();
+    let challenge_presented = Arc::new(Notify::new());
+    let cleanup_started = Arc::new(AtomicBool::new(false));
+    let cleanup_completed = Arc::new(AtomicBool::new(false));
+    let cleanup_on_drop = CleanupOnDrop {
+        tracker: cleanup_tracker.clone(),
+        started: Arc::clone(&cleanup_started),
+        completed: Arc::clone(&cleanup_completed),
+    };
+    let issuance = {
+        let challenge_presented = Arc::clone(&challenge_presented);
+        async move {
+            let _cleanup_on_drop = cleanup_on_drop;
+            challenge_presented.notify_one();
+            pending::<Result<(), CliError>>().await
+        }
+    };
+    let (shutdown_tx, shutdown_rx) = tokio_watch::channel(false);
+    let shutdown = tokio::spawn(async move {
+        challenge_presented.notified().await;
+        shutdown_tx.send(true).expect("request startup shutdown");
+    });
+
+    let control = timeout(
+        Duration::from_secs(2),
+        run_initial_acme_until_shutdown(shutdown_rx, &cleanup_tracker, issuance),
+    )
+    .await
+    .expect("initial ACME shutdown should not time out")
+    .expect("initial ACME shutdown should succeed");
+    shutdown.await.expect("join shutdown request");
+
+    assert_eq!(control, RemoteInitialAcmeControl::Shutdown);
+    assert!(cleanup_started.load(Ordering::SeqCst));
+    assert!(cleanup_completed.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn daemon_remote_initial_acme_shutdown_persists_account_cleanup_and_failure() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let config = remote_serve_args().contract_config().expect("serve config");
+    db.record_remote_acme_serve_config(&config, "2026-07-11T10:00:00Z")
+        .expect("record serve config");
+    let cleanup_tracker = RemoteAcmeCleanupTracker::default();
+    let issuer = BlockingInitialIssuer::new(cleanup_tracker.clone());
+    let (shutdown_tx, shutdown_rx) = tokio_watch::channel(false);
+    let challenge_presented = Arc::clone(&issuer.challenge_presented);
+    let shutdown = tokio::spawn(async move {
+        challenge_presented.notified().await;
+        shutdown_tx.send(true).expect("request startup shutdown");
+    });
+    let initial_acme = ensure_initial_remote_acme(
+        &db,
+        &issuer,
+        "2026-07-11T10:00:00Z",
+        false,
+        &cleanup_tracker,
+    );
+
+    let control = run_initial_acme_until_shutdown(shutdown_rx, &cleanup_tracker, initial_acme)
+        .await
+        .expect("cancel initial ACME issuance");
+    shutdown.await.expect("join shutdown request");
+    record_initial_acme_shutdown(&db, "2026-07-11T10:00:01Z")
+        .expect("record initial ACME shutdown");
+
+    assert_eq!(control, RemoteInitialAcmeControl::Shutdown);
+    assert!(issuer.cleanup_started.load(Ordering::SeqCst));
+    assert!(issuer.cleanup_completed.load(Ordering::SeqCst));
+    let issuance = db
+        .load_remote_acme_issuance_state()
+        .expect("load ACME issuance state");
+    assert_eq!(
+        issuance
+            .account
+            .as_ref()
+            .map(|account| account.account_id()),
+        Some("https://acme.test/acct/startup")
+    );
+    let state = db.load_remote_acme_state().expect("load ACME state");
+    assert!(!state.certificate_configured);
+    assert_eq!(state.renewal_status.as_str(), "failed");
+    assert!(
+        state
+            .renewal_error
+            .as_deref()
+            .is_some_and(|detail| detail.contains("cancelled during daemon shutdown"))
+    );
+    let events = db.load_remote_audit_events(10).expect("load audit events");
+    assert!(events.iter().any(|event| {
+        event.route_or_method == "remote.acme.renew"
+            && event.outcome.as_str() == "failure"
+            && event
+                .error_detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("cancelled during daemon shutdown"))
+    }));
+}
+
+struct CleanupOnDrop {
+    tracker: RemoteAcmeCleanupTracker,
+    started: Arc<AtomicBool>,
+    completed: Arc<AtomicBool>,
+}
+
+impl Drop for CleanupOnDrop {
+    fn drop(&mut self) {
+        let started = Arc::clone(&self.started);
+        let completed = Arc::clone(&self.completed);
+        drop(self.tracker.spawn_cleanup(async move {
+            started.store(true, Ordering::SeqCst);
+            sleep(Duration::from_millis(50)).await;
+            completed.store(true, Ordering::SeqCst);
+            Ok(())
+        }));
+    }
+}
+
+struct BlockingInitialIssuer {
+    tracker: RemoteAcmeCleanupTracker,
+    challenge_presented: Arc<Notify>,
+    cleanup_started: Arc<AtomicBool>,
+    cleanup_completed: Arc<AtomicBool>,
+}
+
+impl BlockingInitialIssuer {
+    fn new(tracker: RemoteAcmeCleanupTracker) -> Self {
+        Self {
+            tracker,
+            challenge_presented: Arc::new(Notify::new()),
+            cleanup_started: Arc::new(AtomicBool::new(false)),
+            cleanup_completed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+#[async_trait]
+impl RemoteInitialAcmeIssuer for BlockingInitialIssuer {
+    async fn create_account(
+        &self,
+        config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        assert_eq!(config.domain, "daemon.example.com");
+        RemoteAcmeAccountCredentials::new(
+            "https://acme.test/acct/startup",
+            r#"{"id":"https://acme.test/acct/startup","key_pkcs8":"startup-account-key"}"#,
+        )
+        .map_err(|error| error.to_string())
+    }
+
+    async fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+        cleanup_tracker: &RemoteAcmeCleanupTracker,
+    ) -> Result<RemoteCertificateBundle, String> {
+        assert_eq!(request.account_id(), "https://acme.test/acct/startup");
+        assert!(cleanup_tracker.same_operation(&self.tracker));
+        let _cleanup_on_drop = CleanupOnDrop {
+            tracker: cleanup_tracker.clone(),
+            started: Arc::clone(&self.cleanup_started),
+            completed: Arc::clone(&self.cleanup_completed),
+        };
+        self.challenge_presented.notify_one();
+        pending().await
+    }
 }
 
 fn remote_serve_args() -> DaemonRemoteServeArgs {

--- a/src/daemon/transport/tests/remote_systemd.rs
+++ b/src/daemon/transport/tests/remote_systemd.rs
@@ -114,72 +114,6 @@ fn daemon_remote_systemd_lifecycle_parses_custom_env_file() {
 }
 
 #[test]
-fn remote_systemd_unit_is_hardened_and_runs_remote_serve() {
-    let args = install_args([
-        "test",
-        "--domain",
-        "daemon.example.com",
-        "--acme-email",
-        "ops@example.com",
-    ]);
-    let plan = RemoteSystemdInstallPlan::for_tests(
-        &args,
-        PathBuf::from("/usr/local/bin/harness"),
-        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
-        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
-    )
-    .expect("systemd install plan");
-
-    assert!(plan.needs_bind_capability);
-    assert!(plan.unit_contents.contains(
-        "ExecStart=/usr/local/bin/harness daemon remote serve --domain daemon.example.com"
-    ));
-    assert!(plan.unit_contents.contains("--https-port 443"));
-    assert!(plan.unit_contents.contains("--http-port 80"));
-    assert!(plan.unit_contents.contains("--acme-email ops@example.com"));
-    assert!(plan.unit_contents.contains("--acme-challenge tls-alpn"));
-    assert!(
-        plan.unit_contents
-            .contains("EnvironmentFile=/etc/harness/harness-remote-daemon.env")
-    );
-    assert!(
-        plan.unit_contents
-            .contains("Environment=HARNESS_DAEMON_DATA_HOME=%S/harness-remote-daemon")
-    );
-    assert!(
-        plan.unit_contents
-            .contains("Environment=XDG_DATA_HOME=%S/harness-remote-daemon")
-    );
-    assert!(
-        plan.unit_contents
-            .contains("Environment=HARNESS_DAEMON_OWNERSHIP=external")
-    );
-    assert!(plan.unit_contents.contains("NoNewPrivileges=true"));
-    assert!(plan.unit_contents.contains("DynamicUser=yes"));
-    assert!(plan.unit_contents.contains("PrivateTmp=true"));
-    assert!(plan.unit_contents.contains("ProtectSystem=strict"));
-    assert!(plan.unit_contents.contains("ProtectHome=true"));
-    assert!(
-        plan.unit_contents
-            .contains("RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX")
-    );
-    assert!(
-        plan.unit_contents
-            .contains("StateDirectory=harness-remote-daemon")
-    );
-    assert!(plan.unit_contents.contains("StateDirectoryMode=0700"));
-    assert!(plan.unit_contents.contains("UMask=0077"));
-    assert!(
-        plan.unit_contents
-            .contains("AmbientCapabilities=CAP_NET_BIND_SERVICE")
-    );
-    assert!(
-        plan.unit_contents
-            .contains("CapabilityBoundingSet=CAP_NET_BIND_SERVICE")
-    );
-}
-
-#[test]
 fn remote_systemd_execstart_uses_trimmed_remote_serve_config() {
     let args = install_args([
         "test",
@@ -205,40 +139,6 @@ fn remote_systemd_execstart_uses_trimmed_remote_serve_config() {
     assert!(plan.unit_contents.contains("--acme-email ops@example.com"));
     assert!(!plan.unit_contents.contains("' daemon.example.com '"));
     assert!(!plan.unit_contents.contains("' ops@example.com '"));
-}
-
-#[test]
-fn remote_systemd_high_ports_omit_bind_capability() {
-    let args = install_args([
-        "test",
-        "--domain",
-        "daemon.example.com",
-        "--https-port",
-        "8443",
-        "--http-port",
-        "8080",
-        "--acme-email",
-        "ops@example.com",
-    ]);
-    let plan = RemoteSystemdInstallPlan::for_tests(
-        &args,
-        PathBuf::from("/usr/local/bin/harness"),
-        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
-        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
-    )
-    .expect("systemd install plan");
-
-    assert!(!plan.needs_bind_capability);
-    assert!(
-        !plan
-            .unit_contents
-            .contains("AmbientCapabilities=CAP_NET_BIND_SERVICE")
-    );
-    assert!(
-        !plan
-            .unit_contents
-            .contains("CapabilityBoundingSet=CAP_NET_BIND_SERVICE")
-    );
 }
 
 #[test]

--- a/src/daemon/transport/tests/remote_systemd_security.rs
+++ b/src/daemon/transport/tests/remote_systemd_security.rs
@@ -1,0 +1,136 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use super::super::remote_systemd::{DaemonRemoteSystemdInstallArgs, RemoteSystemdInstallPlan};
+
+#[test]
+fn remote_systemd_unit_is_hardened_and_runs_remote_serve() {
+    let plan = hardened_unit_plan();
+
+    assert!(plan.needs_bind_capability);
+    assert!(plan.unit_contents.contains(
+        "ExecStart=/usr/local/bin/harness daemon remote serve --domain daemon.example.com"
+    ));
+    for value in [
+        "--https-port 443",
+        "--http-port 80",
+        "--acme-email ops@example.com",
+        "--acme-challenge tls-alpn",
+        "EnvironmentFile=/etc/harness/harness-remote-daemon.env",
+        "Environment=HARNESS_DAEMON_DATA_HOME=%S/harness-remote-daemon",
+        "Environment=XDG_DATA_HOME=%S/harness-remote-daemon",
+        "Environment=HARNESS_DAEMON_OWNERSHIP=external",
+        "StateDirectory=harness-remote-daemon",
+        "StateDirectoryMode=0700",
+        "UMask=0077",
+        "AmbientCapabilities=CAP_NET_BIND_SERVICE",
+        "CapabilityBoundingSet=CAP_NET_BIND_SERVICE",
+    ] {
+        assert!(plan.unit_contents.contains(value), "missing {value}");
+    }
+
+    let required_sandbox = [
+        "NoNewPrivileges=true",
+        "DynamicUser=yes",
+        "PrivateTmp=true",
+        "PrivateDevices=true",
+        "PrivateMounts=true",
+        "ProtectSystem=strict",
+        "ProtectHome=true",
+        "ProtectClock=true",
+        "ProtectControlGroups=true",
+        "ProtectHostname=true",
+        "ProtectKernelLogs=true",
+        "ProtectKernelModules=true",
+        "ProtectKernelTunables=true",
+        "ProtectProc=invisible",
+        "ProcSubset=pid",
+        "LockPersonality=true",
+        "MemoryDenyWriteExecute=true",
+        "RestrictNamespaces=true",
+        "RestrictRealtime=true",
+        "RestrictSUIDSGID=true",
+        "RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX",
+        "SystemCallArchitectures=native",
+        "SystemCallFilter=@system-service",
+        "SystemCallFilter=~@privileged @resources",
+        "SystemCallErrorNumber=EPERM",
+    ];
+    let missing = required_sandbox
+        .iter()
+        .filter(|directive| !plan.unit_contents.contains(*directive))
+        .copied()
+        .collect::<Vec<_>>();
+    assert!(
+        missing.is_empty(),
+        "missing sandbox directives: {missing:?}"
+    );
+    assert!(
+        !plan.unit_contents.contains("PrivateUsers=true"),
+        "low-port capability must remain in the host user namespace"
+    );
+}
+
+fn hardened_unit_plan() -> RemoteSystemdInstallPlan {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+    unit_plan(&args)
+}
+
+#[test]
+fn remote_systemd_high_ports_isolate_users_without_bind_capability() {
+    let args = install_args([
+        "test",
+        "--domain",
+        "daemon.example.com",
+        "--https-port",
+        "8443",
+        "--http-port",
+        "8080",
+        "--acme-email",
+        "ops@example.com",
+    ]);
+    let plan = unit_plan(&args);
+
+    assert!(!plan.needs_bind_capability);
+    assert!(plan.unit_contents.contains("PrivateUsers=true"));
+    assert!(plan.unit_contents.contains("CapabilityBoundingSet=\n"));
+    assert!(
+        !plan
+            .unit_contents
+            .contains("AmbientCapabilities=CAP_NET_BIND_SERVICE")
+    );
+    assert!(
+        !plan
+            .unit_contents
+            .contains("CapabilityBoundingSet=CAP_NET_BIND_SERVICE")
+    );
+}
+
+fn unit_plan(args: &DaemonRemoteSystemdInstallArgs) -> RemoteSystemdInstallPlan {
+    RemoteSystemdInstallPlan::for_tests(
+        args,
+        PathBuf::from("/usr/local/bin/harness"),
+        PathBuf::from("/etc/systemd/system/harness-remote-daemon.service"),
+        PathBuf::from("/etc/harness/harness-remote-daemon.env"),
+    )
+    .expect("systemd install plan")
+}
+
+fn install_args<const N: usize>(args: [&str; N]) -> DaemonRemoteSystemdInstallArgs {
+    #[derive(Debug, Parser)]
+    struct Harness {
+        #[command(flatten)]
+        args: DaemonRemoteSystemdInstallArgs,
+    }
+
+    Harness::try_parse_from(args)
+        .expect("parse install args")
+        .args
+}


### PR DESCRIPTION
## Motivation
Remote daemon deployment needed a hardened Linux service without weakening low-port operation. Live DNS-01 testing also proved that SIGTERM during initial ACME startup could leave a provider record behind, and the Aftermarket request format did not match its official form-encoded contract.

## Implementation
- Harden systemd units with namespace, device, kernel, process, syscall, and capability restrictions. Low ports retain only `CAP_NET_BIND_SERVICE`; high ports add `PrivateUsers` and an empty capability set.
- Install signal handling before initial ACME issuance, cancel startup issuance on shutdown, wait for challenge cleanup, and persist a redacted cancellation audit result.
- Send Aftermarket DNS requests as form data and isolate visibility tests from process-global environment changes.
- Add TDD coverage for low/high-port units, startup cancellation cleanup, durable account/failure state, and provider encoding.
- Prove the installed Ubuntu unit with `systemd-analyze security` at `1.4 OK`, interrupted DNS-01 cleanup with an empty provider/API record set and empty authoritative TXT answers, authenticated HTTPS `200`, WSS `101`, and post-revocation HTTPS `401`.
- Validate with focused remote suites and `mise run harness:check`.
