### PR TITLE
fix(task-board): canonicalize stored lane statuses

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardModels.swift
@@ -1,6 +1,19 @@
 import Foundation
 
 extension TaskBoardStatus {
+  public static let currentLaneCases: [Self] = [
+    .umbrella,
+    .todo,
+    .planning,
+    .inProgress,
+    .agenticReview,
+    .testing,
+    .inReview,
+    .toReview,
+    .humanRequired,
+    .failed,
+  ]
+
   public var title: String {
     switch self {
     case .umbrella:

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardModels.swift
@@ -14,6 +14,21 @@ extension TaskBoardStatus {
     .failed,
   ]
 
+  public var canonicalPersistedStatus: Self {
+    switch self {
+    case .new:
+      .todo
+    case .planReview:
+      .agenticReview
+    case .needsYou:
+      .humanRequired
+    case .blocked:
+      .failed
+    default:
+      self
+    }
+  }
+
   public var title: String {
     switch self {
     case .umbrella:

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardDraftSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardDraftSupport.swift
@@ -28,7 +28,7 @@ enum DispatchStatusFilterChoice: String, CaseIterable, Hashable {
   ]
 
   init(status: TaskBoardStatus?) {
-    self = status.flatMap { Self.statusChoices[$0] } ?? .all
+    self = status.flatMap { Self.statusChoices[$0.canonicalPersistedStatus] } ?? .all
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardDraftSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardDraftSupport.swift
@@ -13,11 +13,6 @@ enum DispatchStatusFilterChoice: String, CaseIterable, Hashable {
   case toReview
   case humanRequired
   case failed
-  case done
-  case new
-  case planReview
-  case needsYou
-  case blocked
 
   private static let statusChoices: [TaskBoardStatus: Self] = [
     .umbrella: .umbrella,
@@ -30,11 +25,6 @@ enum DispatchStatusFilterChoice: String, CaseIterable, Hashable {
     .toReview: .toReview,
     .humanRequired: .humanRequired,
     .failed: .failed,
-    .done: .done,
-    .new: .new,
-    .planReview: .planReview,
-    .needsYou: .needsYou,
-    .blocked: .blocked,
   ]
 
   init(status: TaskBoardStatus?) {
@@ -56,11 +46,6 @@ extension DispatchStatusFilterChoice {
     case .toReview: "To Review"
     case .humanRequired: "Human Required"
     case .failed: "Failed"
-    case .done: "Done"
-    case .new: "New"
-    case .planReview: "Plan Review"
-    case .needsYou: "Needs You"
-    case .blocked: "Blocked"
     }
   }
 
@@ -77,11 +62,6 @@ extension DispatchStatusFilterChoice {
     case .toReview: .toReview
     case .humanRequired: .humanRequired
     case .failed: .failed
-    case .done: .done
-    case .new: .new
-    case .planReview: .planReview
-    case .needsYou: .needsYou
-    case .blocked: .blocked
     }
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardItemEditorDraft.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardItemEditorDraft.swift
@@ -22,7 +22,7 @@ struct TaskBoardItemEditorDraft: Equatable {
   init(item: TaskBoardItem) {
     title = item.title
     body = item.body
-    status = item.status
+    status = item.status.canonicalPersistedStatus
     priority = item.priority
     tagsText = item.tags.joined(separator: ", ")
     projectId = item.projectId ?? ""

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardItemManagementPanel.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardItemManagementPanel.swift
@@ -200,7 +200,7 @@ struct TaskBoardItemManagementPanel: View {
         TaskBoardManagementPickerField(
           label: "Status",
           selection: $draft.status,
-          values: TaskBoardStatus.allCases
+          values: TaskBoardStatus.currentLaneCases
         )
         TaskBoardManagementPickerField(
           label: "Priority",

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsSupport.swift
@@ -33,7 +33,7 @@ enum TaskBoardStatusFilterChoice: String, CaseIterable, Identifiable, Hashable {
   ]
 
   init(status: TaskBoardStatus?) {
-    self = status.flatMap { Self.statusChoices[$0] } ?? .all
+    self = status.flatMap { Self.statusChoices[$0.canonicalPersistedStatus] } ?? .all
   }
 
   var id: String { rawValue }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsSupport.swift
@@ -12,11 +12,6 @@ enum TaskBoardStatusFilterChoice: String, CaseIterable, Identifiable, Hashable {
   case toReview
   case humanRequired
   case failed
-  case done
-  case new
-  case planReview
-  case needsYou
-  case blocked
 
   /// Stable storage for `allCases` so `ForEach` pickers do not see a new
   /// array identity on every parent body re-evaluation. CaseIterable's
@@ -35,11 +30,6 @@ enum TaskBoardStatusFilterChoice: String, CaseIterable, Identifiable, Hashable {
     .toReview: .toReview,
     .humanRequired: .humanRequired,
     .failed: .failed,
-    .done: .done,
-    .new: .new,
-    .planReview: .planReview,
-    .needsYou: .needsYou,
-    .blocked: .blocked,
   ]
 
   init(status: TaskBoardStatus?) {
@@ -76,16 +66,6 @@ enum TaskBoardStatusFilterChoice: String, CaseIterable, Identifiable, Hashable {
       .humanRequired
     case .failed:
       .failed
-    case .done:
-      .done
-    case .new:
-      .new
-    case .planReview:
-      .planReview
-    case .needsYou:
-      .needsYou
-    case .blocked:
-      .blocked
     }
   }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardEnumsWireDecodingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardEnumsWireDecodingTests.swift
@@ -68,6 +68,16 @@ struct TaskBoardEnumsWireDecodingTests {
     #expect(!TaskBoardStatus.currentLaneCases.contains(.blocked))
   }
 
+  @Test("legacy statuses map to current persisted lanes")
+  func legacyStatusesMapToCurrentPersistedLanes() {
+    #expect(TaskBoardStatus.new.canonicalPersistedStatus == .todo)
+    #expect(TaskBoardStatus.planReview.canonicalPersistedStatus == .agenticReview)
+    #expect(TaskBoardStatus.needsYou.canonicalPersistedStatus == .humanRequired)
+    #expect(TaskBoardStatus.blocked.canonicalPersistedStatus == .failed)
+    #expect(TaskBoardStatus.done.canonicalPersistedStatus == .done)
+    #expect(TaskBoardStatus.unknown("custom").canonicalPersistedStatus == .unknown("custom"))
+  }
+
   @Test("decodes agent mode including the unknown fallback")
   func decodesAgentMode() throws {
     #expect(try decode(TaskBoardAgentMode.self, "headless") == .headless)

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardEnumsWireDecodingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardEnumsWireDecodingTests.swift
@@ -46,6 +46,28 @@ struct TaskBoardEnumsWireDecodingTests {
     #expect(TaskBoardStatus.unknown("custom").title == "custom")
   }
 
+  @Test("current lane status choices exclude legacy and hidden statuses")
+  func currentLaneStatusChoicesExcludeLegacyAndHiddenStatuses() {
+    #expect(
+      TaskBoardStatus.currentLaneCases == [
+        .umbrella,
+        .todo,
+        .planning,
+        .inProgress,
+        .agenticReview,
+        .testing,
+        .inReview,
+        .toReview,
+        .humanRequired,
+        .failed,
+      ])
+    #expect(!TaskBoardStatus.currentLaneCases.contains(.done))
+    #expect(!TaskBoardStatus.currentLaneCases.contains(.new))
+    #expect(!TaskBoardStatus.currentLaneCases.contains(.planReview))
+    #expect(!TaskBoardStatus.currentLaneCases.contains(.needsYou))
+    #expect(!TaskBoardStatus.currentLaneCases.contains(.blocked))
+  }
+
   @Test("decodes agent mode including the unknown fallback")
   func decodesAgentMode() throws {
     #expect(try decode(TaskBoardAgentMode.self, "headless") == .headless)

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardItemEditorDraftTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardItemEditorDraftTests.swift
@@ -84,6 +84,27 @@ struct TaskBoardItemEditorDraftTests {
     #expect(DispatchStatusFilterChoice.allCases.map(\.title) == expectedFilterTitles)
   }
 
+  @Test("Legacy statuses seed current picker-compatible draft values")
+  func legacyStatusesSeedCurrentPickerCompatibleDraftValues() {
+    #expect(TaskBoardItemEditorDraft(item: sampleTaskBoardItem(status: .new)).status == .todo)
+    #expect(
+      TaskBoardItemEditorDraft(item: sampleTaskBoardItem(status: .planReview)).status
+        == .agenticReview)
+    #expect(
+      TaskBoardItemEditorDraft(item: sampleTaskBoardItem(status: .needsYou)).status
+        == .humanRequired)
+    #expect(TaskBoardItemEditorDraft(item: sampleTaskBoardItem(status: .blocked)).status == .failed)
+
+    #expect(TaskBoardStatusFilterChoice(status: .new) == .todo)
+    #expect(TaskBoardStatusFilterChoice(status: .planReview) == .agenticReview)
+    #expect(TaskBoardStatusFilterChoice(status: .needsYou) == .humanRequired)
+    #expect(TaskBoardStatusFilterChoice(status: .blocked) == .failed)
+    #expect(DispatchStatusFilterChoice(status: .new) == .todo)
+    #expect(DispatchStatusFilterChoice(status: .planReview) == .agenticReview)
+    #expect(DispatchStatusFilterChoice(status: .needsYou) == .humanRequired)
+    #expect(DispatchStatusFilterChoice(status: .blocked) == .failed)
+  }
+
   @Test("Monitor public UI hides Todoist sync summaries")
   func monitorPublicUIHidesTodoistSyncSummaries() {
     let summary = TaskBoardSyncSummary(
@@ -180,6 +201,7 @@ struct TaskBoardItemEditorDraftTests {
   }
 
   private func sampleTaskBoardItem(
+    status: TaskBoardStatus = .todo,
     targetProjectTypes: [String] = [],
     externalRefs: [TaskBoardExternalRef] = []
   ) -> TaskBoardItem {
@@ -188,7 +210,7 @@ struct TaskBoardItemEditorDraftTests {
       id: "board-1",
       title: "Board item",
       body: "Body",
-      status: .todo,
+      status: status,
       priority: .high,
       tags: ["automation"],
       projectId: "project-1",

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardItemEditorDraftTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardItemEditorDraftTests.swift
@@ -60,6 +60,30 @@ struct TaskBoardItemEditorDraftTests {
     #expect(TaskBoardExternalRefProvider.taskBoardCases == [.gitHub])
   }
 
+  @Test("Status menus expose only current task board lanes")
+  func statusMenusExposeOnlyCurrentTaskBoardLanes() {
+    let expectedFilterTitles = [
+      "All Items",
+      "Umbrella",
+      "Todo",
+      "Planning",
+      "In Progress",
+      "Agentic Review",
+      "Testing",
+      "In Review",
+      "To Review",
+      "Human Required",
+      "Failed",
+    ]
+
+    #expect(
+      TaskBoardStatus.currentLaneCases.map(\.title)
+        == Array(expectedFilterTitles.dropFirst())
+    )
+    #expect(TaskBoardStatusFilterChoice.stableAllCases.map(\.title) == expectedFilterTitles)
+    #expect(DispatchStatusFilterChoice.allCases.map(\.title) == expectedFilterTitles)
+  }
+
   @Test("Monitor public UI hides Todoist sync summaries")
   func monitorPublicUIHidesTodoistSyncSummaries() {
     let summary = TaskBoardSyncSummary(

--- a/src/task_board/orchestrator/settings.rs
+++ b/src/task_board/orchestrator/settings.rs
@@ -14,10 +14,11 @@ use super::types::{
     TaskBoardOrchestratorSettingsUpdateRequest, TaskBoardTodoistInboxConfig,
 };
 
-/// Rewrite legacy `enabled_workflows` entries on disk so the strict enum
-/// deserializer can load settings written before the Dependencies → Reviews
-/// rename. Idempotent: once the file holds only current variants, no write
-/// happens.
+/// Rewrite legacy persisted settings entries on disk so strict enum
+/// deserializers can load older settings files. This repairs workflow names
+/// written before the Dependencies → Reviews rename and legacy dispatch status
+/// filters from earlier task-board lanes. Idempotent: once the file holds only
+/// current variants, no write happens.
 ///
 /// Returns the parsed settings when the file exists, or `None` when it is
 /// absent. Callers can use the returned value directly to avoid a second

--- a/src/task_board/orchestrator/settings.rs
+++ b/src/task_board/orchestrator/settings.rs
@@ -77,28 +77,25 @@ fn normalize_enabled_workflows(document: &mut Value) -> bool {
 }
 
 fn repair_dispatch_status_filter(document: &mut Value) -> bool {
-    let Some(status) = document
+    let Some(status_value) = document
         .as_object()
         .and_then(|map| map.get("dispatch_status_filter"))
-        .and_then(Value::as_str)
+        .cloned()
     else {
         return false;
     };
-    let Some(canonical) = canonical_status_wire_value(status) else {
+    let Ok(status) = serde_json::from_value::<TaskBoardStatus>(status_value) else {
         return false;
     };
-    document["dispatch_status_filter"] = Value::String(canonical.to_owned());
-    true
-}
-
-fn canonical_status_wire_value(raw: &str) -> Option<&'static str> {
-    match raw {
-        "new" => Some("todo"),
-        "plan_review" => Some("agentic_review"),
-        "needs_you" => Some("human_required"),
-        "blocked" => Some("failed"),
-        _ => None,
+    let canonical = status.canonical_persisted_status();
+    if status == canonical {
+        return false;
     }
+    let Ok(canonical_value) = serde_json::to_value(canonical) else {
+        return false;
+    };
+    document["dispatch_status_filter"] = canonical_value;
+    true
 }
 
 pub(super) fn apply_settings_update(

--- a/src/task_board/orchestrator/settings.rs
+++ b/src/task_board/orchestrator/settings.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use crate::errors::{CliError, CliErrorKind};
 use crate::infra::io::{read_json_typed, write_json_pretty};
 use crate::task_board::normalize_repository_slug;
+use crate::task_board::types::TaskBoardStatus;
 
 use super::types::{
     TaskBoardGitHubInboxConfig, TaskBoardOrchestratorDispatchInput,
@@ -31,7 +32,9 @@ pub(super) fn migrate_persisted_settings(
         return Ok(None);
     }
     let mut document: Value = read_json_typed(path)?;
-    if normalize_enabled_workflows(&mut document) {
+    let workflows_changed = normalize_enabled_workflows(&mut document);
+    let status_changed = repair_dispatch_status_filter(&mut document);
+    if workflows_changed || status_changed {
         write_json_pretty(path, &document)?;
     }
     let settings: TaskBoardOrchestratorSettings =
@@ -71,6 +74,31 @@ fn normalize_enabled_workflows(document: &mut Value) -> bool {
     }
     *workflows = normalized;
     changed
+}
+
+fn repair_dispatch_status_filter(document: &mut Value) -> bool {
+    let Some(status) = document
+        .as_object()
+        .and_then(|map| map.get("dispatch_status_filter"))
+        .and_then(Value::as_str)
+    else {
+        return false;
+    };
+    let Some(canonical) = canonical_status_wire_value(status) else {
+        return false;
+    };
+    document["dispatch_status_filter"] = Value::String(canonical.to_owned());
+    true
+}
+
+fn canonical_status_wire_value(raw: &str) -> Option<&'static str> {
+    match raw {
+        "new" => Some("todo"),
+        "plan_review" => Some("agentic_review"),
+        "needs_you" => Some("human_required"),
+        "blocked" => Some("failed"),
+        _ => None,
+    }
 }
 
 pub(super) fn apply_settings_update(
@@ -150,7 +178,7 @@ fn apply_status_filter_update(
     if update.clear_dispatch_status_filter {
         settings.dispatch_status_filter = None;
     } else if let Some(status) = update.dispatch_status_filter {
-        settings.dispatch_status_filter = Some(status);
+        settings.dispatch_status_filter = Some(status.canonical_persisted_status());
     }
 }
 
@@ -171,7 +199,7 @@ pub(super) fn dispatch_input(
 ) -> TaskBoardOrchestratorDispatchInput {
     TaskBoardOrchestratorDispatchInput {
         item_id: request.item_id.clone(),
-        status: request.status.or(settings.dispatch_status_filter),
+        status: canonical_status_filter(request.status.or(settings.dispatch_status_filter)),
         dry_run: request.dry_run.unwrap_or(settings.dry_run_default),
         project_dir: request
             .project_dir
@@ -188,4 +216,8 @@ pub(super) fn dispatch_input(
             }),
         actor: request.actor.clone(),
     }
+}
+
+fn canonical_status_filter(status: Option<TaskBoardStatus>) -> Option<TaskBoardStatus> {
+    status.map(TaskBoardStatus::canonical_persisted_status)
 }

--- a/src/task_board/orchestrator/tests.rs
+++ b/src/task_board/orchestrator/tests.rs
@@ -1,3 +1,4 @@
+use fs_err as fs;
 use tempfile::tempdir;
 
 use super::*;
@@ -211,6 +212,69 @@ fn partial_settings_json_populates_defaults() {
     assert_eq!(settings.enabled_workflows, defaults.enabled_workflows);
     assert_eq!(settings.dry_run_default, defaults.dry_run_default);
     assert_eq!(settings.policy_version, defaults.policy_version);
+}
+
+#[test]
+fn settings_read_repairs_legacy_dispatch_status_filter_on_disk() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("board");
+    fs::create_dir_all(&root).expect("create board root");
+    let settings_path = root.join(SETTINGS_FILE);
+    fs::write(
+        &settings_path,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "dispatch_status_filter": "needs_you"
+        }))
+        .expect("serialize settings"),
+    )
+    .expect("write settings");
+    let orchestrator = TaskBoardOrchestrator::new(root);
+
+    let settings = orchestrator.settings().expect("load settings");
+
+    assert_eq!(
+        settings.dispatch_status_filter,
+        Some(TaskBoardStatus::HumanRequired)
+    );
+    let contents = fs::read_to_string(settings_path).expect("read repaired settings");
+    assert!(contents.contains("\"dispatch_status_filter\": \"human_required\""));
+    assert!(!contents.contains("\"dispatch_status_filter\": \"needs_you\""));
+}
+
+#[test]
+fn settings_update_writes_current_dispatch_status_filter() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("board");
+    let settings_path = root.join(SETTINGS_FILE);
+    let orchestrator = TaskBoardOrchestrator::new(root);
+
+    let settings = orchestrator
+        .update_settings(&TaskBoardOrchestratorSettingsUpdateRequest {
+            dispatch_status_filter: Some(TaskBoardStatus::PlanReview),
+            ..TaskBoardOrchestratorSettingsUpdateRequest::default()
+        })
+        .expect("update settings");
+
+    assert_eq!(
+        settings.dispatch_status_filter,
+        Some(TaskBoardStatus::AgenticReview)
+    );
+    let contents = fs::read_to_string(settings_path).expect("read current settings");
+    assert!(contents.contains("\"dispatch_status_filter\": \"agentic_review\""));
+    assert!(!contents.contains("\"dispatch_status_filter\": \"plan_review\""));
+}
+
+#[test]
+fn dispatch_input_maps_legacy_filter_to_current_lane() {
+    let settings = TaskBoardOrchestratorSettings::default();
+    let request = TaskBoardOrchestratorRunOnceRequest {
+        status: Some(TaskBoardStatus::Blocked),
+        ..TaskBoardOrchestratorRunOnceRequest::default()
+    };
+
+    let input = settings::dispatch_input(&request, &settings);
+
+    assert_eq!(input.status, Some(TaskBoardStatus::Failed));
 }
 
 #[test]

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -197,6 +197,7 @@ impl TaskBoardStore {
     /// Returns `CliError` if the tasks directory cannot be read or an item
     /// cannot be parsed.
     pub fn list(&self, status: Option<TaskBoardStatus>) -> Result<Vec<TaskBoardItem>, CliError> {
+        let status = status.map(TaskBoardStatus::canonical_persisted_status);
         let mut items = self.read_all_items()?;
         items
             .retain(|item| !item.is_deleted() && status.is_none_or(|target| item.status == target));

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -187,7 +187,8 @@ impl TaskBoardStore {
     pub fn get(&self, id: &str) -> Result<TaskBoardItem, CliError> {
         let path = self.path_for(id)?;
         let mut item = read_path(&path)?;
-        self.repair_legacy_status(&mut item)?;
+        validate_loaded_id(id, &item)?;
+        Self::repair_legacy_status_at(&path, &mut item)?;
         Ok(item)
     }
 
@@ -253,7 +254,7 @@ impl TaskBoardStore {
                 // returned Arc has refcount >= 2. Clone outside the Mutex so
                 // the lock is held only for an atomic refcount increment rather
                 // than a full TaskBoardItem deep-clone.
-                Resolve::Hit(arc) => items.push((*arc).clone()),
+                Resolve::Hit(arc) => items.push((path, (*arc).clone())),
                 Resolve::Miss { mtime, len } => misses.push((path, mtime, len)),
             }
         }
@@ -263,15 +264,15 @@ impl TaskBoardStore {
                 .map(|(path, mtime, len)| {
                     BOARD_PARSE_CACHE
                         .parse_miss(path, *mtime, *len)
-                        .map(|arc| (*arc).clone())
+                        .map(|arc| (path.clone(), (*arc).clone()))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             items.extend(parsed);
         }
-        for item in &mut items {
-            self.repair_legacy_status(item)?;
+        for (path, item) in &mut items {
+            Self::repair_legacy_status_at(path, item)?;
         }
-        Ok(items)
+        Ok(items.into_iter().map(|(_, item)| item).collect())
     }
 
     /// Patch one board item in place.
@@ -302,6 +303,11 @@ impl TaskBoardStore {
     }
 
     fn save(&self, item: &TaskBoardItem) -> Result<(), CliError> {
+        let path = self.path_for(&item.id)?;
+        Self::save_to_path(&path, item)
+    }
+
+    fn save_to_path(path: &Path, item: &TaskBoardItem) -> Result<(), CliError> {
         if item.schema_version != CURRENT_TASK_BOARD_ITEM_VERSION {
             return Err(CliErrorKind::workflow_version(format!(
                 "task-board item '{}' uses unsupported schema v{}",
@@ -309,7 +315,6 @@ impl TaskBoardStore {
             ))
             .into());
         }
-        let path = self.path_for(&item.id)?;
         let frontmatter = TaskBoardFrontmatter::from(item);
         let yaml = serde_yml::to_string(&frontmatter).map_err(|error| {
             CliErrorKind::workflow_serialize(format!("serialize task-board item: {error}"))
@@ -317,10 +322,10 @@ impl TaskBoardStore {
         // serde_yml does not guarantee a trailing newline, so anchor the closing
         // fence on its own line rather than gluing it onto the last YAML value.
         io::write_text(
-            &path,
+            path,
             &format!("---\n{}\n---\n\n{}", yaml.trim_end(), item.body),
         )?;
-        BOARD_PARSE_CACHE.forget(&path);
+        BOARD_PARSE_CACHE.forget(path);
         Ok(())
     }
 
@@ -340,12 +345,23 @@ impl TaskBoardStore {
         Ok(())
     }
 
-    fn repair_legacy_status(&self, item: &mut TaskBoardItem) -> Result<(), CliError> {
+    fn repair_legacy_status_at(path: &Path, item: &mut TaskBoardItem) -> Result<(), CliError> {
         if apply_canonical_persisted_status(item) {
-            self.save(item)?;
+            Self::save_to_path(path, item)?;
         }
         Ok(())
     }
+}
+
+fn validate_loaded_id(expected: &str, item: &TaskBoardItem) -> Result<(), CliError> {
+    if item.id == expected {
+        return Ok(());
+    }
+    Err(CliErrorKind::workflow_parse(format!(
+        "task-board item file id mismatch: expected '{expected}', found '{}'",
+        item.id
+    ))
+    .into())
 }
 
 fn apply_canonical_persisted_status(item: &mut TaskBoardItem) -> bool {

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -183,7 +183,7 @@ impl TaskBoardStore {
     ///
     /// # Errors
     /// Returns `CliError` if the ID is unsafe, the file is missing, or the
-    /// markdown/frontmatter payload cannot be parsed.
+    /// markdown/frontmatter payload cannot be parsed or repaired on disk.
     pub fn get(&self, id: &str) -> Result<TaskBoardItem, CliError> {
         let path = self.path_for(id)?;
         let mut item = read_path(&path)?;

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -196,7 +196,7 @@ impl TaskBoardStore {
     ///
     /// # Errors
     /// Returns `CliError` if the tasks directory cannot be read or an item
-    /// cannot be parsed.
+    /// cannot be parsed or repaired on disk.
     pub fn list(&self, status: Option<TaskBoardStatus>) -> Result<Vec<TaskBoardItem>, CliError> {
         let status = status.map(TaskBoardStatus::canonical_persisted_status);
         let mut items = self.read_all_items()?;

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -173,6 +173,7 @@ impl TaskBoardStore {
     ) -> Result<TaskBoardItem, CliError> {
         item.title = title.to_string();
         item.body = body.to_string();
+        apply_canonical_persisted_status(&mut item);
         self.validate_new_id(&item.id)?;
         self.save(&item)?;
         Ok(item)
@@ -185,7 +186,9 @@ impl TaskBoardStore {
     /// markdown/frontmatter payload cannot be parsed.
     pub fn get(&self, id: &str) -> Result<TaskBoardItem, CliError> {
         let path = self.path_for(id)?;
-        read_path(&path)
+        let mut item = read_path(&path)?;
+        self.repair_legacy_status(&mut item)?;
+        Ok(item)
     }
 
     /// List active board items, optionally filtered by status.
@@ -264,6 +267,9 @@ impl TaskBoardStore {
                 .collect::<Result<Vec<_>, _>>()?;
             items.extend(parsed);
         }
+        for item in &mut items {
+            self.repair_legacy_status(item)?;
+        }
         Ok(items)
     }
 
@@ -274,6 +280,7 @@ impl TaskBoardStore {
     pub fn update(&self, id: &str, patch: TaskBoardItemPatch) -> Result<TaskBoardItem, CliError> {
         let mut item = self.get(id)?;
         apply_patch(&mut item, patch);
+        apply_canonical_persisted_status(&mut item);
         item.updated_at = utc_now();
         self.save(&item)?;
         Ok(item)
@@ -285,6 +292,7 @@ impl TaskBoardStore {
     /// Returns `CliError` if the item cannot be loaded or saved.
     pub fn delete(&self, id: &str) -> Result<TaskBoardItem, CliError> {
         let mut item = self.get(id)?;
+        apply_canonical_persisted_status(&mut item);
         let now = utc_now();
         item.deleted_at = Some(now.clone());
         item.updated_at = now;
@@ -330,6 +338,22 @@ impl TaskBoardStore {
         }
         Ok(())
     }
+
+    fn repair_legacy_status(&self, item: &mut TaskBoardItem) -> Result<(), CliError> {
+        if apply_canonical_persisted_status(item) {
+            self.save(item)?;
+        }
+        Ok(())
+    }
+}
+
+fn apply_canonical_persisted_status(item: &mut TaskBoardItem) -> bool {
+    let status = item.status.canonical_persisted_status();
+    if item.status == status {
+        return false;
+    }
+    item.status = status;
+    true
 }
 
 fn apply_patch(item: &mut TaskBoardItem, patch: TaskBoardItemPatch) {

--- a/src/task_board/store/tests.rs
+++ b/src/task_board/store/tests.rs
@@ -6,6 +6,7 @@ use crate::task_board::types::{
     AgentMode, PlanningState, TaskBoardItem, TaskBoardPriority, TaskBoardStatus,
     TaskBoardWorkflowStatus,
 };
+use fs_err as fs;
 
 fn seed_item(store: &TaskBoardStore, id: &str, title: &str) {
     let item = TaskBoardItem::new(
@@ -71,6 +72,58 @@ fn parse_cache_reparses_after_file_changes() {
 }
 
 #[test]
+fn get_repairs_legacy_status_on_disk() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    let path = seed_raw_item(&store, "legacy-new", "new");
+
+    let loaded = store.get("legacy-new").expect("load legacy item");
+
+    assert_eq!(loaded.status, TaskBoardStatus::Todo);
+    let contents = fs::read_to_string(path).expect("read repaired file");
+    assert!(contents.contains("status: todo"));
+    assert!(!contents.contains("status: new"));
+}
+
+#[test]
+fn list_repairs_legacy_statuses_before_filtering() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    seed_raw_item(&store, "legacy-needs-you", "needs_you");
+
+    let listed = store
+        .list(Some(TaskBoardStatus::HumanRequired))
+        .expect("list repaired status");
+
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, "legacy-needs-you");
+    assert_eq!(listed[0].status, TaskBoardStatus::HumanRequired);
+}
+
+#[test]
+fn update_writes_current_status_for_legacy_status_patch() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    seed_item(&store, "task-0", "Task 0");
+
+    let updated = store
+        .update(
+            "task-0",
+            TaskBoardItemPatch {
+                status: Some(TaskBoardStatus::PlanReview),
+                ..TaskBoardItemPatch::default()
+            },
+        )
+        .expect("update item");
+
+    assert_eq!(updated.status, TaskBoardStatus::AgenticReview);
+    let contents =
+        fs::read_to_string(store.tasks_dir().join("task-0.md")).expect("read current status file");
+    assert!(contents.contains("status: agentic_review"));
+    assert!(!contents.contains("status: plan_review"));
+}
+
+#[test]
 fn list_keeps_filter_and_sort_across_parallel_parse() {
     let temp = tempdir().expect("tempdir");
     let store = TaskBoardStore::new(temp.path().join("board"));
@@ -110,6 +163,29 @@ fn list_keeps_filter_and_sort_across_parallel_parse() {
         all, sorted,
         "list output is already sorted regardless of parse order"
     );
+}
+
+fn seed_raw_item(store: &TaskBoardStore, id: &str, status: &str) -> std::path::PathBuf {
+    let path = store.tasks_dir().join(format!("{id}.md"));
+    fs::create_dir_all(store.tasks_dir()).expect("create tasks dir");
+    fs::write(
+        &path,
+        format!(
+            "---\n\
+             schema_version: 1\n\
+             id: {id}\n\
+             title: Legacy status\n\
+             status: {status}\n\
+             priority: medium\n\
+             agent_mode: headless\n\
+             created_at: 2026-05-14T00:00:00Z\n\
+             updated_at: 2026-05-14T00:00:00Z\n\
+             ---\n\n\
+             body\n"
+        ),
+    )
+    .expect("write raw item");
+    path
 }
 
 #[test]

--- a/src/task_board/store/tests.rs
+++ b/src/task_board/store/tests.rs
@@ -101,6 +101,21 @@ fn list_repairs_legacy_statuses_before_filtering() {
 }
 
 #[test]
+fn list_maps_legacy_status_filter_to_current_status() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    seed_raw_item(&store, "legacy-blocked", "blocked");
+
+    let listed = store
+        .list(Some(TaskBoardStatus::Blocked))
+        .expect("list legacy filter");
+
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, "legacy-blocked");
+    assert_eq!(listed[0].status, TaskBoardStatus::Failed);
+}
+
+#[test]
 fn update_writes_current_status_for_legacy_status_patch() {
     let temp = tempdir().expect("tempdir");
     let store = TaskBoardStore::new(temp.path().join("board"));

--- a/src/task_board/store/tests.rs
+++ b/src/task_board/store/tests.rs
@@ -86,6 +86,28 @@ fn get_repairs_legacy_status_on_disk() {
 }
 
 #[test]
+fn get_rejects_mismatched_frontmatter_id_before_repair() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    let path = seed_raw_item_with_frontmatter_id(&store, "file-id", "frontmatter-id", "new");
+
+    let error = store.get("file-id").expect_err("mismatched id must fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("expected 'file-id', found 'frontmatter-id'")
+    );
+    assert!(
+        !store.tasks_dir().join("frontmatter-id.md").exists(),
+        "repair must not create a second file from frontmatter id"
+    );
+    let contents = fs::read_to_string(path).expect("read source file");
+    assert!(contents.contains("status: new"));
+    assert!(!contents.contains("status: todo"));
+}
+
+#[test]
 fn list_repairs_legacy_statuses_before_filtering() {
     let temp = tempdir().expect("tempdir");
     let store = TaskBoardStore::new(temp.path().join("board"));
@@ -98,6 +120,29 @@ fn list_repairs_legacy_statuses_before_filtering() {
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id, "legacy-needs-you");
     assert_eq!(listed[0].status, TaskBoardStatus::HumanRequired);
+}
+
+#[test]
+fn list_repairs_mismatched_frontmatter_id_at_source_path() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    let source =
+        seed_raw_item_with_frontmatter_id(&store, "source-file", "frontmatter-id", "needs_you");
+
+    let listed = store
+        .list(Some(TaskBoardStatus::HumanRequired))
+        .expect("list repaired status");
+
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, "frontmatter-id");
+    assert_eq!(listed[0].status, TaskBoardStatus::HumanRequired);
+    let contents = fs::read_to_string(source).expect("read repaired source file");
+    assert!(contents.contains("status: human_required"));
+    assert!(!contents.contains("status: needs_you"));
+    assert!(
+        !store.tasks_dir().join("frontmatter-id.md").exists(),
+        "list repair must write the original path, not the frontmatter id path"
+    );
 }
 
 #[test]
@@ -181,14 +226,23 @@ fn list_keeps_filter_and_sort_across_parallel_parse() {
 }
 
 fn seed_raw_item(store: &TaskBoardStore, id: &str, status: &str) -> std::path::PathBuf {
-    let path = store.tasks_dir().join(format!("{id}.md"));
+    seed_raw_item_with_frontmatter_id(store, id, id, status)
+}
+
+fn seed_raw_item_with_frontmatter_id(
+    store: &TaskBoardStore,
+    filename_id: &str,
+    frontmatter_id: &str,
+    status: &str,
+) -> std::path::PathBuf {
+    let path = store.tasks_dir().join(format!("{filename_id}.md"));
     fs::create_dir_all(store.tasks_dir()).expect("create tasks dir");
     fs::write(
         &path,
         format!(
             "---\n\
              schema_version: 1\n\
-             id: {id}\n\
+             id: {frontmatter_id}\n\
              title: Legacy status\n\
              status: {status}\n\
              priority: medium\n\

--- a/src/task_board/types.rs
+++ b/src/task_board/types.rs
@@ -167,6 +167,19 @@ pub enum TaskBoardStatus {
     Blocked,
 }
 
+impl TaskBoardStatus {
+    #[must_use]
+    pub fn canonical_persisted_status(self) -> Self {
+        match self {
+            Self::New => Self::Todo,
+            Self::PlanReview => Self::AgenticReview,
+            Self::NeedsYou => Self::HumanRequired,
+            Self::Blocked => Self::Failed,
+            status => status,
+        }
+    }
+}
+
 #[derive(
     Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum,
 )]


### PR DESCRIPTION
## Summary
- Repair persisted task-board markdown items from legacy statuses to current lane statuses on store read/write
- Limit Task Board status menus and filters to current lane-backed statuses
- Keep legacy wire decoding compatibility for older data while preventing new legacy status writes

## Validation
- `git diff --check`
- `mise run cargo:local -- test --lib task_board::store::tests`
- `mise run cargo:local -- clippy --lib -- -D warnings`
- `mise run monitor:lint`
- `XCODE_ONLY_TESTING='HarnessMonitorKitTests/TaskBoardEnumsWireDecodingTests,HarnessMonitorKitTests/TaskBoardItemEditorDraftTests' mise run monitor:test`