### PR TITLE
feat(task-board): toggle priority badges per lane

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardLaneAppearanceSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardLaneAppearanceSection.swift
@@ -123,6 +123,8 @@ private struct SettingsTaskBoardLaneAppearancePopover: View {
       colorSection
       Divider()
       symbolSection
+      Divider()
+      cardsSection
     }
     .padding(HarnessMonitorTheme.spacingMD)
     .frame(width: 360, alignment: .topLeading)
@@ -208,6 +210,26 @@ private struct SettingsTaskBoardLaneAppearancePopover: View {
     }
   }
 
+  private var cardsSection: some View {
+    VStack(alignment: .leading, spacing: HarnessMonitorTheme.spacingSM) {
+      sectionHeader(title: "Cards") {
+        Button {
+          rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
+            true,
+            for: lane,
+            rawValue: rawValue
+          )
+        } label: {
+          Label("Reset", systemImage: "arrow.counterclockwise")
+        }
+        .buttonStyle(.borderless)
+        .disabled(!appearance.hasPriorityBadgeOverride(for: lane))
+      }
+
+      Toggle("Priority Badge", isOn: priorityBadgeBinding)
+    }
+  }
+
   private func sectionHeader<Actions: View>(
     title: String,
     @ViewBuilder actions: () -> Actions
@@ -260,6 +282,19 @@ private struct SettingsTaskBoardLaneAppearancePopover: View {
       set: { color in
         rawValue = TaskBoardLaneAppearancePreferences.settingCustomColor(
           color,
+          for: lane,
+          rawValue: rawValue
+        )
+      }
+    )
+  }
+
+  private var priorityBadgeBinding: Binding<Bool> {
+    Binding(
+      get: { appearance.showsPriorityBadge(for: lane) },
+      set: { isVisible in
+        rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
+          isVisible,
           for: lane,
           rawValue: rawValue
         )

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneAppearancePreferences.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneAppearancePreferences.swift
@@ -113,9 +113,14 @@ struct TaskBoardLaneAppearanceOverride: Codable, Equatable, Sendable {
   var customColor: TaskBoardLaneCustomColor?
   var symbolName: String?
   var hidesSymbol: Bool?
+  var hidesPriorityBadge: Bool?
 
   var isEmpty: Bool {
-    colorToken == nil && customColor == nil && symbolName == nil && hidesSymbol != true
+    colorToken == nil
+      && customColor == nil
+      && symbolName == nil
+      && hidesSymbol != true
+      && hidesPriorityBadge != true
   }
 }
 
@@ -150,6 +155,10 @@ struct TaskBoardLaneAppearance: Equatable {
     overrides[lane]?.hidesSymbol == true
   }
 
+  func showsPriorityBadge(for lane: TaskBoardInboxLane) -> Bool {
+    overrides[lane]?.hidesPriorityBadge != true
+  }
+
   func hasOverride(for lane: TaskBoardInboxLane) -> Bool {
     overrides[lane]?.isEmpty == false
   }
@@ -162,6 +171,10 @@ struct TaskBoardLaneAppearance: Equatable {
   func hasSymbolOverride(for lane: TaskBoardInboxLane) -> Bool {
     let override = overrides[lane]
     return override?.symbolName != nil || override?.hidesSymbol == true
+  }
+
+  func hasPriorityBadgeOverride(for lane: TaskBoardInboxLane) -> Bool {
+    overrides[lane]?.hidesPriorityBadge == true
   }
 }
 
@@ -276,6 +289,18 @@ enum TaskBoardLaneAppearancePreferences {
     if !isVisible {
       override.symbolName = nil
     }
+    overrides[lane] = override
+    return Self.rawValue(for: overrides)
+  }
+
+  static func settingPriorityBadgeVisibility(
+    _ isVisible: Bool,
+    for lane: TaskBoardInboxLane,
+    rawValue: String
+  ) -> String {
+    var overrides = overrides(from: rawValue)
+    var override = overrides[lane] ?? TaskBoardLaneAppearanceOverride()
+    override.hidesPriorityBadge = isVisible ? nil : true
     overrides[lane] = override
     return Self.rawValue(for: overrides)
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneColors.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneColors.swift
@@ -1,0 +1,34 @@
+import HarnessMonitorKit
+import SwiftUI
+
+func priorityColor(for priority: TaskBoardPriority) -> Color {
+  switch priority {
+  case .critical:
+    HarnessMonitorTheme.danger
+  case .high:
+    HarnessMonitorTheme.caution
+  case .medium:
+    HarnessMonitorTheme.accent
+  case .low:
+    HarnessMonitorTheme.secondaryInk
+  }
+}
+
+func taskBoardStatusColor(for status: TaskBoardStatus) -> Color {
+  switch status {
+  case .failed, .blocked:
+    HarnessMonitorTheme.danger
+  case .agenticReview, .planReview, .testing, .inReview, .toReview:
+    HarnessMonitorTheme.caution
+  case .humanRequired, .needsYou:
+    HarnessMonitorTheme.danger
+  case .planning, .inProgress:
+    HarnessMonitorTheme.warmAccent
+  case .umbrella, .new, .todo:
+    HarnessMonitorTheme.accent
+  case .done:
+    HarnessMonitorTheme.secondaryInk
+  case .unknown:
+    HarnessMonitorTheme.secondaryInk
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
@@ -233,10 +233,17 @@ struct TaskBoardItemRow: View {
   }
 
   @ViewBuilder private var badgeContent: some View {
-    TaskBoardCardPill(label: item.priority.title, tint: priorityColor(for: item.priority))
+    if showsPriorityBadge {
+      TaskBoardCardPill(label: item.priority.title, tint: priorityColor(for: item.priority))
+    }
     if let policyTraceCount = item.workflow?.policyTraceIds.count, policyTraceCount > 0 {
       TaskBoardCardPill(label: "\(policyTraceCount) policy", tint: HarnessMonitorTheme.secondaryInk)
     }
+  }
+
+  private var showsPriorityBadge: Bool {
+    TaskBoardInboxLane(status: item.status)
+      .map { laneAppearance.showsPriorityBadge(for: $0) } ?? true
   }
 }
 
@@ -383,37 +390,5 @@ private struct TaskBoardInboxItemDragPreviewCard: View {
     .frame(width: metrics.dragPreviewWidth, alignment: .leading)
     .padding(metrics.cardPadding)
     .background(.background.opacity(0.92), in: .rect(cornerRadius: metrics.cardCornerRadius))
-  }
-}
-
-func priorityColor(for priority: TaskBoardPriority) -> Color {
-  switch priority {
-  case .critical:
-    HarnessMonitorTheme.danger
-  case .high:
-    HarnessMonitorTheme.caution
-  case .medium:
-    HarnessMonitorTheme.accent
-  case .low:
-    HarnessMonitorTheme.secondaryInk
-  }
-}
-
-func taskBoardStatusColor(for status: TaskBoardStatus) -> Color {
-  switch status {
-  case .failed, .blocked:
-    HarnessMonitorTheme.danger
-  case .agenticReview, .planReview, .testing, .inReview, .toReview:
-    HarnessMonitorTheme.caution
-  case .humanRequired, .needsYou:
-    HarnessMonitorTheme.danger
-  case .planning, .inProgress:
-    HarnessMonitorTheme.warmAccent
-  case .umbrella, .new, .todo:
-    HarnessMonitorTheme.accent
-  case .done:
-    HarnessMonitorTheme.secondaryInk
-  case .unknown:
-    HarnessMonitorTheme.secondaryInk
   }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneAppearancePreferencesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneAppearancePreferencesTests.swift
@@ -17,6 +17,7 @@ struct TaskBoardLaneAppearancePreferencesTests {
         == TaskBoardLaneAppearancePreferences.defaultSymbolName(for: .agenticReview)
     )
     #expect(!appearance.hidesSymbol(for: .agenticReview))
+    #expect(appearance.showsPriorityBadge(for: .agenticReview))
     #expect(!appearance.hasOverride(for: .agenticReview))
   }
 
@@ -85,6 +86,36 @@ struct TaskBoardLaneAppearancePreferencesTests {
     #expect(restoredAppearance.symbolName(for: .planning) == nil)
     #expect(restoredAppearance.hidesSymbol(for: .planning))
     #expect(restoredAppearance.hasOverride(for: .planning))
+  }
+
+  @Test("Hidden priority badges persist through UserDefaults")
+  func hiddenPriorityBadgesPersistThroughUserDefaults() throws {
+    let suiteName = "TaskBoardLaneAppearancePreferencesTests.\(UUID().uuidString)"
+    let userDefaults = try #require(UserDefaults(suiteName: suiteName))
+    defer {
+      userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    let rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
+      false,
+      for: .todo,
+      rawValue: TaskBoardLaneAppearancePreferences.emptyRawValue
+    )
+    TaskBoardLaneAppearancePreferences.save(
+      TaskBoardLaneAppearancePreferences.overrides(from: rawValue),
+      to: userDefaults
+    )
+    userDefaults.synchronize()
+
+    let restartedDefaults = try #require(UserDefaults(suiteName: suiteName))
+    let storedRawValue = try #require(
+      restartedDefaults.string(forKey: TaskBoardLaneAppearancePreferences.storageKey)
+    )
+    let restoredAppearance = TaskBoardLaneAppearance(rawValue: storedRawValue)
+
+    #expect(!restoredAppearance.showsPriorityBadge(for: .todo))
+    #expect(restoredAppearance.hasPriorityBadgeOverride(for: .todo))
+    #expect(restoredAppearance.hasOverride(for: .todo))
   }
 
   @Test("Custom colors persist through UserDefaults")
@@ -157,6 +188,20 @@ struct TaskBoardLaneAppearancePreferencesTests {
     )
     #expect(rawValue == TaskBoardLaneAppearancePreferences.emptyRawValue)
 
+    rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
+      false,
+      for: .testing,
+      rawValue: rawValue
+    )
+    #expect(!TaskBoardLaneAppearance(rawValue: rawValue).showsPriorityBadge(for: .testing))
+
+    rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
+      true,
+      for: .testing,
+      rawValue: rawValue
+    )
+    #expect(rawValue == TaskBoardLaneAppearancePreferences.emptyRawValue)
+
     rawValue = TaskBoardLaneAppearancePreferences.settingColorToken(
       .pink,
       for: .testing,
@@ -209,6 +254,10 @@ struct TaskBoardLaneAppearancePreferencesTests {
     #expect(source.contains(".frame(width: 58, height: 30)"))
     #expect(source.contains("Label(\"Clear\", systemImage: \"slash.circle\")"))
     #expect(source.contains("Label(\"Reset\", systemImage: \"arrow.counterclockwise\")"))
+    #expect(source.contains("Toggle(\"Priority Badge\", isOn: priorityBadgeBinding)"))
+    #expect(
+      source.contains("TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(")
+    )
     #expect(source.contains("HarnessMonitorTextSize.scaledFont(.body.weight(.medium)"))
     #expect(source.contains("\"terminal\""))
     #expect(source.contains("\"gearshape\""))
@@ -231,7 +280,17 @@ struct TaskBoardLaneAppearancePreferencesTests {
 
     let colorRange = try #require(source.range(of: "colorSection"))
     let symbolRange = try #require(source.range(of: "symbolSection"))
+    let cardsRange = try #require(source.range(of: "cardsSection"))
     #expect(colorRange.lowerBound < symbolRange.lowerBound)
+    #expect(symbolRange.lowerBound < cardsRange.lowerBound)
+  }
+
+  @Test("Task cards read priority badge visibility from lane appearance")
+  func taskCardsReadPriorityBadgeVisibilityFromLaneAppearance() throws {
+    let source = try sourceFile(named: "Views/TaskBoard/TaskBoardLaneViews.swift")
+
+    #expect(source.contains("if showsPriorityBadge"))
+    #expect(source.contains(".map { laneAppearance.showsPriorityBadge(for: $0) } ?? true"))
   }
 
   private func sourceFile(named relativePath: String) throws -> String {


### PR DESCRIPTION
## Summary

- add a per-lane persisted appearance override for task-card priority badge visibility
- expose a Priority Badge toggle in each lane Customize popover
- make task cards hide/show the priority badge from lane appearance settings
- extract task-board card color helpers to keep TaskBoardLaneViews under the file-length gate