### PR TITLE
feat(github): unify Reviews and Task Board data

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/DaemonStatusModels+Wire.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/DaemonStatusModels+Wire.swift
@@ -139,7 +139,8 @@ extension GitHubApiDiagnostics {
       cacheStaleHits: wire.cacheStaleHits,
       cacheDeferredHits: wire.cacheDeferredHits,
       deferredBudget: wire.deferredBudget,
-      topOperations: wire.topOperations.map(GitHubOperationSpendDiagnostics.init(wire:))
+      topOperations: wire.topOperations.map(GitHubOperationSpendDiagnostics.init(wire:)),
+      dataRevision: wire.dataRevision
     )
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/DaemonStatusModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/DaemonStatusModels.swift
@@ -161,6 +161,7 @@ public struct DaemonDiagnosticsReport: Codable, Equatable, Sendable {
 }
 
 public struct GitHubApiDiagnostics: Codable, Equatable, Sendable {
+  public let dataRevision: UInt64?
   public let buckets: [GitHubRateBucketDiagnostics]
   public let cooling: [GitHubCooldownDiagnostics]
   public let lastHourNetworkRequests: UInt64
@@ -180,8 +181,10 @@ public struct GitHubApiDiagnostics: Codable, Equatable, Sendable {
     cacheStaleHits: UInt64,
     cacheDeferredHits: UInt64,
     deferredBudget: UInt64,
-    topOperations: [GitHubOperationSpendDiagnostics]
+    topOperations: [GitHubOperationSpendDiagnostics],
+    dataRevision: UInt64? = nil
   ) {
+    self.dataRevision = dataRevision
     self.buckets = buckets
     self.cooling = cooling
     self.lastHourNetworkRequests = lastHourNetworkRequests

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/SummariesWireTypes.generated.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/SummariesWireTypes.generated.swift
@@ -122,6 +122,7 @@ public struct HostBridgeReconfigureRequestWire: Codable, Equatable, Sendable {
 }
 
 public struct GitHubApiDiagnosticsWire: Codable, Equatable, Sendable {
+  public var dataRevision: UInt64?
   public var buckets: [GitHubRateBucketDiagnosticsWire]
   public var cooling: [GitHubCooldownDiagnosticsWire]
   public var lastHourNetworkRequests: UInt64
@@ -132,7 +133,8 @@ public struct GitHubApiDiagnosticsWire: Codable, Equatable, Sendable {
   public var deferredBudget: UInt64
   public var topOperations: [GitHubOperationSpendDiagnosticsWire]
 
-  public init(buckets: [GitHubRateBucketDiagnosticsWire], cooling: [GitHubCooldownDiagnosticsWire], lastHourNetworkRequests: UInt64, lastHourGraphqlPoints: UInt64, cacheHits: UInt64, cacheStaleHits: UInt64, cacheDeferredHits: UInt64, deferredBudget: UInt64, topOperations: [GitHubOperationSpendDiagnosticsWire]) {
+  public init(dataRevision: UInt64? = nil, buckets: [GitHubRateBucketDiagnosticsWire], cooling: [GitHubCooldownDiagnosticsWire], lastHourNetworkRequests: UInt64, lastHourGraphqlPoints: UInt64, cacheHits: UInt64, cacheStaleHits: UInt64, cacheDeferredHits: UInt64, deferredBudget: UInt64, topOperations: [GitHubOperationSpendDiagnosticsWire]) {
+    self.dataRevision = dataRevision
     self.buckets = buckets
     self.cooling = cooling
     self.lastHourNetworkRequests = lastHourNetworkRequests
@@ -145,6 +147,7 @@ public struct GitHubApiDiagnosticsWire: Codable, Equatable, Sendable {
   }
 
   enum CodingKeys: String, CodingKey {
+    case dataRevision = "data_revision"
     case buckets
     case cooling
     case lastHourNetworkRequests = "last_hour_network_requests"

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorDaemonPushEvent.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorDaemonPushEvent.swift
@@ -30,6 +30,16 @@ public struct AcpPermissionBatchRemovedPayload: Equatable, Sendable {
   }
 }
 
+public struct GitHubDataChangedPayload: Codable, Equatable, Sendable {
+  public let revision: UInt64
+  public let operation: String
+
+  public init(revision: UInt64, operation: String) {
+    self.revision = revision
+    self.operation = operation
+  }
+}
+
 public struct DaemonPushEvent: Equatable, Identifiable, Sendable {
   public enum Kind: Equatable, Sendable {
     case ready
@@ -49,6 +59,7 @@ public struct DaemonPushEvent: Equatable, Identifiable, Sendable {
     case acpBridgeResyncIncident(AcpBridgeResyncIncidentPayload)
     case acpPermissionBatch(AcpPermissionBatch)
     case acpPermissionBatchRemoved(AcpPermissionBatchRemovedPayload)
+    case githubDataChanged(GitHubDataChangedPayload)
     case reviewsLocalCloneProgress(ReviewLocalCloneProgress)
     case auditEvent(HarnessMonitorAuditEvent)
     case unknown(eventName: String, payload: JSONValue)
@@ -125,6 +136,14 @@ public struct DaemonPushEvent: Equatable, Identifiable, Sendable {
           ReviewLocalCloneProgress(
             wire: try streamEvent.decodePayloadWire(as: LocalCloneProgressEventPayloadWire.self)
           )
+        )
+      )
+    case "github_data_changed":
+      return Self(
+        recordedAt: at,
+        sessionId: nil,
+        kind: .githubDataChanged(
+          try streamEvent.decodePayloadWire(as: GitHubDataChangedPayload.self)
         )
       )
     case "audit_event":

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ContentSlices.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ContentSlices.swift
@@ -318,6 +318,8 @@ extension HarnessMonitorStore {
     public var notificationHistory: [NotificationHistoryEntry] = []
     public var auditEvents: [HarnessMonitorAuditEvent] = []
     public var auditHasOlder = false
+    public var githubDataRevision: UInt64 = 0
+    public var latestGitHubDataChange: GitHubDataChangedPayload?
     public var taskBoardItems: [TaskBoardItem] = []
     public var taskBoardOrchestratorStatus: TaskBoardOrchestratorStatus?
     public var taskBoardSyncSummary: TaskBoardSyncSummary?

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamControl.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamControl.swift
@@ -4,6 +4,9 @@ extension HarnessMonitorStore {
   func stopGlobalStream() {
     globalStreamTask?.cancel()
     globalStreamTask = nil
+    cacheWriteSync.githubDataRefreshGeneration &+= 1
+    cacheWriteSync.githubDataTaskBoardRefreshTask?.cancel()
+    cacheWriteSync.githubDataTaskBoardRefreshTask = nil
   }
 
   func stopSessionStream(resetSubscriptions: Bool = true) {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Streaming.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Streaming.swift
@@ -149,6 +149,7 @@ extension HarnessMonitorStore {
         "websocket reconnect log-level refresh failed: \(err, privacy: .public)"
       )
     }
+    await recoverGitHubDataPushState(using: client)
   }
 
   func applyGlobalPushEvent(_ event: DaemonPushEvent) {
@@ -241,7 +242,7 @@ extension HarnessMonitorStore {
       shouldTickSupervisor = true
     case .codexRunUpdated, .codexApprovalRequested, .agentTuiUpdated, .acpAgentUpdated,
       .acpInspect, .acpAgentsReconciled, .acpProcessIncident, .acpBridgeResyncIncident,
-      .acpEvents, .acpPermissionBatch, .acpPermissionBatchRemoved, .auditEvent:
+      .acpEvents, .acpPermissionBatch, .acpPermissionBatchRemoved, .githubDataChanged, .auditEvent:
       break
     case .reviewsLocalCloneProgress(let progress):
       applyLocalCloneProgress(progress)
@@ -299,10 +300,7 @@ extension HarnessMonitorStore {
       scheduleSupervisorTick(reason: "global-managed-agent")
       return
     }
-    if case .auditEvent(let auditEvent) = event.kind {
-      await applyApplicationAuditEventFromStream(auditEvent)
-      return
-    }
+    if await applyGlobalDataPushEventFromStream(event) { return }
     applyGlobalPushEvent(event)
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingDataPush.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingDataPush.swift
@@ -1,0 +1,53 @@
+extension HarnessMonitorStore {
+  func applyGlobalDataPushEventFromStream(_ event: DaemonPushEvent) async -> Bool {
+    switch event.kind {
+    case .auditEvent(let auditEvent):
+      await applyApplicationAuditEventFromStream(auditEvent)
+    case .githubDataChanged:
+      applyGlobalPushEvent(event)
+      if let client {
+        scheduleGitHubTaskBoardRefresh(using: client)
+      }
+    default:
+      return false
+    }
+    return true
+  }
+
+  func scheduleGitHubTaskBoardRefresh(using client: any HarnessMonitorClientProtocol) {
+    cacheWriteSync.githubDataRefreshGeneration &+= 1
+    let generation = cacheWriteSync.githubDataRefreshGeneration
+    cacheWriteSync.githubDataTaskBoardRefreshTask?.cancel()
+    cacheWriteSync.githubDataTaskBoardRefreshTask = Task { @MainActor [weak self] in
+      do {
+        try await Task.sleep(for: .milliseconds(50))
+      } catch {
+        return
+      }
+      guard let self, self.cacheWriteSync.githubDataRefreshGeneration == generation else { return }
+      let snapshot = await Self.loadTaskBoardRefreshSnapshot(using: client)
+      guard self.cacheWriteSync.githubDataRefreshGeneration == generation else { return }
+      self.cancelInitialTaskBoardConfirmationRefresh()
+      self.applyTaskBoardDashboardSnapshot(snapshot)
+      self.cacheWriteSync.githubDataTaskBoardRefreshTask = nil
+    }
+  }
+
+  func recoverGitHubDataPushState(using client: any HarnessMonitorClientProtocol) async {
+    do {
+      let githubStatus = try await client.githubStatus()
+      if let revision = githubStatus.dataRevision,
+        contentUI.dashboard.githubDataRevision != revision
+      {
+        contentUI.dashboard.latestGitHubDataChange = nil
+        contentUI.dashboard.githubDataRevision = revision
+      }
+    } catch {
+      let err = error.localizedDescription
+      HarnessMonitorLogger.store.warning(
+        "websocket reconnect GitHub data refresh failed: \(err, privacy: .public)"
+      )
+    }
+    scheduleGitHubTaskBoardRefresh(using: client)
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingGlobalPush.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingGlobalPush.swift
@@ -42,7 +42,7 @@ extension HarnessMonitorStore {
     case .reviewsLocalCloneProgress(let progress):
       applyLocalCloneProgress(progress)
     case .githubDataChanged(let payload):
-      if contentUI.dashboard.latestGitHubDataChange?.revision != payload.revision {
+      if contentUI.dashboard.latestGitHubDataChange != payload {
         contentUI.dashboard.latestGitHubDataChange = payload
       }
       if contentUI.dashboard.githubDataRevision != payload.revision {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingGlobalPush.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingGlobalPush.swift
@@ -41,6 +41,13 @@ extension HarnessMonitorStore {
       break
     case .reviewsLocalCloneProgress(let progress):
       applyLocalCloneProgress(progress)
+    case .githubDataChanged(let payload):
+      if contentUI.dashboard.latestGitHubDataChange?.revision != payload.revision {
+        contentUI.dashboard.latestGitHubDataChange = payload
+      }
+      if contentUI.dashboard.githubDataRevision != payload.revision {
+        contentUI.dashboard.githubDataRevision = payload.revision
+      }
     case .auditEvent(let event):
       applyApplicationAuditEvent(event)
     case .unknown:

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
@@ -61,6 +61,13 @@ extension HarnessMonitorStore {
   ) async {
     cancelInitialTaskBoardConfirmationRefresh()
     let snapshot = await Self.loadTaskBoardRefreshSnapshot(using: client)
+    applyTaskBoardDashboardSnapshot(snapshot, fallbackStatus: fallbackStatus)
+  }
+
+  func applyTaskBoardDashboardSnapshot(
+    _ snapshot: TaskBoardRefreshSnapshot,
+    fallbackStatus: TaskBoardOrchestratorStatus? = nil
+  ) {
     let resolvedItems = snapshot.items.value ?? globalTaskBoardItems
     let resolvedStatus =
       if let measuredStatus = snapshot.orchestratorStatus.measured {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStoreState.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStoreState.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 struct CacheWriteSyncState {
+  var githubDataTaskBoardRefreshTask: Task<Void, Never>?
+  var githubDataRefreshGeneration: UInt64 = 0
   var pendingCacheWriteTask: Task<Void, Never>?
   var pendingCacheWriteTaskToken: UInt64 = 0
   var pendingTaskBoardSnapshotCacheWriteTask: Task<Void, Never>?

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsGitHubMutationCoherence.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsGitHubMutationCoherence.swift
@@ -185,8 +185,8 @@ struct DashboardReviewsGitHubMutationRefreshCoordinator {
   }
 }
 
-private extension Optional where Wrapped: Comparable {
-  func isSomeAndLess(than value: Wrapped) -> Bool {
+extension Optional where Wrapped: Comparable {
+  fileprivate func isSomeAndLess(than value: Wrapped) -> Bool {
     guard let self else { return false }
     return self < value
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsGitHubMutationCoherence.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsGitHubMutationCoherence.swift
@@ -1,0 +1,340 @@
+import Foundation
+import HarnessMonitorKit
+
+enum DashboardReviewsGitHubChangeDecision: Equatable {
+  case refreshAll
+  case waitForTargetedRefresh
+  case acknowledge(revision: UInt64)
+}
+
+enum DashboardReviewsGitHubMutationCompletion: Equatable {
+  case none
+  case refreshAll
+  case acknowledge(revision: UInt64)
+}
+
+enum DashboardReviewsGitHubMutationConfirmation: Equatable {
+  case confirmed
+  case discarded
+  case refreshAll
+}
+
+struct DashboardReviewsGitHubMutationRefreshCoordinator {
+  struct Token: Hashable, Sendable {
+    fileprivate let value: UInt64
+  }
+
+  private enum RefreshState {
+    case pending
+    case succeeded
+  }
+
+  private struct PendingMutation {
+    let baselineRevision: UInt64
+    let operations: Set<String>
+    let expectedRevisionCount: UInt64
+    let expiresAt: Date
+    var refreshState: RefreshState = .pending
+    var matchedRevision: UInt64?
+    var confirmedRevision: UInt64?
+  }
+
+  private static let retentionInterval: TimeInterval = 180
+
+  private var nextToken: UInt64 = 0
+  private var pendingMutations: [Token: PendingMutation] = [:]
+
+  mutating func begin(
+    baselineRevision: UInt64,
+    operations: Set<String>,
+    expectedRevisionCount: UInt64,
+    now: Date = Date()
+  ) -> Token? {
+    guard !operations.isEmpty, expectedRevisionCount > 0 else { return nil }
+    nextToken &+= 1
+    let token = Token(value: nextToken)
+    pendingMutations[token] = PendingMutation(
+      baselineRevision: baselineRevision,
+      operations: operations,
+      expectedRevisionCount: expectedRevisionCount,
+      expiresAt: now.addingTimeInterval(Self.retentionInterval)
+    )
+    return token
+  }
+
+  mutating func changeDecision(
+    for change: GitHubDataChangedPayload,
+    now: Date = Date()
+  ) -> DashboardReviewsGitHubChangeDecision {
+    discardExpired(at: now)
+    let candidateTokens = pendingMutations.compactMap { token, mutation in
+      mutation.baselineRevision < change.revision
+        && mutation.operations.contains(change.operation)
+        ? token
+        : nil
+    }
+    guard !candidateTokens.isEmpty else { return .refreshAll }
+
+    for token in candidateTokens {
+      guard var mutation = pendingMutations[token] else { continue }
+      let expectedRevision = mutation.baselineRevision.addingReportingOverflow(
+        mutation.expectedRevisionCount
+      )
+      if expectedRevision.overflow
+        || change.revision > expectedRevision.partialValue
+        || mutation.confirmedRevision.isSomeAndLess(than: change.revision)
+      {
+        for candidateToken in candidateTokens {
+          pendingMutations.removeValue(forKey: candidateToken)
+        }
+        return .refreshAll
+      }
+      mutation.matchedRevision = max(mutation.matchedRevision ?? 0, change.revision)
+      pendingMutations[token] = mutation
+    }
+    guard
+      candidateTokens.allSatisfy({ token in
+        pendingMutations[token]?.confirmedRevision == change.revision
+          && pendingMutations[token]?.refreshState == .succeeded
+      })
+    else {
+      return .waitForTargetedRefresh
+    }
+    for token in candidateTokens {
+      pendingMutations.removeValue(forKey: token)
+    }
+    return .acknowledge(revision: change.revision)
+  }
+
+  mutating func confirm(
+    _ token: Token,
+    endingRevision: UInt64,
+    appliedRevisionCount: UInt64
+  ) -> DashboardReviewsGitHubMutationConfirmation {
+    guard var mutation = pendingMutations[token] else { return .discarded }
+    let expectedRevision = mutation.baselineRevision.addingReportingOverflow(
+      mutation.expectedRevisionCount
+    )
+    guard appliedRevisionCount == mutation.expectedRevisionCount,
+      !expectedRevision.overflow,
+      endingRevision == expectedRevision.partialValue
+    else {
+      pendingMutations.removeValue(forKey: token)
+      return mutation.matchedRevision == nil ? .discarded : .refreshAll
+    }
+    if let matchedRevision = mutation.matchedRevision,
+      matchedRevision > endingRevision
+    {
+      pendingMutations.removeValue(forKey: token)
+      return .refreshAll
+    }
+    mutation.confirmedRevision = endingRevision
+    pendingMutations[token] = mutation
+    return .confirmed
+  }
+
+  mutating func targetedRefreshSucceeded(
+    for token: Token
+  ) -> DashboardReviewsGitHubMutationCompletion {
+    guard var mutation = pendingMutations[token] else { return .none }
+    mutation.refreshState = .succeeded
+    pendingMutations[token] = mutation
+    guard let revision = mutation.matchedRevision else { return .none }
+    return resolveSucceededMutations(matching: revision)
+  }
+
+  mutating func targetedRefreshFailed(
+    for token: Token
+  ) -> DashboardReviewsGitHubMutationCompletion {
+    guard let mutation = pendingMutations.removeValue(forKey: token) else { return .none }
+    return mutation.matchedRevision == nil ? .none : .refreshAll
+  }
+
+  mutating func discardAcknowledgedChanges(upTo revision: UInt64) {
+    pendingMutations = pendingMutations.filter { _, mutation in
+      guard let matchedRevision = mutation.matchedRevision else { return true }
+      return matchedRevision > revision
+    }
+  }
+
+  private mutating func resolveSucceededMutations(
+    matching revision: UInt64
+  ) -> DashboardReviewsGitHubMutationCompletion {
+    let matchingTokens = pendingMutations.compactMap { token, mutation in
+      mutation.matchedRevision == revision ? token : nil
+    }
+    guard !matchingTokens.isEmpty else { return .none }
+    guard
+      matchingTokens.allSatisfy({ token in
+        pendingMutations[token]?.confirmedRevision == revision
+          && pendingMutations[token]?.refreshState == .succeeded
+      })
+    else {
+      return .none
+    }
+    for token in matchingTokens {
+      pendingMutations.removeValue(forKey: token)
+    }
+    return .acknowledge(revision: revision)
+  }
+
+  private mutating func discardExpired(at now: Date) {
+    pendingMutations = pendingMutations.filter { _, mutation in
+      mutation.expiresAt > now
+    }
+  }
+}
+
+private extension Optional where Wrapped: Comparable {
+  func isSomeAndLess(than value: Wrapped) -> Bool {
+    guard let self else { return false }
+    return self < value
+  }
+}
+
+func dashboardReviewsGitHubMutationOperations(
+  for action: ReviewActionKind
+) -> Set<String> {
+  switch action {
+  case .approve:
+    ["reviews.approve"]
+  case .merge, .autoMerge:
+    ["task_board.github.merge_pull_request"]
+  case .rerunChecks:
+    ["reviews.rerequest_checks"]
+  case .addLabel:
+    ["task_board.github.replace_labels"]
+  case .autoApprove:
+    ["reviews.auto_approve"]
+  case .comment:
+    ["reviews.comment"]
+  case .requestReview:
+    ["task_board.github.request_reviewers"]
+  case .unknown:
+    []
+  }
+}
+
+func dashboardReviewsMutationFullyApplied(
+  _ response: ReviewsActionResponse,
+  expectedResultCount: Int
+) -> Bool {
+  response.results.count == expectedResultCount
+    && response.results.allSatisfy { $0.outcome == .applied }
+}
+
+func dashboardReviewsExpectedGitHubRevisionCount(
+  action: ReviewActionKind,
+  items: [ReviewItem]
+) -> UInt64 {
+  switch action {
+  case .rerunChecks:
+    items.reduce(into: UInt64(0)) { count, item in
+      count += UInt64(item.rerunnableCheckSuiteIDs.count)
+    }
+  case .approve, .merge, .addLabel, .autoApprove, .autoMerge, .comment, .requestReview:
+    UInt64(items.count)
+  case .unknown:
+    0
+  }
+}
+
+@MainActor
+extension DashboardReviewsRouteView {
+  func beginTargetedGitHubMutation(
+    action: ReviewActionKind,
+    expectedRevisionCount: UInt64
+  ) -> DashboardReviewsGitHubMutationRefreshCoordinator.Token? {
+    routeStateStorage.githubMutationRefreshCoordinator.begin(
+      baselineRevision: store.contentUI.dashboard.githubDataRevision,
+      operations: dashboardReviewsGitHubMutationOperations(for: action),
+      expectedRevisionCount: expectedRevisionCount
+    )
+  }
+
+  func confirmTargetedGitHubMutation(
+    _ token: DashboardReviewsGitHubMutationRefreshCoordinator.Token?,
+    appliedRevisionCount: UInt64?,
+    using client: any HarnessMonitorClientProtocol
+  ) async -> DashboardReviewsGitHubMutationRefreshCoordinator.Token? {
+    guard let token, let appliedRevisionCount else {
+      targetedGitHubMutationFailed(token)
+      return nil
+    }
+    let endingRevision: UInt64?
+    do {
+      endingRevision = try await client.githubStatus().dataRevision
+    } catch {
+      targetedGitHubMutationFailed(token)
+      return nil
+    }
+    guard let endingRevision else {
+      targetedGitHubMutationFailed(token)
+      return nil
+    }
+    let confirmation = routeStateStorage.githubMutationRefreshCoordinator.confirm(
+      token,
+      endingRevision: endingRevision,
+      appliedRevisionCount: appliedRevisionCount
+    )
+    switch confirmation {
+    case .confirmed:
+      return token
+    case .discarded:
+      return nil
+    case .refreshAll:
+      await reloadForCurrentGitHubRevision()
+      return nil
+    }
+  }
+
+  func currentGitHubChangeDecision() -> DashboardReviewsGitHubChangeDecision? {
+    let dashboard = store.contentUI.dashboard
+    guard let change = dashboard.latestGitHubDataChange,
+      change.revision == dashboard.githubDataRevision
+    else {
+      return nil
+    }
+    return routeStateStorage.githubMutationRefreshCoordinator.changeDecision(for: change)
+  }
+
+  func targetedGitHubMutationFailed(
+    _ token: DashboardReviewsGitHubMutationRefreshCoordinator.Token?
+  ) {
+    guard let token else { return }
+    let completion =
+      routeStateStorage.githubMutationRefreshCoordinator
+      .targetedRefreshFailed(for: token)
+    guard completion == .refreshAll else { return }
+    Task { await reloadForCurrentGitHubRevision() }
+  }
+
+  func targetedGitHubMutationRefreshFinished(
+    _ token: DashboardReviewsGitHubMutationRefreshCoordinator.Token?,
+    succeeded: Bool
+  ) async {
+    guard let token else { return }
+    let completion =
+      if succeeded {
+        routeStateStorage.githubMutationRefreshCoordinator
+          .targetedRefreshSucceeded(for: token)
+      } else {
+        routeStateStorage.githubMutationRefreshCoordinator
+          .targetedRefreshFailed(for: token)
+      }
+    switch completion {
+    case .none:
+      break
+    case .refreshAll:
+      await reloadForCurrentGitHubRevision()
+    case .acknowledge(let revision):
+      guard store.contentUI.dashboard.githubDataRevision == revision else {
+        await reloadForCurrentGitHubRevision()
+        return
+      }
+      routeLoadedGitHubDataRevision = revision
+      routeStateStorage.githubMutationRefreshCoordinator
+        .discardAcknowledgedChanges(upTo: revision)
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsGitHubMutationCoherence.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsGitHubMutationCoherence.swift
@@ -50,6 +50,7 @@ struct DashboardReviewsGitHubMutationRefreshCoordinator {
     expectedRevisionCount: UInt64,
     now: Date = Date()
   ) -> Token? {
+    discardExpiredUnmatched(at: now)
     guard !operations.isEmpty, expectedRevisionCount > 0 else { return nil }
     nextToken &+= 1
     let token = Token(value: nextToken)
@@ -66,7 +67,7 @@ struct DashboardReviewsGitHubMutationRefreshCoordinator {
     for change: GitHubDataChangedPayload,
     now: Date = Date()
   ) -> DashboardReviewsGitHubChangeDecision {
-    discardExpired(at: now)
+    guard !discardExpired(at: now) else { return .refreshAll }
     let candidateTokens = pendingMutations.compactMap { token, mutation in
       mutation.baselineRevision < change.revision
         && mutation.operations.contains(change.operation)
@@ -109,8 +110,13 @@ struct DashboardReviewsGitHubMutationRefreshCoordinator {
   mutating func confirm(
     _ token: Token,
     endingRevision: UInt64,
-    appliedRevisionCount: UInt64
+    appliedRevisionCount: UInt64,
+    now: Date = Date()
   ) -> DashboardReviewsGitHubMutationConfirmation {
+    guard !discardExpired(at: now) else {
+      pendingMutations.removeValue(forKey: token)
+      return .refreshAll
+    }
     guard var mutation = pendingMutations[token] else { return .discarded }
     let expectedRevision = mutation.baselineRevision.addingReportingOverflow(
       mutation.expectedRevisionCount
@@ -134,8 +140,13 @@ struct DashboardReviewsGitHubMutationRefreshCoordinator {
   }
 
   mutating func targetedRefreshSucceeded(
-    for token: Token
+    for token: Token,
+    now: Date = Date()
   ) -> DashboardReviewsGitHubMutationCompletion {
+    guard !discardExpired(at: now) else {
+      pendingMutations.removeValue(forKey: token)
+      return .refreshAll
+    }
     guard var mutation = pendingMutations[token] else { return .none }
     mutation.refreshState = .succeeded
     pendingMutations[token] = mutation
@@ -144,17 +155,26 @@ struct DashboardReviewsGitHubMutationRefreshCoordinator {
   }
 
   mutating func targetedRefreshFailed(
-    for token: Token
+    for token: Token,
+    now: Date = Date()
   ) -> DashboardReviewsGitHubMutationCompletion {
+    guard !discardExpired(at: now) else {
+      pendingMutations.removeValue(forKey: token)
+      return .refreshAll
+    }
     guard let mutation = pendingMutations.removeValue(forKey: token) else { return .none }
     return mutation.matchedRevision == nil ? .none : .refreshAll
   }
 
-  mutating func discardAcknowledgedChanges(upTo revision: UInt64) {
+  mutating func discardAcknowledgedChanges(
+    upTo revision: UInt64,
+    now: Date = Date()
+  ) {
     pendingMutations = pendingMutations.filter { _, mutation in
       guard let matchedRevision = mutation.matchedRevision else { return true }
       return matchedRevision > revision
     }
+    discardExpiredUnmatched(at: now)
   }
 
   private mutating func resolveSucceededMutations(
@@ -178,9 +198,19 @@ struct DashboardReviewsGitHubMutationRefreshCoordinator {
     return .acknowledge(revision: revision)
   }
 
-  private mutating func discardExpired(at now: Date) {
+  private mutating func discardExpired(at now: Date) -> Bool {
+    let discardedMatchedMutation = pendingMutations.values.contains { mutation in
+      mutation.expiresAt <= now && mutation.matchedRevision != nil
+    }
     pendingMutations = pendingMutations.filter { _, mutation in
       mutation.expiresAt > now
+    }
+    return discardedMatchedMutation
+  }
+
+  private mutating func discardExpiredUnmatched(at now: Date) {
+    pendingMutations = pendingMutations.filter { _, mutation in
+      mutation.expiresAt > now || mutation.matchedRevision != nil
     }
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteSupport.swift
@@ -40,6 +40,17 @@ enum DashboardReviewsRemoteLoader {
 struct DashboardReviewsReloadTaskKey: Hashable {
   let preferencesSignature: String
   let isConnected: Bool
+  let githubDataRevision: UInt64
+
+  init(
+    preferencesSignature: String,
+    isConnected: Bool,
+    githubDataRevision: UInt64 = 0
+  ) {
+    self.preferencesSignature = preferencesSignature
+    self.isConnected = isConnected
+    self.githubDataRevision = githubDataRevision
+  }
 }
 
 /// Classify a `HarnessMonitorStore.ConnectionState` into a stable boolean for the
@@ -54,6 +65,20 @@ func isReviewsReloadConnected(_ state: HarnessMonitorStore.ConnectionState) -> B
   case .idle, .connecting, .offline:
     return false
   }
+}
+
+func dashboardReviewsGitHubRevisionNeedsForceRefresh(
+  loadedRevision: UInt64,
+  currentRevision: UInt64
+) -> Bool {
+  loadedRevision != currentRevision
+}
+
+func dashboardReviewsShouldAcknowledgeGitHubRevision(
+  refreshIsDurablyScheduled: Bool,
+  taskIsCancelled: Bool
+) -> Bool {
+  refreshIsDurablyScheduled && !taskIsCancelled
 }
 
 /// Decision produced by `dashboardReviewsRouteChangeDecision`. The route view

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Accessors.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Accessors.swift
@@ -28,6 +28,11 @@ extension DashboardReviewsRouteView {
     DashboardReviewsItemsVersion(revision: routeStateStorage.responseItemsRevision)
   }
 
+  var routeLoadedGitHubDataRevision: UInt64 {
+    get { routeStateStorage.loadedGitHubDataRevision }
+    nonmutating set { routeStateStorage.loadedGitHubDataRevision = newValue }
+  }
+
   var routeErrorMessage: String? {
     get { routeStateStorage.errorMessage }
     nonmutating set { routeStateStorage.errorMessage = newValue }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Actions.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Actions.swift
@@ -3,7 +3,45 @@ import HarnessMonitorKit
 import SwiftUI
 
 extension DashboardReviewsRouteView {
-  func reload(forceRefresh: Bool, backgroundRefresh: Bool = false) async {
+  func reloadForCurrentGitHubRevision() async {
+    let revision = store.contentUI.dashboard.githubDataRevision
+    routeStateStorage.githubMutationRefreshCoordinator.discardAcknowledgedChanges(
+      upTo: routeLoadedGitHubDataRevision
+    )
+    let forceRefresh = dashboardReviewsGitHubRevisionNeedsForceRefresh(
+      loadedRevision: routeLoadedGitHubDataRevision,
+      currentRevision: revision
+    )
+    if forceRefresh, let decision = currentGitHubChangeDecision() {
+      switch decision {
+      case .refreshAll:
+        break
+      case .waitForTargetedRefresh:
+        return
+      case .acknowledge(let acknowledgedRevision):
+        routeLoadedGitHubDataRevision = acknowledgedRevision
+        return
+      }
+    }
+    // Once accepted, forced scheduler work remains queued until a successful
+    // fetch, including across cancellation and scheduler restarts.
+    let refreshIsDurablyScheduled = await reload(
+      forceRefresh: forceRefresh,
+      backgroundRefresh: forceRefresh
+    )
+    if dashboardReviewsShouldAcknowledgeGitHubRevision(
+      refreshIsDurablyScheduled: refreshIsDurablyScheduled,
+      taskIsCancelled: Task.isCancelled
+    ) {
+      routeLoadedGitHubDataRevision = revision
+      routeStateStorage.githubMutationRefreshCoordinator.discardAcknowledgedChanges(
+        upTo: revision
+      )
+    }
+  }
+
+  @discardableResult
+  func reload(forceRefresh: Bool, backgroundRefresh: Bool = false) async -> Bool {
     let cacheApplied = hydrateReviewsFromCacheIfNeeded()
     guard store.apiClient != nil else {
       switch dashboardReviewsMissingClientState(
@@ -11,15 +49,15 @@ extension DashboardReviewsRouteView {
         connectionState: store.connectionState
       ) {
       case .ignore:
-        return
+        return false
       case .loading:
         routeIsLoading = true
         routeErrorMessage = nil
-        return
+        return false
       case .error(let message):
         routeIsLoading = false
         routeErrorMessage = message
-        return
+        return false
       }
     }
     if backgroundRefresh {
@@ -38,7 +76,7 @@ extension DashboardReviewsRouteView {
     if let client = store.apiClient {
       await loadReviewCapabilitiesIfNeeded(client: client)
     }
-    await startScheduler(
+    return await startScheduler(
       forceRefreshAll: dashboardReviewsShouldForceSchedulerRefresh(
         explicitForceRefresh: forceRefresh,
         cacheApplied: cacheApplied,
@@ -68,7 +106,15 @@ extension DashboardReviewsRouteView {
   func approve(items: [ReviewItem]) async {
     let actionableItems = items.filter(\.canAttemptManualApproval)
     HarnessMonitorIntentDonations.donateApprove(items: actionableItems)
-    await performMutation("Approving", items: actionableItems) { client in
+    await performMutation(
+      "Approving",
+      items: actionableItems,
+      githubAction: .approve,
+      githubRevisionCount: dashboardReviewsExpectedGitHubRevisionCount(
+        action: .approve,
+        items: actionableItems
+      )
+    ) { client in
       try await client.approveReviews(
         request: ReviewsApproveRequest(
           targets: actionableItems.map(\.target),
@@ -85,6 +131,11 @@ extension DashboardReviewsRouteView {
     await performMutation(
       "Merging",
       items: actionableItems,
+      githubAction: .merge,
+      githubRevisionCount: dashboardReviewsExpectedGitHubRevisionCount(
+        action: .merge,
+        items: actionableItems
+      ),
       onSuccess: {
         if let nextID {
           routeSelectedIDs = [nextID]
@@ -117,7 +168,15 @@ extension DashboardReviewsRouteView {
   func rerunChecks(items: [ReviewItem]) async {
     let actionableItems = items.filter(\.canAttemptRerunChecks)
     HarnessMonitorIntentDonations.donateRerunChecks(items: actionableItems)
-    await performMutation("Rerunning", items: actionableItems) { client in
+    await performMutation(
+      "Rerunning",
+      items: actionableItems,
+      githubAction: .rerunChecks,
+      githubRevisionCount: dashboardReviewsExpectedGitHubRevisionCount(
+        action: .rerunChecks,
+        items: actionableItems
+      )
+    ) { client in
       try await client.rerunReviewChecks(
         request: ReviewsRerunChecksRequest(targets: actionableItems.map(\.rerunTarget))
       )
@@ -156,7 +215,12 @@ extension DashboardReviewsRouteView {
       checkSuiteIDs: [checkSuiteID],
       viewerCanUpdate: item.viewerCanUpdate
     )
-    await performMutation("Rerunning \(check.name)", items: [item]) { client in
+    await performMutation(
+      "Rerunning \(check.name)",
+      items: [item],
+      githubAction: .rerunChecks,
+      githubRevisionCount: 1
+    ) { client in
       try await client.rerunReviewChecks(
         request: ReviewsRerunChecksRequest(targets: [target])
       )
@@ -174,6 +238,11 @@ extension DashboardReviewsRouteView {
     await performMutation(
       "Labeling",
       items: actionableItems,
+      githubAction: .addLabel,
+      githubRevisionCount: dashboardReviewsExpectedGitHubRevisionCount(
+        action: .addLabel,
+        items: actionableItems
+      ),
       onSuccess: { recordLabelUsage(label, items: actionableItems) },
       operation: { client in
         try await client.addReviewLabel(
@@ -189,7 +258,12 @@ extension DashboardReviewsRouteView {
   func reRequestReview(from reviewer: String, on item: ReviewItem) async {
     let trimmed = reviewer.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
-    await performMutation("Re-requesting review from @\(trimmed)", items: [item]) { client in
+    await performMutation(
+      "Re-requesting review from @\(trimmed)",
+      items: [item],
+      githubAction: .requestReview,
+      githubRevisionCount: 1
+    ) { client in
       try await client.reRequestReview(
         request: ReviewsRequestReviewRequest(
           targets: [item.target],
@@ -254,7 +328,12 @@ extension DashboardReviewsRouteView {
       )
       return
     }
-    await performMutation(bot.rebaseActionTitle, items: [item]) { client in
+    await performMutation(
+      bot.rebaseActionTitle,
+      items: [item],
+      githubAction: .comment,
+      githubRevisionCount: 1
+    ) { client in
       try await client.commentReviews(
         request: ReviewsCommentRequest(
           targets: [item.target],
@@ -265,7 +344,6 @@ extension DashboardReviewsRouteView {
   }
 
   func fixCI(item: ReviewItem) async {
-    guard let client = store.apiClient else { return }
     let request = TaskBoardCreateItemRequest(
       title: "Fix CI · \(item.repository)#\(item.number)",
       body: dashboardReviewFixCIBody(for: item, activity: activitySnapshot(for: item)),
@@ -283,58 +361,8 @@ extension DashboardReviewsRouteView {
         summary: "Repair review CI failures and restore mergeability"
       )
     )
-    do {
-      _ = try await DashboardReviewsTimeoutRacer.race(
-        timeoutSeconds: DashboardReviewsTimeoutRacer.defaultMutationTimeoutSeconds
-      ) {
-        try await client.createTaskBoardItem(request: request)
-      }
+    if await store.createTaskBoardItem(request: request) {
       selectedRoute = .taskBoard
-    } catch {
-      store.presentFailureFeedback(error.localizedDescription)
-    }
-  }
-
-  func performMutation(
-    _ title: String,
-    items: [ReviewItem],
-    onSuccess: @MainActor () -> Void = {},
-    operation:
-      @Sendable @escaping (any HarnessMonitorClientProtocol) async throws
-      -> ReviewsActionResponse
-  ) async {
-    guard !items.isEmpty else { return }
-    guard let client = store.apiClient else { return }
-    let trackedIDs = items.map(\.pullRequestID)
-    beginRefreshing(pullRequestIDs: trackedIDs, actionTitle: title)
-    defer {
-      endRefreshing(pullRequestIDs: trackedIDs)
-    }
-    do {
-      let response = try await DashboardReviewsTimeoutRacer.race(
-        timeoutSeconds: DashboardReviewsTimeoutRacer.defaultMutationTimeoutSeconds
-      ) {
-        try await operation(client)
-      }
-      recordReviewActionResponse(response, title: title, items: items)
-      let feedback = dashboardReviewsActionFeedback(
-        title: title,
-        items: items,
-        response: response
-      )
-      switch feedback.severity {
-      case .success:
-        store.presentSuccessFeedback(feedback.message)
-      case .failure:
-        store.presentFailureFeedback(feedback.message)
-      case .warning, .undoable, .activity:
-        store.toast.presentWarning(feedback.message)
-      }
-      onSuccess()
-      scheduleAffectedRefresh(for: items, using: client)
-    } catch {
-      recordReviewActionFailure(error, title: title, items: items)
-      store.presentFailureFeedback(dashboardReviewsErrorMessage(for: error))
     }
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+ComputedState.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+ComputedState.swift
@@ -5,7 +5,8 @@ extension DashboardReviewsRouteView {
   var reloadTaskKey: DashboardReviewsReloadTaskKey {
     DashboardReviewsReloadTaskKey(
       preferencesSignature: routeResolvedPreferences.cacheHash,
-      isConnected: isReviewsReloadConnected(store.connectionState)
+      isConnected: isReviewsReloadConnected(store.connectionState),
+      githubDataRevision: store.contentUI.dashboard.githubDataRevision
     )
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Mutations.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Mutations.swift
@@ -1,0 +1,74 @@
+import HarnessMonitorKit
+
+extension DashboardReviewsRouteView {
+  func performMutation(
+    _ title: String,
+    items: [ReviewItem],
+    githubAction: ReviewActionKind,
+    githubRevisionCount: UInt64,
+    onSuccess: @MainActor () -> Void = {},
+    operation:
+      @Sendable @escaping (any HarnessMonitorClientProtocol) async throws
+      -> ReviewsActionResponse
+  ) async {
+    guard !items.isEmpty else { return }
+    guard let client = store.apiClient else { return }
+    let githubMutationToken = beginTargetedGitHubMutation(
+      action: githubAction,
+      expectedRevisionCount: githubRevisionCount
+    )
+    let trackedIDs = items.map(\.pullRequestID)
+    beginRefreshing(pullRequestIDs: trackedIDs, actionTitle: title)
+    defer {
+      endRefreshing(pullRequestIDs: trackedIDs)
+    }
+    do {
+      let response = try await DashboardReviewsTimeoutRacer.race(
+        timeoutSeconds: DashboardReviewsTimeoutRacer.defaultMutationTimeoutSeconds
+      ) {
+        try await operation(client)
+      }
+      recordReviewActionResponse(response, title: title, items: items)
+      presentMutationFeedback(response, title: title, items: items)
+      onSuccess()
+      let confirmedGitHubMutationToken = await confirmTargetedGitHubMutation(
+        githubMutationToken,
+        appliedRevisionCount:
+          dashboardReviewsMutationFullyApplied(
+            response,
+            expectedResultCount: items.count
+          ) ? githubRevisionCount : nil,
+        using: client
+      )
+      scheduleAffectedRefresh(
+        for: items,
+        using: client,
+        githubMutationToken: confirmedGitHubMutationToken
+      )
+    } catch {
+      targetedGitHubMutationFailed(githubMutationToken)
+      recordReviewActionFailure(error, title: title, items: items)
+      store.presentFailureFeedback(dashboardReviewsErrorMessage(for: error))
+    }
+  }
+
+  private func presentMutationFeedback(
+    _ response: ReviewsActionResponse,
+    title: String,
+    items: [ReviewItem]
+  ) {
+    let feedback = dashboardReviewsActionFeedback(
+      title: title,
+      items: items,
+      response: response
+    )
+    switch feedback.severity {
+    case .success:
+      store.presentSuccessFeedback(feedback.message)
+    case .failure:
+      store.presentFailureFeedback(feedback.message)
+    case .warning, .undoable, .activity:
+      store.toast.presentWarning(feedback.message)
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Refresh.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Refresh.swift
@@ -4,7 +4,8 @@ import SwiftUI
 extension DashboardReviewsRouteView {
   func scheduleAffectedRefresh(
     for items: [ReviewItem],
-    using client: any HarnessMonitorClientProtocol
+    using client: any HarnessMonitorClientProtocol,
+    githubMutationToken: DashboardReviewsGitHubMutationRefreshCoordinator.Token? = nil
   ) {
     guard !items.isEmpty else { return }
     let targetIDs = items.map(\.pullRequestID)
@@ -27,7 +28,15 @@ extension DashboardReviewsRouteView {
             )
           }
           applyRefreshedItems(refreshed)
+          await targetedGitHubMutationRefreshFinished(
+            githubMutationToken,
+            succeeded: true
+          )
         } catch let error as DashboardReviewsSchedulerError {
+          await targetedGitHubMutationRefreshFinished(
+            githubMutationToken,
+            succeeded: false
+          )
           HarnessMonitorLogger.api.warning(
             """
             Review targeted refresh timed out: \
@@ -37,6 +46,10 @@ extension DashboardReviewsRouteView {
           )
           presentRefreshTimeoutBanner(for: items)
         } catch {
+          await targetedGitHubMutationRefreshFinished(
+            githubMutationToken,
+            succeeded: false
+          )
           HarnessMonitorLogger.api.warning(
             "Review targeted refresh failed: \(String(reflecting: error), privacy: .public)"
           )

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Scheduler.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView+Scheduler.swift
@@ -6,10 +6,11 @@ extension DashboardReviewsRouteView {
   /// per-repository scheduler. Idempotent and safe to call on every
   /// preferences-change tick; the scheduler internally cancels its prior
   /// tick task and any in-flight fetches before resuming.
-  func startScheduler(forceRefreshAll: Bool = false) async {
+  @discardableResult
+  func startScheduler(forceRefreshAll: Bool = false) async -> Bool {
     guard let client = store.apiClient else {
       routeScheduler.stop()
-      return
+      return false
     }
     let preferences = routeResolvedPreferences
     let resolver = ensureRepoResolver(client: client)
@@ -20,7 +21,7 @@ extension DashboardReviewsRouteView {
         excludeRepositories: preferences.excludeRepositories,
         expandOrganizations: preferences.preferences.expandOrganizations
       )
-      guard !Task.isCancelled else { return }
+      guard !Task.isCancelled else { return false }
       let trackedRepositories = dashboardReviewsTrackedRepositories(
         resolvedRepositories: resolvedRepositories,
         visibleRepositories: routeResponse.items.map(\.repository),
@@ -47,6 +48,7 @@ extension DashboardReviewsRouteView {
           self.applyPerRepoResponse(repository: repository, response: response)
         }
       )
+      return true
     } catch {
       HarnessMonitorLogger.api.warning(
         """
@@ -60,6 +62,7 @@ extension DashboardReviewsRouteView {
       } else {
         store.presentFailureFeedback(displayMessage)
       }
+      return false
     }
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteView.swift
@@ -128,7 +128,7 @@ struct DashboardReviewsRouteView: View {
         .accessibilityIdentifier(HarnessMonitorAccessibility.dashboardReviewsRoot)
         .environment(\.reviewsPreferences, reviewsPreferencesStore)
         .task(id: reloadTaskKey) {
-          await reload(forceRefresh: false)
+          await reloadForCurrentGitHubRevision()
         }
         .task(id: presentationTaskID) {
           await rebuildPresentation(input: listPresentationInput)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteViewState.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsRouteViewState.swift
@@ -23,6 +23,8 @@ final class DashboardReviewsRouteViewState {
     items: []
   )
   var responseItemsRevision: UInt64 = 0
+  var loadedGitHubDataRevision: UInt64 = 0
+  var githubMutationRefreshCoordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
   var isLoading = false
   var isBackgroundRefreshing = false
   var errorMessage: String?

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsScheduler.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardReviewsScheduler.swift
@@ -23,6 +23,7 @@ final class DashboardReviewsScheduler {
     var lastSyncedAt: Date?
     var lastErrorMessage: String?
     var forceRefreshRequested: Bool = false
+    fileprivate var forceRefreshGeneration: UInt64 = 0
   }
 
   /// Per-fetch upper bound. The daemon's WebSocket RPC has no resource timeout,
@@ -113,7 +114,7 @@ final class DashboardReviewsScheduler {
         states[repository]?.lastSyncedAt = hydrated
       }
       if forceRefreshAll {
-        states[repository]?.forceRefreshRequested = true
+        requestForceRefresh(repository: repository)
       }
     }
     for key in Array(states.keys) where !repositories.contains(key) {
@@ -144,7 +145,7 @@ final class DashboardReviewsScheduler {
   /// Mark every tracked repository for refresh on the next tick.
   func forceRefreshAll() {
     for key in states.keys {
-      states[key]?.forceRefreshRequested = true
+      requestForceRefresh(repository: key)
     }
   }
 
@@ -152,7 +153,7 @@ final class DashboardReviewsScheduler {
   /// repository is not tracked.
   func forceRefresh(repository: String) {
     guard let tracked = trackedRepository(matching: repository) else { return }
-    states[tracked]?.forceRefreshRequested = true
+    requestForceRefresh(repository: tracked)
   }
 
   /// Mark a repository for refresh and immediately try to dispatch it.
@@ -265,7 +266,8 @@ final class DashboardReviewsScheduler {
   private func launchFetch(for repository: String, forceRefresh: Bool) {
     guard let client, let onMerge else { return }
     repositoriesInFlight.insert(repository)
-    states[repository]?.forceRefreshRequested = false
+    let forceRefreshGeneration =
+      forceRefresh ? states[repository]?.forceRefreshGeneration : nil
     let request = preferences.perRepositoryQueryRequest(
       for: repository,
       forceRefresh: forceRefresh
@@ -283,6 +285,11 @@ final class DashboardReviewsScheduler {
           )
         }
         guard let self, self.fetchGeneration == generation else { return }
+        if let forceRefreshGeneration,
+          self.states[repository]?.forceRefreshGeneration == forceRefreshGeneration
+        {
+          self.states[repository]?.forceRefreshRequested = false
+        }
         self.states[repository]?.lastSyncedAt = Date()
         self.states[repository]?.lastErrorMessage = nil
         onMerge(repository, response)
@@ -310,6 +317,11 @@ final class DashboardReviewsScheduler {
       }
     }
     fetchTasks[repository] = task
+  }
+
+  private func requestForceRefresh(repository: String) {
+    states[repository]?.forceRefreshGeneration &+= 1
+    states[repository]?.forceRefreshRequested = true
   }
 
   private func trackedRepository(matching repository: String) -> String? {

--- a/apps/harness-monitor/Tests/HarnessMonitorAppTests/DashboardReviewsSchedulerTimeoutTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorAppTests/DashboardReviewsSchedulerTimeoutTests.swift
@@ -7,7 +7,7 @@ import Testing
 @MainActor
 @Suite("Dashboard reviews scheduler timeout + race")
 struct DashboardReviewsSchedulerTimeoutTests {
-  @Test("fetch that never returns clears in-flight after the configured timeout")
+  @Test("forced fetch timeout clears in-flight and remains eligible for retry")
   func neverReturningFetchTimesOut() async throws {
     let stub = HangingStub()
     let scheduler = DashboardReviewsScheduler()
@@ -21,6 +21,7 @@ struct DashboardReviewsSchedulerTimeoutTests {
       repositories: ["acme/api"],
       preferences: prefs,
       client: stub,
+      forceRefreshAll: true,
       onMerge: { _, _ in }
     )
 
@@ -30,6 +31,7 @@ struct DashboardReviewsSchedulerTimeoutTests {
     try await waitUntilInFlightCleared(scheduler: scheduler)
     #expect(scheduler.repositoriesInFlight.isEmpty)
     #expect(scheduler.states["acme/api"]?.lastErrorMessage != nil)
+    #expect(scheduler.states["acme/api"]?.forceRefreshRequested == true)
     scheduler.stop()
     stub.release()
   }
@@ -74,6 +76,43 @@ struct DashboardReviewsSchedulerTimeoutTests {
 
     scheduler.stop()
     stub.release()
+  }
+
+  @Test("forced refresh remains queued across cancellation and restart")
+  func forcedRefreshSurvivesCancellationAndRestart() async throws {
+    let stub = HangingStub()
+    let scheduler = DashboardReviewsScheduler()
+    scheduler.fetchTimeoutSeconds = 2
+
+    var prefs = DashboardReviewsPreferences()
+    prefs.perRepositoryIntervalSeconds = 3_600
+    prefs.maxConcurrentRepositoryFetches = 1
+
+    scheduler.start(
+      repositories: ["acme/api"],
+      preferences: prefs,
+      client: stub,
+      forceRefreshAll: true,
+      onMerge: { _, _ in }
+    )
+    try await waitUntilInFlightContains(scheduler: scheduler, repo: "acme/api")
+
+    scheduler.stop()
+    #expect(scheduler.states["acme/api"]?.forceRefreshRequested == true)
+    scheduler.start(
+      repositories: ["acme/api"],
+      preferences: prefs,
+      client: stub,
+      onMerge: { _, _ in }
+    )
+    try await waitUntilInFlightContains(scheduler: scheduler, repo: "acme/api")
+    try await Task.sleep(for: .milliseconds(20))
+    #expect(scheduler.states["acme/api"]?.forceRefreshRequested == true)
+
+    stub.release()
+    try await waitUntilInFlightCleared(scheduler: scheduler)
+    #expect(scheduler.states["acme/api"]?.forceRefreshRequested == false)
+    scheduler.stop()
   }
 
   @Test("timeout error message is human-readable")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/DashboardReviewsGitHubMutationCoherenceTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/DashboardReviewsGitHubMutationCoherenceTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import HarnessMonitorKit
+@testable import HarnessMonitorUIPreviewable
+
+@Suite("Dashboard reviews GitHub mutation coherence")
+struct DashboardReviewsGitHubMutationCoherenceTests {
+  @Test("matching change waits for the targeted refresh before acknowledgement")
+  func matchingChangeWaitsForTargetedRefresh() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let started = coordinator.begin(
+      baselineRevision: 10,
+      operations: ["reviews.approve"],
+      expectedRevisionCount: 1
+    )
+    let token = try #require(started)
+
+    #expect(
+      coordinator.changeDecision(for: change(revision: 11, operation: "reviews.approve"))
+        == .waitForTargetedRefresh
+    )
+    #expect(
+      coordinator.confirm(token, endingRevision: 11, appliedRevisionCount: 1) == .confirmed
+    )
+    #expect(
+      coordinator.targetedRefreshSucceeded(for: token) == .acknowledge(revision: 11)
+    )
+  }
+
+  @Test("targeted refresh can finish before its matching push arrives")
+  func targetedRefreshCanFinishBeforePush() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let started = coordinator.begin(
+      baselineRevision: 30,
+      operations: ["reviews.comment"],
+      expectedRevisionCount: 1
+    )
+    let token = try #require(started)
+
+    #expect(
+      coordinator.confirm(token, endingRevision: 31, appliedRevisionCount: 1) == .confirmed
+    )
+    #expect(coordinator.targetedRefreshSucceeded(for: token) == .none)
+    #expect(
+      coordinator.changeDecision(for: change(revision: 31, operation: "reviews.comment"))
+        == .acknowledge(revision: 31)
+    )
+  }
+
+  @Test("unrelated GitHub operation always requests a full refresh")
+  func unrelatedOperationRefreshesAll() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let started = coordinator.begin(
+      baselineRevision: 4,
+      operations: ["reviews.approve"],
+      expectedRevisionCount: 1
+    )
+    _ = try #require(started)
+
+    #expect(
+      coordinator.changeDecision(
+        for: change(revision: 5, operation: "task_board.github.issue_update")
+      ) == .refreshAll
+    )
+  }
+
+  @Test("same-operation concurrent write falls back to a full refresh")
+  func concurrentSameOperationRefreshesAll() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let started = coordinator.begin(
+      baselineRevision: 40,
+      operations: ["reviews.approve"],
+      expectedRevisionCount: 1
+    )
+    let token = try #require(started)
+
+    #expect(
+      coordinator.changeDecision(for: change(revision: 41, operation: "reviews.approve"))
+        == .waitForTargetedRefresh
+    )
+    #expect(
+      coordinator.confirm(token, endingRevision: 42, appliedRevisionCount: 1) == .refreshAll
+    )
+  }
+
+  @Test("multi-item mutation waits for its final revision")
+  func multiItemMutationWaitsForFinalRevision() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let started = coordinator.begin(
+      baselineRevision: 70,
+      operations: ["task_board.github.replace_labels"],
+      expectedRevisionCount: 3
+    )
+    let token = try #require(started)
+
+    #expect(
+      coordinator.changeDecision(
+        for: change(revision: 71, operation: "task_board.github.replace_labels")
+      ) == .waitForTargetedRefresh
+    )
+    #expect(
+      coordinator.changeDecision(
+        for: change(revision: 72, operation: "task_board.github.replace_labels")
+      ) == .waitForTargetedRefresh
+    )
+    #expect(
+      coordinator.confirm(token, endingRevision: 73, appliedRevisionCount: 3) == .confirmed
+    )
+    #expect(coordinator.targetedRefreshSucceeded(for: token) == .none)
+    #expect(
+      coordinator.changeDecision(
+        for: change(revision: 73, operation: "task_board.github.replace_labels")
+      ) == .acknowledge(revision: 73)
+    )
+  }
+
+  @Test("partial mutation result cannot suppress the global refresh")
+  func partialMutationIsNotConfirmed() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let started = coordinator.begin(
+      baselineRevision: 90,
+      operations: ["reviews.rerequest_checks"],
+      expectedRevisionCount: 2
+    )
+    let token = try #require(started)
+
+    #expect(
+      coordinator.confirm(token, endingRevision: 92, appliedRevisionCount: 1) == .discarded
+    )
+    #expect(
+      coordinator.changeDecision(
+        for: change(revision: 92, operation: "reviews.rerequest_checks")
+      ) == .refreshAll
+    )
+  }
+
+  private func change(revision: UInt64, operation: String) -> GitHubDataChangedPayload {
+    GitHubDataChangedPayload(revision: revision, operation: operation)
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/DashboardReviewsGitHubMutationCoherenceTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/DashboardReviewsGitHubMutationCoherenceTests.swift
@@ -135,6 +135,180 @@ struct DashboardReviewsGitHubMutationCoherenceTests {
     )
   }
 
+  @Test("beginning a mutation prunes expired unmatched mutations")
+  func beginningMutationPrunesExpiredUnmatchedMutations() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+    let expiredMutation = coordinator.begin(
+      baselineRevision: 10,
+      operations: ["reviews.approve"],
+      expectedRevisionCount: 1,
+      now: startedAt
+    )
+    let expiredToken = try #require(expiredMutation)
+
+    _ = coordinator.begin(
+      baselineRevision: 20,
+      operations: ["reviews.comment"],
+      expectedRevisionCount: 1,
+      now: startedAt.addingTimeInterval(181)
+    )
+
+    #expect(
+      coordinator.confirm(
+        expiredToken,
+        endingRevision: 11,
+        appliedRevisionCount: 1,
+        now: startedAt
+      ) == .discarded
+    )
+  }
+
+  @Test("confirmation discards an expired mutation")
+  func confirmationDiscardsExpiredMutation() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let startedAt = Date(timeIntervalSinceReferenceDate: 2_000)
+    let started = coordinator.begin(
+      baselineRevision: 30,
+      operations: ["reviews.approve"],
+      expectedRevisionCount: 1,
+      now: startedAt
+    )
+    let token = try #require(started)
+
+    #expect(
+      coordinator.confirm(
+        token,
+        endingRevision: 31,
+        appliedRevisionCount: 1,
+        now: startedAt.addingTimeInterval(181)
+      ) == .discarded
+    )
+  }
+
+  @Test("targeted refresh completions ignore expired mutations")
+  func targetedRefreshCompletionsIgnoreExpiredMutations() throws {
+    var succeededCoordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    var failedCoordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let startedAt = Date(timeIntervalSinceReferenceDate: 3_000)
+    let succeeded = succeededCoordinator.begin(
+      baselineRevision: 40,
+      operations: ["reviews.approve"],
+      expectedRevisionCount: 1,
+      now: startedAt
+    )
+    let succeededToken = try #require(succeeded)
+    let failed = failedCoordinator.begin(
+      baselineRevision: 50,
+      operations: ["reviews.comment"],
+      expectedRevisionCount: 1,
+      now: startedAt
+    )
+    let failedToken = try #require(failed)
+    let expiredAt = startedAt.addingTimeInterval(181)
+
+    #expect(
+      succeededCoordinator.targetedRefreshSucceeded(for: succeededToken, now: expiredAt) == .none
+    )
+    #expect(
+      succeededCoordinator.confirm(
+        succeededToken,
+        endingRevision: 41,
+        appliedRevisionCount: 1,
+        now: startedAt
+      ) == .discarded
+    )
+    #expect(failedCoordinator.targetedRefreshFailed(for: failedToken, now: expiredAt) == .none)
+  }
+
+  @Test("expired matched confirmation requests a full refresh")
+  func expiredMatchedConfirmationRefreshesAll() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let startedAt = Date(timeIntervalSinceReferenceDate: 4_000)
+    let started = coordinator.begin(
+      baselineRevision: 60,
+      operations: ["reviews.approve"],
+      expectedRevisionCount: 1,
+      now: startedAt
+    )
+    let token = try #require(started)
+    #expect(
+      coordinator.changeDecision(
+        for: change(revision: 61, operation: "reviews.approve"),
+        now: startedAt.addingTimeInterval(1)
+      ) == .waitForTargetedRefresh
+    )
+
+    #expect(
+      coordinator.confirm(
+        token,
+        endingRevision: 61,
+        appliedRevisionCount: 1,
+        now: startedAt.addingTimeInterval(181)
+      ) == .refreshAll
+    )
+  }
+
+  @Test("expired matched targeted refresh success requests a full refresh")
+  func expiredMatchedTargetedRefreshSuccessRefreshesAll() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let startedAt = Date(timeIntervalSinceReferenceDate: 5_000)
+    let started = coordinator.begin(
+      baselineRevision: 70,
+      operations: ["reviews.approve"],
+      expectedRevisionCount: 1,
+      now: startedAt
+    )
+    let token = try #require(started)
+    #expect(
+      coordinator.changeDecision(
+        for: change(revision: 71, operation: "reviews.approve"),
+        now: startedAt.addingTimeInterval(1)
+      ) == .waitForTargetedRefresh
+    )
+    #expect(
+      coordinator.confirm(
+        token,
+        endingRevision: 71,
+        appliedRevisionCount: 1,
+        now: startedAt.addingTimeInterval(2)
+      ) == .confirmed
+    )
+
+    #expect(
+      coordinator.targetedRefreshSucceeded(
+        for: token,
+        now: startedAt.addingTimeInterval(181)
+      ) == .refreshAll
+    )
+  }
+
+  @Test("expired matched targeted refresh failure requests a full refresh")
+  func expiredMatchedTargetedRefreshFailureRefreshesAll() throws {
+    var coordinator = DashboardReviewsGitHubMutationRefreshCoordinator()
+    let startedAt = Date(timeIntervalSinceReferenceDate: 6_000)
+    let started = coordinator.begin(
+      baselineRevision: 80,
+      operations: ["reviews.comment"],
+      expectedRevisionCount: 1,
+      now: startedAt
+    )
+    let token = try #require(started)
+    #expect(
+      coordinator.changeDecision(
+        for: change(revision: 81, operation: "reviews.comment"),
+        now: startedAt.addingTimeInterval(1)
+      ) == .waitForTargetedRefresh
+    )
+
+    #expect(
+      coordinator.targetedRefreshFailed(
+        for: token,
+        now: startedAt.addingTimeInterval(181)
+      ) == .refreshAll
+    )
+  }
+
   private func change(revision: UInt64, operation: String) -> GitHubDataChangedPayload {
     GitHubDataChangedPayload(revision: revision, operation: operation)
   }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/DashboardReviewsReloadStabilityTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/DashboardReviewsReloadStabilityTests.swift
@@ -100,4 +100,58 @@ struct DashboardReviewsReloadStabilityTests {
     )
     #expect(oldKey != newKey)
   }
+
+  @Test("GitHub data revision drives a reload")
+  func githubDataRevisionDrivesAReload() {
+    let oldKey = DashboardReviewsReloadTaskKey(
+      preferencesSignature: "preferences=stable",
+      isConnected: true,
+      githubDataRevision: 4
+    )
+    let newKey = DashboardReviewsReloadTaskKey(
+      preferencesSignature: "preferences=stable",
+      isConnected: true,
+      githubDataRevision: 5
+    )
+
+    #expect(oldKey != newKey)
+  }
+
+  @Test("GitHub data revision forces a fresh query only when it changes")
+  func githubDataRevisionForcesFreshQueryOnChange() {
+    #expect(
+      dashboardReviewsGitHubRevisionNeedsForceRefresh(
+        loadedRevision: 8,
+        currentRevision: 9
+      )
+    )
+    #expect(
+      !dashboardReviewsGitHubRevisionNeedsForceRefresh(
+        loadedRevision: 9,
+        currentRevision: 9
+      )
+    )
+  }
+
+  @Test("GitHub revision is acknowledged only after refresh starts")
+  func githubRevisionAcknowledgementRequiresStartedRefresh() {
+    #expect(
+      dashboardReviewsShouldAcknowledgeGitHubRevision(
+        refreshIsDurablyScheduled: true,
+        taskIsCancelled: false
+      )
+    )
+    #expect(
+      !dashboardReviewsShouldAcknowledgeGitHubRevision(
+        refreshIsDurablyScheduled: false,
+        taskIsCancelled: false
+      )
+    )
+    #expect(
+      !dashboardReviewsShouldAcknowledgeGitHubRevision(
+        refreshIsDurablyScheduled: true,
+        taskIsCancelled: true
+      )
+    )
+  }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreUpdateStreamTests+GitHub.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreUpdateStreamTests+GitHub.swift
@@ -1,0 +1,33 @@
+import Testing
+
+@testable import HarnessMonitorKit
+
+extension HarnessMonitorStoreUpdateStreamTests {
+  @Test("Same-revision GitHub pushes replace the latest operation")
+  func sameRevisionGitHubPushReplacesLatestOperation() {
+    let store = HarnessMonitorStore(daemonController: RecordingDaemonController())
+
+    store.applyGlobalNonSessionPushEvent(
+      githubDataChange(revision: 7, operation: "reviews.pull_requests.resolve")
+    )
+    store.applyGlobalNonSessionPushEvent(
+      githubDataChange(revision: 7, operation: "task_board.github.local_sync_ready")
+    )
+
+    #expect(store.contentUI.dashboard.githubDataRevision == 7)
+    #expect(
+      store.contentUI.dashboard.latestGitHubDataChange?.operation
+        == "task_board.github.local_sync_ready"
+    )
+  }
+
+  private func githubDataChange(revision: UInt64, operation: String) -> DaemonPushEvent {
+    DaemonPushEvent(
+      recordedAt: "2026-07-11T14:00:00Z",
+      sessionId: nil,
+      kind: .githubDataChanged(
+        GitHubDataChangedPayload(revision: revision, operation: operation)
+      )
+    )
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SummariesWireTypesDecodingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SummariesWireTypesDecodingTests.swift
@@ -55,7 +55,8 @@ struct SummariesWireTypesDecodingTests {
   @Test("github diagnostics decode their nested buckets and snake_case keys")
   func decodesGitHubDiagnostics() throws {
     let json = #"""
-      {"buckets":[{"resource":"core","remaining":4900,"limit":5000,"used":100,
+      {"data_revision":17,
+      "buckets":[{"resource":"core","remaining":4900,"limit":5000,"used":100,
       "reset_at":"2026-06-17T01:00:00Z"}],
       "cooling":[{"resource":"graphql","reason":"secondary_rate_limit","until_seconds_from_now":42}],
       "last_hour_network_requests":1200,"last_hour_graphql_points":850,"cache_hits":300,
@@ -64,6 +65,7 @@ struct SummariesWireTypesDecodingTests {
       """#
     let diagnostics = try decoder.decode(GitHubApiDiagnosticsWire.self, from: Data(json.utf8))
 
+    #expect(diagnostics.dataRevision == 17)
     #expect(diagnostics.lastHourNetworkRequests == 1200)
     #expect(diagnostics.lastHourGraphqlPoints == 850)
     #expect(diagnostics.cacheStaleHits == 12)

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/WebSocketProtocolTests+Push.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/WebSocketProtocolTests+Push.swift
@@ -133,4 +133,31 @@ extension WebSocketProtocolTests {
     #expect(auditEvent.source == "github")
     #expect(auditEvent.actionKey == "reviews.merge")
   }
+
+  @Test("Daemon push event decodes GitHub data changes")
+  func daemonPushEventDecodesGitHubDataChange() throws {
+    let json = #"""
+      {
+        "event": "github_data_changed",
+        "recorded_at": "2026-07-11T10:00:00Z",
+        "session_id": null,
+        "payload": {
+          "revision": 12,
+          "operation": "task_board.github.update_issue"
+        }
+      }
+      """#
+
+    let streamEvent = try decoder.decode(StreamEvent.self, from: Data(json.utf8))
+    let event = try DaemonPushEvent(streamEvent: streamEvent)
+
+    guard case .githubDataChanged(let payload) = event.kind else {
+      Issue.record("Expected githubDataChanged push, got \(event.kind)")
+      return
+    }
+
+    #expect(event.sessionId == nil)
+    #expect(payload.revision == 12)
+    #expect(payload.operation == "task_board.github.update_issue")
+  }
 }

--- a/src/daemon/protocol/summaries.rs
+++ b/src/daemon/protocol/summaries.rs
@@ -128,6 +128,8 @@ pub struct DaemonDiagnosticsReport {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitHubApiDiagnostics {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_revision: Option<u64>,
     pub buckets: Vec<GitHubRateBucketDiagnostics>,
     pub cooling: Vec<GitHubCooldownDiagnostics>,
     pub last_hour_network_requests: u64,
@@ -165,6 +167,7 @@ pub struct GitHubOperationSpendDiagnostics {
 impl From<GitHubApiStatus> for GitHubApiDiagnostics {
     fn from(status: GitHubApiStatus) -> Self {
         Self {
+            data_revision: Some(status.data_revision),
             buckets: status
                 .buckets
                 .into_iter()

--- a/src/daemon/service/mod.rs
+++ b/src/daemon/service/mod.rs
@@ -324,7 +324,9 @@ pub use reviews_files::{
 pub use reviews_thread_resolve::set_review_thread_resolved;
 pub use reviews_timeline::{clear_reviews_caches_with_timeline, fetch_review_timeline};
 pub use serve::serve;
-pub(crate) use serve::{ShutdownSignalGuard, serve_remote_https};
+pub(crate) use serve::{
+    ShutdownSignalGuard, broadcast_github_data_change, serve_remote_https,
+};
 pub use sessions::{
     list_projects, list_sessions, session_detail, session_detail_core, session_extensions,
     session_timeline,

--- a/src/daemon/service/mod.rs
+++ b/src/daemon/service/mod.rs
@@ -324,9 +324,7 @@ pub use reviews_files::{
 pub use reviews_thread_resolve::set_review_thread_resolved;
 pub use reviews_timeline::{clear_reviews_caches_with_timeline, fetch_review_timeline};
 pub use serve::serve;
-pub(crate) use serve::{
-    ShutdownSignalGuard, broadcast_github_data_change, serve_remote_https,
-};
+pub(crate) use serve::{ShutdownSignalGuard, broadcast_github_data_change, serve_remote_https};
 pub use sessions::{
     list_projects, list_sessions, session_detail, session_detail_core, session_extensions,
     session_timeline,

--- a/src/daemon/service/reviews.rs
+++ b/src/daemon/service/reviews.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use crate::errors::CliError;
-use crate::github_api::GitHubProtectedClient;
+use crate::github_api::retry_stable_read;
 use crate::reviews::timeline;
 use crate::reviews::{
     ReviewActionPreviewKind, ReviewItem, ReviewRepositoryLabel, ReviewsActionPreviewRequest,
@@ -68,7 +68,8 @@ use token::{github_token, missing_token_error, token_bound_requests, token_bound
 ///
 /// # Errors
 /// Returns `CliError` when the request is invalid, a required token is missing,
-/// or GitHub cannot return the requested update data.
+/// GitHub cannot return the requested update data, or concurrent writes prevent
+/// a stable fetch-and-projection attempt.
 pub async fn query_reviews(
     request: &ReviewsQueryRequest,
 ) -> Result<ReviewsQueryResponse, CliError> {
@@ -79,22 +80,22 @@ pub async fn query_reviews(
     {
         return Ok(response);
     }
-    let (response, github_data_revision) = loop {
-        let (fetched, revision) = fetch_reviews_stably(request).await?;
-        let (response, authoritative_viewer_keys) = response_from_fetch(fetched);
-        if github_projection::reconcile_task_board(
-            &response.items,
-            &authoritative_viewer_keys,
-            github_projection::MissingReviewResolution::ExactActiveImports,
-            request.backport_detection_enabled,
-            &request.backport_patterns,
-            revision,
-        )
-        .await
-        {
-            break (response, revision);
-        }
-    };
+    let (response, github_data_revision) =
+        retry_stable_read("reviews.query", |revision| async move {
+            let fetched = fetch_reviews_across_segments(request).await?;
+            let (response, authoritative_viewer_keys) = response_from_fetch(fetched);
+            let _ = github_projection::reconcile_task_board(
+                &response.items,
+                &authoritative_viewer_keys,
+                github_projection::MissingReviewResolution::ExactActiveImports,
+                request.backport_detection_enabled,
+                &request.backport_patterns,
+                revision,
+            )
+            .await;
+            Ok::<_, CliError>(response)
+        })
+        .await?;
     store_cached_query_response_at_revision(cache_key, &response, github_data_revision);
     policy_event_inbox::resume_waiting_reviews_policy_runs(&response.items).await;
     policy::start_background_reviews_policy_runs(&response.items).await;
@@ -130,18 +131,6 @@ struct ReviewsFetchAccumulator {
     repository_labels: BTreeMap<String, Vec<ReviewRepositoryLabel>>,
     viewer_login: Option<String>,
     authoritative_viewer_keys: HashSet<String>,
-}
-
-async fn fetch_reviews_stably(
-    request: &ReviewsQueryRequest,
-) -> Result<(ReviewsFetchAccumulator, u64), CliError> {
-    loop {
-        let revision = GitHubProtectedClient::data_revision();
-        let fetched = fetch_reviews_across_segments(request).await?;
-        if GitHubProtectedClient::data_revision() == revision {
-            return Ok((fetched, revision));
-        }
-    }
 }
 
 /// Fetch updates for each token segment, deduplicating items by repository and

--- a/src/daemon/service/reviews.rs
+++ b/src/daemon/service/reviews.rs
@@ -1,6 +1,7 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::errors::CliError;
+use crate::github_api::GitHubProtectedClient;
 use crate::reviews::timeline;
 use crate::reviews::{
     ReviewActionPreviewKind, ReviewItem, ReviewRepositoryLabel, ReviewsActionPreviewRequest,
@@ -9,8 +10,8 @@ use crate::reviews::{
     ReviewsFileCommentRequest, ReviewsFileCommentResponse, ReviewsGitHubClient,
     ReviewsLabelRequest, ReviewsMergeRequest, ReviewsPolicyPreviewRequest,
     ReviewsPolicyRunStartRequest, ReviewsPolicyTrigger, ReviewsQueryRequest, ReviewsQueryResponse,
-    ReviewsRefreshRequest, ReviewsRefreshResponse, ReviewsRepositoryCatalogRequest,
-    ReviewsRepositoryCatalogResponse, ReviewsRequestReviewRequest, ReviewsRerunChecksRequest,
+    ReviewsRepositoryCatalogRequest, ReviewsRepositoryCatalogResponse, ReviewsRequestReviewRequest,
+    ReviewsRerunChecksRequest,
 };
 use crate::workspace::utc_now;
 
@@ -24,6 +25,7 @@ mod cache_internal;
 
 mod auto_policy;
 mod body;
+mod github_projection;
 pub(crate) mod policy;
 mod policy_audit;
 mod policy_enrichment;
@@ -33,6 +35,7 @@ pub(crate) mod policy_history;
 pub(crate) mod policy_mapping;
 pub(crate) mod policy_resume;
 mod preview;
+mod refresh;
 mod resolve;
 mod token;
 
@@ -46,16 +49,18 @@ pub use body::{fetch_review_body, update_review_body};
 #[cfg(test)]
 pub(super) use cache_internal::apply_refresh_to_items;
 use cache_internal::{
-    body_cache, cache, cached_query_response, patch_cached_items, patch_cached_repository_labels,
-    store_cached_query_response,
+    body_cache, cache, cached_query_response, store_cached_query_response_at_revision,
 };
 #[cfg(test)]
-use cache_internal::{cached_body_response, store_cached_body_response};
+use cache_internal::{
+    cached_body_response, store_cached_body_response, store_cached_query_response,
+};
 pub(crate) use policy::start_reviews_policy_run_with_audit_db;
 pub use policy::{preview_reviews_policy, reviews_policy_status, start_reviews_policy_run};
 use policy_enrichment::enrich_policy_target_for_execution;
 pub use policy_history::reviews_policy_history;
 use preview::{preview_action_target, preview_action_warnings};
+pub use refresh::refresh_reviews;
 pub use resolve::resolve_review_pull_requests;
 use token::{github_token, missing_token_error, token_bound_requests, token_bound_targets};
 
@@ -74,13 +79,38 @@ pub async fn query_reviews(
     {
         return Ok(response);
     }
+    let (response, github_data_revision) = loop {
+        let (fetched, revision) = fetch_reviews_stably(request).await?;
+        let (response, authoritative_viewer_keys) = response_from_fetch(fetched);
+        if github_projection::reconcile_task_board(
+            &response.items,
+            &authoritative_viewer_keys,
+            github_projection::MissingReviewResolution::ExactActiveImports,
+            request.backport_detection_enabled,
+            &request.backport_patterns,
+            revision,
+        )
+        .await
+        {
+            break (response, revision);
+        }
+    };
+    store_cached_query_response_at_revision(cache_key, &response, github_data_revision);
+    policy_event_inbox::resume_waiting_reviews_policy_runs(&response.items).await;
+    policy::start_background_reviews_policy_runs(&response.items).await;
+    Ok(response)
+}
 
-    let fetched = fetch_reviews_across_segments(request).await?;
-
-    let mut items = fetched
-        .items_by_key
-        .into_values()
-        .collect::<Vec<ReviewItem>>();
+fn response_from_fetch(
+    fetched: ReviewsFetchAccumulator,
+) -> (ReviewsQueryResponse, HashSet<String>) {
+    let ReviewsFetchAccumulator {
+        items_by_key,
+        repository_labels,
+        viewer_login,
+        authoritative_viewer_keys,
+    } = fetched;
+    let mut items = items_by_key.into_values().collect::<Vec<ReviewItem>>();
     items.sort_by(|left, right| {
         right
             .updated_at
@@ -89,12 +119,9 @@ pub async fn query_reviews(
             .then_with(|| left.number.cmp(&right.number))
     });
     let mut response = ReviewsQueryResponse::new(items, utc_now());
-    response.set_repository_labels(fetched.repository_labels);
-    response.set_viewer_login(fetched.viewer_login);
-    store_cached_query_response(cache_key, &response);
-    policy_event_inbox::resume_waiting_reviews_policy_runs(&response.items).await;
-    policy::start_background_reviews_policy_runs(&response.items).await;
-    Ok(response)
+    response.set_repository_labels(repository_labels);
+    response.set_viewer_login(viewer_login);
+    (response, authoritative_viewer_keys)
 }
 
 /// Accumulated fetch results across every token segment of a reviews query.
@@ -102,10 +129,23 @@ struct ReviewsFetchAccumulator {
     items_by_key: BTreeMap<String, ReviewItem>,
     repository_labels: BTreeMap<String, Vec<ReviewRepositoryLabel>>,
     viewer_login: Option<String>,
+    authoritative_viewer_keys: HashSet<String>,
+}
+
+async fn fetch_reviews_stably(
+    request: &ReviewsQueryRequest,
+) -> Result<(ReviewsFetchAccumulator, u64), CliError> {
+    loop {
+        let revision = GitHubProtectedClient::data_revision();
+        let fetched = fetch_reviews_across_segments(request).await?;
+        if GitHubProtectedClient::data_revision() == revision {
+            return Ok((fetched, revision));
+        }
+    }
 }
 
 /// Fetch updates for each token segment, deduplicating items by repository and
-/// number and resolving the viewer login once across segments.
+/// number and resolving the viewer independently for each token.
 async fn fetch_reviews_across_segments(
     request: &ReviewsQueryRequest,
 ) -> Result<ReviewsFetchAccumulator, CliError> {
@@ -113,22 +153,24 @@ async fn fetch_reviews_across_segments(
     let mut items_by_key = BTreeMap::new();
     let mut repository_labels: BTreeMap<String, Vec<ReviewRepositoryLabel>> = BTreeMap::new();
     let mut viewer_login: Option<String> = None;
+    let mut authoritative_viewer_keys = HashSet::new();
     for segment in segments {
         let client = ReviewsGitHubClient::new(&segment.token)?;
+        let segment_viewer_login = client.fetch_viewer_login().await;
         if viewer_login.is_none() {
-            // Resolve the viewer once across token segments. Same-token
-            // segments share a login; cross-token splits are rare and
-            // the first resolved login matches the token whose PRs
-            // dominate the response in practice.
-            viewer_login = client.fetch_viewer_login().await;
+            viewer_login.clone_from(&segment_viewer_login);
         }
         let fetch = client
-            .fetch_updates(&segment.request, viewer_login.as_deref())
+            .fetch_updates(&segment.request, segment_viewer_login.as_deref())
             .await?;
         for item in fetch.items {
-            items_by_key
-                .entry(format!("{}#{}", item.repository, item.number))
-                .or_insert(item);
+            let key = review_item_key(&item);
+            if segment_viewer_login.is_some() {
+                authoritative_viewer_keys.insert(key.clone());
+                items_by_key.insert(key, item);
+            } else {
+                items_by_key.entry(key).or_insert(item);
+            }
         }
         merge_segment_repository_labels(&mut repository_labels, fetch.repository_labels);
     }
@@ -136,7 +178,12 @@ async fn fetch_reviews_across_segments(
         items_by_key,
         repository_labels,
         viewer_login,
+        authoritative_viewer_keys,
     })
+}
+
+fn review_item_key(item: &ReviewItem) -> String {
+    format!("{}#{}", item.repository.to_ascii_lowercase(), item.number)
 }
 
 fn merge_segment_repository_labels(
@@ -429,45 +476,6 @@ pub async fn auto_reviews(request: &ReviewsAutoRequest) -> Result<ReviewsActionR
     }
 
     Ok(action_response("Auto mode finished", results))
-}
-
-/// Re-fetch a focused list of dependency update pull requests by GraphQL ID,
-/// patching matching cache entries in place and returning the refreshed items.
-///
-/// # Errors
-/// Returns `CliError` when the request is invalid, a required token is missing,
-/// or GitHub cannot return the requested pull requests.
-pub async fn refresh_reviews(
-    request: &ReviewsRefreshRequest,
-) -> Result<ReviewsRefreshResponse, CliError> {
-    request.validate()?;
-    let mut items = Vec::new();
-    let mut missing = Vec::new();
-    for segment in token_bound_targets(&request.targets)? {
-        let ids: Vec<String> = segment
-            .targets
-            .iter()
-            .map(|target| target.pull_request_id.clone())
-            .collect();
-        let client = ReviewsGitHubClient::new(&segment.token)?;
-        let viewer_login = client.fetch_viewer_login().await;
-        let fetch = client
-            .fetch_by_ids(&ids, request, viewer_login.as_deref())
-            .await?;
-        items.extend(fetch.items);
-        missing.extend(fetch.missing);
-        if !fetch.repository_labels.is_empty() {
-            patch_cached_repository_labels(&fetch.repository_labels);
-        }
-    }
-    patch_cached_items(&items, &missing);
-    policy_event_inbox::resume_waiting_reviews_policy_runs(&items).await;
-    policy::start_background_reviews_policy_runs(&items).await;
-    Ok(ReviewsRefreshResponse {
-        fetched_at: utc_now(),
-        items,
-        missing_pull_request_ids: missing,
-    })
 }
 
 /// Clear the in-memory dependency updates query cache (list + body).

--- a/src/daemon/service/reviews/body.rs
+++ b/src/daemon/service/reviews/body.rs
@@ -1,4 +1,5 @@
 use crate::errors::CliError;
+use crate::github_api::GitHubProtectedClient;
 use crate::reviews::{
     ReviewsBodyRequest, ReviewsBodyResponse, ReviewsBodyUpdateOutcome, ReviewsBodyUpdateRequest,
     ReviewsBodyUpdateResponse, ReviewsGitHubClient,
@@ -8,7 +9,9 @@ use crate::workspace::utc_now;
 use super::super::reviews_github_policy::{
     ReviewsGitHubMutation, enforce_review_pull_request_policy,
 };
-use super::cache_internal::{cached_body_response, store_cached_body_response};
+use super::cache_internal::{
+    cached_body_response, store_cached_body_response, store_cached_body_response_at_revision,
+};
 use super::token::{github_token, missing_token_error};
 
 /// Fetch the description body for a single dependency update pull request.
@@ -29,6 +32,7 @@ pub async fn fetch_review_body(
     {
         return Ok(response);
     }
+    let github_data_revision = GitHubProtectedClient::data_revision();
 
     let token = github_token(None).ok_or_else(|| missing_token_error(None))?;
     let client = ReviewsGitHubClient::new(&token)?;
@@ -40,7 +44,7 @@ pub async fn fetch_review_body(
         fetched_at: utc_now(),
         from_cache: false,
     };
-    store_cached_body_response(cache_key, &response);
+    store_cached_body_response_at_revision(cache_key, &response, github_data_revision);
     Ok(response)
 }
 

--- a/src/daemon/service/reviews/github_projection.rs
+++ b/src/daemon/service/reviews/github_projection.rs
@@ -1,0 +1,218 @@
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock, PoisonError};
+
+use chrono::SecondsFormat;
+use tokio::task::spawn_blocking;
+
+use crate::daemon::service::{broadcast_github_data_change, observe_sender};
+use crate::errors::{CliError, CliErrorKind};
+use crate::github_api::stable_data_revision_guard;
+use crate::github_api::{GitHubDataChange, GitHubProtectedClient, GitHubPullRequestSnapshot};
+use crate::reviews::{
+    ReviewItem, ReviewPullRequestState, ReviewsPullRequestReference,
+    ReviewsPullRequestResolveRequest,
+};
+use crate::task_board::{
+    TaskBoardStore, default_board_root, imported_review_pull_request_references,
+    reconcile_pull_request_snapshots,
+};
+
+static PROJECTION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+pub(super) enum MissingReviewResolution {
+    ExactActiveImports,
+    ProvidedSnapshotsOnly,
+}
+
+impl MissingReviewResolution {
+    const fn resolves_active_imports(&self) -> bool {
+        matches!(self, Self::ExactActiveImports)
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "the projection boundary handles the changed, unchanged, and failed persistence outcomes"
+)]
+pub(super) async fn reconcile_task_board(
+    items: &[ReviewItem],
+    authoritative_viewer_keys: &HashSet<String>,
+    missing_review_resolution: MissingReviewResolution,
+    backport_detection_enabled: bool,
+    backport_patterns: &[String],
+    expected_revision: u64,
+) -> bool {
+    let Some(sender) = observe_sender() else {
+        return true;
+    };
+    let mut snapshots = items
+        .iter()
+        .map(|item| snapshot_from_review(item, authoritative_viewer_keys))
+        .collect::<Vec<_>>();
+    if missing_review_resolution.resolves_active_imports() {
+        match resolve_missing_review_snapshots(
+            &snapshots,
+            backport_detection_enabled,
+            backport_patterns,
+        )
+        .await
+        {
+            Ok(resolved) => snapshots.extend(resolved),
+            Err(error) => {
+                tracing::warn!(%error, "resolve missing task-board review pull requests");
+            }
+        }
+    }
+    let result = reconcile_snapshots(snapshots, expected_revision).await;
+    let changed = match result {
+        Ok(Some(changed)) => changed,
+        Ok(None) => return false,
+        Err(error) => {
+            tracing::warn!(%error, "reconcile reviews into task board");
+            return true;
+        }
+    };
+    let revision_stable = GitHubProtectedClient::data_revision() == expected_revision;
+    if changed && revision_stable {
+        broadcast_github_data_change(
+            &sender,
+            &GitHubDataChange {
+                revision: GitHubProtectedClient::data_revision(),
+                operation: "reviews.shared_pull_request_projection".to_string(),
+            },
+        );
+    }
+    revision_stable
+}
+
+async fn resolve_missing_review_snapshots(
+    snapshots: &[GitHubPullRequestSnapshot],
+    backport_detection_enabled: bool,
+    backport_patterns: &[String],
+) -> Result<Vec<GitHubPullRequestSnapshot>, CliError> {
+    let imported = load_imported_review_references().await?;
+    let references = references_missing_from_snapshots(imported, snapshots);
+    if references.is_empty() {
+        return Ok(Vec::new());
+    }
+    let request = ReviewsPullRequestResolveRequest {
+        references,
+        backport_detection_enabled,
+        backport_patterns: backport_patterns.to_vec(),
+    };
+    let resolved = super::resolve::fetch_pull_requests_by_reference(&request).await?;
+    Ok(resolved
+        .items
+        .iter()
+        .map(|item| snapshot_from_review(item, &resolved.authoritative_viewer_keys))
+        .collect())
+}
+
+async fn load_imported_review_references() -> Result<Vec<(String, u64)>, CliError> {
+    spawn_blocking(|| {
+        imported_review_pull_request_references(&TaskBoardStore::new(default_board_root()))
+    })
+    .await
+    .map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "join task-board review reference discovery: {error}"
+        )))
+    })?
+}
+
+fn references_missing_from_snapshots(
+    imported: Vec<(String, u64)>,
+    snapshots: &[GitHubPullRequestSnapshot],
+) -> Vec<ReviewsPullRequestReference> {
+    let covered = snapshots
+        .iter()
+        .map(|snapshot| snapshot_key(&snapshot.repository, snapshot.number))
+        .collect::<HashSet<_>>();
+    imported
+        .into_iter()
+        .filter(|(repository, number)| !covered.contains(&snapshot_key(repository, *number)))
+        .map(|(repository, number)| ReviewsPullRequestReference { repository, number })
+        .collect()
+}
+
+fn snapshot_key(repository: &str, number: u64) -> String {
+    format!("{}#{number}", repository.trim().to_ascii_lowercase())
+}
+
+async fn reconcile_snapshots(
+    snapshots: Vec<GitHubPullRequestSnapshot>,
+    expected_revision: u64,
+) -> Result<Option<bool>, CliError> {
+    let Some(_revision_guard) = stable_data_revision_guard(expected_revision).await else {
+        return Ok(None);
+    };
+    spawn_blocking(move || {
+        let _guard = PROJECTION_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let board = TaskBoardStore::new(default_board_root());
+        reconcile_pull_request_snapshots(&board, &snapshots).map(Some)
+    })
+    .await
+    .map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "join reviews task-board reconciliation: {error}"
+        )))
+    })?
+}
+
+fn snapshot_from_review(
+    item: &ReviewItem,
+    authoritative_viewer_keys: &HashSet<String>,
+) -> GitHubPullRequestSnapshot {
+    let key = format!("{}#{}", item.repository.to_ascii_lowercase(), item.number);
+    GitHubPullRequestSnapshot {
+        repository: item.repository.clone(),
+        number: item.number,
+        is_open: match item.state {
+            ReviewPullRequestState::Open => Some(true),
+            ReviewPullRequestState::Closed | ReviewPullRequestState::Merged => Some(false),
+            ReviewPullRequestState::Unknown => None,
+        },
+        viewer_review_requested: authoritative_viewer_keys
+            .contains(&key)
+            .then_some(item.flags.viewer_is_requested_reviewer),
+        updated_at: item.updated_at.to_rfc3339_opts(SecondsFormat::Secs, true),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_imported_references_absent_from_the_aggregate_are_resolved() {
+        let snapshots = vec![GitHubPullRequestSnapshot {
+            repository: "example/repo".into(),
+            number: 42,
+            is_open: Some(true),
+            viewer_review_requested: Some(true),
+            updated_at: "2026-07-11T11:00:00Z".into(),
+        }];
+
+        let missing = references_missing_from_snapshots(
+            vec![("Example/Repo".into(), 42), ("example/other".into(), 7)],
+            &snapshots,
+        );
+
+        assert_eq!(
+            missing,
+            vec![ReviewsPullRequestReference {
+                repository: "example/other".into(),
+                number: 7,
+            }]
+        );
+    }
+
+    #[test]
+    fn targeted_refresh_uses_only_its_provided_snapshots() {
+        assert!(MissingReviewResolution::ExactActiveImports.resolves_active_imports());
+        assert!(!MissingReviewResolution::ProvidedSnapshotsOnly.resolves_active_imports());
+    }
+}

--- a/src/daemon/service/reviews/refresh.rs
+++ b/src/daemon/service/reviews/refresh.rs
@@ -1,0 +1,110 @@
+use std::collections::{BTreeMap, HashSet};
+
+use crate::errors::CliError;
+use crate::github_api::GitHubProtectedClient;
+use crate::reviews::{
+    ReviewItem, ReviewRepositoryLabel, ReviewsGitHubClient, ReviewsRefreshRequest,
+    ReviewsRefreshResponse,
+};
+use crate::workspace::utc_now;
+
+use super::cache_internal::{patch_cached_items, patch_cached_repository_labels};
+use super::token::token_bound_targets;
+use super::{
+    github_projection, merge_segment_repository_labels, policy, policy_event_inbox, review_item_key,
+};
+
+/// Re-fetch a focused list of dependency update pull requests by GraphQL ID,
+/// patching matching cache entries in place and returning the refreshed items.
+///
+/// # Errors
+/// Returns `CliError` when the request is invalid, a required token is missing,
+/// or GitHub cannot return the requested pull requests.
+pub async fn refresh_reviews(
+    request: &ReviewsRefreshRequest,
+) -> Result<ReviewsRefreshResponse, CliError> {
+    request.validate()?;
+    let fetched = loop {
+        let (fetched, revision) = fetch_reviews_refresh_stably(request).await?;
+        if github_projection::reconcile_task_board(
+            &fetched.items,
+            &fetched.authoritative_viewer_keys,
+            github_projection::MissingReviewResolution::ProvidedSnapshotsOnly,
+            request.backport_detection_enabled,
+            &request.backport_patterns,
+            revision,
+        )
+        .await
+        {
+            break fetched;
+        }
+    };
+    if !fetched.repository_labels.is_empty() {
+        patch_cached_repository_labels(&fetched.repository_labels);
+    }
+    patch_cached_items(&fetched.items, &fetched.missing);
+    policy_event_inbox::resume_waiting_reviews_policy_runs(&fetched.items).await;
+    policy::start_background_reviews_policy_runs(&fetched.items).await;
+    Ok(ReviewsRefreshResponse {
+        fetched_at: utc_now(),
+        items: fetched.items,
+        missing_pull_request_ids: fetched.missing,
+    })
+}
+
+struct ReviewsRefreshFetch {
+    items: Vec<ReviewItem>,
+    missing: Vec<String>,
+    repository_labels: BTreeMap<String, Vec<ReviewRepositoryLabel>>,
+    authoritative_viewer_keys: HashSet<String>,
+}
+
+async fn fetch_reviews_refresh_stably(
+    request: &ReviewsRefreshRequest,
+) -> Result<(ReviewsRefreshFetch, u64), CliError> {
+    loop {
+        let revision = GitHubProtectedClient::data_revision();
+        let fetched = fetch_reviews_refresh_once(request).await?;
+        if GitHubProtectedClient::data_revision() == revision {
+            return Ok((fetched, revision));
+        }
+    }
+}
+
+async fn fetch_reviews_refresh_once(
+    request: &ReviewsRefreshRequest,
+) -> Result<ReviewsRefreshFetch, CliError> {
+    let mut items_by_key = BTreeMap::new();
+    let mut missing = Vec::new();
+    let mut repository_labels = BTreeMap::new();
+    let mut authoritative_viewer_keys = HashSet::new();
+    for segment in token_bound_targets(&request.targets)? {
+        let ids = segment
+            .targets
+            .iter()
+            .map(|target| target.pull_request_id.clone())
+            .collect::<Vec<_>>();
+        let client = ReviewsGitHubClient::new(&segment.token)?;
+        let viewer_login = client.fetch_viewer_login().await;
+        let fetch = client
+            .fetch_by_ids(&ids, request, viewer_login.as_deref())
+            .await?;
+        for item in fetch.items {
+            let key = review_item_key(&item);
+            if viewer_login.is_some() {
+                authoritative_viewer_keys.insert(key.clone());
+                items_by_key.insert(key, item);
+            } else {
+                items_by_key.entry(key).or_insert(item);
+            }
+        }
+        missing.extend(fetch.missing);
+        merge_segment_repository_labels(&mut repository_labels, fetch.repository_labels);
+    }
+    Ok(ReviewsRefreshFetch {
+        items: items_by_key.into_values().collect(),
+        missing,
+        repository_labels,
+        authoritative_viewer_keys,
+    })
+}

--- a/src/daemon/service/reviews/refresh.rs
+++ b/src/daemon/service/reviews/refresh.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use crate::errors::CliError;
-use crate::github_api::GitHubProtectedClient;
+use crate::github_api::retry_stable_read;
 use crate::reviews::{
     ReviewItem, ReviewRepositoryLabel, ReviewsGitHubClient, ReviewsRefreshRequest,
     ReviewsRefreshResponse,
@@ -19,14 +19,15 @@ use super::{
 ///
 /// # Errors
 /// Returns `CliError` when the request is invalid, a required token is missing,
-/// or GitHub cannot return the requested pull requests.
+/// GitHub cannot return the requested pull requests, or concurrent writes
+/// prevent a stable fetch-and-projection attempt.
 pub async fn refresh_reviews(
     request: &ReviewsRefreshRequest,
 ) -> Result<ReviewsRefreshResponse, CliError> {
     request.validate()?;
-    let fetched = loop {
-        let (fetched, revision) = fetch_reviews_refresh_stably(request).await?;
-        if github_projection::reconcile_task_board(
+    let (fetched, _) = retry_stable_read("reviews.refresh", |revision| async move {
+        let fetched = fetch_reviews_refresh_once(request).await?;
+        let _ = github_projection::reconcile_task_board(
             &fetched.items,
             &fetched.authoritative_viewer_keys,
             github_projection::MissingReviewResolution::ProvidedSnapshotsOnly,
@@ -34,11 +35,10 @@ pub async fn refresh_reviews(
             &request.backport_patterns,
             revision,
         )
-        .await
-        {
-            break fetched;
-        }
-    };
+        .await;
+        Ok::<_, CliError>(fetched)
+    })
+    .await?;
     if !fetched.repository_labels.is_empty() {
         patch_cached_repository_labels(&fetched.repository_labels);
     }
@@ -57,18 +57,6 @@ struct ReviewsRefreshFetch {
     missing: Vec<String>,
     repository_labels: BTreeMap<String, Vec<ReviewRepositoryLabel>>,
     authoritative_viewer_keys: HashSet<String>,
-}
-
-async fn fetch_reviews_refresh_stably(
-    request: &ReviewsRefreshRequest,
-) -> Result<(ReviewsRefreshFetch, u64), CliError> {
-    loop {
-        let revision = GitHubProtectedClient::data_revision();
-        let fetched = fetch_reviews_refresh_once(request).await?;
-        if GitHubProtectedClient::data_revision() == revision {
-            return Ok((fetched, revision));
-        }
-    }
 }
 
 async fn fetch_reviews_refresh_once(

--- a/src/daemon/service/reviews/resolve.rs
+++ b/src/daemon/service/reviews/resolve.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::errors::CliError;
 use crate::reviews::{
-    ReviewsGitHubClient, ReviewsPullRequestReference, ReviewsPullRequestResolveRequest,
-    ReviewsPullRequestResolveResponse,
+    ReviewItem, ReviewRepositoryLabel, ReviewsGitHubClient, ReviewsPullRequestReference,
+    ReviewsPullRequestResolveRequest, ReviewsPullRequestResolveResponse,
 };
 use crate::workspace::utc_now;
 
@@ -11,6 +11,13 @@ use super::cache_internal::{patch_cached_items, patch_cached_repository_labels};
 use super::policy;
 use super::policy_event_inbox;
 use super::token::token_bound_pull_request_references;
+
+pub(super) struct ResolvedPullRequests {
+    pub(super) items: Vec<ReviewItem>,
+    missing_references: Vec<ReviewsPullRequestReference>,
+    repository_labels: BTreeMap<String, Vec<ReviewRepositoryLabel>>,
+    pub(super) authoritative_viewer_keys: HashSet<String>,
+}
 
 /// Resolve exact `owner/repo#number` pull request references without loading
 /// all open pull requests from those repositories.
@@ -21,6 +28,23 @@ use super::token::token_bound_pull_request_references;
 pub async fn resolve_review_pull_requests(
     request: &ReviewsPullRequestResolveRequest,
 ) -> Result<ReviewsPullRequestResolveResponse, CliError> {
+    let resolved = fetch_pull_requests_by_reference(request).await?;
+    if !resolved.repository_labels.is_empty() {
+        patch_cached_repository_labels(&resolved.repository_labels);
+    }
+    patch_cached_items(&resolved.items, &[]);
+    policy_event_inbox::resume_waiting_reviews_policy_runs(&resolved.items).await;
+    policy::start_background_reviews_policy_runs(&resolved.items).await;
+    Ok(ReviewsPullRequestResolveResponse {
+        fetched_at: utc_now(),
+        items: resolved.items,
+        missing_references: resolved.missing_references,
+    })
+}
+
+pub(super) async fn fetch_pull_requests_by_reference(
+    request: &ReviewsPullRequestResolveRequest,
+) -> Result<ResolvedPullRequests, CliError> {
     request.validate()?;
     let normalized = request.normalized_references();
     let references_by_key = normalized
@@ -29,6 +53,8 @@ pub async fn resolve_review_pull_requests(
         .collect::<BTreeMap<_, _>>();
     let mut items = Vec::new();
     let mut missing_references = Vec::<ReviewsPullRequestReference>::new();
+    let mut repository_labels = BTreeMap::new();
+    let mut authoritative_viewer_keys = HashSet::new();
     for segment in token_bound_pull_request_references(&normalized)? {
         let segment_request = ReviewsPullRequestResolveRequest {
             references: segment.references,
@@ -40,6 +66,9 @@ pub async fn resolve_review_pull_requests(
         let fetch = client
             .fetch_by_references(&segment_request, viewer_login.as_deref())
             .await?;
+        if viewer_login.is_some() {
+            authoritative_viewer_keys.extend(fetch.items.iter().map(super::review_item_key));
+        }
         items.extend(fetch.items);
         missing_references.extend(
             fetch
@@ -47,16 +76,12 @@ pub async fn resolve_review_pull_requests(
                 .iter()
                 .filter_map(|key| references_by_key.get(key).cloned()),
         );
-        if !fetch.repository_labels.is_empty() {
-            patch_cached_repository_labels(&fetch.repository_labels);
-        }
+        super::merge_segment_repository_labels(&mut repository_labels, fetch.repository_labels);
     }
-    patch_cached_items(&items, &[]);
-    policy_event_inbox::resume_waiting_reviews_policy_runs(&items).await;
-    policy::start_background_reviews_policy_runs(&items).await;
-    Ok(ReviewsPullRequestResolveResponse {
-        fetched_at: utc_now(),
+    Ok(ResolvedPullRequests {
         items,
         missing_references,
+        repository_labels,
+        authoritative_viewer_keys,
     })
 }

--- a/src/daemon/service/reviews_cache.rs
+++ b/src/daemon/service/reviews_cache.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
+use crate::github_api::GitHubProtectedClient;
 use crate::reviews::{
     ReviewItem, ReviewPullRequestState, ReviewRepositoryLabel, ReviewsBodyResponse,
     ReviewsQueryResponse, ReviewsSummary,
@@ -13,12 +14,14 @@ static REVIEWS_BODY_CACHE: OnceLock<Mutex<BTreeMap<String, CachedReviewBody>>> =
 #[derive(Clone)]
 pub(crate) struct CachedReviews {
     stored_at: Instant,
+    github_data_revision: u64,
     response: ReviewsQueryResponse,
 }
 
 #[derive(Clone)]
 pub(crate) struct CachedReviewBody {
     stored_at: Instant,
+    github_data_revision: u64,
     response: ReviewsBodyResponse,
 }
 
@@ -34,8 +37,23 @@ pub(crate) fn cached_query_response(
     cache_key: &str,
     max_age_seconds: u64,
 ) -> Option<ReviewsQueryResponse> {
+    cached_query_response_at_revision(
+        cache_key,
+        max_age_seconds,
+        GitHubProtectedClient::data_revision(),
+    )
+}
+
+fn cached_query_response_at_revision(
+    cache_key: &str,
+    max_age_seconds: u64,
+    github_data_revision: u64,
+) -> Option<ReviewsQueryResponse> {
     let cache = cache().lock().expect("reviews cache lock");
     let entry = cache.get(cache_key)?;
+    if entry.github_data_revision != github_data_revision {
+        return None;
+    }
     if entry.stored_at.elapsed().as_secs() > max_age_seconds {
         return None;
     }
@@ -44,12 +62,26 @@ pub(crate) fn cached_query_response(
     Some(response)
 }
 
+#[cfg(test)]
 pub(crate) fn store_cached_query_response(cache_key: String, response: &ReviewsQueryResponse) {
+    store_cached_query_response_at_revision(
+        cache_key,
+        response,
+        GitHubProtectedClient::data_revision(),
+    );
+}
+
+pub(super) fn store_cached_query_response_at_revision(
+    cache_key: String,
+    response: &ReviewsQueryResponse,
+    github_data_revision: u64,
+) {
     let mut cache = cache().lock().expect("reviews cache lock");
     cache.insert(
         cache_key,
         CachedReviews {
             stored_at: Instant::now(),
+            github_data_revision,
             response: response.clone(),
         },
     );
@@ -59,8 +91,23 @@ pub(crate) fn cached_body_response(
     cache_key: &str,
     max_age_seconds: u64,
 ) -> Option<ReviewsBodyResponse> {
+    cached_body_response_at_revision(
+        cache_key,
+        max_age_seconds,
+        GitHubProtectedClient::data_revision(),
+    )
+}
+
+fn cached_body_response_at_revision(
+    cache_key: &str,
+    max_age_seconds: u64,
+    github_data_revision: u64,
+) -> Option<ReviewsBodyResponse> {
     let cache = body_cache().lock().expect("reviews body cache lock");
     let entry = cache.get(cache_key)?;
+    if entry.github_data_revision != github_data_revision {
+        return None;
+    }
     if entry.stored_at.elapsed().as_secs() > max_age_seconds {
         return None;
     }
@@ -70,11 +117,24 @@ pub(crate) fn cached_body_response(
 }
 
 pub(crate) fn store_cached_body_response(cache_key: String, response: &ReviewsBodyResponse) {
+    store_cached_body_response_at_revision(
+        cache_key,
+        response,
+        GitHubProtectedClient::data_revision(),
+    );
+}
+
+pub(super) fn store_cached_body_response_at_revision(
+    cache_key: String,
+    response: &ReviewsBodyResponse,
+    github_data_revision: u64,
+) {
     let mut cache = body_cache().lock().expect("reviews body cache lock");
     cache.insert(
         cache_key,
         CachedReviewBody {
             stored_at: Instant::now(),
+            github_data_revision,
             response: response.clone(),
         },
     );
@@ -144,4 +204,37 @@ pub(crate) fn apply_refresh_to_items(
     }
 
     if changed { Some(next) } else { None }
+}
+
+#[cfg(test)]
+mod revision_tests {
+    use chrono::Utc;
+
+    use super::*;
+
+    #[test]
+    fn query_cache_rejects_entries_from_an_older_github_revision() {
+        let key = "reviews-cache-revision-query".to_string();
+        let response = ReviewsQueryResponse::new(Vec::new(), "2026-07-11T12:00:00Z".into());
+        store_cached_query_response_at_revision(key.clone(), &response, 41);
+
+        assert!(cached_query_response_at_revision(&key, 600, 42).is_none());
+        assert!(cached_query_response_at_revision(&key, 600, 41).is_some());
+    }
+
+    #[test]
+    fn body_cache_rejects_entries_from_an_older_github_revision() {
+        let key = "reviews-cache-revision-body".to_string();
+        let response = ReviewsBodyResponse {
+            pull_request_id: "PR_revision_body".into(),
+            body: "body before mutation".into(),
+            pr_updated_at: Utc::now(),
+            fetched_at: "2026-07-11T12:00:00Z".into(),
+            from_cache: false,
+        };
+        store_cached_body_response_at_revision(key.clone(), &response, 17);
+
+        assert!(cached_body_response_at_revision(&key, 600, 18).is_none());
+        assert!(cached_body_response_at_revision(&key, 600, 17).is_some());
+    }
 }

--- a/src/daemon/service/serve/background_tasks.rs
+++ b/src/daemon/service/serve/background_tasks.rs
@@ -10,6 +10,7 @@ use crate::daemon::protocol::StreamEvent;
 use crate::daemon::websocket::{PreparedBroadcast, ReplayBuffer, run_broadcast_fanout};
 
 use super::acp_inspect_publisher::spawn_acp_inspect_publisher;
+use super::github_data_change_publisher::spawn_github_data_change_publisher;
 use super::machine_heartbeat_loop::spawn_machine_heartbeat_loop;
 use super::task_board_orchestrator_loop::spawn_task_board_orchestrator_loop;
 
@@ -32,6 +33,7 @@ pub(super) fn spawn_broadcast_fanout(
 
 pub(super) struct BackgroundTaskHandles {
     pub _acp_inspect_push: JoinHandle<()>,
+    pub _github_data_change_push: JoinHandle<()>,
     pub _machine_heartbeat: JoinHandle<()>,
     pub _task_board_orchestrator_loop: Option<JoinHandle<()>>,
 }
@@ -46,6 +48,10 @@ pub(super) fn spawn_background_tasks(
             app_state.sender.clone(),
             shutdown_rx.clone(),
             app_state.acp_agent_manager.clone(),
+        ),
+        _github_data_change_push: spawn_github_data_change_publisher(
+            app_state.sender.clone(),
+            shutdown_rx.clone(),
         ),
         _machine_heartbeat: spawn_machine_heartbeat_loop(shutdown_rx.clone()),
         _task_board_orchestrator_loop: app_state.async_db.get().map(|_| {

--- a/src/daemon/service/serve/github_data_change_publisher.rs
+++ b/src/daemon/service/serve/github_data_change_publisher.rs
@@ -1,0 +1,139 @@
+use tokio::sync::{broadcast, watch};
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, sleep};
+
+use crate::daemon::protocol::StreamEvent;
+use crate::github_api::{GitHubDataChange, GitHubProtectedClient};
+use crate::workspace::utc_now;
+
+const EVENT_NAME: &str = "github_data_changed";
+
+pub(super) fn spawn_github_data_change_publisher(
+    sender: broadcast::Sender<StreamEvent>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    let mut changes = GitHubProtectedClient::data_changes();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                shutdown_changed = shutdown_rx.changed() => {
+                    if shutdown_changed.is_err() || *shutdown_rx.borrow() {
+                        return;
+                    }
+                }
+                received = changes.recv() => {
+                    match received {
+                        Ok(change) => {
+                            let change = coalesce_changes(&mut changes, change).await;
+                            broadcast_github_data_change(&sender, &change);
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            tracing::warn!(skipped, "github data change publisher lagged");
+                            broadcast_github_data_change(
+                                &sender,
+                                &GitHubDataChange {
+                                    revision: GitHubProtectedClient::data_revision(),
+                                    operation: "github.data_change_recovery".to_string(),
+                                },
+                            );
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return,
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn coalesce_changes(
+    changes: &mut broadcast::Receiver<GitHubDataChange>,
+    mut latest: GitHubDataChange,
+) -> GitHubDataChange {
+    sleep(Duration::from_millis(100)).await;
+    while let Ok(change) = changes.try_recv() {
+        if change.revision >= latest.revision {
+            latest = change;
+        }
+    }
+    latest
+}
+
+pub(crate) fn broadcast_github_data_change(
+    sender: &broadcast::Sender<StreamEvent>,
+    change: &GitHubDataChange,
+) {
+    let Some(event) = stream_event_for_change(change) else {
+        return;
+    };
+    let _ = sender.send(event);
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "the push boundary logs serialization failure before dropping an unencodable event"
+)]
+fn stream_event_for_change(change: &GitHubDataChange) -> Option<StreamEvent> {
+    let payload = match serde_json::to_value(change) {
+        Ok(payload) => payload,
+        Err(error) => {
+            tracing::warn!(%error, "serialize github data change push payload");
+            return None;
+        }
+    };
+    Some(StreamEvent {
+        event: EVENT_NAME.to_string(),
+        recorded_at: utc_now(),
+        session_id: None,
+        payload,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::broadcast;
+
+    use super::{GitHubDataChange, broadcast_github_data_change, coalesce_changes};
+    use crate::daemon::protocol::StreamEvent;
+
+    #[test]
+    fn publishes_global_github_data_change() {
+        let (sender, mut receiver) = broadcast::channel::<StreamEvent>(2);
+
+        broadcast_github_data_change(
+            &sender,
+            &GitHubDataChange {
+                revision: 7,
+                operation: "reviews.merge".to_string(),
+            },
+        );
+
+        let event = receiver.try_recv().expect("github data change event");
+        assert_eq!(event.event, "github_data_changed");
+        assert_eq!(event.session_id, None);
+        assert_eq!(event.payload["revision"], 7);
+        assert_eq!(event.payload["operation"], "reviews.merge");
+    }
+
+    #[tokio::test]
+    async fn same_revision_local_ready_event_replaces_early_mutation_event() {
+        let (sender, mut receiver) = broadcast::channel(2);
+        sender
+            .send(GitHubDataChange {
+                revision: 7,
+                operation: "task_board.github.issue_update".to_string(),
+            })
+            .expect("first change");
+        let first = receiver.recv().await.expect("first receive");
+        sender
+            .send(GitHubDataChange {
+                revision: 7,
+                operation: "task_board.github.local_sync_ready".to_string(),
+            })
+            .expect("ready change");
+
+        let coalesced = coalesce_changes(&mut receiver, first).await;
+
+        assert_eq!(coalesced.revision, 7);
+        assert_eq!(coalesced.operation, "task_board.github.local_sync_ready");
+    }
+}

--- a/src/daemon/service/serve/github_data_change_publisher.rs
+++ b/src/daemon/service/serve/github_data_change_publisher.rs
@@ -166,13 +166,17 @@ mod tests {
     #[tokio::test]
     async fn coalescer_drains_to_latest_change_after_lagging() {
         let (sender, mut receiver) = broadcast::channel(2);
-        sender
-            .send(change(1, "first"))
-            .expect("send first change");
+        sender.send(change(1, "first")).expect("send first change");
         let first = receiver.recv().await.expect("receive first change");
-        sender.send(change(2, "skipped")).expect("send skipped change");
-        sender.send(change(3, "retained")).expect("send retained change");
-        sender.send(change(4, "latest")).expect("send latest change");
+        sender
+            .send(change(2, "skipped"))
+            .expect("send skipped change");
+        sender
+            .send(change(3, "retained"))
+            .expect("send retained change");
+        sender
+            .send(change(4, "latest"))
+            .expect("send latest change");
 
         let coalesced = coalesce_changes(&mut receiver, first).await;
 

--- a/src/daemon/service/serve/github_data_change_publisher.rs
+++ b/src/daemon/service/serve/github_data_change_publisher.rs
@@ -50,12 +50,38 @@ async fn coalesce_changes(
     mut latest: GitHubDataChange,
 ) -> GitHubDataChange {
     sleep(Duration::from_millis(100)).await;
-    while let Ok(change) = changes.try_recv() {
-        if change.revision >= latest.revision {
-            latest = change;
-        }
-    }
+    while drain_next_change(changes, &mut latest) {}
     latest
+}
+
+fn drain_next_change(
+    changes: &mut broadcast::Receiver<GitHubDataChange>,
+    latest: &mut GitHubDataChange,
+) -> bool {
+    let change = match changes.try_recv() {
+        Ok(change) => change,
+        Err(error) => return should_continue_after_drain_error(&error),
+    };
+    if change.revision >= latest.revision {
+        *latest = change;
+    }
+    true
+}
+
+fn should_continue_after_drain_error(error: &broadcast::error::TryRecvError) -> bool {
+    let broadcast::error::TryRecvError::Lagged(skipped) = error else {
+        return false;
+    };
+    log_coalescer_lag(*skipped);
+    true
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "the tracing macro expansion exceeds the threshold without adding control flow"
+)]
+fn log_coalescer_lag(skipped: u64) {
+    tracing::warn!(skipped, "github data change coalescer lagged");
 }
 
 pub(crate) fn broadcast_github_data_change(
@@ -135,5 +161,28 @@ mod tests {
 
         assert_eq!(coalesced.revision, 7);
         assert_eq!(coalesced.operation, "task_board.github.local_sync_ready");
+    }
+
+    #[tokio::test]
+    async fn coalescer_drains_to_latest_change_after_lagging() {
+        let (sender, mut receiver) = broadcast::channel(2);
+        sender
+            .send(change(1, "first"))
+            .expect("send first change");
+        let first = receiver.recv().await.expect("receive first change");
+        sender.send(change(2, "skipped")).expect("send skipped change");
+        sender.send(change(3, "retained")).expect("send retained change");
+        sender.send(change(4, "latest")).expect("send latest change");
+
+        let coalesced = coalesce_changes(&mut receiver, first).await;
+
+        assert_eq!(coalesced, change(4, "latest"));
+    }
+
+    fn change(revision: u64, operation: &str) -> GitHubDataChange {
+        GitHubDataChange {
+            revision,
+            operation: operation.to_string(),
+        }
     }
 }

--- a/src/daemon/service/serve/mod.rs
+++ b/src/daemon/service/serve/mod.rs
@@ -4,6 +4,7 @@ mod audit;
 mod background_tasks;
 mod binary_stamp;
 mod config;
+mod github_data_change_publisher;
 mod legacy_migration;
 mod machine_heartbeat_loop;
 mod manifest;
@@ -16,6 +17,7 @@ mod task_board_orchestrator_loop;
 pub(crate) use shutdown_signals::ShutdownSignalGuard;
 
 pub(crate) use config::{http_auth_mode, validate_serve_config};
+pub(crate) use github_data_change_publisher::broadcast_github_data_change;
 pub(crate) use open_db::{open_daemon_async_db, open_daemon_db};
 pub(crate) use remote::serve_remote_https;
 

--- a/src/daemon/service/task_board_github.rs
+++ b/src/daemon/service/task_board_github.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use crate::daemon::db::{AsyncDaemonDb, DaemonDb};
 use crate::errors::CliError;
+use crate::github_api::{GitHubProtectedClient, republish_current_data_change};
 use crate::task_board::github::{
     GitHubApiAutomationClient, GitHubAutomationClient, GitHubProjectConfig,
 };
@@ -95,6 +96,7 @@ async fn run_task_board_github_automation_with_client(
 ) -> Result<(), CliError> {
     let board = TaskBoardStore::new(board_root.to_path_buf());
     for item in items {
+        let revision_before = GitHubProtectedClient::data_revision();
         let workflow = automate_item(AutomationRequest {
             board_root,
             config,
@@ -114,6 +116,9 @@ async fn run_task_board_github_automation_with_client(
                     ..TaskBoardItemPatch::default()
                 },
             )?;
+            if GitHubProtectedClient::data_revision() != revision_before {
+                republish_current_data_change("task_board.github.local_automation_ready");
+            }
         }
     }
     Ok(())

--- a/src/github_api/cache.rs
+++ b/src/github_api/cache.rs
@@ -170,12 +170,17 @@ impl GitHubCache {
                 )
             }),
         };
-        match (control_result, quarantine_result) {
-            (Ok(()), _) | (_, Ok(())) => Ok(()),
-            (Err(control_error), Err(quarantine_error)) => Err(Error::new(
-                control_error.kind(),
-                format!("rotate github cache control: {control_error}; {quarantine_error}"),
-            )),
+        match control_result {
+            Ok(()) => Ok(()),
+            Err(control_error) => {
+                let message = match quarantine_result {
+                    Ok(()) => format!("rotate github cache control: {control_error}"),
+                    Err(quarantine_error) => format!(
+                        "rotate github cache control: {control_error}; {quarantine_error}"
+                    ),
+                };
+                Err(Error::new(control_error.kind(), message))
+            }
         }
     }
 

--- a/src/github_api/cache.rs
+++ b/src/github_api/cache.rs
@@ -1,18 +1,24 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::Mutex;
+use std::io::{Error, ErrorKind, Result as IoResult};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, PoisonError};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use fs_err as fs;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 use crate::daemon::state;
 
 use super::types::GitHubCachePolicy;
 
 const MEMORY_ENTRY_CAP: usize = 512;
+const LEGACY_DATA_REVISION_FILE: &str = "data-revision";
+const CACHE_CONTROL_FILE: &str = "github-cache-control.json";
 #[cfg(not(test))]
 const DISK_GC_ENTRY_CAP: usize = 4096;
 #[cfg(test)]
@@ -47,23 +53,56 @@ struct MemoryCacheEntry {
     last_used: SystemTime,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GitHubCacheControl {
+    data_revision: u64,
+    scope: String,
+}
+
 pub(crate) struct GitHubCache {
     root: PathBuf,
+    control_path: PathBuf,
+    control: Mutex<GitHubCacheControl>,
+    disk_enabled: AtomicBool,
     memory: Mutex<HashMap<String, MemoryCacheEntry>>,
 }
 
 impl GitHubCache {
     pub(crate) fn new() -> Self {
-        Self {
-            root: state::daemon_root().join("github-cache").join("v1"),
-            memory: Mutex::new(HashMap::new()),
+        let state_root = state::daemon_root();
+        #[cfg(not(test))]
+        {
+            Self::with_root(&state_root)
+        }
+        #[cfg(test)]
+        {
+            Self {
+                root: state_root.join("github-cache").join("v1"),
+                control_path: state_root.join(CACHE_CONTROL_FILE),
+                control: Mutex::new(GitHubCacheControl {
+                    data_revision: 0,
+                    scope: Uuid::new_v4().to_string(),
+                }),
+                disk_enabled: AtomicBool::new(false),
+                memory: Mutex::new(HashMap::new()),
+            }
         }
     }
 
     #[cfg(test)]
     pub(crate) fn test_with_root(root: PathBuf) -> Self {
+        Self::with_root(&root)
+    }
+
+    fn with_root(state_root: &Path) -> Self {
+        let root = state_root.join("github-cache").join("v1");
+        let control_path = state_root.join(CACHE_CONTROL_FILE);
+        let (control, disk_enabled) = initialize_control(&root, &control_path);
         Self {
-            root: root.join("github-cache").join("v1"),
+            root,
+            control_path,
+            control: Mutex::new(control),
+            disk_enabled: AtomicBool::new(disk_enabled),
             memory: Mutex::new(HashMap::new()),
         }
     }
@@ -77,6 +116,69 @@ impl GitHubCache {
         hex::encode(hasher.finalize())
     }
 
+    pub(crate) fn scope(&self) -> String {
+        self.control
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .scope
+            .clone()
+    }
+
+    pub(crate) fn data_revision(&self) -> u64 {
+        self.control
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .data_revision
+    }
+
+    pub(crate) fn persist_data_revision(&self, revision: u64) -> IoResult<()> {
+        let mut guard = self.control.lock().unwrap_or_else(PoisonError::into_inner);
+        let next = GitHubCacheControl {
+            data_revision: revision,
+            scope: guard.scope.clone(),
+        };
+        persist_control(&self.control_path, &next)?;
+        *guard = next;
+        Ok(())
+    }
+
+    pub(crate) fn disable_disk_after_revision_failure(&self, revision: u64) -> IoResult<()> {
+        self.disk_enabled.store(false, Ordering::Release);
+        let recovery = GitHubCacheControl {
+            data_revision: revision,
+            scope: Uuid::new_v4().to_string(),
+        };
+        let control_result = persist_control(&self.control_path, &recovery);
+        if control_result.is_ok() {
+            *self.control.lock().unwrap_or_else(PoisonError::into_inner) = recovery;
+        }
+        let quarantine = self
+            .root
+            .with_file_name(format!("v1-invalid-{}-{revision}", process::id()));
+        let quarantine_result = match fs::rename(&self.root, &quarantine) {
+            Ok(()) => {
+                let _ = fs::remove_dir_all(quarantine);
+                Ok(())
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(rename_error) => fs::remove_dir_all(&self.root).map_err(|remove_error| {
+                Error::new(
+                    remove_error.kind(),
+                    format!(
+                        "quarantine github cache: {rename_error}; remove github cache: {remove_error}"
+                    ),
+                )
+            }),
+        };
+        match (control_result, quarantine_result) {
+            (Ok(()), _) | (_, Ok(())) => Ok(()),
+            (Err(control_error), Err(quarantine_error)) => Err(Error::new(
+                control_error.kind(),
+                format!("rotate github cache control: {control_error}; {quarantine_error}"),
+            )),
+        }
+    }
+
     pub(crate) fn get(&self, key: &str, policy: GitHubCachePolicy) -> Option<GitHubCacheHit> {
         if !policy.is_enabled() {
             return None;
@@ -84,7 +186,7 @@ impl GitHubCache {
         if let Some(hit) = self.get_memory(key, policy) {
             return Some(hit);
         }
-        if !policy.disk {
+        if !policy.disk || !self.disk_enabled.load(Ordering::Acquire) {
             return None;
         }
         let hit = self.get_disk(key, policy)?;
@@ -124,7 +226,7 @@ impl GitHubCache {
             last_used: SystemTime::now(),
         };
         self.store_memory(key, entry);
-        if policy.disk {
+        if policy.disk && self.disk_enabled.load(Ordering::Acquire) {
             self.store_disk(key, body, etag);
         }
     }
@@ -217,6 +319,36 @@ impl GitHubCache {
     fn path_for_key(&self, key: &str) -> PathBuf {
         self.path_dir_for_key(key).join(format!("{key}.json"))
     }
+}
+
+fn initialize_control(root: &Path, control_path: &Path) -> (GitHubCacheControl, bool) {
+    if let Ok(raw) = fs::read_to_string(control_path)
+        && let Ok(control) = serde_json::from_str::<GitHubCacheControl>(&raw)
+        && !control.scope.trim().is_empty()
+    {
+        return (control, true);
+    }
+    let legacy_revision = fs::read_to_string(root.join(LEGACY_DATA_REVISION_FILE))
+        .ok()
+        .and_then(|raw| raw.trim().parse().ok())
+        .unwrap_or(0);
+    let control = GitHubCacheControl {
+        data_revision: legacy_revision,
+        scope: Uuid::new_v4().to_string(),
+    };
+    let disk_enabled = persist_control(control_path, &control).is_ok();
+    (control, disk_enabled)
+}
+
+fn persist_control(path: &Path, control: &GitHubCacheControl) -> IoResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp_path = path.with_extension(format!("{}.tmp", process::id()));
+    let raw = serde_json::to_vec(control)
+        .map_err(|error| Error::other(format!("serialize github cache control: {error}")))?;
+    fs::write(&tmp_path, raw)?;
+    fs::rename(tmp_path, path)
 }
 
 fn classify_age(age: Duration, policy: GitHubCachePolicy) -> Option<GitHubCacheState> {

--- a/src/github_api/client.rs
+++ b/src/github_api/client.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
-use std::time::Duration;
 
-use reqwest::header::{
-    ACCEPT, AUTHORIZATION, ETAG, HeaderMap, HeaderValue, IF_NONE_MATCH, USER_AGENT,
-};
+use reqwest::header::{ETAG, HeaderMap};
 use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use tokio::sync::broadcast;
 
 use crate::errors::{CliError, CliErrorKind};
 
@@ -15,23 +13,22 @@ use super::response::{
     GitHubApiResponse, budget_error, cache_state, context_error, ensure_graphql_ok, graphql_data,
     http_status_error, provenance_with_snapshot, request_error, revalidated_response, value_u32,
 };
-use super::state::{GitHubApiState, InflightGuard, InflightRole, global_state, register_inflight};
+use super::state::{
+    GitHubApiState, GitHubMutationGuard, InflightGuard, InflightRole, global_state,
+    register_inflight,
+};
 use super::{
     GitHubCache, GitHubCachePolicy, GitHubPriority, GitHubRateLimitSnapshot, GitHubRateResource,
     GitHubRequestDescriptor, GitHubResponseProvenance,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.github.com";
-const USER_AGENT_VALUE: &str = "harness-github-rate-shield";
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-const READ_TIMEOUT: Duration = Duration::from_mins(1);
-
 #[derive(Clone)]
 pub(crate) struct GitHubProtectedClient {
-    token: String,
+    pub(super) token: String,
     token_hash: String,
-    base_url: String,
-    http: reqwest::Client,
+    pub(super) base_url: String,
+    pub(super) http: reqwest::Client,
     pub(super) state: Arc<GitHubApiState>,
 }
 
@@ -45,25 +42,33 @@ impl GitHubProtectedClient {
         if token.is_empty() {
             return Err(CliErrorKind::workflow_io("github token missing").into());
         }
-        let http = reqwest::Client::builder()
-            .connect_timeout(CONNECT_TIMEOUT)
-            .read_timeout(READ_TIMEOUT)
-            .build()
-            .map_err(|error| {
-                CliErrorKind::workflow_io(format!("build github http client: {error}"))
-            })?;
+        let state = global_state();
+        let http = state.http.clone().map_err(|error| {
+            CliErrorKind::workflow_io(format!("build github http client: {error}"))
+        })?;
         Ok(Self {
             token: token.to_string(),
             token_hash: GitHubCache::key(&["token", token]),
             base_url: base_url.trim_end_matches('/').to_string(),
             http,
-            state: global_state(),
+            state,
         })
+    }
+
+    pub(crate) fn data_revision() -> u64 {
+        global_state().data_revision()
+    }
+
+    pub(crate) fn data_changes() -> broadcast::Receiver<super::GitHubDataChange> {
+        global_state().data_changes()
     }
 
     pub(crate) async fn status() -> super::types::GitHubApiStatus {
         let state = global_state();
-        state.recorder.status(&state.budget).await
+        state
+            .recorder
+            .status(&state.budget, state.data_revision())
+            .await
     }
 
     pub(crate) async fn graphql<T>(
@@ -77,7 +82,7 @@ impl GitHubProtectedClient {
         let operation = descriptor.operation.clone();
         let priority = descriptor.priority;
         let raw = self
-            .execute_json(Method::POST, "/graphql", Some(body), descriptor)
+            .execute_json_with_mutation_boundary(Method::POST, "/graphql", Some(body), descriptor)
             .await?;
         let snapshot = self.observe_graphql_rate_limit(&raw).await;
         self.record_network(
@@ -106,7 +111,7 @@ impl GitHubProtectedClient {
         let operation = descriptor.operation.clone();
         let priority = descriptor.priority;
         let raw = self
-            .execute_json(Method::POST, "/graphql", Some(body), descriptor)
+            .execute_json_with_mutation_boundary(Method::POST, "/graphql", Some(body), descriptor)
             .await?;
         let snapshot = self.observe_graphql_rate_limit(&raw).await;
         self.record_network(
@@ -138,7 +143,7 @@ impl GitHubProtectedClient {
         let operation = descriptor.operation.clone();
         let priority = descriptor.priority;
         let raw = self
-            .execute_json(method, route.as_ref(), body, descriptor)
+            .execute_json_with_mutation_boundary(method, route.as_ref(), body, descriptor)
             .await?;
         self.record_network(
             &operation,
@@ -157,14 +162,42 @@ impl GitHubProtectedClient {
         })
     }
 
-    async fn execute_json(
+    pub(super) async fn execute_json(
         &self,
         method: Method,
         route: &str,
         body: Option<Value>,
         descriptor: GitHubRequestDescriptor,
+        mutation_guard: &mut Option<GitHubMutationGuard>,
     ) -> Result<GitHubApiResponse<Value>, CliError> {
-        let cache_key = self.cache_key(method.as_str(), route, body.as_ref(), &descriptor);
+        loop {
+            let data_revision = self.state.data_revision();
+            let response = self
+                .execute_json_at_revision(
+                    method.clone(),
+                    route,
+                    body.clone(),
+                    descriptor.clone(),
+                    data_revision,
+                    mutation_guard,
+                )
+                .await?;
+            if descriptor.priority.is_write() || self.state.data_revision() == data_revision {
+                return Ok(response);
+            }
+        }
+    }
+
+    async fn execute_json_at_revision(
+        &self,
+        method: Method,
+        route: &str,
+        body: Option<Value>,
+        descriptor: GitHubRequestDescriptor,
+        data_revision: u64,
+        mutation_guard: &mut Option<GitHubMutationGuard>,
+    ) -> Result<GitHubApiResponse<Value>, CliError> {
+        let cache_key = self.cache_key(method.as_str(), route, body.as_ref(), data_revision);
         if !descriptor.cache_policy.force_refresh
             && let Some(hit) = self.state.cache.get(&cache_key, descriptor.cache_policy)
         {
@@ -193,63 +226,28 @@ impl GitHubProtectedClient {
             .send_json(method, route, body, stale.as_ref())
             .await
             .map_err(|error| request_error(&descriptor.operation, &error))?;
-        self.handle_http_response(response, &cache_key, &descriptor, stale)
+        self.handle_http_response(response, &cache_key, &descriptor, stale, mutation_guard)
             .await
             .map_err(|error| context_error(&descriptor.operation, &error))
     }
 
-    pub(super) async fn send_json(
-        &self,
-        method: Method,
-        route: &str,
-        body: Option<Value>,
-        stale: Option<&super::cache::GitHubCacheHit>,
-    ) -> Result<reqwest::Response, reqwest::Error> {
-        let mut headers = self.default_headers();
-        if method == Method::GET
-            && let Some(etag) = stale.and_then(|hit| hit.etag.as_deref())
-            && let Ok(value) = HeaderValue::from_str(etag)
-        {
-            headers.insert(IF_NONE_MATCH, value);
-        }
-        let url = self.route_url(route);
-        let request = self.http.request(method, url).headers(headers);
-        match body {
-            Some(body) => request.json(&body).send().await,
-            None => request.send().await,
-        }
-    }
-
-    pub(super) async fn send_json_with_headers(
-        &self,
-        method: Method,
-        route: &str,
-        body: Option<Value>,
-        extra_headers: HeaderMap,
-    ) -> Result<reqwest::Response, reqwest::Error> {
-        let mut headers = self.default_headers();
-        for (name, value) in extra_headers {
-            if let Some(name) = name {
-                headers.insert(name, value);
-            }
-        }
-        let url = self.route_url(route);
-        let request = self.http.request(method, url).headers(headers);
-        match body {
-            Some(body) => request.json(&body).send().await,
-            None => request.send().await,
-        }
-    }
-
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "the HTTP response boundary handles cache revalidation, rate limits, and mutation certainty"
+    )]
     async fn handle_http_response(
         &self,
         response: reqwest::Response,
         cache_key: &str,
         descriptor: &GitHubRequestDescriptor,
         stale: Option<super::cache::GitHubCacheHit>,
+        mutation_guard: &mut Option<GitHubMutationGuard>,
     ) -> Result<GitHubApiResponse<Value>, CliError> {
         let status = response.status();
         let headers = response.headers().clone();
+        if status.is_success() {
+            mark_remote_success(mutation_guard);
+        }
         let snapshot = self.state.budget.observe_headers(&headers).await;
         if descriptor.resource != GitHubRateResource::Graphql {
             self.state
@@ -276,8 +274,16 @@ impl GitHubProtectedClient {
         if !status.is_success() {
             return Err(http_status_error(status, &text));
         }
-        self.finalize_success_response(cache_key, descriptor, &headers, status, &text, snapshot)
-            .await
+        self.finalize_success_response(
+            cache_key,
+            descriptor,
+            &headers,
+            status,
+            &text,
+            snapshot,
+            mutation_guard,
+        )
+        .await
     }
 
     async fn observe_secondary_limit_if_throttled(
@@ -297,6 +303,10 @@ impl GitHubProtectedClient {
         }
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the finalizer needs the exact response and cache context without cloning bodies"
+    )]
     async fn finalize_success_response(
         &self,
         cache_key: &str,
@@ -305,9 +315,13 @@ impl GitHubProtectedClient {
         status: StatusCode,
         text: &str,
         snapshot: Option<GitHubRateLimitSnapshot>,
+        mutation_guard: &mut Option<GitHubMutationGuard>,
     ) -> Result<GitHubApiResponse<Value>, CliError> {
         let body: Value = serde_json::from_str(text)
             .map_err(|error| CliErrorKind::workflow_parse(format!("parse github json: {error}")))?;
+        if descriptor.resource == GitHubRateResource::Graphql && graphql_mutation_failed(&body) {
+            mark_remote_failure(mutation_guard);
+        }
         self.observe_graphql_body_cost(descriptor, &body).await;
         let etag = headers
             .get(ETAG)
@@ -422,41 +436,42 @@ impl GitHubProtectedClient {
         method: &str,
         route: &str,
         body: Option<&Value>,
-        descriptor: &GitHubRequestDescriptor,
+        data_revision: u64,
     ) -> String {
         let body = body.map_or_else(String::new, Value::to_string);
+        let data_revision = data_revision.to_string();
+        let cache_scope = self.state.cache.scope();
         GitHubCache::key(&[
+            cache_scope.as_str(),
             &self.token_hash,
             &self.base_url,
             method,
             route,
-            descriptor.operation.as_str(),
             body.as_str(),
+            data_revision.as_str(),
         ])
-    }
-
-    fn default_headers(&self) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
-        headers.insert(
-            ACCEPT,
-            HeaderValue::from_static("application/vnd.github+json"),
-        );
-        let auth = format!("Bearer {}", self.token);
-        if let Ok(value) = HeaderValue::from_str(&auth) {
-            headers.insert(AUTHORIZATION, value);
-        }
-        headers
-    }
-
-    fn route_url(&self, route: &str) -> String {
-        if route.starts_with("http://") || route.starts_with("https://") {
-            return route.to_string();
-        }
-        format!("{}/{}", self.base_url, route.trim_start_matches('/'))
     }
 }
 
 fn observed_rest_cost(status: StatusCode) -> u32 {
     u32::from(status != StatusCode::NOT_MODIFIED)
+}
+
+fn graphql_mutation_failed(body: &Value) -> bool {
+    body.get("errors")
+        .and_then(Value::as_array)
+        .is_some_and(|errors| !errors.is_empty())
+        && body.get("data").is_none_or(Value::is_null)
+}
+
+fn mark_remote_success(mutation_guard: &mut Option<GitHubMutationGuard>) {
+    if let Some(guard) = mutation_guard {
+        guard.mark_remote_success();
+    }
+}
+
+fn mark_remote_failure(mutation_guard: &mut Option<GitHubMutationGuard>) {
+    if let Some(guard) = mutation_guard {
+        guard.mark_remote_failure();
+    }
 }

--- a/src/github_api/client.rs
+++ b/src/github_api/client.rs
@@ -19,7 +19,7 @@ use super::state::{
 };
 use super::{
     GitHubCache, GitHubCachePolicy, GitHubPriority, GitHubRateLimitSnapshot, GitHubRateResource,
-    GitHubRequestDescriptor, GitHubResponseProvenance,
+    GitHubRequestDescriptor, GitHubResponseProvenance, retry_stable_read,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.github.com";
@@ -170,22 +170,39 @@ impl GitHubProtectedClient {
         descriptor: GitHubRequestDescriptor,
         mutation_guard: &mut Option<GitHubMutationGuard>,
     ) -> Result<GitHubApiResponse<Value>, CliError> {
-        loop {
+        if descriptor.priority.is_write() {
             let data_revision = self.state.data_revision();
-            let response = self
+            return self
                 .execute_json_at_revision(
-                    method.clone(),
+                    method,
                     route,
-                    body.clone(),
-                    descriptor.clone(),
+                    body,
+                    descriptor,
                     data_revision,
                     mutation_guard,
                 )
-                .await?;
-            if descriptor.priority.is_write() || self.state.data_revision() == data_revision {
-                return Ok(response);
-            }
+                .await;
         }
+        let operation = descriptor.operation.clone();
+        retry_stable_read(&operation, |data_revision| {
+            let method = method.clone();
+            let body = body.clone();
+            let descriptor = descriptor.clone();
+            async move {
+                let mut read_guard = None;
+                self.execute_json_at_revision(
+                    method,
+                    route,
+                    body,
+                    descriptor,
+                    data_revision,
+                    &mut read_guard,
+                )
+                .await
+            }
+        })
+        .await
+        .map(|(response, _)| response)
     }
 
     async fn execute_json_at_revision(

--- a/src/github_api/coherence_tests.rs
+++ b/src/github_api/coherence_tests.rs
@@ -230,6 +230,52 @@ async fn raw_read_started_before_mutation_retries_at_current_epoch() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exact_and_raw_reads_stop_after_the_shared_stability_budget() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let requests = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route("/resource", get(always_mutating_response))
+        .with_state(Arc::clone(&requests));
+    let (base_url, server) = spawn_server(app).await;
+    let client =
+        GitHubProtectedClient::with_base_url("unstable-read-token", &base_url).expect("client");
+    let descriptor = |operation| {
+        GitHubRequestDescriptor::rest_core(
+            operation,
+            GitHubPriority::NormalRead,
+            GitHubCachePolicy::no_store(),
+        )
+    };
+
+    let exact_error = client
+        .rest_json::<Value>(
+            Method::GET,
+            "/resource",
+            None,
+            descriptor("reviews.never_stable"),
+        )
+        .await
+        .err()
+        .expect("exact read must exhaust its stability budget");
+    let raw_error = client
+        .rest_json_with_headers::<Value>(
+            Method::GET,
+            "/resource",
+            None,
+            descriptor("task_board.never_stable"),
+            HeaderMap::new(),
+        )
+        .await
+        .err()
+        .expect("raw read must exhaust its stability budget");
+
+    assert_eq!(exact_error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(raw_error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(requests.load(Ordering::SeqCst), 6);
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stable_projection_guard_blocks_mutation_until_commit_finishes() {
     let _budget_guard = super::acquire_global_budget_test_lock().await;
     let initial_revision = GitHubProtectedClient::data_revision();
@@ -381,6 +427,14 @@ async fn delayed_first_response(State(state): State<DelayedReadState>) -> impl I
 
 async fn counted_response(requests: Arc<AtomicUsize>) -> impl IntoResponse {
     let request = requests.fetch_add(1, Ordering::SeqCst) + 1;
+    Json(json!({ "request": request }))
+}
+
+async fn always_mutating_response(State(requests): State<Arc<AtomicUsize>>) -> impl IntoResponse {
+    let request = requests.fetch_add(1, Ordering::SeqCst) + 1;
+    let mut guard = super::begin_external_mutation("test.read_instability").await;
+    guard.mark_remote_success();
+    drop(guard);
     Json(json!({ "request": request }))
 }
 

--- a/src/github_api/coherence_tests.rs
+++ b/src/github_api/coherence_tests.rs
@@ -1,0 +1,436 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use reqwest::Method;
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+
+use super::{
+    GitHubCachePolicy, GitHubDataChange, GitHubPriority, GitHubProtectedClient,
+    GitHubRequestDescriptor,
+};
+
+const CACHE_TTL: Duration = Duration::from_secs(60);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exact_reads_share_cache_across_operation_labels() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let requests = Arc::new(AtomicUsize::new(0));
+    let app = Router::new().route(
+        "/resource",
+        get({
+            let requests = Arc::clone(&requests);
+            move || counted_response(Arc::clone(&requests))
+        }),
+    );
+    let (base_url, server) = spawn_server(app).await;
+    let client =
+        GitHubProtectedClient::with_base_url("cross-operation-token", &base_url).expect("client");
+
+    let first = client
+        .rest_json::<Value>(
+            Method::GET,
+            "/resource",
+            None,
+            read_descriptor("reviews.resource"),
+        )
+        .await
+        .expect("first read");
+    let second = client
+        .rest_json::<Value>(
+            Method::GET,
+            "/resource",
+            None,
+            read_descriptor("task_board.resource"),
+        )
+        .await
+        .expect("second read");
+
+    assert_eq!(first.body, second.body);
+    assert!(!first.provenance.from_cache);
+    assert!(second.provenance.from_cache);
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mutation_epoch_invalidates_exact_read_cache_and_publishes_change() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let requests = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route(
+            "/resource",
+            get({
+                let requests = Arc::clone(&requests);
+                move || counted_response(Arc::clone(&requests))
+            }),
+        )
+        .route(
+            "/mutate",
+            post(|| async { Json(json!({ "updated": true })) }),
+        );
+    let (base_url, server) = spawn_server(app).await;
+    let client =
+        GitHubProtectedClient::with_base_url("mutation-epoch-token", &base_url).expect("client");
+    let mut changes = GitHubProtectedClient::data_changes();
+    let initial_revision = GitHubProtectedClient::data_revision();
+
+    let first = client
+        .rest_json::<Value>(
+            Method::GET,
+            "/resource",
+            None,
+            read_descriptor("reviews.before_mutation"),
+        )
+        .await
+        .expect("initial read");
+    client
+        .rest_json::<Value>(
+            Method::POST,
+            "/mutate",
+            Some(json!({ "title": "changed" })),
+            mutation_descriptor("reviews.update_resource"),
+        )
+        .await
+        .expect("mutation");
+    let change = recv_change(&mut changes).await;
+    let second = client
+        .rest_json::<Value>(
+            Method::GET,
+            "/resource",
+            None,
+            read_descriptor("task_board.after_mutation"),
+        )
+        .await
+        .expect("post-mutation read");
+
+    assert_eq!(change.revision, initial_revision + 1);
+    assert_eq!(change.operation, "reviews.update_resource");
+    assert_eq!(GitHubProtectedClient::data_revision(), initial_revision + 1);
+    assert_eq!(first.body["request"], 1);
+    assert_eq!(second.body["request"], 2);
+    assert_eq!(requests.load(Ordering::SeqCst), 2);
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn read_started_before_mutation_cannot_repopulate_current_epoch() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let state = DelayedReadState::default();
+    let app = Router::new()
+        .route("/resource", get(delayed_first_response))
+        .route(
+            "/mutate",
+            post(|| async { Json(json!({ "updated": true })) }),
+        )
+        .with_state(state.clone());
+    let (base_url, server) = spawn_server(app).await;
+    let client =
+        GitHubProtectedClient::with_base_url("inflight-epoch-token", &base_url).expect("client");
+
+    let old_read = tokio::spawn({
+        let client = client.clone();
+        async move {
+            client
+                .rest_json::<Value>(
+                    Method::GET,
+                    "/resource",
+                    None,
+                    read_descriptor("reviews.inflight"),
+                )
+                .await
+        }
+    });
+    state.started.notified().await;
+    client
+        .rest_json::<Value>(
+            Method::POST,
+            "/mutate",
+            None,
+            mutation_descriptor("task_board.concurrent_mutation"),
+        )
+        .await
+        .expect("mutation");
+    state.release.notify_one();
+    let retried = old_read.await.expect("old read join").expect("old read");
+
+    let current = client
+        .rest_json::<Value>(
+            Method::GET,
+            "/resource",
+            None,
+            read_descriptor("task_board.current"),
+        )
+        .await
+        .expect("current read");
+
+    assert_eq!(retried.body["request"], 2);
+    assert_eq!(current.body["request"], 2);
+    assert!(current.provenance.from_cache);
+    assert_eq!(state.requests.load(Ordering::SeqCst), 2);
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn raw_read_started_before_mutation_retries_at_current_epoch() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let state = DelayedReadState::default();
+    let app = Router::new()
+        .route("/resource", get(delayed_first_response))
+        .route(
+            "/mutate",
+            post(|| async { Json(json!({ "updated": true })) }),
+        )
+        .with_state(state.clone());
+    let (base_url, server) = spawn_server(app).await;
+    let client =
+        GitHubProtectedClient::with_base_url("raw-inflight-token", &base_url).expect("client");
+
+    let old_read = tokio::spawn({
+        let client = client.clone();
+        async move {
+            client
+                .rest_json_with_headers::<Value>(
+                    Method::GET,
+                    "/resource",
+                    None,
+                    GitHubRequestDescriptor::rest_core(
+                        "reviews.raw_inflight",
+                        GitHubPriority::NormalRead,
+                        GitHubCachePolicy::no_store(),
+                    ),
+                    HeaderMap::new(),
+                )
+                .await
+        }
+    });
+    state.started.notified().await;
+    client
+        .rest_json::<Value>(
+            Method::POST,
+            "/mutate",
+            None,
+            mutation_descriptor("task_board.concurrent_raw_mutation"),
+        )
+        .await
+        .expect("mutation");
+    state.release.notify_one();
+    let retried = old_read.await.expect("old read join").expect("old read");
+
+    assert_eq!(retried.body.expect("body")["request"], 2);
+    assert_eq!(state.requests.load(Ordering::SeqCst), 2);
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stable_projection_guard_blocks_mutation_until_commit_finishes() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let initial_revision = GitHubProtectedClient::data_revision();
+    let projection_guard = super::stable_data_revision_guard(initial_revision)
+        .await
+        .expect("stable revision guard");
+    let mut mutation = tokio::spawn(async {
+        let mut guard = super::begin_external_mutation("mutation.after_projection").await;
+        guard.mark_remote_success();
+    });
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), &mut mutation)
+            .await
+            .is_err(),
+        "mutation must wait for the projection commit boundary"
+    );
+    assert_eq!(GitHubProtectedClient::data_revision(), initial_revision);
+    drop(projection_guard);
+    mutation.await.expect("mutation join");
+    assert_eq!(GitHubProtectedClient::data_revision(), initial_revision + 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_ready_event_republishes_without_advancing_revision() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let revision = GitHubProtectedClient::data_revision();
+    let mut changes = GitHubProtectedClient::data_changes();
+
+    super::republish_current_data_change("task_board.github.local_sync_ready");
+    let change = recv_change(&mut changes).await;
+
+    assert_eq!(change.revision, revision);
+    assert_eq!(change.operation, "task_board.github.local_sync_ready");
+    assert_eq!(GitHubProtectedClient::data_revision(), revision);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn every_mutation_entry_point_publishes_exactly_once() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let app = Router::new()
+        .route(
+            "/graphql",
+            post(|| async { Json(json!({ "data": { "ok": true } })) }),
+        )
+        .route("/json", post(|| async { Json(json!({ "ok": true })) }))
+        .route("/empty", post(|| async { StatusCode::NO_CONTENT }));
+    let (base_url, server) = spawn_server(app).await;
+    let client =
+        GitHubProtectedClient::with_base_url("mutation-entry-token", &base_url).expect("client");
+    let mut changes = GitHubProtectedClient::data_changes();
+    let mut expected_revision = GitHubProtectedClient::data_revision();
+
+    client
+        .graphql::<Value>(
+            mutation_descriptor("mutation.graphql"),
+            json!({ "query": "mutation { first: __typename }" }),
+        )
+        .await
+        .expect("graphql mutation");
+    expected_revision += 1;
+    assert_change(&mut changes, expected_revision, "mutation.graphql").await;
+
+    client
+        .graphql_envelope(
+            mutation_descriptor("mutation.graphql_envelope"),
+            json!({ "query": "mutation { second: __typename }" }),
+        )
+        .await
+        .expect("graphql envelope mutation");
+    expected_revision += 1;
+    assert_change(&mut changes, expected_revision, "mutation.graphql_envelope").await;
+
+    client
+        .rest_json::<Value>(
+            Method::POST,
+            "/json",
+            None,
+            mutation_descriptor("mutation.rest_json"),
+        )
+        .await
+        .expect("rest json mutation");
+    expected_revision += 1;
+    assert_change(&mut changes, expected_revision, "mutation.rest_json").await;
+
+    client
+        .rest_json_with_headers::<Value>(
+            Method::POST,
+            "/json",
+            None,
+            mutation_descriptor("mutation.rest_json_with_headers"),
+            HeaderMap::new(),
+        )
+        .await
+        .expect("rest json with headers mutation");
+    expected_revision += 1;
+    assert_change(
+        &mut changes,
+        expected_revision,
+        "mutation.rest_json_with_headers",
+    )
+    .await;
+
+    client
+        .rest_empty(
+            Method::POST,
+            "/empty",
+            None,
+            mutation_descriptor("mutation.rest_empty"),
+        )
+        .await
+        .expect("rest empty mutation");
+    expected_revision += 1;
+    assert_change(&mut changes, expected_revision, "mutation.rest_empty").await;
+
+    let mut mutation_guard = super::begin_external_mutation("mutation.external_transport").await;
+    mutation_guard.mark_remote_success();
+    drop(mutation_guard);
+    expected_revision += 1;
+    assert_change(
+        &mut changes,
+        expected_revision,
+        "mutation.external_transport",
+    )
+    .await;
+    assert_eq!(GitHubProtectedClient::data_revision(), expected_revision);
+    assert!(
+        changes.try_recv().is_err(),
+        "unexpected duplicate data change"
+    );
+    server.abort();
+}
+
+#[derive(Clone, Default)]
+struct DelayedReadState {
+    requests: Arc<AtomicUsize>,
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+async fn delayed_first_response(State(state): State<DelayedReadState>) -> impl IntoResponse {
+    let request = state.requests.fetch_add(1, Ordering::SeqCst) + 1;
+    if request == 1 {
+        state.started.notify_one();
+        state.release.notified().await;
+    }
+    Json(json!({ "request": request }))
+}
+
+async fn counted_response(requests: Arc<AtomicUsize>) -> impl IntoResponse {
+    let request = requests.fetch_add(1, Ordering::SeqCst) + 1;
+    Json(json!({ "request": request }))
+}
+
+fn read_descriptor(operation: &str) -> GitHubRequestDescriptor {
+    GitHubRequestDescriptor::rest_core(
+        operation,
+        GitHubPriority::NormalRead,
+        GitHubCachePolicy::read_through(CACHE_TTL, CACHE_TTL),
+    )
+}
+
+fn mutation_descriptor(operation: &str) -> GitHubRequestDescriptor {
+    if operation.contains("graphql") {
+        return GitHubRequestDescriptor::graphql(
+            operation,
+            GitHubPriority::Mutation,
+            GitHubCachePolicy::no_store(),
+        );
+    }
+    GitHubRequestDescriptor::rest_core(
+        operation,
+        GitHubPriority::Mutation,
+        GitHubCachePolicy::no_store(),
+    )
+}
+
+async fn recv_change(
+    changes: &mut tokio::sync::broadcast::Receiver<GitHubDataChange>,
+) -> GitHubDataChange {
+    tokio::time::timeout(Duration::from_secs(1), changes.recv())
+        .await
+        .expect("data change timeout")
+        .expect("data change")
+}
+
+async fn assert_change(
+    changes: &mut tokio::sync::broadcast::Receiver<GitHubDataChange>,
+    revision: u64,
+    operation: &str,
+) {
+    let change = recv_change(changes).await;
+    assert_eq!(change.revision, revision);
+    assert_eq!(change.operation, operation);
+}
+
+async fn spawn_server(app: Router) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://127.0.0.1:{port}"), server)
+}

--- a/src/github_api/mod.rs
+++ b/src/github_api/mod.rs
@@ -6,6 +6,7 @@ mod predictor;
 mod raw;
 mod recorder;
 mod response;
+mod stability;
 mod state;
 mod transport;
 mod types;
@@ -17,6 +18,7 @@ pub(crate) use budget::{
 pub(crate) use cache::GitHubCache;
 pub(crate) use client::GitHubProtectedClient;
 pub(crate) use recorder::GitHubUsageRecorder;
+pub(crate) use stability::{GitHubReadStabilityError, retry_stable_read};
 pub(crate) use state::{
     begin_external_mutation, republish_current_data_change, stable_data_revision_guard,
 };

--- a/src/github_api/mod.rs
+++ b/src/github_api/mod.rs
@@ -1,12 +1,15 @@
 mod budget;
 mod cache;
 mod client;
+mod mutation;
 mod predictor;
 mod raw;
 mod recorder;
 mod response;
 mod state;
+mod transport;
 mod types;
+mod viewer;
 
 pub(crate) use budget::{
     GitHubBudgetError, GitHubRateBudget, GitHubRateLimitSnapshot, GitHubRateResource,
@@ -14,9 +17,12 @@ pub(crate) use budget::{
 pub(crate) use cache::GitHubCache;
 pub(crate) use client::GitHubProtectedClient;
 pub(crate) use recorder::GitHubUsageRecorder;
+pub(crate) use state::{
+    begin_external_mutation, republish_current_data_change, stable_data_revision_guard,
+};
 pub(crate) use types::{
-    GitHubApiStatus, GitHubCachePolicy, GitHubPriority, GitHubRequestDescriptor,
-    GitHubResponseProvenance,
+    GitHubApiStatus, GitHubCachePolicy, GitHubDataChange, GitHubPriority,
+    GitHubPullRequestSnapshot, GitHubRequestDescriptor, GitHubResponseProvenance,
 };
 
 #[cfg(test)]
@@ -24,3 +30,9 @@ pub(crate) use state::acquire_global_budget_test_lock;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod coherence_tests;
+
+#[cfg(test)]
+mod mutation_tests;

--- a/src/github_api/mutation.rs
+++ b/src/github_api/mutation.rs
@@ -1,0 +1,60 @@
+use std::future::Future;
+
+use reqwest::Method;
+use serde_json::Value;
+
+use crate::errors::{CliError, CliErrorKind};
+
+use super::client::GitHubProtectedClient;
+use super::response::GitHubApiResponse;
+use super::state::GitHubMutationGuard;
+use super::{GitHubRequestDescriptor, begin_external_mutation};
+
+impl GitHubProtectedClient {
+    pub(super) async fn execute_json_with_mutation_boundary(
+        &self,
+        method: Method,
+        route: &str,
+        body: Option<Value>,
+        descriptor: GitHubRequestDescriptor,
+    ) -> Result<GitHubApiResponse<Value>, CliError> {
+        if !descriptor.priority.is_write() {
+            let mut mutation_guard = None;
+            return self
+                .execute_json(method, route, body, descriptor, &mut mutation_guard)
+                .await;
+        }
+
+        let operation = descriptor.operation.clone();
+        let route = route.to_string();
+        let client = self.clone();
+        run_detached_mutation(operation, move |guard| async move {
+            let mut mutation_guard = Some(guard);
+            client
+                .execute_json(method, &route, body, descriptor, &mut mutation_guard)
+                .await
+        })
+        .await
+    }
+}
+
+pub(super) async fn run_detached_mutation<T, Run, RunFuture>(
+    operation: String,
+    run: Run,
+) -> Result<T, CliError>
+where
+    T: Send + 'static,
+    Run: FnOnce(GitHubMutationGuard) -> RunFuture + Send + 'static,
+    RunFuture: Future<Output = Result<T, CliError>> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let guard = begin_external_mutation(&operation).await;
+        run(guard).await
+    })
+    .await
+    .map_err(|error| {
+        CliError::from(CliErrorKind::workflow_io(format!(
+            "join github mutation request: {error}"
+        )))
+    })?
+}

--- a/src/github_api/mutation_tests.rs
+++ b/src/github_api/mutation_tests.rs
@@ -1,0 +1,333 @@
+use std::time::Duration;
+
+use axum::http::{HeaderMap, StatusCode};
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use reqwest::Method;
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+
+use super::{
+    GitHubCachePolicy, GitHubDataChange, GitHubPriority, GitHubProtectedClient,
+    GitHubRequestDescriptor,
+};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn successful_mutations_publish_even_when_local_decoding_fails() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let app = Router::new()
+        .route(
+            "/graphql",
+            post(|| async { Json(json!({ "data": { "updated": true } })) }),
+        )
+        .route("/json", post(|| async { Json(json!({ "updated": true })) }));
+    let (base_url, server) = spawn_server(app).await;
+    let client = GitHubProtectedClient::with_base_url("decode-failure-token", &base_url)
+        .expect("protected client");
+    let mut changes = GitHubProtectedClient::data_changes();
+    let mut expected_revision = GitHubProtectedClient::data_revision();
+
+    assert!(
+        client
+            .graphql::<Vec<Value>>(
+                mutation_descriptor("mutation.graphql_decode_failure"),
+                json!({ "query": "mutation { update: __typename }" }),
+            )
+            .await
+            .is_err(),
+        "typed GraphQL decoding should fail"
+    );
+    expected_revision += 1;
+    assert_change(
+        &mut changes,
+        expected_revision,
+        "mutation.graphql_decode_failure",
+    )
+    .await;
+
+    assert!(
+        client
+            .rest_json::<Vec<Value>>(
+                Method::POST,
+                "/json",
+                None,
+                mutation_descriptor("mutation.rest_decode_failure"),
+            )
+            .await
+            .is_err(),
+        "typed REST decoding should fail"
+    );
+    expected_revision += 1;
+    assert_change(
+        &mut changes,
+        expected_revision,
+        "mutation.rest_decode_failure",
+    )
+    .await;
+
+    assert!(
+        client
+            .rest_json_with_headers::<Vec<Value>>(
+                Method::POST,
+                "/json",
+                None,
+                mutation_descriptor("mutation.raw_decode_failure"),
+                HeaderMap::new(),
+            )
+            .await
+            .is_err(),
+        "raw REST decoding should fail"
+    );
+    expected_revision += 1;
+    assert_change(
+        &mut changes,
+        expected_revision,
+        "mutation.raw_decode_failure",
+    )
+    .await;
+
+    assert_eq!(GitHubProtectedClient::data_revision(), expected_revision);
+    assert!(
+        changes.try_recv().is_err(),
+        "mutation published more than once"
+    );
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn malformed_successful_graphql_response_still_publishes_mutation() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let app = Router::new().route(
+        "/graphql",
+        post(|| async { (StatusCode::OK, "{malformed-json") }),
+    );
+    let (base_url, server) = spawn_server(app).await;
+    let client = GitHubProtectedClient::with_base_url("malformed-graphql-token", &base_url)
+        .expect("protected client");
+    let mut changes = GitHubProtectedClient::data_changes();
+    let initial_revision = GitHubProtectedClient::data_revision();
+
+    assert!(
+        client
+            .graphql_envelope(
+                mutation_descriptor("mutation.graphql_malformed_success"),
+                json!({ "query": "mutation { update: __typename }" }),
+            )
+            .await
+            .is_err(),
+        "malformed GraphQL response"
+    );
+
+    assert_change(
+        &mut changes,
+        initial_revision + 1,
+        "mutation.graphql_malformed_success",
+    )
+    .await;
+    assert!(
+        changes.try_recv().is_err(),
+        "mutation published more than once"
+    );
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn partial_graphql_data_with_errors_still_publishes_mutation() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let app = Router::new().route(
+        "/graphql",
+        post(|| async {
+            Json(json!({
+                "data": { "updated": true },
+                "errors": [{ "message": "another field failed" }],
+            }))
+        }),
+    );
+    let (base_url, server) = spawn_server(app).await;
+    let client = GitHubProtectedClient::with_base_url("partial-graphql-token", &base_url)
+        .expect("protected client");
+    let mut changes = GitHubProtectedClient::data_changes();
+    let initial_revision = GitHubProtectedClient::data_revision();
+
+    assert!(
+        client
+            .graphql_envelope(
+                mutation_descriptor("mutation.graphql_partial_success"),
+                json!({ "query": "mutation { firstMutation secondMutation }" }),
+            )
+            .await
+            .is_err(),
+        "partial GraphQL response reports an error"
+    );
+
+    assert_change(
+        &mut changes,
+        initial_revision + 1,
+        "mutation.graphql_partial_success",
+    )
+    .await;
+    assert!(
+        changes.try_recv().is_err(),
+        "mutation published more than once"
+    );
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelled_http_waiter_leaves_mutation_owned_by_detached_request() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let state = DelayedMutationState::default();
+    let app = Router::new()
+        .route("/mutate", post(delayed_mutation_response))
+        .with_state(state.clone());
+    let (base_url, server) = spawn_server(app).await;
+    let client = GitHubProtectedClient::with_base_url("cancelled-http-token", &base_url)
+        .expect("protected client");
+    let mut changes = GitHubProtectedClient::data_changes();
+    let initial_revision = GitHubProtectedClient::data_revision();
+
+    let mutation = tokio::spawn(async move {
+        client
+            .rest_json::<Value>(
+                Method::POST,
+                "/mutate",
+                None,
+                mutation_descriptor("mutation.cancelled_http_waiter"),
+            )
+            .await
+    });
+    state.started.notified().await;
+    mutation.abort();
+    let cancelled = match mutation.await {
+        Err(error) => error,
+        Ok(_) => panic!("mutation waiter was not cancelled"),
+    };
+    assert!(cancelled.is_cancelled());
+
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(25),
+            super::stable_data_revision_guard(initial_revision),
+        )
+        .await
+        .is_err(),
+        "the detached request must retain the mutation barrier"
+    );
+    state.release.notify_one();
+
+    assert_change(
+        &mut changes,
+        initial_revision + 1,
+        "mutation.cancelled_http_waiter",
+    )
+    .await;
+    assert!(
+        changes.try_recv().is_err(),
+        "mutation published more than once"
+    );
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn definite_remote_failures_do_not_publish_mutations() {
+    let _budget_guard = super::acquire_global_budget_test_lock().await;
+    let app = Router::new()
+        .route(
+            "/graphql",
+            post(|| async { Json(json!({ "errors": [{ "message": "denied" }] })) }),
+        )
+        .route(
+            "/failure",
+            post(|| async {
+                (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(json!({ "message": "denied" })),
+                )
+            }),
+        );
+    let (base_url, server) = spawn_server(app).await;
+    let client = GitHubProtectedClient::with_base_url("remote-failure-token", &base_url)
+        .expect("protected client");
+    let mut changes = GitHubProtectedClient::data_changes();
+    let initial_revision = GitHubProtectedClient::data_revision();
+
+    assert!(
+        client
+            .graphql_envelope(
+                mutation_descriptor("mutation.graphql_rejected"),
+                json!({ "query": "mutation { rejected: __typename }" }),
+            )
+            .await
+            .is_err(),
+        "GraphQL rejection"
+    );
+    assert!(
+        client
+            .rest_json::<Value>(
+                Method::POST,
+                "/failure",
+                None,
+                mutation_descriptor("mutation.rest_rejected"),
+            )
+            .await
+            .is_err(),
+        "REST rejection"
+    );
+
+    assert_eq!(GitHubProtectedClient::data_revision(), initial_revision);
+    assert!(changes.try_recv().is_err(), "remote failure published");
+    server.abort();
+}
+
+#[derive(Clone, Default)]
+struct DelayedMutationState {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+async fn delayed_mutation_response(State(state): State<DelayedMutationState>) -> Json<Value> {
+    state.started.notify_one();
+    state.release.notified().await;
+    Json(json!({ "updated": true }))
+}
+
+fn mutation_descriptor(operation: &str) -> GitHubRequestDescriptor {
+    if operation.contains("graphql") {
+        return GitHubRequestDescriptor::graphql(
+            operation,
+            GitHubPriority::Mutation,
+            GitHubCachePolicy::no_store(),
+        );
+    }
+    GitHubRequestDescriptor::rest_core(
+        operation,
+        GitHubPriority::Mutation,
+        GitHubCachePolicy::no_store(),
+    )
+}
+
+async fn assert_change(
+    changes: &mut tokio::sync::broadcast::Receiver<GitHubDataChange>,
+    revision: u64,
+    operation: &str,
+) {
+    let change = tokio::time::timeout(Duration::from_secs(1), changes.recv())
+        .await
+        .expect("data change timeout")
+        .expect("data change");
+    assert_eq!(change.revision, revision);
+    assert_eq!(change.operation, operation);
+}
+
+async fn spawn_server(app: Router) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://127.0.0.1:{port}"), server)
+}

--- a/src/github_api/raw.rs
+++ b/src/github_api/raw.rs
@@ -10,7 +10,7 @@ use super::client::GitHubProtectedClient;
 use super::mutation::run_detached_mutation;
 use super::response::{budget_error, context_error, http_status_error, request_error};
 use super::state::GitHubMutationGuard;
-use super::{GitHubRateResource, GitHubRequestDescriptor};
+use super::{GitHubRateResource, GitHubRequestDescriptor, retry_stable_read};
 
 pub(crate) struct GitHubRestRawResponse<T> {
     pub(crate) status: StatusCode,
@@ -51,23 +51,28 @@ impl GitHubProtectedClient {
             .await;
         }
 
-        let mut mutation_guard = None;
-        loop {
-            let data_revision = self.state.data_revision();
-            let response = self
-                .rest_json_with_headers_at_revision(
-                    method.clone(),
+        let operation = descriptor.operation.clone();
+        retry_stable_read(&operation, |_| {
+            let method = method.clone();
+            let route = route.clone();
+            let body = body.clone();
+            let descriptor = descriptor.clone();
+            let extra_headers = extra_headers.clone();
+            async move {
+                let mut mutation_guard = None;
+                self.rest_json_with_headers_at_revision(
+                    method,
                     &route,
-                    body.clone(),
-                    descriptor.clone(),
-                    extra_headers.clone(),
+                    body,
+                    descriptor,
+                    extra_headers,
                     &mut mutation_guard,
                 )
-                .await?;
-            if priority.is_write() || self.state.data_revision() == data_revision {
-                return Ok(response);
+                .await
             }
-        }
+        })
+        .await
+        .map(|(response, _)| response)
     }
 
     async fn rest_json_with_headers_at_revision<T>(

--- a/src/github_api/raw.rs
+++ b/src/github_api/raw.rs
@@ -7,7 +7,9 @@ use crate::errors::{CliError, CliErrorKind};
 
 use super::budget::parse_retry_after;
 use super::client::GitHubProtectedClient;
+use super::mutation::run_detached_mutation;
 use super::response::{budget_error, context_error, http_status_error, request_error};
+use super::state::GitHubMutationGuard;
 use super::{GitHubRateResource, GitHubRequestDescriptor};
 
 pub(crate) struct GitHubRestRawResponse<T> {
@@ -26,6 +28,58 @@ impl GitHubProtectedClient {
         extra_headers: HeaderMap,
     ) -> Result<GitHubRestRawResponse<T>, CliError>
     where
+        T: DeserializeOwned + Send + 'static,
+    {
+        let priority = descriptor.priority;
+        let route = route.as_ref().to_string();
+        if priority.is_write() {
+            let operation = descriptor.operation.clone();
+            let client = self.clone();
+            return run_detached_mutation(operation, move |guard| async move {
+                let mut mutation_guard = Some(guard);
+                client
+                    .rest_json_with_headers_at_revision(
+                        method,
+                        &route,
+                        body,
+                        descriptor,
+                        extra_headers,
+                        &mut mutation_guard,
+                    )
+                    .await
+            })
+            .await;
+        }
+
+        let mut mutation_guard = None;
+        loop {
+            let data_revision = self.state.data_revision();
+            let response = self
+                .rest_json_with_headers_at_revision(
+                    method.clone(),
+                    &route,
+                    body.clone(),
+                    descriptor.clone(),
+                    extra_headers.clone(),
+                    &mut mutation_guard,
+                )
+                .await?;
+            if priority.is_write() || self.state.data_revision() == data_revision {
+                return Ok(response);
+            }
+        }
+    }
+
+    async fn rest_json_with_headers_at_revision<T>(
+        &self,
+        method: Method,
+        route: &str,
+        body: Option<Value>,
+        descriptor: GitHubRequestDescriptor,
+        extra_headers: HeaderMap,
+        mutation_guard: &mut Option<GitHubMutationGuard>,
+    ) -> Result<GitHubRestRawResponse<T>, CliError>
+    where
         T: DeserializeOwned,
     {
         let _permit = self
@@ -35,11 +89,16 @@ impl GitHubProtectedClient {
             .await
             .map_err(|error| budget_error(&descriptor.operation, error))?;
         let response = self
-            .send_json_with_headers(method, route.as_ref(), body, extra_headers)
+            .send_json_with_headers(method, route, body, extra_headers)
             .await
             .map_err(|error| request_error(&descriptor.operation, &error))?;
         let status = response.status();
         let headers = response.headers().clone();
+        if status.is_success()
+            && let Some(guard) = mutation_guard.as_mut()
+        {
+            guard.mark_remote_success();
+        }
         self.observe_rest_status(&descriptor, status, &headers)
             .await;
         if status == StatusCode::NOT_MODIFIED {
@@ -79,6 +138,45 @@ impl GitHubProtectedClient {
         body: Option<Value>,
         descriptor: GitHubRequestDescriptor,
     ) -> Result<(), CliError> {
+        let priority = descriptor.priority;
+        let route = route.as_ref().to_string();
+        if priority.is_write() {
+            let operation = descriptor.operation.clone();
+            let client = self.clone();
+            return run_detached_mutation(operation, move |guard| async move {
+                let mut mutation_guard = Some(guard);
+                client
+                    .rest_empty_with_mutation_boundary(
+                        method,
+                        &route,
+                        body,
+                        descriptor,
+                        &mut mutation_guard,
+                    )
+                    .await
+            })
+            .await;
+        }
+
+        let mut mutation_guard = None;
+        self.rest_empty_with_mutation_boundary(
+            method,
+            &route,
+            body,
+            descriptor,
+            &mut mutation_guard,
+        )
+        .await
+    }
+
+    async fn rest_empty_with_mutation_boundary(
+        &self,
+        method: Method,
+        route: &str,
+        body: Option<Value>,
+        descriptor: GitHubRequestDescriptor,
+        mutation_guard: &mut Option<GitHubMutationGuard>,
+    ) -> Result<(), CliError> {
         let _permit = self
             .state
             .budget
@@ -86,11 +184,16 @@ impl GitHubProtectedClient {
             .await
             .map_err(|error| budget_error(&descriptor.operation, error))?;
         let response = self
-            .send_json(method, route.as_ref(), body, None)
+            .send_json(method, route, body, None)
             .await
             .map_err(|error| request_error(&descriptor.operation, &error))?;
         let status = response.status();
         let headers = response.headers().clone();
+        if status.is_success()
+            && let Some(guard) = mutation_guard.as_mut()
+        {
+            guard.mark_remote_success();
+        }
         self.observe_rest_status(&descriptor, status, &headers)
             .await;
         let text = response

--- a/src/github_api/recorder.rs
+++ b/src/github_api/recorder.rs
@@ -101,9 +101,14 @@ impl GitHubUsageRecorder {
         });
     }
 
-    pub(crate) async fn status(&self, budget: &GitHubRateBudget) -> GitHubApiStatus {
+    pub(crate) async fn status(
+        &self,
+        budget: &GitHubRateBudget,
+        data_revision: u64,
+    ) -> GitHubApiStatus {
         let events = self.window_events();
         GitHubApiStatus {
+            data_revision,
             buckets: budget.bucket_statuses().await,
             cooling: budget.cooldown_statuses().await,
             last_hour_network_requests: count_network(&events),

--- a/src/github_api/stability.rs
+++ b/src/github_api/stability.rs
@@ -1,0 +1,193 @@
+use std::error::Error;
+use std::fmt;
+use std::future::Future;
+
+use crate::errors::{CliError, CliErrorKind};
+
+use super::state::global_state;
+
+const MAX_STABLE_READ_ATTEMPTS: usize = 3;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GitHubReadStabilityError {
+    operation: String,
+    attempts: usize,
+    final_start_revision: u64,
+    final_end_revision: u64,
+}
+
+impl fmt::Display for GitHubReadStabilityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "github read '{}' did not stabilize after {} attempts; final data revision changed from {} to {}",
+            self.operation, self.attempts, self.final_start_revision, self.final_end_revision
+        )
+    }
+}
+
+impl Error for GitHubReadStabilityError {}
+
+impl From<GitHubReadStabilityError> for CliError {
+    fn from(error: GitHubReadStabilityError) -> Self {
+        CliErrorKind::concurrent_modification(error.to_string()).into()
+    }
+}
+
+pub(crate) async fn retry_stable_read<T, E, Fetch, FetchFuture>(
+    operation: &str,
+    fetch: Fetch,
+) -> Result<(T, u64), E>
+where
+    E: From<GitHubReadStabilityError>,
+    Fetch: FnMut(u64) -> FetchFuture,
+    FetchFuture: Future<Output = Result<T, E>>,
+{
+    retry_stable_read_with_revision(operation, fetch, || global_state().data_revision()).await
+}
+
+async fn retry_stable_read_with_revision<T, E, Fetch, FetchFuture, Revision>(
+    operation: &str,
+    mut fetch: Fetch,
+    revision: Revision,
+) -> Result<(T, u64), E>
+where
+    E: From<GitHubReadStabilityError>,
+    Fetch: FnMut(u64) -> FetchFuture,
+    FetchFuture: Future<Output = Result<T, E>>,
+    Revision: Fn() -> u64,
+{
+    let mut final_start_revision = 0;
+    let mut final_end_revision = 0;
+    for _ in 0..MAX_STABLE_READ_ATTEMPTS {
+        final_start_revision = revision();
+        let value = fetch(final_start_revision).await?;
+        final_end_revision = revision();
+        if final_end_revision == final_start_revision {
+            return Ok((value, final_start_revision));
+        }
+    }
+    Err(GitHubReadStabilityError {
+        operation: operation.to_string(),
+        attempts: MAX_STABLE_READ_ATTEMPTS,
+        final_start_revision,
+        final_end_revision,
+    }
+    .into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum TestError {
+        Source,
+        Unstable(GitHubReadStabilityError),
+    }
+
+    impl From<GitHubReadStabilityError> for TestError {
+        fn from(error: GitHubReadStabilityError) -> Self {
+            Self::Unstable(error)
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_until_one_attempt_uses_a_stable_revision() {
+        let revisions = Arc::new(AtomicU64::new(1));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let fetch_revisions = Arc::clone(&revisions);
+        let fetch_calls = Arc::clone(&calls);
+        let observed_revisions = Arc::clone(&revisions);
+
+        let result: Result<(usize, u64), TestError> = retry_stable_read_with_revision(
+            "test.eventually_stable",
+            move |_| {
+                let revisions = Arc::clone(&fetch_revisions);
+                let calls = Arc::clone(&fetch_calls);
+                async move {
+                    let attempt = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                    if attempt < MAX_STABLE_READ_ATTEMPTS {
+                        revisions.fetch_add(1, Ordering::SeqCst);
+                    }
+                    Ok(attempt)
+                }
+            },
+            move || observed_revisions.load(Ordering::SeqCst),
+        )
+        .await;
+
+        assert_eq!(result, Ok((MAX_STABLE_READ_ATTEMPTS, 3)));
+        assert_eq!(calls.load(Ordering::SeqCst), MAX_STABLE_READ_ATTEMPTS);
+    }
+
+    #[tokio::test]
+    async fn returns_a_controlled_error_after_the_retry_budget() {
+        let revisions = Arc::new(AtomicU64::new(7));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let fetch_revisions = Arc::clone(&revisions);
+        let fetch_calls = Arc::clone(&calls);
+        let observed_revisions = Arc::clone(&revisions);
+
+        let result: Result<((), u64), TestError> = retry_stable_read_with_revision(
+            "test.never_stable",
+            move |_| {
+                let revisions = Arc::clone(&fetch_revisions);
+                let calls = Arc::clone(&fetch_calls);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    revisions.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            },
+            move || observed_revisions.load(Ordering::SeqCst),
+        )
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), MAX_STABLE_READ_ATTEMPTS);
+        assert_eq!(
+            result,
+            Err(TestError::Unstable(GitHubReadStabilityError {
+                operation: "test.never_stable".to_string(),
+                attempts: MAX_STABLE_READ_ATTEMPTS,
+                final_start_revision: 9,
+                final_end_revision: 10,
+            }))
+        );
+    }
+
+    #[tokio::test]
+    async fn source_errors_return_without_retrying() {
+        let calls = AtomicUsize::new(0);
+
+        let result: Result<((), u64), TestError> = retry_stable_read_with_revision(
+            "test.source_error",
+            |_| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err(TestError::Source)
+            },
+            || 1,
+        )
+        .await;
+
+        assert_eq!(result, Err(TestError::Source));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn instability_maps_to_the_concurrent_workflow_error() {
+        let error = GitHubReadStabilityError {
+            operation: "test.concurrent".to_string(),
+            attempts: MAX_STABLE_READ_ATTEMPTS,
+            final_start_revision: 4,
+            final_end_revision: 5,
+        };
+
+        let cli_error = CliError::from(error);
+
+        assert_eq!(cli_error.code(), "WORKFLOW_CONCURRENT");
+    }
+}

--- a/src/github_api/state.rs
+++ b/src/github_api/state.rs
@@ -1,9 +1,15 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
+use std::time::Duration;
 
-use tokio::sync::Notify;
+use tokio::sync::{Mutex as AsyncMutex, Notify, OwnedMutexGuard, broadcast};
 
-use super::{GitHubCache, GitHubRateBudget, GitHubUsageRecorder};
+use super::{GitHubCache, GitHubDataChange, GitHubRateBudget, GitHubUsageRecorder};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const READ_TIMEOUT: Duration = Duration::from_mins(1);
+const DATA_CHANGE_CAPACITY: usize = 128;
 
 #[cfg(test)]
 static GLOBAL_BUDGET_TEST_LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
@@ -22,6 +28,11 @@ pub(super) struct GitHubApiState {
     pub(super) budget: GitHubRateBudget,
     pub(super) cache: GitHubCache,
     pub(super) recorder: GitHubUsageRecorder,
+    pub(super) http: Result<reqwest::Client, String>,
+    data_revision: AtomicU64,
+    data_revision_write: Mutex<()>,
+    mutation_barrier: Arc<AsyncMutex<()>>,
+    data_changes: broadcast::Sender<GitHubDataChange>,
     inflight: Mutex<HashMap<String, Arc<Notify>>>,
 }
 
@@ -36,6 +47,13 @@ pub(super) struct InflightGuard {
     state: Arc<GitHubApiState>,
 }
 
+pub(crate) struct GitHubMutationGuard {
+    state: Arc<GitHubApiState>,
+    operation: String,
+    remote_succeeded: bool,
+    _barrier: OwnedMutexGuard<()>,
+}
+
 impl Drop for InflightGuard {
     fn drop(&mut self) {
         if let Ok(mut guard) = self.state.inflight.lock() {
@@ -45,15 +63,125 @@ impl Drop for InflightGuard {
     }
 }
 
+impl GitHubMutationGuard {
+    pub(crate) const fn mark_remote_success(&mut self) {
+        self.remote_succeeded = true;
+    }
+
+    pub(super) const fn mark_remote_failure(&mut self) {
+        self.remote_succeeded = false;
+    }
+}
+
+impl Drop for GitHubMutationGuard {
+    fn drop(&mut self) {
+        if self.remote_succeeded {
+            self.state.publish_data_change(&self.operation);
+        }
+    }
+}
+
 pub(super) fn global_state() -> Arc<GitHubApiState> {
     Arc::clone(GLOBAL_STATE.get_or_init(|| {
+        let (data_changes, _) = broadcast::channel(DATA_CHANGE_CAPACITY);
+        let cache = GitHubCache::new();
+        #[cfg(not(test))]
+        let data_revision = cache.data_revision();
+        #[cfg(test)]
+        let data_revision = 0;
         Arc::new(GitHubApiState {
             budget: GitHubRateBudget::new(),
-            cache: GitHubCache::new(),
+            cache,
             recorder: GitHubUsageRecorder::new(),
+            http: reqwest::Client::builder()
+                .connect_timeout(CONNECT_TIMEOUT)
+                .read_timeout(READ_TIMEOUT)
+                .build()
+                .map_err(|error| error.to_string()),
+            data_revision: AtomicU64::new(data_revision),
+            data_revision_write: Mutex::new(()),
+            mutation_barrier: Arc::new(AsyncMutex::new(())),
+            data_changes,
             inflight: Mutex::new(HashMap::new()),
         })
     }))
+}
+
+impl GitHubApiState {
+    pub(super) fn data_revision(&self) -> u64 {
+        self.data_revision.load(Ordering::Acquire)
+    }
+
+    pub(super) fn data_changes(&self) -> broadcast::Receiver<GitHubDataChange> {
+        self.data_changes.subscribe()
+    }
+
+    async fn mutation_guard(self: &Arc<Self>, operation: &str) -> GitHubMutationGuard {
+        let barrier = Arc::clone(&self.mutation_barrier).lock_owned().await;
+        GitHubMutationGuard {
+            state: Arc::clone(self),
+            operation: operation.to_string(),
+            remote_succeeded: false,
+            _barrier: barrier,
+        }
+    }
+
+    pub(super) fn publish_data_change(&self, operation: &str) {
+        let _guard = self
+            .data_revision_write
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let revision = self.data_revision.fetch_add(1, Ordering::AcqRel) + 1;
+        self.persist_data_revision(revision);
+        let _ = self.data_changes.send(GitHubDataChange {
+            revision,
+            operation: operation.to_string(),
+        });
+    }
+
+    fn republish_current_data_change(&self, operation: &str) {
+        let _guard = self
+            .data_revision_write
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let _ = self.data_changes.send(GitHubDataChange {
+            revision: self.data_revision(),
+            operation: operation.to_string(),
+        });
+    }
+
+    #[cfg(not(test))]
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "revision persistence quarantines disk data through a nested recovery path"
+    )]
+    fn persist_data_revision(&self, revision: u64) {
+        if let Err(error) = self.cache.persist_data_revision(revision) {
+            tracing::warn!(%error, revision, "persist github data revision");
+            if let Err(error) = self.cache.disable_disk_after_revision_failure(revision) {
+                tracing::warn!(%error, revision, "disable stale github disk cache");
+            }
+        }
+    }
+
+    #[cfg(test)]
+    const fn persist_data_revision(&self, _revision: u64) {}
+}
+
+pub(crate) async fn begin_external_mutation(operation: &str) -> GitHubMutationGuard {
+    global_state().mutation_guard(operation).await
+}
+
+pub(crate) fn republish_current_data_change(operation: &str) {
+    global_state().republish_current_data_change(operation);
+}
+
+pub(crate) async fn stable_data_revision_guard(
+    expected_revision: u64,
+) -> Option<OwnedMutexGuard<()>> {
+    let state = global_state();
+    let guard = Arc::clone(&state.mutation_barrier).lock_owned().await;
+    (state.data_revision() == expected_revision).then_some(guard)
 }
 
 pub(super) fn register_inflight(state: &Arc<GitHubApiState>, key: &str) -> InflightRole {

--- a/src/github_api/tests.rs
+++ b/src/github_api/tests.rs
@@ -25,6 +25,25 @@ fn cache_key_hashes_secret_material() {
 }
 
 #[test]
+fn disk_cache_control_reuses_healthy_scope_and_rotates_during_recovery() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let first = GitHubCache::test_with_root(temp.path().to_path_buf());
+    first.persist_data_revision(7).expect("persist revision");
+    let second = GitHubCache::test_with_root(temp.path().to_path_buf());
+
+    assert_eq!(first.scope(), second.scope());
+    assert_eq!(second.data_revision(), 7);
+    let healthy_scope = second.scope();
+    second
+        .disable_disk_after_revision_failure(8)
+        .expect("rotate failed cache");
+    let recovered = GitHubCache::test_with_root(temp.path().to_path_buf());
+    assert_ne!(healthy_scope, recovered.scope());
+    assert_eq!(second.scope(), recovered.scope());
+    assert_eq!(recovered.data_revision(), 8);
+}
+
+#[test]
 fn retry_after_header_parses_seconds() {
     let mut headers = HeaderMap::new();
     headers.insert(reqwest::header::RETRY_AFTER, HeaderValue::from_static("42"));

--- a/src/github_api/tests.rs
+++ b/src/github_api/tests.rs
@@ -44,6 +44,26 @@ fn disk_cache_control_reuses_healthy_scope_and_rotates_during_recovery() {
 }
 
 #[test]
+fn disk_cache_recovery_propagates_control_rotation_failure() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cache = GitHubCache::test_with_root(temp.path().to_path_buf());
+    cache.persist_data_revision(7).expect("persist revision");
+    let blocked_tmp = temp
+        .path()
+        .join("github-cache-control.json")
+        .with_extension(format!("{}.tmp", std::process::id()));
+    fs_err::create_dir(&blocked_tmp).expect("block temporary control file");
+
+    let error = cache
+        .disable_disk_after_revision_failure(8)
+        .expect_err("control rotation must remain observable");
+    let restarted = GitHubCache::test_with_root(temp.path().to_path_buf());
+
+    assert!(error.to_string().contains("rotate github cache control"));
+    assert_eq!(restarted.data_revision(), 7);
+}
+
+#[test]
 fn retry_after_header_parses_seconds() {
     let mut headers = HeaderMap::new();
     headers.insert(reqwest::header::RETRY_AFTER, HeaderValue::from_static("42"));

--- a/src/github_api/transport.rs
+++ b/src/github_api/transport.rs
@@ -1,0 +1,80 @@
+use reqwest::Method;
+use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, IF_NONE_MATCH, USER_AGENT};
+use serde_json::Value;
+
+use super::client::GitHubProtectedClient;
+
+const USER_AGENT_VALUE: &str = "harness-github-rate-shield";
+
+impl GitHubProtectedClient {
+    pub(super) async fn send_json(
+        &self,
+        method: Method,
+        route: &str,
+        body: Option<Value>,
+        stale: Option<&super::cache::GitHubCacheHit>,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        let mut headers = self.default_headers();
+        if method == Method::GET
+            && let Some(etag) = stale.and_then(|hit| hit.etag.as_deref())
+            && let Ok(value) = HeaderValue::from_str(etag)
+        {
+            headers.insert(IF_NONE_MATCH, value);
+        }
+        self.send_request(method, route, body, headers).await
+    }
+
+    pub(super) async fn send_json_with_headers(
+        &self,
+        method: Method,
+        route: &str,
+        body: Option<Value>,
+        extra_headers: HeaderMap,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        let mut headers = self.default_headers();
+        for (name, value) in extra_headers {
+            if let Some(name) = name {
+                headers.insert(name, value);
+            }
+        }
+        self.send_request(method, route, body, headers).await
+    }
+
+    async fn send_request(
+        &self,
+        method: Method,
+        route: &str,
+        body: Option<Value>,
+        headers: HeaderMap,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        let request = self
+            .http
+            .request(method, self.route_url(route))
+            .headers(headers);
+        match body {
+            Some(body) => request.json(&body).send().await,
+            None => request.send().await,
+        }
+    }
+
+    fn default_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        let auth = format!("Bearer {}", self.token);
+        if let Ok(value) = HeaderValue::from_str(&auth) {
+            headers.insert(AUTHORIZATION, value);
+        }
+        headers
+    }
+
+    fn route_url(&self, route: &str) -> String {
+        if route.starts_with("http://") || route.starts_with("https://") {
+            return route.to_string();
+        }
+        format!("{}/{}", self.base_url, route.trim_start_matches('/'))
+    }
+}

--- a/src/github_api/types.rs
+++ b/src/github_api/types.rs
@@ -4,6 +4,21 @@ use serde::{Deserialize, Serialize};
 
 use super::budget::GitHubRateResource;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GitHubDataChange {
+    pub revision: u64,
+    pub operation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubPullRequestSnapshot {
+    pub repository: String,
+    pub number: u64,
+    pub is_open: Option<bool>,
+    pub viewer_review_requested: Option<bool>,
+    pub updated_at: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum GitHubPriority {
@@ -135,6 +150,7 @@ impl GitHubResponseProvenance {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct GitHubApiStatus {
+    pub data_revision: u64,
     pub buckets: Vec<GitHubRateBucketStatus>,
     pub cooling: Vec<GitHubCooldownStatus>,
     pub last_hour_network_requests: u64,

--- a/src/github_api/viewer.rs
+++ b/src/github_api/viewer.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::errors::{CliError, CliErrorKind};
+
+use super::{GitHubCachePolicy, GitHubPriority, GitHubProtectedClient, GitHubRequestDescriptor};
+
+const VIEWER_LOGIN_QUERY: &str = r"
+query HarnessViewerLogin {
+  viewer {
+    login
+  }
+}
+";
+
+#[derive(Deserialize)]
+struct ViewerLoginResponse {
+    viewer: ViewerLogin,
+}
+
+#[derive(Deserialize)]
+struct ViewerLogin {
+    login: String,
+}
+
+impl GitHubProtectedClient {
+    pub(crate) async fn viewer_login(&self) -> Result<String, CliError> {
+        let response: ViewerLoginResponse = self
+            .graphql(
+                GitHubRequestDescriptor::graphql(
+                    "github.viewer_login",
+                    GitHubPriority::NormalRead,
+                    GitHubCachePolicy::read_through(
+                        Duration::from_hours(24),
+                        Duration::from_hours(24 * 7),
+                    ),
+                ),
+                json!({ "query": VIEWER_LOGIN_QUERY }),
+            )
+            .await
+            .map(|response| response.body)?;
+        let login = response.viewer.login.trim();
+        if login.is_empty() {
+            return Err(CliErrorKind::workflow_io(
+                "loading authenticated GitHub viewer returned an empty login",
+            )
+            .into());
+        }
+        Ok(login.to_string())
+    }
+}

--- a/src/reviews/files/patch_rest/fetcher.rs
+++ b/src/reviews/files/patch_rest/fetcher.rs
@@ -49,6 +49,31 @@ pub async fn fetch_patches_conditional(
     requested_paths: &[String],
     if_none_match: Option<&str>,
 ) -> Result<ConditionalFetchOutcome, RestFetchError> {
+    loop {
+        let revision = GitHubProtectedClient::data_revision();
+        let outcome = fetch_patches_conditional_at_revision(
+            client,
+            repo_full_name,
+            pr_number,
+            head_ref_oid,
+            requested_paths,
+            if_none_match,
+        )
+        .await?;
+        if GitHubProtectedClient::data_revision() == revision {
+            return Ok(outcome);
+        }
+    }
+}
+
+async fn fetch_patches_conditional_at_revision(
+    client: &GitHubProtectedClient,
+    repo_full_name: &str,
+    pr_number: u64,
+    head_ref_oid: &str,
+    requested_paths: &[String],
+    if_none_match: Option<&str>,
+) -> Result<ConditionalFetchOutcome, RestFetchError> {
     let (owner, repo) = split_repo_full_name(repo_full_name).ok_or_else(|| {
         RestFetchError::InvalidRequest("repo_full_name must be owner/name".into())
     })?;
@@ -129,6 +154,25 @@ pub async fn any_patch_matches<F>(
 where
     F: Fn(&str) -> bool + Send + Sync,
 {
+    loop {
+        let revision = GitHubProtectedClient::data_revision();
+        let matched =
+            any_patch_matches_at_revision(client, repo_full_name, pr_number, &predicate).await?;
+        if GitHubProtectedClient::data_revision() == revision {
+            return Ok(matched);
+        }
+    }
+}
+
+async fn any_patch_matches_at_revision<F>(
+    client: &GitHubProtectedClient,
+    repo_full_name: &str,
+    pr_number: u64,
+    predicate: &F,
+) -> Result<bool, RestFetchError>
+where
+    F: Fn(&str) -> bool + Send + Sync,
+{
     let (owner, repo) = split_repo_full_name(repo_full_name).ok_or_else(|| {
         RestFetchError::InvalidRequest("repo_full_name must be owner/name".into())
     })?;
@@ -157,7 +201,7 @@ where
     let first_page = response
         .body
         .ok_or_else(|| RestFetchError::Http("rest patches missing body".into()))?;
-    if page_has_matching_patch(&first_page, &predicate) {
+    if page_has_matching_patch(&first_page, predicate) {
         return Ok(true);
     }
 
@@ -189,7 +233,7 @@ where
         let page = response
             .body
             .ok_or_else(|| RestFetchError::Http("paginated body missing".into()))?;
-        if page_has_matching_patch(&page, &predicate) {
+        if page_has_matching_patch(&page, predicate) {
             return Ok(true);
         }
         visited_pages += 1;

--- a/src/reviews/files/patch_rest/fetcher.rs
+++ b/src/reviews/files/patch_rest/fetcher.rs
@@ -9,7 +9,8 @@ use std::fmt;
 
 use super::parsing::{RestPullFile, parse_next_link, select_patches_by_path, split_repo_full_name};
 use crate::github_api::{
-    GitHubCachePolicy, GitHubPriority, GitHubProtectedClient, GitHubRequestDescriptor,
+    GitHubCachePolicy, GitHubPriority, GitHubProtectedClient, GitHubReadStabilityError,
+    GitHubRequestDescriptor, retry_stable_read,
 };
 use crate::reviews::files::{FILES_PAGE_CAP, ReviewFilePatch};
 
@@ -39,8 +40,8 @@ pub enum ConditionalFetchOutcome {
 /// with no body fetched. Without an etag the first call is unconditional.
 ///
 /// # Errors
-/// Returns `RestFetchError` on network / auth failures and on malformed
-/// `repo_full_name`.
+/// Returns `RestFetchError` on network / auth failures, malformed
+/// `repo_full_name`, or repeated concurrent GitHub data changes.
 pub async fn fetch_patches_conditional(
     client: &GitHubProtectedClient,
     repo_full_name: &str,
@@ -49,9 +50,8 @@ pub async fn fetch_patches_conditional(
     requested_paths: &[String],
     if_none_match: Option<&str>,
 ) -> Result<ConditionalFetchOutcome, RestFetchError> {
-    loop {
-        let revision = GitHubProtectedClient::data_revision();
-        let outcome = fetch_patches_conditional_at_revision(
+    retry_stable_read("reviews.files_patch", |_| {
+        fetch_patches_conditional_at_revision(
             client,
             repo_full_name,
             pr_number,
@@ -59,11 +59,9 @@ pub async fn fetch_patches_conditional(
             requested_paths,
             if_none_match,
         )
-        .await?;
-        if GitHubProtectedClient::data_revision() == revision {
-            return Ok(outcome);
-        }
-    }
+    })
+    .await
+    .map(|(outcome, _)| outcome)
 }
 
 async fn fetch_patches_conditional_at_revision(
@@ -143,8 +141,8 @@ async fn fetch_patches_conditional_at_revision(
 /// need a yes/no answer do not materialize every patch for large pull requests.
 ///
 /// # Errors
-/// Returns `RestFetchError` on network / auth failures and on malformed
-/// `repo_full_name`.
+/// Returns `RestFetchError` on network / auth failures, malformed
+/// `repo_full_name`, or repeated concurrent GitHub data changes.
 pub async fn any_patch_matches<F>(
     client: &GitHubProtectedClient,
     repo_full_name: &str,
@@ -154,14 +152,11 @@ pub async fn any_patch_matches<F>(
 where
     F: Fn(&str) -> bool + Send + Sync,
 {
-    loop {
-        let revision = GitHubProtectedClient::data_revision();
-        let matched =
-            any_patch_matches_at_revision(client, repo_full_name, pr_number, &predicate).await?;
-        if GitHubProtectedClient::data_revision() == revision {
-            return Ok(matched);
-        }
-    }
+    retry_stable_read("reviews.files_patch_scan", |_| {
+        any_patch_matches_at_revision(client, repo_full_name, pr_number, &predicate)
+    })
+    .await
+    .map(|(matched, _)| matched)
 }
 
 async fn any_patch_matches_at_revision<F>(
@@ -344,6 +339,7 @@ pub async fn fetch_patches(
 pub enum RestFetchError {
     InvalidRequest(String),
     Http(String),
+    UnstableRead(String),
 }
 
 impl fmt::Display for RestFetchError {
@@ -351,11 +347,18 @@ impl fmt::Display for RestFetchError {
         match self {
             Self::InvalidRequest(msg) => write!(f, "rest patch fetch: {msg}"),
             Self::Http(msg) => write!(f, "rest patch fetch http: {msg}"),
+            Self::UnstableRead(msg) => write!(f, "rest patch fetch unstable: {msg}"),
         }
     }
 }
 
 impl Error for RestFetchError {}
+
+impl From<GitHubReadStabilityError> for RestFetchError {
+    fn from(error: GitHubReadStabilityError) -> Self {
+        Self::UnstableRead(error.to_string())
+    }
+}
 
 fn patch_descriptor(operation: &str) -> GitHubRequestDescriptor {
     GitHubRequestDescriptor::rest_core(

--- a/src/reviews/files/patch_rest/tests.rs
+++ b/src/reviews/files/patch_rest/tests.rs
@@ -2,6 +2,7 @@
 //! collected here (rather than split per submodule) because the integration
 //! cases need both the helpers and the fetcher visible at once.
 
+mod revision;
 mod scan;
 
 use super::fetcher::{

--- a/src/reviews/files/patch_rest/tests/revision.rs
+++ b/src/reviews/files/patch_rest/tests/revision.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use axum::Router;
+use axum::extract::Query;
+use axum::http::HeaderValue;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use serde::Deserialize;
+use serde_json::json;
+use tokio::net::TcpListener;
+
+use super::super::fetcher::fetch_patches;
+use super::protected_client_at;
+
+#[derive(Deserialize)]
+struct PageQuery {
+    page: Option<u8>,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fetch_patches_restarts_all_pages_after_revision_change() {
+    let _budget_guard = crate::github_api::acquire_global_budget_test_lock().await;
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let revision_changed = Arc::new(AtomicBool::new(false));
+    let route_calls = Arc::clone(&calls);
+    let route_revision_changed = Arc::clone(&revision_changed);
+    let app = Router::new().route(
+        "/repos/{owner}/{repo}/pulls/{number}/files",
+        get(move |Query(query): Query<PageQuery>| {
+            let calls = Arc::clone(&route_calls);
+            let revision_changed = Arc::clone(&route_revision_changed);
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                publish_change_on_second_page(&query, &revision_changed).await;
+                page_response(port, &query, revision_changed.load(Ordering::SeqCst))
+            }
+        }),
+    );
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let client = protected_client_at(port);
+
+    let patches = fetch_patches(&client, "o/r", 1, "head", &[])
+        .await
+        .expect("fetch");
+
+    assert_eq!(patches.len(), 2);
+    assert!(patches.iter().all(|patch| patch.path.starts_with("new-")));
+    assert!(calls.load(Ordering::SeqCst) >= 4);
+    server.abort();
+}
+
+async fn publish_change_on_second_page(query: &PageQuery, revision_changed: &AtomicBool) {
+    if query.page == Some(2) && !revision_changed.swap(true, Ordering::SeqCst) {
+        let mut guard =
+            crate::github_api::begin_external_mutation("test.patch_pagination_change").await;
+        guard.mark_remote_success();
+        drop(guard);
+    }
+}
+
+fn page_response(port: u16, query: &PageQuery, revision_changed: bool) -> axum::response::Response {
+    let epoch = if revision_changed { "new" } else { "old" };
+    let page = query.page.unwrap_or(1);
+    let mut response = axum::Json(json!([{
+        "sha": format!("{epoch}-{page}"),
+        "filename": format!("{epoch}-page-{page}.rs"),
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "patch": "+changed"
+    }]))
+    .into_response();
+    if query.page.is_none() {
+        response.headers_mut().insert(
+            "link",
+            HeaderValue::from_str(&format!(
+                "<http://127.0.0.1:{port}/repos/o/r/pulls/1/files?page=2>; rel=\"next\""
+            ))
+            .expect("link header"),
+        );
+    }
+    response
+}

--- a/src/reviews/github/actions.rs
+++ b/src/reviews/github/actions.rs
@@ -1,5 +1,4 @@
 use std::slice;
-use std::time::Duration;
 
 use serde_json::json;
 
@@ -15,7 +14,7 @@ use super::client::ReviewsGitHubClient;
 use super::mapping::{action_result, github_project_config};
 use super::queries::{
     ADD_COMMENT_MUTATION, ADD_REVIEW_THREAD_MUTATION, ADD_REVIEW_THREAD_REPLY_MUTATION,
-    APPROVE_MUTATION, REREQUEST_CHECK_SUITE_MUTATION, VIEWER_LOGIN_QUERY,
+    APPROVE_MUTATION, REREQUEST_CHECK_SUITE_MUTATION,
 };
 use super::{
     ReviewActionKind, ReviewActionOutcome, ReviewActionResult, ReviewTarget, ReviewsApproveRequest,
@@ -24,43 +23,13 @@ use super::{
     ReviewsRequestReviewRequest, ReviewsRerunChecksRequest, timeline,
 };
 
-const HOURS: u64 = 60 * 60;
-const DAYS: u64 = 24 * HOURS;
-
 impl ReviewsGitHubClient {
-    /// Resolve the authenticated GitHub viewer's login via the simplest
-    /// `viewer { login }` GraphQL query. Used to mark "(you)" on the
-    /// current viewer's reviewer pill and surface the "Commenting as
-    /// @viewer" caption in the composer. Returns `None` when GitHub
-    /// either rejects the call (revoked token) or returns an empty
-    /// login — both are non-fatal: the UI just doesn't surface the
-    /// affordances.
+    /// Resolve the authenticated GitHub viewer through the shared GitHub data
+    /// source. Used to mark "(you)" on the current viewer's reviewer pill and
+    /// surface the "Commenting as @viewer" caption in the composer. Failures
+    /// remain non-fatal: the UI simply omits those affordances.
     pub(crate) async fn fetch_viewer_login(&self) -> Option<String> {
-        let response: serde_json::Value = self
-            .client
-            .graphql_envelope(
-                GitHubRequestDescriptor::graphql(
-                    "reviews.viewer_login",
-                    GitHubPriority::NormalRead,
-                    GitHubCachePolicy::read_through(
-                        Duration::from_secs(24 * HOURS),
-                        Duration::from_secs(7 * DAYS),
-                    ),
-                ),
-                json!({ "query": VIEWER_LOGIN_QUERY }),
-            )
-            .await
-            .ok()?
-            .body;
-        let login = response
-            .pointer("/data/viewer/login")
-            .and_then(serde_json::Value::as_str)?
-            .trim();
-        if login.is_empty() {
-            None
-        } else {
-            Some(login.to_string())
-        }
+        self.client.viewer_login().await.ok()
     }
 
     pub(crate) async fn approve(

--- a/src/reviews/github/queries.rs
+++ b/src/reviews/github/queries.rs
@@ -302,14 +302,6 @@ query PullRequestBody($id: ID!) {
 }
 ";
 
-pub(super) const VIEWER_LOGIN_QUERY: &str = r"
-query ReviewsViewerLogin {
-  viewer {
-    login
-  }
-}
-";
-
 pub(super) const APPROVE_MUTATION: &str = r"
 mutation ApproveReview($id: ID!) {
   addPullRequestReview(input: { pullRequestId: $id, event: APPROVE }) {

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -19,6 +19,9 @@ pub use capabilities::{
     ExternalTaskUpdate, ExternalUpdateOutcome,
 };
 pub use github::{GitHubInboxSyncClient, GitHubSyncClient};
+pub(crate) use github::{
+    imported_review_pull_request_references, reconcile_pull_request_snapshots,
+};
 pub use sync::{
     ExternalSyncAction, ExternalSyncDirection, ExternalSyncOperation, ExternalSyncOptions,
     configured_sync_clients, sync_external_tasks,

--- a/src/task_board/external/github.rs
+++ b/src/task_board/external/github.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 use crate::errors::{CliError, CliErrorKind};
 use crate::github_api::{
     GitHubCachePolicy, GitHubPriority, GitHubProtectedClient, GitHubRequestDescriptor,
+    retry_stable_read,
 };
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 
@@ -190,13 +191,11 @@ impl ExternalSyncClient for GitHubSyncClient {
         if !self.pull_enabled {
             return Ok(Vec::new());
         }
-        loop {
-            let revision = GitHubProtectedClient::data_revision();
-            let tasks = self.pull_tasks_at_revision().await?;
-            if GitHubProtectedClient::data_revision() == revision {
-                return Ok(tasks);
-            }
-        }
+        retry_stable_read("task_board.github.pull_tasks", |_| {
+            self.pull_tasks_at_revision()
+        })
+        .await
+        .map(|(tasks, _)| tasks)
     }
 
     async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {

--- a/src/task_board/external/github.rs
+++ b/src/task_board/external/github.rs
@@ -21,14 +21,17 @@ use super::{
 mod errors;
 mod graphql;
 mod inbox;
+mod review_projection;
 
 use errors::{github_sync_error_with_context, warn_github_message};
 pub use inbox::GitHubInboxSyncClient;
+pub(crate) use review_projection::{
+    imported_review_pull_request_references, reconcile_pull_request_snapshots,
+};
 
 #[derive(Clone)]
 pub struct GitHubSyncClient {
     client: GitHubProtectedClient,
-    graphql_cache_key: graphql::GitHubGraphqlCacheKey,
     repository: Option<GitHubRepository>,
     pull_enabled: bool,
     import_labels: Vec<String>,
@@ -64,12 +67,10 @@ impl GitHubSyncClient {
         pull_enabled: bool,
     ) -> Result<Self, CliError> {
         let token = normalize_token(ExternalProvider::GitHub, token)?;
-        let graphql_cache_key = graphql::token_cache_key(token.as_str());
         let repository = repository.map(parse_github_repository).transpose()?;
         let client = GitHubProtectedClient::new(&token)?;
         Ok(Self {
             client,
-            graphql_cache_key,
             repository,
             pull_enabled,
             import_labels: Vec::new(),
@@ -117,6 +118,44 @@ impl GitHubSyncClient {
             .or_else(|| self.repository.clone())
             .ok_or_else(missing_github_repository_error)
     }
+
+    async fn pull_tasks_at_revision(&self) -> Result<Vec<ExternalTask>, CliError> {
+        let repository = self.repository_for(None)?;
+        let project_id = repository.slug();
+        let login = self.protected().viewer_login().await?;
+        let mut tasks = BTreeMap::new();
+        for query in graphql::personal_issue_queries(&repository, login.as_str()) {
+            let context = format!("searching task-board issues in {}", repository.slug());
+            let issues =
+                graphql::search_issue_pull_requests(self.protected(), &query, &context).await?;
+            tasks.extend(
+                issues
+                    .into_iter()
+                    .filter(|issue| {
+                        search_label_matches_filter(&issue.label_names(), &self.import_labels)
+                    })
+                    .map(|issue| {
+                        let number = issue.number;
+                        (
+                            number,
+                            ExternalTask {
+                                reference: ExternalTaskRef::new(
+                                    ExternalProvider::GitHub,
+                                    github_external_id(&repository, number),
+                                )
+                                .with_url(issue.url),
+                                title: issue.title,
+                                body: issue.body.unwrap_or_default(),
+                                status: github_issue_search_status(issue.state.as_str()),
+                                project_id: Some(project_id.clone()),
+                                updated_at: Some(issue.updated_at),
+                            },
+                        )
+                    }),
+            );
+        }
+        Ok(tasks.into_values().collect())
+    }
 }
 
 impl fmt::Debug for GitHubSyncClient {
@@ -151,46 +190,13 @@ impl ExternalSyncClient for GitHubSyncClient {
         if !self.pull_enabled {
             return Ok(Vec::new());
         }
-        let repository = self.repository_for(None)?;
-        let project_id = repository.slug();
-        let login = graphql::current_user_login(self.protected(), self.graphql_cache_key).await?;
-        let mut tasks = BTreeMap::new();
-        for query in graphql::personal_issue_queries(&repository, login.as_str()) {
-            let context = format!("searching task-board issues in {}", repository.slug());
-            let issues = graphql::search_issue_pull_requests(
-                self.protected(),
-                self.graphql_cache_key,
-                &query,
-                &context,
-            )
-            .await?;
-            tasks.extend(
-                issues
-                    .into_iter()
-                    .filter(|issue| {
-                        search_label_matches_filter(&issue.label_names(), &self.import_labels)
-                    })
-                    .map(|issue| {
-                        let number = issue.number;
-                        (
-                            number,
-                            ExternalTask {
-                                reference: ExternalTaskRef::new(
-                                    ExternalProvider::GitHub,
-                                    github_external_id(&repository, number),
-                                )
-                                .with_url(issue.url),
-                                title: issue.title,
-                                body: issue.body.unwrap_or_default(),
-                                status: github_issue_search_status(issue.state.as_str()),
-                                project_id: Some(project_id.clone()),
-                                updated_at: Some(issue.updated_at),
-                            },
-                        )
-                    }),
-            );
+        loop {
+            let revision = GitHubProtectedClient::data_revision();
+            let tasks = self.pull_tasks_at_revision().await?;
+            if GitHubProtectedClient::data_revision() == revision {
+                return Ok(tasks);
+            }
         }
-        Ok(tasks.into_values().collect())
     }
 
     async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {

--- a/src/task_board/external/github/graphql.rs
+++ b/src/task_board/external/github/graphql.rs
@@ -1,8 +1,4 @@
-use std::collections::BTreeMap;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::sync::{Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use serde::Deserialize;
 use serde_json::json;
@@ -18,26 +14,7 @@ pub(super) const GITHUB_SEARCH_PAGE_CAP: u32 = 10;
 
 const GITHUB_SEARCH_PAGE_SIZE: u32 = 100;
 const AUTOMATION_ISSUE_AUTHORS: &[&str] = &["renovate[bot]"];
-const HOURS: u64 = 60 * 60;
-const DAYS: u64 = 24 * HOURS;
 const GITHUB_GRAPHQL_CACHE_TTL: Duration = Duration::from_mins(1);
-const GITHUB_GRAPHQL_CACHE_ENTRY_CAP: usize = 128;
-
-pub(super) type GitHubGraphqlCacheKey = u64;
-
-static VIEWER_CACHE: OnceLock<Mutex<BTreeMap<GitHubGraphqlCacheKey, CachedViewerLogin>>> =
-    OnceLock::new();
-static SEARCH_CACHE: OnceLock<
-    Mutex<BTreeMap<(GitHubGraphqlCacheKey, String), CachedSearchResults>>,
-> = OnceLock::new();
-
-const VIEWER_QUERY: &str = r"
-query TaskBoardViewer {
-  viewer {
-    login
-  }
-}
-";
 
 const ISSUE_SEARCH_QUERY: &str = r"
 query TaskBoardGitHubSearch($query: String!, $after: String) {
@@ -87,44 +64,6 @@ query TaskBoardIssueUpdatedAt($owner: String!, $repo: String!, $number: Int!) {
   }
 }
 ";
-
-pub(super) fn token_cache_key(token: &str) -> GitHubGraphqlCacheKey {
-    let mut hasher = DefaultHasher::new();
-    token.hash(&mut hasher);
-    hasher.finish()
-}
-
-pub(super) async fn current_user_login(
-    client: &GitHubProtectedClient,
-    cache_key: GitHubGraphqlCacheKey,
-) -> Result<String, CliError> {
-    if let Some(login) = cached_viewer_login(cache_key) {
-        return Ok(login);
-    }
-    let response: GitHubViewerResponse = client
-        .graphql(
-            GitHubRequestDescriptor::graphql(
-                "task_board.github.viewer",
-                GitHubPriority::NormalRead,
-                GitHubCachePolicy::read_through(
-                    Duration::from_secs(24 * HOURS),
-                    Duration::from_secs(7 * DAYS),
-                ),
-            ),
-            json!({ "query": VIEWER_QUERY }),
-        )
-        .await
-        .map(|response| response.body)?;
-    let login = response.viewer.login.trim();
-    if login.is_empty() {
-        return Err(CliErrorKind::workflow_io(
-            "loading authenticated GitHub viewer returned an empty login",
-        )
-        .into());
-    }
-    store_viewer_login(cache_key, login);
-    Ok(login.to_string())
-}
 
 pub(super) async fn issue_updated_at(
     client: &GitHubProtectedClient,
@@ -179,13 +118,23 @@ pub(super) fn personal_issue_queries(repository: &GitHubRepository, login: &str)
 
 pub(super) async fn search_issue_pull_requests(
     client: &GitHubProtectedClient,
-    cache_key: GitHubGraphqlCacheKey,
     query: &str,
     context: &str,
 ) -> Result<Vec<GitHubSearchIssuePullRequestItem>, CliError> {
-    if let Some(items) = cached_search_results(cache_key, query) {
-        return Ok(items);
+    loop {
+        let revision = GitHubProtectedClient::data_revision();
+        let items = search_issue_pull_requests_at_revision(client, query, context).await?;
+        if GitHubProtectedClient::data_revision() == revision {
+            return Ok(items);
+        }
     }
+}
+
+async fn search_issue_pull_requests_at_revision(
+    client: &GitHubProtectedClient,
+    query: &str,
+    context: &str,
+) -> Result<Vec<GitHubSearchIssuePullRequestItem>, CliError> {
     let mut cursor = None;
     let mut page = 1_u32;
     let mut items = Vec::new();
@@ -219,7 +168,6 @@ pub(super) async fn search_issue_pull_requests(
         page += 1;
         cursor = Some(next_cursor);
     }
-    store_search_results(cache_key, query, &items);
     Ok(items)
 }
 
@@ -243,140 +191,11 @@ fn next_search_cursor(
     })
 }
 
-fn cached_viewer_login(cache_key: GitHubGraphqlCacheKey) -> Option<String> {
-    let mut cache = VIEWER_CACHE
-        .get_or_init(|| Mutex::new(BTreeMap::new()))
-        .lock()
-        .ok()?;
-    prune_viewer_cache(&mut cache);
-    cache.get(&cache_key).map(|cached| cached.login.clone())
-}
-
-fn store_viewer_login(cache_key: GitHubGraphqlCacheKey, login: &str) {
-    if let Ok(mut cache) = VIEWER_CACHE
-        .get_or_init(|| Mutex::new(BTreeMap::new()))
-        .lock()
-    {
-        prune_viewer_cache(&mut cache);
-        cache.insert(
-            cache_key,
-            CachedViewerLogin {
-                login: login.to_owned(),
-                stored_at: Instant::now(),
-            },
-        );
-        trim_viewer_cache(&mut cache);
-    }
-}
-
-fn cached_search_results(
-    cache_key: GitHubGraphqlCacheKey,
-    query: &str,
-) -> Option<Vec<GitHubSearchIssuePullRequestItem>> {
-    let mut cache = SEARCH_CACHE
-        .get_or_init(|| Mutex::new(BTreeMap::new()))
-        .lock()
-        .ok()?;
-    prune_search_cache(&mut cache);
-    cache
-        .get(&(cache_key, query.to_owned()))
-        .map(|cached| cached.items.clone())
-}
-
-fn store_search_results(
-    cache_key: GitHubGraphqlCacheKey,
-    query: &str,
-    items: &[GitHubSearchIssuePullRequestItem],
-) {
-    if let Ok(mut cache) = SEARCH_CACHE
-        .get_or_init(|| Mutex::new(BTreeMap::new()))
-        .lock()
-    {
-        prune_search_cache(&mut cache);
-        cache.insert(
-            (cache_key, query.to_owned()),
-            CachedSearchResults {
-                items: items.to_vec(),
-                stored_at: Instant::now(),
-            },
-        );
-        trim_search_cache(&mut cache);
-    }
-}
-
-fn prune_viewer_cache(cache: &mut BTreeMap<GitHubGraphqlCacheKey, CachedViewerLogin>) {
-    cache.retain(|_, cached| cached.is_fresh());
-}
-
-fn prune_search_cache(cache: &mut BTreeMap<(GitHubGraphqlCacheKey, String), CachedSearchResults>) {
-    cache.retain(|_, cached| cached.is_fresh());
-}
-
-fn trim_viewer_cache(cache: &mut BTreeMap<GitHubGraphqlCacheKey, CachedViewerLogin>) {
-    while cache.len() > GITHUB_GRAPHQL_CACHE_ENTRY_CAP {
-        let Some(key) = cache
-            .iter()
-            .min_by_key(|(_, cached)| cached.stored_at)
-            .map(|(key, _)| *key)
-        else {
-            break;
-        };
-        cache.remove(&key);
-    }
-}
-
-fn trim_search_cache(cache: &mut BTreeMap<(GitHubGraphqlCacheKey, String), CachedSearchResults>) {
-    while cache.len() > GITHUB_GRAPHQL_CACHE_ENTRY_CAP {
-        let Some(key) = cache
-            .iter()
-            .min_by_key(|(_, cached)| cached.stored_at)
-            .map(|(key, _)| key.clone())
-        else {
-            break;
-        };
-        cache.remove(&key);
-    }
-}
-
 fn warn_search_results_truncated(context: &str) {
     warn_github_message(&format!(
         "github search results truncated at {} hits while {context}",
         GITHUB_SEARCH_PAGE_CAP * GITHUB_SEARCH_PAGE_SIZE
     ));
-}
-
-#[derive(Debug, Clone)]
-struct CachedViewerLogin {
-    login: String,
-    stored_at: Instant,
-}
-
-impl CachedViewerLogin {
-    fn is_fresh(&self) -> bool {
-        self.stored_at.elapsed() <= GITHUB_GRAPHQL_CACHE_TTL
-    }
-}
-
-#[derive(Debug, Clone)]
-struct CachedSearchResults {
-    items: Vec<GitHubSearchIssuePullRequestItem>,
-    stored_at: Instant,
-}
-
-impl CachedSearchResults {
-    fn is_fresh(&self) -> bool {
-        self.stored_at.elapsed() <= GITHUB_GRAPHQL_CACHE_TTL
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubViewerResponse {
-    viewer: GitHubViewer,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubViewer {
-    login: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/task_board/external/github/graphql.rs
+++ b/src/task_board/external/github/graphql.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 use crate::errors::{CliError, CliErrorKind};
 use crate::github_api::{
     GitHubCachePolicy, GitHubPriority, GitHubProtectedClient, GitHubRequestDescriptor,
+    retry_stable_read,
 };
 
 use super::{GitHubRepository, assigned_issue_query, author_issue_query, warn_github_message};
@@ -121,13 +122,11 @@ pub(super) async fn search_issue_pull_requests(
     query: &str,
     context: &str,
 ) -> Result<Vec<GitHubSearchIssuePullRequestItem>, CliError> {
-    loop {
-        let revision = GitHubProtectedClient::data_revision();
-        let items = search_issue_pull_requests_at_revision(client, query, context).await?;
-        if GitHubProtectedClient::data_revision() == revision {
-            return Ok(items);
-        }
-    }
+    retry_stable_read("task_board.github.search_issues", |_| {
+        search_issue_pull_requests_at_revision(client, query, context)
+    })
+    .await
+    .map(|(items, _)| items)
 }
 
 async fn search_issue_pull_requests_at_revision(

--- a/src/task_board/external/github/graphql/tests.rs
+++ b/src/task_board/external/github/graphql/tests.rs
@@ -80,11 +80,3 @@ fn next_search_cursor_requires_cursor_when_more_pages_exist() {
 
     assert!(error.message().contains("next page without a cursor"));
 }
-
-#[test]
-fn graphql_cache_keys_do_not_expose_token_text() {
-    let key = token_cache_key("ghp_secret");
-
-    assert_ne!(key, 0);
-    assert_eq!(token_cache_key("ghp_secret"), key);
-}

--- a/src/task_board/external/github/inbox.rs
+++ b/src/task_board/external/github/inbox.rs
@@ -19,7 +19,6 @@ use super::{
 #[derive(Clone)]
 pub struct GitHubInboxSyncClient {
     client: GitHubProtectedClient,
-    graphql_cache_key: graphql::GitHubGraphqlCacheKey,
     repositories: Vec<GitHubRepository>,
     import_labels: Vec<String>,
 }
@@ -46,7 +45,6 @@ impl GitHubInboxSyncClient {
         import_labels: &[String],
     ) -> Result<Self, CliError> {
         let token = normalize_token(ExternalProvider::GitHub, token)?;
-        let graphql_cache_key = graphql::token_cache_key(token.as_str());
         let client = GitHubProtectedClient::new(&token)?;
         let repositories = repositories
             .iter()
@@ -55,7 +53,6 @@ impl GitHubInboxSyncClient {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             client,
-            graphql_cache_key,
             repositories,
             import_labels: import_labels.to_vec(),
         })
@@ -74,7 +71,7 @@ impl GitHubInboxSyncClient {
     }
 
     async fn current_user_login(&self) -> Result<String, CliError> {
-        graphql::current_user_login(&self.client, self.graphql_cache_key).await
+        self.client.viewer_login().await
     }
 
     async fn search(
@@ -84,13 +81,7 @@ impl GitHubInboxSyncClient {
         login: &str,
     ) -> Result<Vec<graphql::GitHubSearchIssuePullRequestItem>, CliError> {
         let query = kind.query(repository, login);
-        graphql::search_issue_pull_requests(
-            &self.client,
-            self.graphql_cache_key,
-            &query,
-            &kind.context(repository),
-        )
-        .await
+        graphql::search_issue_pull_requests(&self.client, &query, &kind.context(repository)).await
     }
 }
 

--- a/src/task_board/external/github/inbox/tests.rs
+++ b/src/task_board/external/github/inbox/tests.rs
@@ -116,7 +116,6 @@ async fn github_inbox_pull_fails_when_no_repository_can_be_pulled() {
 }
 
 fn inbox_client_with_base_uri(base_uri: String, repositories: &[&str]) -> GitHubInboxSyncClient {
-    let graphql_cache_key = graphql::token_cache_key(base_uri.as_str());
     let client = crate::github_api::GitHubProtectedClient::with_base_url("token", &base_uri)
         .expect("protected client");
     let repositories = repositories
@@ -126,7 +125,6 @@ fn inbox_client_with_base_uri(base_uri: String, repositories: &[&str]) -> GitHub
         .expect("repositories");
     GitHubInboxSyncClient {
         client,
-        graphql_cache_key,
         repositories,
         import_labels: Vec::new(),
     }

--- a/src/task_board/external/github/review_projection.rs
+++ b/src/task_board/external/github/review_projection.rs
@@ -1,0 +1,172 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::errors::CliError;
+use crate::github_api::GitHubPullRequestSnapshot;
+use crate::task_board::store::{TaskBoardItemPatch, TaskBoardStore};
+use crate::task_board::types::{ExternalRef, ExternalRefProvider, TaskBoardItem, TaskBoardStatus};
+use crate::workspace::utc_now;
+
+pub(crate) fn reconcile_pull_request_snapshots(
+    board: &TaskBoardStore,
+    snapshots: &[GitHubPullRequestSnapshot],
+) -> Result<bool, CliError> {
+    let snapshots = snapshots
+        .iter()
+        .map(|snapshot| {
+            (
+                snapshot_key(&snapshot.repository, snapshot.number),
+                snapshot,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let candidates = board
+        .list(None)?
+        .into_iter()
+        .map(|item| item.id)
+        .collect::<Vec<_>>();
+    let mut changed = false;
+    for item_id in candidates {
+        changed |= reconcile_candidate(board, &item_id, &snapshots)?;
+    }
+    Ok(changed)
+}
+
+pub(crate) fn imported_review_pull_request_references(
+    board: &TaskBoardStore,
+) -> Result<Vec<(String, u64)>, CliError> {
+    Ok(board
+        .list(None)?
+        .into_iter()
+        .filter(|item| is_imported_review(item) && is_review_inbox_status(item.status))
+        .flat_map(|item| {
+            item.external_refs
+                .clone()
+                .into_iter()
+                .filter(is_github_pull_request)
+                .filter_map(move |reference| normalized_reference(&item, &reference))
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect())
+}
+
+fn reconcile_candidate(
+    board: &TaskBoardStore,
+    item_id: &str,
+    snapshots: &BTreeMap<String, &GitHubPullRequestSnapshot>,
+) -> Result<bool, CliError> {
+    board
+        .update_if(item_id, |item| projection_patch(item, snapshots))
+        .map(|updated| updated.is_some())
+}
+
+fn projection_patch(
+    item: &TaskBoardItem,
+    snapshots: &BTreeMap<String, &GitHubPullRequestSnapshot>,
+) -> Option<TaskBoardItemPatch> {
+    let (reference_index, snapshot) = matching_imported_review(item, snapshots)?;
+    let status = projected_status(snapshot, item.status);
+    if item.status == status {
+        return None;
+    }
+    let mut external_refs = item.external_refs.clone();
+    update_sync_state(&mut external_refs[reference_index], snapshot, status);
+    Some(TaskBoardItemPatch {
+        status: Some(status),
+        external_refs: Some(external_refs),
+        ..TaskBoardItemPatch::default()
+    })
+}
+
+fn matching_imported_review<'a>(
+    item: &TaskBoardItem,
+    snapshots: &'a BTreeMap<String, &GitHubPullRequestSnapshot>,
+) -> Option<(usize, &'a GitHubPullRequestSnapshot)> {
+    if !is_imported_review(item) {
+        return None;
+    }
+    item.external_refs
+        .iter()
+        .enumerate()
+        .filter(|(_, reference)| is_github_pull_request(reference))
+        .find_map(|(index, reference)| {
+            let key = normalized_reference_key(item, reference)?;
+            snapshots.get(&key).map(|snapshot| (index, *snapshot))
+        })
+}
+
+fn normalized_reference_key(item: &TaskBoardItem, reference: &ExternalRef) -> Option<String> {
+    normalized_reference(item, reference)
+        .map(|(repository, number)| snapshot_key(&repository, number))
+}
+
+fn normalized_reference(item: &TaskBoardItem, reference: &ExternalRef) -> Option<(String, u64)> {
+    if let Some((repository, number)) = reference.external_id.rsplit_once('#') {
+        return number
+            .parse::<u64>()
+            .ok()
+            .map(|number| (repository.trim().to_ascii_lowercase(), number));
+    }
+    let number = reference.external_id.parse::<u64>().ok()?;
+    item.project_id
+        .as_deref()
+        .map(|repository| (repository.trim().to_ascii_lowercase(), number))
+}
+
+fn snapshot_key(repository: &str, number: u64) -> String {
+    format!("{}#{number}", repository.trim().to_ascii_lowercase())
+}
+
+fn is_github_pull_request(reference: &ExternalRef) -> bool {
+    reference.provider == ExternalRefProvider::GitHub
+        && reference
+            .url
+            .as_deref()
+            .is_some_and(|url| url.contains("/pull/"))
+}
+
+fn is_imported_review(item: &TaskBoardItem) -> bool {
+    item.imported_from_provider == Some(ExternalRefProvider::GitHub)
+        && item.planning.summary.is_none()
+}
+
+fn projected_status(
+    snapshot: &GitHubPullRequestSnapshot,
+    current: TaskBoardStatus,
+) -> TaskBoardStatus {
+    if snapshot.is_open == Some(false) || snapshot.viewer_review_requested == Some(false) {
+        return if is_review_inbox_status(current) {
+            TaskBoardStatus::Done
+        } else {
+            current
+        };
+    }
+    if snapshot.viewer_review_requested == Some(true) && current == TaskBoardStatus::Done {
+        return TaskBoardStatus::HumanRequired;
+    }
+    current
+}
+
+fn is_review_inbox_status(status: TaskBoardStatus) -> bool {
+    matches!(
+        status,
+        TaskBoardStatus::HumanRequired
+            | TaskBoardStatus::AgenticReview
+            | TaskBoardStatus::NeedsYou
+            | TaskBoardStatus::PlanReview
+    )
+}
+
+fn update_sync_state(
+    reference: &mut ExternalRef,
+    snapshot: &GitHubPullRequestSnapshot,
+    status: TaskBoardStatus,
+) {
+    let state = reference.sync_state.get_or_insert_default();
+    state.status = Some(status);
+    state.updated_at = Some(snapshot.updated_at.clone());
+    state.synced_at = Some(utc_now());
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/task_board/external/github/review_projection.rs
+++ b/src/task_board/external/github/review_projection.rs
@@ -22,6 +22,7 @@ pub(crate) fn reconcile_pull_request_snapshots(
     let candidates = board
         .list(None)?
         .into_iter()
+        .filter(is_imported_review)
         .map(|item| item.id)
         .collect::<Vec<_>>();
     let mut changed = false;

--- a/src/task_board/external/github/review_projection/tests.rs
+++ b/src/task_board/external/github/review_projection/tests.rs
@@ -1,0 +1,353 @@
+use tempfile::tempdir;
+
+use super::*;
+use crate::task_board::types::{ExternalRefSyncState, PlanningState, TaskBoardItem};
+
+#[test]
+fn shared_review_snapshot_completes_imported_review_request() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "github-example-repo-42".into(),
+        "Old title".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    item.status = TaskBoardStatus::HumanRequired;
+    item.project_id = Some("Example/Repo".into());
+    item.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    item.planning = PlanningState::default();
+    item.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "example/repo#42".into(),
+        url: Some("https://github.com/example/repo/pull/42".into()),
+        sync_state: Some(ExternalRefSyncState::default()),
+    }];
+    board.create("Old title", "Body", item).expect("create");
+
+    let changed = reconcile_pull_request_snapshots(
+        &board,
+        &[GitHubPullRequestSnapshot {
+            repository: "example/repo".into(),
+            number: 42,
+            is_open: Some(true),
+            viewer_review_requested: Some(false),
+            updated_at: "2026-07-11T11:00:00Z".into(),
+        }],
+    )
+    .expect("reconcile");
+
+    let updated = board.get("github-example-repo-42").expect("updated item");
+    assert!(changed);
+    assert_eq!(updated.title, "Old title");
+    assert_eq!(updated.status, TaskBoardStatus::Done);
+    assert_eq!(
+        updated.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::Done)
+    );
+    assert_eq!(
+        updated.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.updated_at.as_deref()),
+        Some("2026-07-11T11:00:00Z")
+    );
+}
+
+#[test]
+fn shared_review_snapshot_does_not_touch_manual_task() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "manual-review".into(),
+        "Manual task".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    item.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "example/repo#42".into(),
+        url: Some("https://github.com/example/repo/pull/42".into()),
+        sync_state: None,
+    }];
+    board.create("Manual task", "Body", item).expect("create");
+
+    let changed = reconcile_pull_request_snapshots(
+        &board,
+        &[GitHubPullRequestSnapshot {
+            repository: "example/repo".into(),
+            number: 42,
+            is_open: Some(false),
+            viewer_review_requested: Some(false),
+            updated_at: "2026-07-11T11:00:00Z".into(),
+        }],
+    )
+    .expect("reconcile");
+
+    assert!(!changed);
+    assert_eq!(
+        board.get("manual-review").expect("manual item").title,
+        "Manual task"
+    );
+}
+
+#[test]
+fn active_review_request_preserves_local_workflow_progress() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "github-example-repo-42".into(),
+        "Review title".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    item.status = TaskBoardStatus::AgenticReview;
+    item.project_id = Some("example/repo".into());
+    item.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    item.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "example/repo#42".into(),
+        url: Some("https://github.com/example/repo/pull/42".into()),
+        sync_state: None,
+    }];
+    board.create("Review title", "Body", item).expect("create");
+
+    let changed = reconcile_pull_request_snapshots(
+        &board,
+        &[GitHubPullRequestSnapshot {
+            repository: "example/repo".into(),
+            number: 42,
+            is_open: Some(true),
+            viewer_review_requested: Some(true),
+            updated_at: "2026-07-11T11:00:00Z".into(),
+        }],
+    )
+    .expect("reconcile");
+
+    assert!(!changed);
+    assert_eq!(
+        board
+            .get("github-example-repo-42")
+            .expect("review item")
+            .status,
+        TaskBoardStatus::AgenticReview
+    );
+}
+
+#[test]
+fn unknown_viewer_does_not_complete_review_request() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "github-example-repo-42".into(),
+        "Review title".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    item.status = TaskBoardStatus::HumanRequired;
+    item.project_id = Some("example/repo".into());
+    item.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    item.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "example/repo#42".into(),
+        url: Some("https://github.com/example/repo/pull/42".into()),
+        sync_state: None,
+    }];
+    board.create("Review title", "Body", item).expect("create");
+
+    let changed = reconcile_pull_request_snapshots(
+        &board,
+        &[GitHubPullRequestSnapshot {
+            repository: "example/repo".into(),
+            number: 42,
+            is_open: Some(true),
+            viewer_review_requested: None,
+            updated_at: "2026-07-11T11:00:00Z".into(),
+        }],
+    )
+    .expect("reconcile");
+
+    assert!(!changed);
+    assert_eq!(
+        board
+            .get("github-example-repo-42")
+            .expect("review item")
+            .status,
+        TaskBoardStatus::HumanRequired
+    );
+}
+
+#[test]
+fn completed_remote_review_does_not_interrupt_active_execution() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "github-example-repo-42".into(),
+        "Review title".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    item.status = TaskBoardStatus::InProgress;
+    item.project_id = Some("example/repo".into());
+    item.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    item.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "example/repo#42".into(),
+        url: Some("https://github.com/example/repo/pull/42".into()),
+        sync_state: None,
+    }];
+    board.create("Review title", "Body", item).expect("create");
+
+    let changed = reconcile_pull_request_snapshots(
+        &board,
+        &[GitHubPullRequestSnapshot {
+            repository: "example/repo".into(),
+            number: 42,
+            is_open: Some(false),
+            viewer_review_requested: Some(false),
+            updated_at: "2026-07-11T11:00:00Z".into(),
+        }],
+    )
+    .expect("reconcile");
+
+    assert!(!changed);
+    assert_eq!(
+        board
+            .get("github-example-repo-42")
+            .expect("review item")
+            .status,
+        TaskBoardStatus::InProgress
+    );
+}
+
+#[test]
+fn candidate_projection_reloads_refs_edited_after_listing() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "github-example-repo-42".into(),
+        "Review title".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    item.status = TaskBoardStatus::HumanRequired;
+    item.project_id = Some("example/repo".into());
+    item.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    item.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "example/repo#42".into(),
+        url: Some("https://github.com/example/repo/pull/42".into()),
+        sync_state: None,
+    }];
+    board.create("Review title", "Body", item).expect("create");
+    let candidate_id = board.list(None).expect("list")[0].id.clone();
+    let mut latest_refs = board.get(&candidate_id).expect("item").external_refs;
+    latest_refs.push(ExternalRef {
+        provider: ExternalRefProvider::Todoist,
+        external_id: "user-added".into(),
+        url: Some("https://todoist.com/showTask?id=user-added".into()),
+        sync_state: None,
+    });
+    board
+        .update(
+            &candidate_id,
+            TaskBoardItemPatch {
+                external_refs: Some(latest_refs),
+                ..TaskBoardItemPatch::default()
+            },
+        )
+        .expect("user ref edit");
+    let snapshot = GitHubPullRequestSnapshot {
+        repository: "example/repo".into(),
+        number: 42,
+        is_open: Some(false),
+        viewer_review_requested: Some(false),
+        updated_at: "2026-07-11T11:00:00Z".into(),
+    };
+    let snapshots = BTreeMap::from([(snapshot_key("example/repo", 42), &snapshot)]);
+
+    assert!(reconcile_candidate(&board, &candidate_id, &snapshots).expect("reconcile"));
+    let updated = board.get(&candidate_id).expect("updated");
+    assert_eq!(updated.status, TaskBoardStatus::Done);
+    assert_eq!(updated.external_refs.len(), 2);
+    assert_eq!(updated.external_refs[1].external_id, "user-added");
+}
+
+#[test]
+fn aggregate_omission_does_not_complete_imported_review_request() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "github-example-repo-42".into(),
+        "Review title".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    item.status = TaskBoardStatus::HumanRequired;
+    item.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    item.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "example/repo#42".into(),
+        url: Some("https://github.com/example/repo/pull/42".into()),
+        sync_state: None,
+    }];
+    board.create("Review title", "Body", item).expect("create");
+
+    assert!(!reconcile_pull_request_snapshots(&board, &[]).expect("reconcile"));
+    assert_eq!(
+        board
+            .get("github-example-repo-42")
+            .expect("review item")
+            .status,
+        TaskBoardStatus::HumanRequired
+    );
+}
+
+#[test]
+fn active_imported_reviews_are_discovered_for_exact_resolution() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut active = TaskBoardItem::new(
+        "github-example-repo-42".into(),
+        "Active review".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    active.status = TaskBoardStatus::HumanRequired;
+    active.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    active.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "Example/Repo#42".into(),
+        url: Some("https://github.com/Example/Repo/pull/42".into()),
+        sync_state: None,
+    }];
+    board
+        .create("Active review", "Body", active)
+        .expect("create active");
+
+    let mut completed = TaskBoardItem::new(
+        "github-example-repo-43".into(),
+        "Completed review".into(),
+        "Body".into(),
+        "2026-07-11T10:00:00Z".into(),
+    );
+    completed.status = TaskBoardStatus::Done;
+    completed.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    completed.external_refs = vec![ExternalRef {
+        provider: ExternalRefProvider::GitHub,
+        external_id: "example/repo#43".into(),
+        url: Some("https://github.com/example/repo/pull/43".into()),
+        sync_state: None,
+    }];
+    board
+        .create("Completed review", "Body", completed)
+        .expect("create completed");
+
+    assert_eq!(
+        imported_review_pull_request_references(&board).expect("references"),
+        vec![("example/repo".to_string(), 42)]
+    );
+}

--- a/src/task_board/external/sync.rs
+++ b/src/task_board/external/sync.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::{CliError, CliErrorKind};
+use crate::github_api::republish_current_data_change;
 use crate::task_board::store::{TaskBoardItemPatch, TaskBoardStore};
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 use crate::workspace::utc_now;
@@ -326,6 +327,7 @@ async fn create_remote_item(
         )
     })
     .await?;
+    republish_github_board_ready(client.provider());
     operations.push(operation(OperationDraft {
         provider: client.provider(),
         action: ExternalSyncAction::Push,
@@ -409,7 +411,14 @@ async fn update_linked_remote(
         )
     })
     .await?;
+    republish_github_board_ready(client.provider());
     Ok(())
+}
+
+fn republish_github_board_ready(provider: ExternalProvider) {
+    if provider == ExternalProvider::GitHub {
+        republish_current_data_change("task_board.github.local_sync_ready");
+    }
 }
 
 pub(super) async fn run_board_blocking<T, F>(

--- a/src/task_board/github/publication.rs
+++ b/src/task_board/github/publication.rs
@@ -19,6 +19,8 @@ use signing::{commit_author, local_commit_signature};
 use types::{BranchPublicationMode, LocalBranchSnapshot};
 
 mod git_ssh_publish;
+#[cfg(test)]
+mod mutation_tests;
 mod signing;
 mod ssh_signing;
 mod types;

--- a/src/task_board/github/publication/git_ssh_publish.rs
+++ b/src/task_board/github/publication/git_ssh_publish.rs
@@ -9,6 +9,7 @@ use gix::{ObjectId, objs};
 use tokio::task::spawn_blocking;
 
 use crate::errors::{CliError, CliErrorKind};
+use crate::github_api::begin_external_mutation;
 use crate::sandbox;
 use crate::task_board::github::GitHubProjectConfig;
 
@@ -22,6 +23,8 @@ use super::types::{
     RestCommitSignatureBoundary,
 };
 
+const PUBLICATION_OPERATION: &str = "task_board.github.publish_branch";
+
 pub(super) async fn publish_native_branch(
     config: &GitHubProjectConfig,
     worktree: &Path,
@@ -31,14 +34,27 @@ pub(super) async fn publish_native_branch(
     mode: &BranchPublicationMode,
 ) -> Result<(), CliError> {
     let plan = GitPublishPlan::new(config, worktree, branch, github_token, snapshot, mode)?;
-    spawn_blocking(move || plan.publish())
-        .await
-        .unwrap_or_else(|error| {
-            Err(CliErrorKind::workflow_io(format!(
-                "task-board github SSH git publisher worker failed: {error}"
-            ))
-            .into())
-        })
+    run_native_publication_worker(move || plan.publish()).await
+}
+
+pub(super) async fn run_native_publication_worker(
+    publish: impl FnOnce() -> Result<(), CliError> + Send + 'static,
+) -> Result<(), CliError> {
+    let mut mutation = begin_external_mutation(PUBLICATION_OPERATION).await;
+    spawn_blocking(move || {
+        let result = publish();
+        if result.is_ok() {
+            mutation.mark_remote_success();
+        }
+        result
+    })
+    .await
+    .unwrap_or_else(|error| {
+        Err(CliErrorKind::workflow_io(format!(
+            "task-board github SSH git publisher worker failed: {error}"
+        ))
+        .into())
+    })
 }
 
 struct GitPublishPlan {

--- a/src/task_board/github/publication/mutation_tests.rs
+++ b/src/task_board/github/publication/mutation_tests.rs
@@ -1,0 +1,48 @@
+use std::sync::mpsc;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+
+use super::git_ssh_publish::run_native_publication_worker;
+use crate::github_api::{GitHubProtectedClient, stable_data_revision_guard};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelled_waiter_leaves_native_mutation_owned_by_worker() {
+    let _test_guard = crate::github_api::acquire_global_budget_test_lock().await;
+    let mut changes = GitHubProtectedClient::data_changes();
+    let initial_revision = GitHubProtectedClient::data_revision();
+    let (started_tx, started_rx) = oneshot::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+
+    let publication = tokio::spawn(run_native_publication_worker(move || {
+        let _ = started_tx.send(());
+        release_rx.recv().expect("release native worker");
+        Ok(())
+    }));
+    started_rx.await.expect("native worker started");
+    publication.abort();
+    let cancelled = publication.await.expect_err("publication waiter cancelled");
+    assert!(cancelled.is_cancelled());
+
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(25),
+            stable_data_revision_guard(initial_revision),
+        )
+        .await
+        .is_err(),
+        "the native worker must retain the mutation barrier after caller cancellation"
+    );
+    release_tx.send(()).expect("release native worker");
+
+    let change = tokio::time::timeout(Duration::from_secs(1), changes.recv())
+        .await
+        .expect("data change timeout")
+        .expect("data change");
+    assert_eq!(change.revision, initial_revision + 1);
+    assert_eq!(change.operation, "task_board.github.publish_branch");
+    assert!(
+        changes.try_recv().is_err(),
+        "mutation published more than once"
+    );
+}

--- a/src/task_board/mod.rs
+++ b/src/task_board/mod.rs
@@ -36,6 +36,9 @@ pub use external::{
     GitHubSyncClient, HARNESS_GITHUB_REPOSITORY_ENV, HARNESS_GITHUB_TOKEN_ENV,
     HARNESS_TODOIST_TOKEN_ENV, TodoistSyncClient, configured_sync_clients, sync_external_tasks,
 };
+pub(crate) use external::{
+    imported_review_pull_request_references, reconcile_pull_request_snapshots,
+};
 pub use git_identity_defaults::{
     TaskBoardEnvDefaults, TaskBoardGhCliDefaults, TaskBoardGitConfigDefaults,
     TaskBoardGitIdentityDefaults, TaskBoardSshKeyDiscovery,

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{CliError, CliErrorKind, io_for};
 use crate::infra::io;
+use crate::infra::persistence::flock::{FlockErrorContext, with_exclusive_flock};
 use crate::workspace::{harness_data_root, utc_now};
 
 mod parse_cache;
@@ -171,12 +172,14 @@ impl TaskBoardStore {
         body: &str,
         mut item: TaskBoardItem,
     ) -> Result<TaskBoardItem, CliError> {
-        item.title = title.to_string();
-        item.body = body.to_string();
-        apply_canonical_persisted_status(&mut item);
-        self.validate_new_id(&item.id)?;
-        self.save(&item)?;
-        Ok(item)
+        self.with_mutation_lock(|| {
+            item.title = title.to_string();
+            item.body = body.to_string();
+            apply_canonical_persisted_status(&mut item);
+            self.validate_new_id(&item.id)?;
+            self.save(&item)?;
+            Ok(item)
+        })
     }
 
     /// Load one board item by ID.
@@ -280,7 +283,58 @@ impl TaskBoardStore {
     /// # Errors
     /// Returns `CliError` if the item cannot be loaded or saved.
     pub fn update(&self, id: &str, patch: TaskBoardItemPatch) -> Result<TaskBoardItem, CliError> {
-        let mut item = self.get(id)?;
+        self.with_mutation_lock(|| self.update_unlocked(id, patch))
+    }
+    /// Conditionally patch one board item from its latest persisted value.
+    ///
+    /// The decision and write share the board mutation lock, so a derived
+    /// update cannot overwrite a user edit made after an earlier list/get.
+    ///
+    /// # Errors
+    /// Returns `CliError` if the item cannot be loaded, locked, or saved.
+    pub(crate) fn update_if(
+        &self,
+        id: &str,
+        patch_for: impl FnOnce(&TaskBoardItem) -> Option<TaskBoardItemPatch>,
+    ) -> Result<Option<TaskBoardItem>, CliError> {
+        self.with_mutation_lock(|| {
+            let item = self.get(id)?;
+            let Some(patch) = patch_for(&item) else {
+                return Ok(None);
+            };
+            self.update_item(item, patch).map(Some)
+        })
+    }
+    /// Tombstone one board item.
+    ///
+    /// # Errors
+    /// Returns `CliError` if the item cannot be loaded or saved.
+    pub fn delete(&self, id: &str) -> Result<TaskBoardItem, CliError> {
+        self.with_mutation_lock(|| {
+            let mut item = self.get(id)?;
+            apply_canonical_persisted_status(&mut item);
+            let now = utc_now();
+            item.deleted_at = Some(now.clone());
+            item.updated_at = now;
+            self.save(&item)?;
+            Ok(item)
+        })
+    }
+
+    fn update_unlocked(
+        &self,
+        id: &str,
+        patch: TaskBoardItemPatch,
+    ) -> Result<TaskBoardItem, CliError> {
+        let item = self.get(id)?;
+        self.update_item(item, patch)
+    }
+
+    fn update_item(
+        &self,
+        mut item: TaskBoardItem,
+        patch: TaskBoardItemPatch,
+    ) -> Result<TaskBoardItem, CliError> {
         apply_patch(&mut item, patch);
         apply_canonical_persisted_status(&mut item);
         item.updated_at = utc_now();
@@ -288,18 +342,15 @@ impl TaskBoardStore {
         Ok(item)
     }
 
-    /// Tombstone one board item.
-    ///
-    /// # Errors
-    /// Returns `CliError` if the item cannot be loaded or saved.
-    pub fn delete(&self, id: &str) -> Result<TaskBoardItem, CliError> {
-        let mut item = self.get(id)?;
-        apply_canonical_persisted_status(&mut item);
-        let now = utc_now();
-        item.deleted_at = Some(now.clone());
-        item.updated_at = now;
-        self.save(&item)?;
-        Ok(item)
+    fn with_mutation_lock<T>(
+        &self,
+        action: impl FnOnce() -> Result<T, CliError>,
+    ) -> Result<T, CliError> {
+        with_exclusive_flock(
+            &self.root.join(".mutation.lock"),
+            FlockErrorContext::new("task board persistence"),
+            action,
+        )
     }
 
     fn save(&self, item: &TaskBoardItem) -> Result<(), CliError> {

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -1,16 +1,15 @@
 use std::path::{Path, PathBuf};
 
-use fs_err as fs;
-use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::errors::{CliError, CliErrorKind, io_for};
+use crate::errors::{CliError, CliErrorKind};
 use crate::infra::io;
 use crate::infra::persistence::flock::{FlockErrorContext, with_exclusive_flock};
 use crate::workspace::{harness_data_root, utc_now};
 
+mod loading;
 mod parse_cache;
-use parse_cache::{BOARD_PARSE_CACHE, Resolve};
+use parse_cache::BOARD_PARSE_CACHE;
 
 use super::types::{
     AgentMode, CURRENT_TASK_BOARD_ITEM_VERSION, ExternalRef, ExternalRefProvider, PlanningState,
@@ -182,19 +181,6 @@ impl TaskBoardStore {
         })
     }
 
-    /// Load one board item by ID.
-    ///
-    /// # Errors
-    /// Returns `CliError` if the ID is unsafe, the file is missing, or the
-    /// markdown/frontmatter payload cannot be parsed or repaired on disk.
-    pub fn get(&self, id: &str) -> Result<TaskBoardItem, CliError> {
-        let path = self.path_for(id)?;
-        let mut item = read_path(&path)?;
-        validate_loaded_id(id, &item)?;
-        Self::repair_legacy_status_at(&path, &mut item)?;
-        Ok(item)
-    }
-
     /// List active board items, optionally filtered by status.
     ///
     /// # Errors
@@ -220,64 +206,6 @@ impl TaskBoardStore {
         Ok(items)
     }
 
-    /// Read and parse every markdown item in the tasks directory.
-    ///
-    /// The directory scan is cheap, but parsing the YAML frontmatter is not, so
-    /// the per-file parse fans out across the rayon pool and each result is
-    /// memoized by `(mtime, len)` in [`BOARD_PARSE_CACHE`]. A steady-state
-    /// listing (the daemon orchestrator lists every couple of seconds) then
-    /// costs one `stat` per file instead of a full reparse.
-    ///
-    /// # Errors
-    /// Returns `CliError` if the tasks directory cannot be read or an item
-    /// cannot be parsed.
-    fn read_all_items(&self) -> Result<Vec<TaskBoardItem>, CliError> {
-        let dir = self.tasks_dir();
-        if !dir.exists() {
-            return Ok(Vec::new());
-        }
-        let mut paths = Vec::new();
-        for entry in fs::read_dir(&dir).map_err(|error| io_for("read dir", &dir, &error))? {
-            let path = entry
-                .map_err(|error| io_for("read dir entry", &dir, &error))?
-                .path();
-            if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
-                paths.push(path);
-            }
-        }
-        // Resolve cache hits serially - it is just a `stat` plus a map lookup,
-        // and the steady-state listing is all hits, so paying rayon's fork/join
-        // overhead there would cost more than the work itself. Only the cold
-        // parses (`yaml_rust2` scanning) fan out across the pool.
-        let mut items = Vec::with_capacity(paths.len());
-        let mut misses = Vec::new();
-        for path in paths {
-            match BOARD_PARSE_CACHE.resolve(&path)? {
-                // The cache always holds its own Arc reference, so the
-                // returned Arc has refcount >= 2. Clone outside the Mutex so
-                // the lock is held only for an atomic refcount increment rather
-                // than a full TaskBoardItem deep-clone.
-                Resolve::Hit(arc) => items.push((path, (*arc).clone())),
-                Resolve::Miss { mtime, len } => misses.push((path, mtime, len)),
-            }
-        }
-        if !misses.is_empty() {
-            let parsed = misses
-                .par_iter()
-                .map(|(path, mtime, len)| {
-                    BOARD_PARSE_CACHE
-                        .parse_miss(path, *mtime, *len)
-                        .map(|arc| (path.clone(), (*arc).clone()))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            items.extend(parsed);
-        }
-        for (path, item) in &mut items {
-            Self::repair_legacy_status_at(path, item)?;
-        }
-        Ok(items.into_iter().map(|(_, item)| item).collect())
-    }
-
     /// Patch one board item in place.
     ///
     /// # Errors
@@ -298,7 +226,7 @@ impl TaskBoardStore {
         patch_for: impl FnOnce(&TaskBoardItem) -> Option<TaskBoardItemPatch>,
     ) -> Result<Option<TaskBoardItem>, CliError> {
         self.with_mutation_lock(|| {
-            let item = self.get(id)?;
+            let item = self.get_locked(id)?;
             let Some(patch) = patch_for(&item) else {
                 return Ok(None);
             };
@@ -311,7 +239,7 @@ impl TaskBoardStore {
     /// Returns `CliError` if the item cannot be loaded or saved.
     pub fn delete(&self, id: &str) -> Result<TaskBoardItem, CliError> {
         self.with_mutation_lock(|| {
-            let mut item = self.get(id)?;
+            let mut item = self.get_locked(id)?;
             apply_canonical_persisted_status(&mut item);
             let now = utc_now();
             item.deleted_at = Some(now.clone());
@@ -326,7 +254,7 @@ impl TaskBoardStore {
         id: &str,
         patch: TaskBoardItemPatch,
     ) -> Result<TaskBoardItem, CliError> {
-        let item = self.get(id)?;
+        let item = self.get_locked(id)?;
         self.update_item(item, patch)
     }
 
@@ -396,7 +324,10 @@ impl TaskBoardStore {
         Ok(())
     }
 
-    fn repair_legacy_status_at(path: &Path, item: &mut TaskBoardItem) -> Result<(), CliError> {
+    fn repair_legacy_status_at_locked(
+        path: &Path,
+        item: &mut TaskBoardItem,
+    ) -> Result<(), CliError> {
         if apply_canonical_persisted_status(item) {
             Self::save_to_path(path, item)?;
         }

--- a/src/task_board/store/loading.rs
+++ b/src/task_board/store/loading.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+
+use fs_err as fs;
+use rayon::prelude::*;
+
+use crate::errors::{CliError, io_for};
+
+use super::parse_cache::{BOARD_PARSE_CACHE, Resolve};
+use super::{
+    TaskBoardItem, TaskBoardStore, apply_canonical_persisted_status, read_path, validate_loaded_id,
+};
+
+type ItemAtPath = (PathBuf, TaskBoardItem);
+
+impl TaskBoardStore {
+    /// Load one board item by ID.
+    ///
+    /// # Errors
+    /// Returns `CliError` if the ID is unsafe, the file is missing, or the
+    /// markdown/frontmatter payload cannot be parsed or repaired on disk.
+    pub fn get(&self, id: &str) -> Result<TaskBoardItem, CliError> {
+        let path = self.path_for(id)?;
+        let item = read_path(&path)?;
+        self.finish_get(id, item)
+    }
+
+    pub(super) fn finish_get(
+        &self,
+        id: &str,
+        mut item: TaskBoardItem,
+    ) -> Result<TaskBoardItem, CliError> {
+        validate_loaded_id(id, &item)?;
+        if !apply_canonical_persisted_status(&mut item) {
+            return Ok(item);
+        }
+        self.with_mutation_lock(|| self.get_locked(id))
+    }
+
+    pub(super) fn get_locked(&self, id: &str) -> Result<TaskBoardItem, CliError> {
+        let path = self.path_for(id)?;
+        let mut item = read_path(&path)?;
+        validate_loaded_id(id, &item)?;
+        Self::repair_legacy_status_at_locked(&path, &mut item)?;
+        Ok(item)
+    }
+
+    /// Read and parse every markdown item in the tasks directory.
+    ///
+    /// The directory scan is cheap, but parsing the YAML frontmatter is not, so
+    /// cold parses fan out across rayon and steady-state cache hits cost one
+    /// `stat` per file.
+    ///
+    /// # Errors
+    /// Returns `CliError` if the directory or an item cannot be read, parsed,
+    /// or repaired on disk.
+    pub(super) fn read_all_items(&self) -> Result<Vec<TaskBoardItem>, CliError> {
+        let items = self.read_all_items_unrepaired()?;
+        self.finish_read_all_items(items)
+    }
+
+    pub(super) fn finish_read_all_items(
+        &self,
+        items: Vec<ItemAtPath>,
+    ) -> Result<Vec<TaskBoardItem>, CliError> {
+        if !items.iter().any(|(_, item)| needs_status_repair(item)) {
+            return Ok(without_paths(items));
+        }
+        self.with_mutation_lock(|| self.read_all_items_locked())
+    }
+
+    fn read_all_items_locked(&self) -> Result<Vec<TaskBoardItem>, CliError> {
+        let mut items = self.read_all_items_unrepaired()?;
+        for (path, item) in &mut items {
+            Self::repair_legacy_status_at_locked(path, item)?;
+        }
+        Ok(without_paths(items))
+    }
+
+    fn read_all_items_unrepaired(&self) -> Result<Vec<ItemAtPath>, CliError> {
+        let paths = self.task_paths()?;
+        let mut items = Vec::with_capacity(paths.len());
+        let mut misses = Vec::new();
+        for path in paths {
+            match BOARD_PARSE_CACHE.resolve(&path)? {
+                Resolve::Hit(arc) => items.push((path, (*arc).clone())),
+                Resolve::Miss { mtime, len } => misses.push((path, mtime, len)),
+            }
+        }
+        if !misses.is_empty() {
+            let parsed = misses
+                .par_iter()
+                .map(|(path, mtime, len)| {
+                    BOARD_PARSE_CACHE
+                        .parse_miss(path, *mtime, *len)
+                        .map(|arc| (path.clone(), (*arc).clone()))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            items.extend(parsed);
+        }
+        Ok(items)
+    }
+
+    fn task_paths(&self) -> Result<Vec<PathBuf>, CliError> {
+        let dir = self.tasks_dir();
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut paths = Vec::new();
+        for entry in fs::read_dir(&dir).map_err(|error| io_for("read dir", &dir, &error))? {
+            let path = entry
+                .map_err(|error| io_for("read dir entry", &dir, &error))?
+                .path();
+            if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+                paths.push(path);
+            }
+        }
+        Ok(paths)
+    }
+}
+
+fn needs_status_repair(item: &TaskBoardItem) -> bool {
+    item.status != item.status.canonical_persisted_status()
+}
+
+fn without_paths(items: Vec<ItemAtPath>) -> Vec<TaskBoardItem> {
+    items.into_iter().map(|(_, item)| item).collect()
+}

--- a/src/task_board/store/tests.rs
+++ b/src/task_board/store/tests.rs
@@ -86,6 +86,26 @@ fn get_repairs_legacy_status_on_disk() {
 }
 
 #[test]
+fn get_repair_reloads_a_newer_item_before_persisting() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    let path = seed_raw_item(&store, "repair-race", "new");
+    let stale = super::read_path(&path).expect("read stale item");
+    write_raw_item(&path, "repair-race", "Concurrent edit", "in_progress");
+
+    let loaded = store
+        .finish_get("repair-race", stale)
+        .expect("finish legacy repair");
+
+    assert_eq!(loaded.title, "Concurrent edit");
+    assert_eq!(loaded.status, TaskBoardStatus::InProgress);
+    let contents = fs::read_to_string(path).expect("read latest file");
+    assert!(contents.contains("title: Concurrent edit"));
+    assert!(contents.contains("status: in_progress"));
+    assert!(!contents.contains("status: todo"));
+}
+
+#[test]
 fn get_rejects_mismatched_frontmatter_id_before_repair() {
     let temp = tempdir().expect("tempdir");
     let store = TaskBoardStore::new(temp.path().join("board"));
@@ -120,6 +140,32 @@ fn list_repairs_legacy_statuses_before_filtering() {
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id, "legacy-needs-you");
     assert_eq!(listed[0].status, TaskBoardStatus::HumanRequired);
+}
+
+#[test]
+fn list_repair_reloads_newer_items_before_persisting() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    let path = seed_raw_item(&store, "list-repair-race", "needs_you");
+    let stale = super::read_path(&path).expect("read stale item");
+    write_raw_item(
+        &path,
+        "list-repair-race",
+        "Concurrent list edit",
+        "in_progress",
+    );
+
+    let loaded = store
+        .finish_read_all_items(vec![(path.clone(), stale)])
+        .expect("finish list repair");
+
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].title, "Concurrent list edit");
+    assert_eq!(loaded[0].status, TaskBoardStatus::InProgress);
+    let contents = fs::read_to_string(path).expect("read latest file");
+    assert!(contents.contains("title: Concurrent list edit"));
+    assert!(contents.contains("status: in_progress"));
+    assert!(!contents.contains("status: human_required"));
 }
 
 #[test]
@@ -237,13 +283,18 @@ fn seed_raw_item_with_frontmatter_id(
 ) -> std::path::PathBuf {
     let path = store.tasks_dir().join(format!("{filename_id}.md"));
     fs::create_dir_all(store.tasks_dir()).expect("create tasks dir");
+    write_raw_item(&path, frontmatter_id, "Legacy status", status);
+    path
+}
+
+fn write_raw_item(path: &std::path::Path, frontmatter_id: &str, title: &str, status: &str) {
     fs::write(
-        &path,
+        path,
         format!(
             "---\n\
              schema_version: 1\n\
              id: {frontmatter_id}\n\
-             title: Legacy status\n\
+             title: {title}\n\
              status: {status}\n\
              priority: medium\n\
              agent_mode: headless\n\
@@ -254,7 +305,6 @@ fn seed_raw_item_with_frontmatter_id(
         ),
     )
     .expect("write raw item");
-    path
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Route Reviews and Task Board through one shared GitHub client, viewer lookup, request cache, and data revision.
- Project authoritative Reviews pull-request state into imported Task Board cards without overwriting manual or active workflow state.
- Broadcast revisioned GitHub mutations so both surfaces refresh immediately and recover coherently across cancellation and reconnect races.

## Validation

- `mise run check`
- `mise run monitor:lint`
- Focused Harness Monitor tests: 19 passed
- Focused Rust cache, mutation, projection, publication, pagination, and store tests
- `mise run cargo:local -- clippy --lib`