### PR TITLE
feat(monitor): pair watch directly with remote daemon

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobilePairingMutationGate.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobilePairingMutationGate.swift
@@ -1,0 +1,32 @@
+public actor MobilePairingMutationGate {
+  private var locked = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  public init() {}
+
+  public func perform<Result: Sendable>(
+    _ operation: @escaping @Sendable () async throws -> Result
+  ) async throws -> Result {
+    await acquire()
+    defer { release() }
+    return try await operation()
+  }
+
+  private func acquire() async {
+    guard locked else {
+      locked = true
+      return
+    }
+    await withCheckedContinuation { continuation in
+      waiters.append(continuation)
+    }
+  }
+
+  private func release() {
+    guard !waiters.isEmpty else {
+      locked = false
+      return
+    }
+    waiters.removeFirst().resume()
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobilePairingMutationGate.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobilePairingMutationGate.swift
@@ -1,15 +1,41 @@
+public enum MobilePairingMutationGateError: Error, Equatable, Sendable {
+  case reentrantMutation
+}
+
+/// Serializes non-reentrant mutations. Calling `perform` again on the same gate
+/// from a gated operation throws instead of waiting on itself indefinitely.
 public actor MobilePairingMutationGate {
+  @TaskLocal private static var activeGateIDs: Set<ObjectIdentifier> = []
+
   private var locked = false
   private var waiters: [CheckedContinuation<Void, Never>] = []
+  private var waiterCountObservers:
+    [(minimumCount: Int, continuation: CheckedContinuation<Void, Never>)] = []
 
   public init() {}
 
   public func perform<Result: Sendable>(
     _ operation: @escaping @Sendable () async throws -> Result
   ) async throws -> Result {
+    let gateID = ObjectIdentifier(self)
+    guard !Self.activeGateIDs.contains(gateID) else {
+      throw MobilePairingMutationGateError.reentrantMutation
+    }
     await acquire()
     defer { release() }
-    return try await operation()
+    return try await Self.$activeGateIDs.withValue(Self.activeGateIDs.union([gateID])) {
+      try await operation()
+    }
+  }
+
+  func waitUntilQueuedOperations(atLeast minimumCount: Int) async {
+    precondition(minimumCount > 0)
+    guard waiters.count < minimumCount else {
+      return
+    }
+    await withCheckedContinuation { continuation in
+      waiterCountObservers.append((minimumCount, continuation))
+    }
   }
 
   private func acquire() async {
@@ -19,6 +45,7 @@ public actor MobilePairingMutationGate {
     }
     await withCheckedContinuation { continuation in
       waiters.append(continuation)
+      resumeWaiterCountObservers()
     }
   }
 
@@ -28,5 +55,17 @@ public actor MobilePairingMutationGate {
       return
     }
     waiters.removeFirst().resume()
+  }
+
+  private func resumeWaiterCountObservers() {
+    var pendingObservers: [(minimumCount: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    for observer in waiterCountObservers {
+      if waiters.count >= observer.minimumCount {
+        observer.continuation.resume()
+      } else {
+        pendingObservers.append(observer)
+      }
+    }
+    waiterCountObservers = pendingObservers
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
@@ -46,6 +46,24 @@ public enum MobileRemoteDaemonPairingError: Error, Equatable, Sendable {
   case claimMismatch
 }
 
+public struct MobileRemoteDaemonPairingDevice: Equatable, Sendable {
+  public static let iOS = Self(identityID: "default-mobile-device", platform: "ios")
+  public static let watchOS = Self(identityID: "default-watch-device", platform: "watchos")
+
+  public let identityID: String
+  public let platform: String
+
+  public init(identityID: String, platform: String) {
+    self.identityID = identityID
+    self.platform = platform
+  }
+
+  public func owns(_ credential: MobilePairedStationCredential) -> Bool {
+    credential.deviceIdentityID == identityID
+      && credential.remoteDaemonAccess?.platform.caseInsensitiveCompare(platform) == .orderedSame
+  }
+}
+
 public struct URLSessionMobileRemoteDaemonPairingTransport:
   MobileRemoteDaemonPairingTransport, Sendable
 {
@@ -112,23 +130,21 @@ public struct URLSessionMobileRemoteDaemonPairingTransport:
 }
 
 public actor MobileRemoteDaemonPairingCoordinator<Transport: MobileRemoteDaemonPairingTransport> {
-  public static var identityID: String { "default-mobile-device" }
-
   private let identityStore: any MobileDeviceIdentityStore
   private let credentialStore: any MobilePairedStationCredentialStore
   private let transport: Transport
-  private let platform: String
+  private let device: MobileRemoteDaemonPairingDevice
 
   public init(
     identityStore: any MobileDeviceIdentityStore,
     credentialStore: any MobilePairedStationCredentialStore,
     transport: Transport,
-    platform: String
+    device: MobileRemoteDaemonPairingDevice
   ) {
     self.identityStore = identityStore
     self.credentialStore = credentialStore
     self.transport = transport
-    self.platform = platform
+    self.device = device
   }
 
   public func pair(
@@ -143,7 +159,7 @@ public actor MobileRemoteDaemonPairingCoordinator<Transport: MobileRemoteDaemonP
       invitation: invitation,
       clientID: clientID,
       displayName: deviceName,
-      platform: platform
+      platform: device.platform
     )
     let access = MobileRemoteDaemonAccess(
       endpoint: invitation.endpoint,
@@ -175,18 +191,40 @@ public actor MobileRemoteDaemonPairingCoordinator<Transport: MobileRemoteDaemonP
       remoteDaemonAccess: access
     )
     try await credentialStore.save(credential)
+    try await removeReplacedIdentityIfUnused(
+      existingCredential: existingCredential,
+      existingCredentials: existing,
+      replacement: credential
+    )
     return credential
+  }
+
+  private func removeReplacedIdentityIfUnused(
+    existingCredential: MobilePairedStationCredential?,
+    existingCredentials: [MobilePairedStationCredential],
+    replacement: MobilePairedStationCredential
+  ) async throws {
+    guard let existingCredential,
+      existingCredential.deviceIdentityID != replacement.deviceIdentityID,
+      !existingCredentials.contains(where: {
+        $0.stationID != replacement.stationID
+          && $0.deviceIdentityID == existingCredential.deviceIdentityID
+      })
+    else {
+      return
+    }
+    try await identityStore.delete(id: existingCredential.deviceIdentityID)
   }
 
   private func loadOrCreateIdentity(
     deviceName: String,
     now: Date
   ) async throws -> MobileDeviceIdentity {
-    if let identity = try await identityStore.load(id: Self.identityID) {
+    if let identity = try await identityStore.load(id: device.identityID) {
       return identity
     }
     let identity = MobileDeviceIdentity(
-      id: Self.identityID,
+      id: device.identityID,
       displayName: deviceName,
       createdAt: now
     )
@@ -197,7 +235,7 @@ public actor MobileRemoteDaemonPairingCoordinator<Transport: MobileRemoteDaemonP
   private func makeClientID(identity: MobileDeviceIdentity) throws -> String {
     let fingerprint = try identity.signingKeyFingerprint()
     let suffix = fingerprint.filter(\.isHexDigit).lowercased().prefix(24)
-    let normalizedPlatform = platform.lowercased().filter { $0.isLetter || $0.isNumber }
+    let normalizedPlatform = device.platform.lowercased().filter { $0.isLetter || $0.isNumber }
     return "\(normalizedPlatform)-\(suffix)"
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileWatchPairingTransfer+RemotePairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileWatchPairingTransfer+RemotePairing.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension MobileWatchPairingTransfer {
+  public func preservingLocallyPairedRemoteCredentials(
+    for device: MobileRemoteDaemonPairingDevice,
+    currentIdentities: [MobileDeviceIdentity],
+    currentCredentials: [MobilePairedStationCredential]
+  ) -> Self {
+    let localCredentials = currentCredentials.filter(device.owns)
+    guard !localCredentials.isEmpty else {
+      return self
+    }
+
+    let localStationIDs = Set(localCredentials.map(\.stationID))
+    let localIdentityIDs = Set(localCredentials.map(\.deviceIdentityID))
+    var mergedCredentials = credentials.filter { !localStationIDs.contains($0.stationID) }
+    if localCredentials.contains(where: \.defaultStation) {
+      for index in mergedCredentials.indices {
+        mergedCredentials[index].defaultStation = false
+      }
+    }
+    mergedCredentials.append(contentsOf: localCredentials)
+    mergedCredentials.sort { $0.stationID < $1.stationID }
+
+    let referencedIdentityIDs = Set(mergedCredentials.map(\.deviceIdentityID))
+    var identitiesByID: [String: MobileDeviceIdentity] = [:]
+    for identity in identities where referencedIdentityIDs.contains(identity.id) {
+      identitiesByID[identity.id] = identity
+    }
+    for identity in currentIdentities where localIdentityIDs.contains(identity.id) {
+      identitiesByID[identity.id] = identity
+    }
+
+    var reconciled = self
+    reconciled.credentials = mergedCredentials
+    reconciled.identities = identitiesByID.values.sorted { $0.id < $1.id }
+    return reconciled
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileWatchPairingTransfer+RemotePairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileWatchPairingTransfer+RemotePairing.swift
@@ -13,14 +13,23 @@ extension MobileWatchPairingTransfer {
 
     let localStationIDs = Set(localCredentials.map(\.stationID))
     let localIdentityIDs = Set(localCredentials.map(\.deviceIdentityID))
-    var mergedCredentials = credentials.filter { !localStationIDs.contains($0.stationID) }
+    var mergedCredentialsByStationID: [String: MobilePairedStationCredential] = [:]
+    for credential in credentials where !localStationIDs.contains(credential.stationID) {
+      mergedCredentialsByStationID[credential.stationID] = credential
+    }
     if localCredentials.contains(where: \.defaultStation) {
-      for index in mergedCredentials.indices {
-        mergedCredentials[index].defaultStation = false
+      mergedCredentialsByStationID = mergedCredentialsByStationID.mapValues { credential in
+        var credential = credential
+        credential.defaultStation = false
+        return credential
       }
     }
-    mergedCredentials.append(contentsOf: localCredentials)
-    mergedCredentials.sort { $0.stationID < $1.stationID }
+    for credential in localCredentials {
+      mergedCredentialsByStationID[credential.stationID] = credential
+    }
+    let mergedCredentials = mergedCredentialsByStationID.values.sorted {
+      $0.stationID < $1.stationID
+    }
 
     let referencedIdentityIDs = Set(mergedCredentials.map(\.deviceIdentityID))
     var identitiesByID: [String: MobileDeviceIdentity] = [:]

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileWatchPairingTransfer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileWatchPairingTransfer.swift
@@ -60,11 +60,12 @@ public struct MobileWatchPairingTransfer: Codable, Equatable, Sendable {
         identityIDsToDelete: []
       )
     }
-    let incomingStationIDs = Set(credentials.map(\.stationID))
-    let incomingIdentityIDs = Set(credentials.map(\.deviceIdentityID))
-    let incomingIdentityIDByStation = Dictionary(
-      uniqueKeysWithValues: credentials.map { ($0.stationID, $0.deviceIdentityID) }
-    )
+    var incomingIdentityIDByStation: [String: String] = [:]
+    for credential in credentials {
+      incomingIdentityIDByStation[credential.stationID] = credential.deviceIdentityID
+    }
+    let incomingStationIDs = Set(incomingIdentityIDByStation.keys)
+    let incomingIdentityIDs = Set(incomingIdentityIDByStation.values)
     let staleCredentials = currentCredentials.filter {
       !incomingStationIDs.contains($0.stationID)
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
@@ -200,16 +200,20 @@ extension MirrorStore {
     guard MobilePairingLink.supports(url) else {
       return
     }
-    await pair(invitationURL: url, deviceName: deviceName)
+    _ = await pair(invitationURL: url, deviceName: deviceName)
   }
 
-  func pair(invitationURL: URL, deviceName: String) async {
+  @discardableResult
+  func pair(
+    invitationURL: URL,
+    deviceName: String,
+    now: Date = .now
+  ) async -> MobilePairedStationCredential? {
     guard let pairer else {
       syncStatus = .stale("Pairing service is unavailable.")
-      return
+      return nil
     }
     do {
-      let now = Date()
       let pairingLink = try MobilePairingLink.decode(invitationURL, now: now)
       let wasDemoModeEnabled = demoModeEnabled
       demoModeEnabled = false
@@ -226,8 +230,10 @@ extension MirrorStore {
       try await rebuildSyncClients(preferredStationID: credential.stationID)
       syncStatus = .paired(credential.stationName)
       await refreshAfterPairingBootstrap()
+      return credential
     } catch {
       syncStatus = mobileMonitorSyncStatus(for: error)
+      return nil
     }
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+WatchRemotePairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+WatchRemotePairing.swift
@@ -1,0 +1,56 @@
+import Foundation
+import HarnessMonitorCrypto
+
+extension MirrorStore {
+  @discardableResult
+  public func pairDirectWatchDaemon(
+    payload: String,
+    deviceName: String,
+    now: Date = .now
+  ) async -> Bool {
+    do {
+      let invitationURL = try MobilePairingLink.normalizedURL(from: payload, now: now)
+      guard case .remote = try MobilePairingLink.decode(invitationURL, now: now) else {
+        throw MobilePairingError.unsupportedURL(invitationURL.absoluteString)
+      }
+      guard
+        let credential = await pair(
+          invitationURL: invitationURL,
+          deviceName: deviceName,
+          now: now
+        )
+      else {
+        return false
+      }
+      return MobileRemoteDaemonPairingDevice.watchOS.owns(credential)
+    } catch {
+      syncStatus = mobileMonitorSyncStatus(for: error)
+      return false
+    }
+  }
+
+  public func removeDirectWatchPairing(stationID: String) async {
+    guard let credential = pairedCredentials.first(where: { $0.stationID == stationID }),
+      MobileRemoteDaemonPairingDevice.watchOS.owns(credential)
+    else {
+      return
+    }
+
+    if let pairingMutationGate {
+      do {
+        try await pairingMutationGate.perform { @MainActor [self] in
+          await unpair(stationID: stationID)
+        }
+      } catch {
+        syncStatus = mobileMonitorSyncStatus(for: error)
+        return
+      }
+    } else {
+      await unpair(stationID: stationID)
+    }
+    guard !pairedCredentials.contains(where: { $0.stationID == stationID }) else {
+      return
+    }
+    requestFreshPairingMaterial?()
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
@@ -32,6 +32,7 @@ public final class MirrorStore {
   let credentialStore: (any MobilePairedStationCredentialStore)?
   let syncClientFactory: any MobileMonitorSyncClientFactory
   let pairer: (any MobileMonitorCredentialPairer)?
+  let pairingMutationGate: MobilePairingMutationGate?
   let privacyServiceProvider: @Sendable () -> any MobileCloudMirrorPrivacyManaging
   let sharedSnapshotStore: MobileSharedSnapshotStore?
   let watchPairingSyncer: (any MobileWatchPairingSyncing)?
@@ -60,6 +61,7 @@ public final class MirrorStore {
     credentialStore: (any MobilePairedStationCredentialStore)? = nil,
     syncClientFactory: any MobileMonitorSyncClientFactory = LiveMobileMonitorSyncClientFactory(),
     pairer: (any MobileMonitorCredentialPairer)? = nil,
+    pairingMutationGate: MobilePairingMutationGate? = nil,
     privacyServiceProvider: @escaping @Sendable () -> any MobileCloudMirrorPrivacyManaging = {
       MobileCloudMirrorPrivacyService(database: LiveMobileCloudMirrorDatabase())
     },
@@ -83,6 +85,7 @@ public final class MirrorStore {
     self.credentialStore = credentialStore
     self.syncClientFactory = syncClientFactory
     self.pairer = pairer
+    self.pairingMutationGate = pairingMutationGate
     self.privacyServiceProvider = privacyServiceProvider
     self.sharedSnapshotStore = sharedSnapshotStore
     self.watchPairingSyncer = watchPairingSyncer

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/LiveMobileMonitorCredentialPairer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/LiveMobileMonitorCredentialPairer.swift
@@ -21,7 +21,7 @@ actor LiveMobileMonitorCredentialPairer: MobileMonitorCredentialPairer {
       identityStore: identityStore,
       credentialStore: credentialStore,
       transport: URLSessionMobileRemoteDaemonPairingTransport(),
-      platform: "ios"
+      device: .iOS
     )
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/HarnessMonitorWatchApp.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/HarnessMonitorWatchApp.swift
@@ -17,6 +17,12 @@ struct HarnessMonitorWatchApp: App {
   init() {
     let identityStore = KeychainMobileDeviceIdentityStore()
     let credentialStore = KeychainMobilePairedStationCredentialStore()
+    let pairingMutationGate = MobilePairingMutationGate()
+    let remotePairer = LiveWatchRemoteDaemonCredentialPairer(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      mutationGate: pairingMutationGate
+    )
     _store = State(
       initialValue: MirrorStore(
         demoModeEnabled: Self.defaultDemoModeEnabled,
@@ -25,12 +31,15 @@ struct HarnessMonitorWatchApp: App {
         credentialStore: credentialStore,
         syncClientFactory: LiveMobileMonitorSyncClientFactory(
           actorDeviceID: { MobileCommandActorDeviceID.watchActorID(baseDeviceID: $0.id) }
-        )
+        ),
+        pairer: remotePairer,
+        pairingMutationGate: pairingMutationGate
       )
     )
     pairingReceiver = WatchPairingSessionReceiver(
       identityStore: identityStore,
-      credentialStore: credentialStore
+      credentialStore: credentialStore,
+      mutationGate: pairingMutationGate
     )
   }
 
@@ -52,6 +61,19 @@ struct HarnessMonitorWatchApp: App {
           }
           pairingReceiver.start {
             await store.loadTransferredPairings()
+          }
+        }
+        .onOpenURL { url in
+          guard MobilePairingLink.supports(url),
+            url.host?.lowercased() == "remote-pair"
+          else {
+            return
+          }
+          Task {
+            await store.handleOpenURL(
+              url,
+              deviceName: WKInterfaceDevice.current().name
+            )
           }
         }
         .onReceive(

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/LiveWatchRemoteDaemonCredentialPairer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/LiveWatchRemoteDaemonCredentialPairer.swift
@@ -1,0 +1,37 @@
+import Foundation
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+
+actor LiveWatchRemoteDaemonCredentialPairer: MobileMonitorCredentialPairer {
+  private let coordinator:
+    MobileRemoteDaemonPairingCoordinator<URLSessionMobileRemoteDaemonPairingTransport>
+  private let mutationGate: MobilePairingMutationGate
+
+  init(
+    identityStore: any MobileDeviceIdentityStore,
+    credentialStore: any MobilePairedStationCredentialStore,
+    mutationGate: MobilePairingMutationGate
+  ) {
+    coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      transport: URLSessionMobileRemoteDaemonPairingTransport(),
+      device: .watchOS
+    )
+    self.mutationGate = mutationGate
+  }
+
+  func pair(
+    invitationURL: URL,
+    deviceName: String,
+    now: Date
+  ) async throws -> MobilePairedStationCredential {
+    try await mutationGate.perform { [coordinator] in
+      try await coordinator.pair(
+        invitationURL: invitationURL,
+        deviceName: deviceName,
+        now: now
+      )
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/MirrorSyncStatus+WatchDisplay.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/MirrorSyncStatus+WatchDisplay.swift
@@ -7,7 +7,7 @@ import HarnessMonitorMirrorStore
 extension MirrorSyncStatus {
   var title: String {
     switch self {
-    case .unpaired: String(localized: "No paired Mac")
+    case .unpaired: String(localized: "Not paired")
     case .demo: String(localized: "Demo station")
     case .pairing: String(localized: "Pairing")
     case .syncing: String(localized: "Syncing")
@@ -15,7 +15,7 @@ extension MirrorSyncStatus {
     case .stale: String(localized: "Stale")
     case .localNetworkDenied: String(localized: "Network blocked")
     case .iCloudAccountUnavailable: String(localized: "iCloud needed")
-    case .paired: String(localized: "Mac paired")
+    case .paired: String(localized: "Station paired")
     case .privacy: String(localized: "Privacy")
     case .commandQueued: String(localized: "Command queued")
     case .commandCompleted: String(localized: "Command completed")
@@ -27,7 +27,7 @@ extension MirrorSyncStatus {
   var subtitle: String {
     switch self {
     case .unpaired:
-      String(localized: "Open iPhone pairing")
+      String(localized: "Open a remote link or pair on iPhone")
     case .demo:
       String(localized: "App Review demo")
     case .pairing(let stationName):

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/RootView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/RootView.swift
@@ -1,4 +1,5 @@
 import HarnessMonitorCore
+import HarnessMonitorCrypto
 import HarnessMonitorMirrorStore
 import SwiftUI
 import WidgetKit
@@ -9,7 +10,9 @@ struct RootView: View {
   @State private var pendingAttention: MobileAttentionItem?
   @State private var pendingCancellation: MobileCommandRecord?
   @State private var pendingRetry: MobileCommandRecord?
+  @State private var pendingDirectPairingRemoval: MobilePairedStationCredential?
   @State private var composerPresented = false
+  @State private var remotePairingPresented = false
   @Namespace private var reviewZoom
   @Namespace private var sessionZoom
 
@@ -96,9 +99,37 @@ struct RootView: View {
         } message: {
           Text(pendingCancellation?.confirmationText ?? "")
         }
+        .confirmationDialog(
+          "Remove Watch Pairing",
+          isPresented: Binding(
+            get: { pendingDirectPairingRemoval != nil },
+            set: { if !$0 { pendingDirectPairingRemoval = nil } }
+          ),
+          titleVisibility: .visible
+        ) {
+          Button("Remove Pairing", role: .destructive) {
+            guard let credential = pendingDirectPairingRemoval else {
+              return
+            }
+            pendingDirectPairingRemoval = nil
+            Task {
+              await store.removeDirectWatchPairing(stationID: credential.stationID)
+            }
+          }
+          Button("Cancel", role: .cancel) {
+            pendingDirectPairingRemoval = nil
+          }
+        } message: {
+          Text("Harness will request the iPhone pairing after removing this watch credential.")
+        }
         .sheet(isPresented: $composerPresented) {
           NavigationStack {
             WatchCommandComposerView(store: store, initialStationID: store.selectedStationID)
+          }
+        }
+        .sheet(isPresented: $remotePairingPresented) {
+          NavigationStack {
+            WatchRemoteDaemonPairingView()
           }
         }
         .alert("Authentication failed", isPresented: $store.lastAuthenticationFailed) {
@@ -128,7 +159,28 @@ struct RootView: View {
   @ViewBuilder private var statusSection: some View {
     Section {
       WatchStatusRow(status: store.syncStatus)
+      if let directWatchCredential {
+        Button(role: .destructive) {
+          pendingDirectPairingRemoval = directWatchCredential
+        } label: {
+          Label("Remove Watch Pairing", systemImage: "trash")
+        }
+      } else {
+        Button {
+          remotePairingPresented = true
+        } label: {
+          Label("Pair Remote Daemon", systemImage: "link.badge.plus")
+        }
+      }
     }
+  }
+
+  private var directWatchCredential: MobilePairedStationCredential? {
+    let directCredentials = store.pairedCredentials.filter(
+      MobileRemoteDaemonPairingDevice.watchOS.owns
+    )
+    return directCredentials.first { $0.stationID == store.selectedStationID }
+      ?? directCredentials.first
   }
 
   @ViewBuilder private var needsYouSection: some View {

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/RootView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/RootView.swift
@@ -176,11 +176,10 @@ struct RootView: View {
   }
 
   private var directWatchCredential: MobilePairedStationCredential? {
-    let directCredentials = store.pairedCredentials.filter(
-      MobileRemoteDaemonPairingDevice.watchOS.owns
-    )
-    return directCredentials.first { $0.stationID == store.selectedStationID }
-      ?? directCredentials.first
+    store.pairedCredentials.first { credential in
+      credential.stationID == store.selectedStationID
+        && MobileRemoteDaemonPairingDevice.watchOS.owns(credential)
+    }
   }
 
   @ViewBuilder private var needsYouSection: some View {

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchPairingSessionReceiver.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchPairingSessionReceiver.swift
@@ -8,6 +8,7 @@ final class WatchPairingSessionReceiver: NSObject, WCSessionDelegate, @unchecked
   private let session: WCSession?
   private let identityStore: any MobileDeviceIdentityStore
   private let credentialStore: any MobilePairedStationCredentialStore
+  private let mutationGate: MobilePairingMutationGate
   private let sharedSnapshotStore: MobileSharedSnapshotStore?
   private let lock = NSLock()
   private var didStart = false
@@ -16,11 +17,13 @@ final class WatchPairingSessionReceiver: NSObject, WCSessionDelegate, @unchecked
   init(
     identityStore: any MobileDeviceIdentityStore,
     credentialStore: any MobilePairedStationCredentialStore,
+    mutationGate: MobilePairingMutationGate,
     sharedSnapshotStore: MobileSharedSnapshotStore? = MobileSharedSnapshotStore()
   ) {
     session = WCSession.isSupported() ? WCSession.default : nil
     self.identityStore = identityStore
     self.credentialStore = credentialStore
+    self.mutationGate = mutationGate
     self.sharedSnapshotStore = sharedSnapshotStore
     super.init()
   }
@@ -123,33 +126,11 @@ final class WatchPairingSessionReceiver: NSObject, WCSessionDelegate, @unchecked
         try sharedSnapshotStore?.save(snapshot, savedAt: transfer.exportedAt)
         WidgetCenter.shared.reloadAllTimelines()
       }
-      let currentCredentials = try await credentialStore.loadAll()
-      let currentIdentities = try await loadIdentities(
-        for: Set(currentCredentials.map(\.deviceIdentityID))
-      )
-      guard
-        transfer.changesPairingMaterial(
-          currentIdentities: currentIdentities,
-          currentCredentials: currentCredentials
-        )
-      else {
-        // The iPhone re-sends the same pairing material with every relayed snapshot.
-        // Reloading here would reset the watch to "Syncing" and restart its refresh on
-        // every push, so a snapshot-only update stops at the cache save above.
+      let pairingMaterialChanged = try await mutationGate.perform { [self] in
+        try await savePairingMaterial(transfer)
+      }
+      guard pairingMaterialChanged else {
         return
-      }
-      let replacementPlan = transfer.replacementPlan(replacing: currentCredentials)
-      for stationID in replacementPlan.credentialStationIDsToDelete {
-        try await credentialStore.delete(stationID: stationID)
-      }
-      for identityID in replacementPlan.identityIDsToDelete {
-        try await identityStore.delete(id: identityID)
-      }
-      for identity in transfer.identities {
-        try await identityStore.save(identity)
-      }
-      for credential in transfer.credentials {
-        try await credentialStore.save(credential)
       }
       let onCredentialsChanged = currentOnCredentialsChanged()
       if let onCredentialsChanged {
@@ -158,6 +139,43 @@ final class WatchPairingSessionReceiver: NSObject, WCSessionDelegate, @unchecked
     } catch {
       // Watch can keep its last known credentials; the next iPhone sync retries this payload.
     }
+  }
+
+  private func savePairingMaterial(_ transfer: MobileWatchPairingTransfer) async throws -> Bool {
+    let currentCredentials = try await credentialStore.loadAll()
+    let currentIdentities = try await loadIdentities(
+      for: Set(currentCredentials.map(\.deviceIdentityID))
+    )
+    let reconciledTransfer = transfer.preservingLocallyPairedRemoteCredentials(
+      for: .watchOS,
+      currentIdentities: currentIdentities,
+      currentCredentials: currentCredentials
+    )
+    guard
+      reconciledTransfer.changesPairingMaterial(
+        currentIdentities: currentIdentities,
+        currentCredentials: currentCredentials
+      )
+    else {
+      // The iPhone re-sends the same pairing material with every relayed snapshot.
+      // Reloading here would reset the watch to "Syncing" and restart its refresh on
+      // every push, so a snapshot-only update stops at the cache save above.
+      return false
+    }
+    let replacementPlan = reconciledTransfer.replacementPlan(replacing: currentCredentials)
+    for stationID in replacementPlan.credentialStationIDsToDelete {
+      try await credentialStore.delete(stationID: stationID)
+    }
+    for identityID in replacementPlan.identityIDsToDelete {
+      try await identityStore.delete(id: identityID)
+    }
+    for identity in reconciledTransfer.identities {
+      try await identityStore.save(identity)
+    }
+    for credential in reconciledTransfer.credentials {
+      try await credentialStore.save(credential)
+    }
+    return true
   }
 
   private func loadIdentities(for ids: Set<String>) async throws -> [MobileDeviceIdentity] {

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
@@ -1,0 +1,66 @@
+import HarnessMonitorMirrorStore
+import SwiftUI
+import WatchKit
+
+struct WatchRemoteDaemonPairingView: View {
+  @Environment(MirrorStore.self)
+  private var store
+  @Environment(\.dismiss)
+  private var dismiss
+  @State private var pairingLink = ""
+  @State private var isPairing = false
+  @State private var didAttemptPairing = false
+
+  var body: some View {
+    Form {
+      Section("Remote Daemon") {
+        TextField("Pairing Link", text: $pairingLink)
+          .privacySensitive()
+          .lineLimit(1)
+          .frame(height: 44)
+        if isPairing {
+          ProgressView("Pairing")
+        } else {
+          Button(action: pair) {
+            Label("Pair", systemImage: "link")
+          }
+          .disabled(pairingLink.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+      }
+      if didAttemptPairing, !isPairing {
+        Section {
+          Text(store.syncStatus.subtitle)
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+    .navigationTitle("Remote Pairing")
+  }
+
+  private func pair() {
+    let payload = pairingLink
+    guard !payload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return
+    }
+    isPairing = true
+    didAttemptPairing = true
+    pairingLink = ""
+    Task {
+      let paired = await store.pairDirectWatchDaemon(
+        payload: payload,
+        deviceName: WKInterfaceDevice.current().name
+      )
+      isPairing = false
+      if paired {
+        dismiss()
+      }
+    }
+  }
+}
+
+#Preview {
+  NavigationStack {
+    WatchRemoteDaemonPairingView()
+      .environment(MirrorStore(demoModeEnabled: false, profile: .watch))
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
@@ -16,6 +16,8 @@ struct WatchRemoteDaemonPairingView: View {
       Section("Remote Daemon") {
         TextField("Pairing Link", text: $pairingLink)
           .privacySensitive()
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled()
           .lineLimit(1)
           .frame(height: 44)
         if isPairing {

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
@@ -45,7 +45,7 @@ struct WatchRemoteDaemonPairingView: View {
     isPairing = true
     didAttemptPairing = true
     pairingLink = ""
-    Task {
+    Task { @MainActor in
       let paired = await store.pairDirectWatchDaemon(
         payload: payload,
         deviceName: WKInterfaceDevice.current().name

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobilePairingMutationGateTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobilePairingMutationGateTests.swift
@@ -1,12 +1,10 @@
-import HarnessMonitorCrypto
+@testable import HarnessMonitorCrypto
 import XCTest
 
 final class MobilePairingMutationGateTests: XCTestCase {
   func testConcurrentMutationsRunOneAtATime() async throws {
     let gate = MobilePairingMutationGate()
     let firstStarted = expectation(description: "first mutation started")
-    let secondStarted = expectation(description: "second mutation started")
-    secondStarted.isInverted = true
     let releaseFirst = MutationReleaseGate()
 
     let first = Task {
@@ -18,15 +16,26 @@ final class MobilePairingMutationGateTests: XCTestCase {
     await fulfillment(of: [firstStarted], timeout: 1)
 
     let second = Task {
-      try await gate.perform {
-        secondStarted.fulfill()
-      }
+      try await gate.perform {}
     }
-    await fulfillment(of: [secondStarted], timeout: 0.1)
+    await gate.waitUntilQueuedOperations(atLeast: 1)
 
     await releaseFirst.release()
     try await first.value
     try await second.value
+  }
+
+  func testReentrantMutationThrowsInsteadOfDeadlocking() async throws {
+    let gate = MobilePairingMutationGate()
+
+    do {
+      try await gate.perform {
+        try await gate.perform {}
+      }
+      XCTFail("nested mutation should fail")
+    } catch let error as MobilePairingMutationGateError {
+      XCTAssertEqual(error, .reentrantMutation)
+    }
   }
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobilePairingMutationGateTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobilePairingMutationGateTests.swift
@@ -1,0 +1,51 @@
+import HarnessMonitorCrypto
+import XCTest
+
+final class MobilePairingMutationGateTests: XCTestCase {
+  func testConcurrentMutationsRunOneAtATime() async throws {
+    let gate = MobilePairingMutationGate()
+    let firstStarted = expectation(description: "first mutation started")
+    let secondStarted = expectation(description: "second mutation started")
+    secondStarted.isInverted = true
+    let releaseFirst = MutationReleaseGate()
+
+    let first = Task {
+      try await gate.perform {
+        firstStarted.fulfill()
+        await releaseFirst.wait()
+      }
+    }
+    await fulfillment(of: [firstStarted], timeout: 1)
+
+    let second = Task {
+      try await gate.perform {
+        secondStarted.fulfill()
+      }
+    }
+    await fulfillment(of: [secondStarted], timeout: 0.1)
+
+    await releaseFirst.release()
+    try await first.value
+    try await second.value
+  }
+}
+
+private actor MutationReleaseGate {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private var released = false
+
+  func wait() async {
+    guard !released else {
+      return
+    }
+    await withCheckedContinuation { continuation in
+      self.continuation = continuation
+    }
+  }
+
+  func release() {
+    released = true
+    continuation?.resume()
+    continuation = nil
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobilePairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobilePairingTests.swift
@@ -318,4 +318,39 @@ final class MobilePairingTests: XCTestCase {
     XCTAssertEqual(plan.credentialStationIDsToDelete, [])
     XCTAssertEqual(plan.identityIDsToDelete, [])
   }
+
+  func testWatchPairingTransferUsesLastDuplicateStationCredential() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let current = [
+      makePairedStationCredential(
+        stationID: "station-studio",
+        deviceIdentityID: "device-first",
+        now: now
+      )
+    ]
+    let transfer = MobileWatchPairingTransfer(
+      identities: [
+        makePairingIdentity(id: "device-first", now: now),
+        makePairingIdentity(id: "device-second", now: now),
+      ],
+      credentials: [
+        makePairedStationCredential(
+          stationID: "station-studio",
+          deviceIdentityID: "device-first",
+          now: now
+        ),
+        makePairedStationCredential(
+          stationID: "station-studio",
+          deviceIdentityID: "device-second",
+          now: now
+        ),
+      ],
+      exportedAt: now.addingTimeInterval(20)
+    )
+
+    let plan = transfer.replacementPlan(replacing: current)
+
+    XCTAssertEqual(plan.credentialStationIDsToDelete, [])
+    XCTAssertEqual(plan.identityIDsToDelete, ["device-first"])
+  }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
@@ -64,7 +64,7 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
       identityStore: identityStore,
       credentialStore: credentialStore,
       transport: transport,
-      platform: "ios"
+      device: .iOS
     )
 
     let credential = try await coordinator.pair(
@@ -85,7 +85,7 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
     let storedCredential = try await credentialStore.load(stationID: credential.stationID)
     XCTAssertEqual(storedCredential, credential)
     let storedIdentity = try await identityStore.load(
-      id: MobileRemoteDaemonPairingCoordinator<RecordingRemotePairingTransport>.identityID
+      id: MobileRemoteDaemonPairingDevice.iOS.identityID
     )
     XCTAssertNotNil(storedIdentity)
   }
@@ -129,7 +129,7 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
       identityStore: InMemoryMobileDeviceIdentityStore(),
       credentialStore: credentialStore,
       transport: transport,
-      platform: "ios"
+      device: .iOS
     )
 
     let credential = try await coordinator.pair(

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonWatchPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonWatchPairingTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import HarnessMonitorCrypto
+import XCTest
+
+final class MobileRemoteDaemonWatchPairingTests: XCTestCase {
+  func testWatchPairingClaimsWithDedicatedDeviceIdentity() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identityStore = InMemoryMobileDeviceIdentityStore()
+    let phoneIdentity = MobileDeviceIdentity(
+      id: "default-mobile-device",
+      displayName: "Bart's iPhone",
+      signingPrivateKeyRawRepresentation: Data(repeating: 1, count: 32),
+      agreementPrivateKeyRawRepresentation: Data(repeating: 2, count: 32),
+      createdAt: now.addingTimeInterval(-60)
+    )
+    try await identityStore.save(phoneIdentity)
+    let phoneCredential = try transferredPhoneCredential(identity: phoneIdentity, now: now)
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [phoneCredential]
+    )
+    let transport = RecordingWatchRemotePairingTransport(pairedAt: now.addingTimeInterval(5))
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      transport: transport,
+      device: .watchOS
+    )
+
+    let credential = try await coordinator.pair(
+      invitationURL: try watchRemoteInvitationURL(now: now),
+      deviceName: "Bart's Apple Watch",
+      now: now
+    )
+
+    let capturedRequest = await transport.lastRequest()
+    let request = try XCTUnwrap(capturedRequest)
+    XCTAssertEqual(request.platform, "watchos")
+    XCTAssertEqual(request.displayName, "Bart's Apple Watch")
+    XCTAssertTrue(request.clientID.hasPrefix("watchos-"))
+    XCTAssertEqual(credential.deviceIdentityID, MobileRemoteDaemonPairingDevice.watchOS.identityID)
+    XCTAssertEqual(credential.remoteDaemonAccess?.platform, "watchos")
+    XCTAssertEqual(credential.remoteDaemonAccess?.clientID, request.clientID)
+    let storedWatchIdentity = try await identityStore.load(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID
+    )
+    let storedPhoneIdentity = try await identityStore.load(id: phoneIdentity.id)
+    XCTAssertNotNil(storedWatchIdentity)
+    XCTAssertNil(storedPhoneIdentity)
+  }
+
+  func testWatchPairingKeepsTransferredIdentityUsedByAnotherStation() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let phoneIdentity = MobileDeviceIdentity(
+      id: "default-mobile-device",
+      displayName: "Bart's iPhone",
+      signingPrivateKeyRawRepresentation: Data(repeating: 1, count: 32),
+      agreementPrivateKeyRawRepresentation: Data(repeating: 2, count: 32),
+      createdAt: now.addingTimeInterval(-60)
+    )
+    let replacedCredential = try transferredPhoneCredential(identity: phoneIdentity, now: now)
+    var retainedCredential = replacedCredential
+    retainedCredential.stationID = "remote-daemon-secondary"
+    retainedCredential.stationName = "secondary.example.com"
+    let identityStore = InMemoryMobileDeviceIdentityStore(identities: [phoneIdentity])
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [replacedCredential, retainedCredential]
+    )
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      transport: RecordingWatchRemotePairingTransport(pairedAt: now),
+      device: .watchOS
+    )
+
+    _ = try await coordinator.pair(
+      invitationURL: try watchRemoteInvitationURL(now: now),
+      deviceName: "Bart's Apple Watch",
+      now: now
+    )
+
+    let storedPhoneIdentity = try await identityStore.load(id: phoneIdentity.id)
+    XCTAssertEqual(storedPhoneIdentity, phoneIdentity)
+  }
+}
+
+private actor RecordingWatchRemotePairingTransport: MobileRemoteDaemonPairingTransport {
+  struct Request: Sendable {
+    var clientID: String
+    var displayName: String
+    var platform: String
+  }
+
+  private let pairedAt: Date
+  private var request: Request?
+
+  init(pairedAt: Date) {
+    self.pairedAt = pairedAt
+  }
+
+  func claim(
+    invitation: MobileRemoteDaemonPairingInvitation,
+    clientID: String,
+    displayName: String,
+    platform: String
+  ) async throws -> MobileRemoteDaemonPairingClaim {
+    request = Request(clientID: clientID, displayName: displayName, platform: platform)
+    return MobileRemoteDaemonPairingClaim(
+      clientID: clientID,
+      displayName: displayName,
+      platform: platform,
+      role: .operator,
+      scopes: ["read", "write"],
+      token: "watch-server-token",
+      tokenHint: "watch123",
+      pairedAt: pairedAt
+    )
+  }
+
+  func lastRequest() -> Request? {
+    request
+  }
+}
+
+private func watchRemoteInvitationURL(now: Date) throws -> URL {
+  let payload: [String: Any] = [
+    "version": 1,
+    "endpoint": "https://daemon.example.com",
+    "code": "watch-one-time-code",
+    "server_spki_sha256": "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY=",
+    "role": "operator",
+    "scopes": ["read", "write"],
+    "expires_at": ISO8601DateFormatter().string(from: now.addingTimeInterval(600)),
+  ]
+  let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+  let encoded =
+    data.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+  return try XCTUnwrap(URL(string: "harness://remote-pair?payload=\(encoded)"))
+}
+
+private func transferredPhoneCredential(
+  identity: MobileDeviceIdentity,
+  now: Date
+) throws -> MobilePairedStationCredential {
+  let endpoint = URL(string: "https://daemon.example.com")!
+  let pin = try MobileRemoteDaemonSPKIPin(
+    validating: "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+  )
+  return MobilePairedStationCredential(
+    stationID: "remote-daemon-example-com",
+    stationName: "daemon.example.com",
+    endpoint: endpoint,
+    stationPublicKeyFingerprint: pin.value,
+    deviceIdentityID: identity.id,
+    snapshotKeyID: "",
+    commandKeyID: "",
+    symmetricKeyRawRepresentation: Data(),
+    pairedAt: now.addingTimeInterval(-30),
+    defaultStation: true,
+    remoteDaemonAccess: MobileRemoteDaemonAccess(
+      endpoint: endpoint,
+      clientID: "ios-client",
+      displayName: identity.displayName,
+      platform: "ios",
+      role: .operator,
+      scopes: ["read", "write"],
+      bearerToken: "phone-server-token",
+      tokenHint: "phone123",
+      serverSPKISHA256: pin,
+      pairedAt: now.addingTimeInterval(-30)
+    )
+  )
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileWatchPairingTransferChangesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileWatchPairingTransferChangesTests.swift
@@ -155,4 +155,191 @@ final class MobileWatchPairingTransferChangesTests: XCTestCase {
 
     XCTAssertTrue(changed, "a rotated identity key must trigger a reload")
   }
+
+  func testPhoneTransferPreservesDirectWatchCredentialForSameStation() throws {
+    let phoneIdentity = makePairingIdentity(id: "default-mobile-device", now: now)
+    let watchIdentity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID,
+      now: now
+    )
+    let phoneCredential = try makeRemoteCredential(
+      identityID: phoneIdentity.id,
+      platform: "ios",
+      token: "phone-token"
+    )
+    let watchCredential = try makeRemoteCredential(
+      identityID: watchIdentity.id,
+      platform: "watchos",
+      token: "watch-token"
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [phoneIdentity],
+      credentials: [phoneCredential],
+      snapshot: .empty(),
+      exportedAt: now
+    )
+
+    let reconciled = transfer.preservingLocallyPairedRemoteCredentials(
+      for: .watchOS,
+      currentIdentities: [watchIdentity],
+      currentCredentials: [watchCredential]
+    )
+
+    XCTAssertEqual(reconciled.credentials, [watchCredential])
+    XCTAssertEqual(reconciled.identities, [watchIdentity])
+    XCTAssertEqual(reconciled.snapshot, transfer.snapshot)
+    XCTAssertFalse(
+      reconciled.changesPairingMaterial(
+        currentIdentities: [watchIdentity],
+        currentCredentials: [watchCredential]
+      )
+    )
+  }
+
+  func testEmptyPhoneTransferPreservesDirectWatchCredential() throws {
+    let watchIdentity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID,
+      now: now
+    )
+    let watchCredential = try makeRemoteCredential(
+      identityID: watchIdentity.id,
+      platform: "watchos",
+      token: "watch-token"
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [],
+      credentials: [],
+      snapshot: .empty(),
+      exportedAt: now
+    )
+
+    let reconciled = transfer.preservingLocallyPairedRemoteCredentials(
+      for: .watchOS,
+      currentIdentities: [watchIdentity],
+      currentCredentials: [watchCredential]
+    )
+
+    XCTAssertEqual(reconciled.credentials, [watchCredential])
+    XCTAssertEqual(reconciled.identities, [watchIdentity])
+    XCTAssertEqual(reconciled.snapshot, transfer.snapshot)
+  }
+
+  func testPhoneTransferStillReplacesStaleTransferredCredentials() throws {
+    let phoneIdentity = makePairingIdentity(id: "default-mobile-device", now: now)
+    let watchIdentity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID,
+      now: now
+    )
+    let watchCredential = try makeRemoteCredential(
+      stationID: "remote-watch",
+      identityID: watchIdentity.id,
+      platform: "watchos",
+      token: "watch-token"
+    )
+    let stalePhoneCredential = makePairedStationCredential(
+      stationID: "relay-stale",
+      deviceIdentityID: phoneIdentity.id,
+      now: now
+    )
+    let replacementPhoneCredential = makePairedStationCredential(
+      stationID: "relay-current",
+      deviceIdentityID: phoneIdentity.id,
+      now: now
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [phoneIdentity],
+      credentials: [replacementPhoneCredential],
+      exportedAt: now
+    )
+
+    let reconciled = transfer.preservingLocallyPairedRemoteCredentials(
+      for: .watchOS,
+      currentIdentities: [phoneIdentity, watchIdentity],
+      currentCredentials: [watchCredential, stalePhoneCredential]
+    )
+    let plan = reconciled.replacementPlan(
+      replacing: [watchCredential, stalePhoneCredential]
+    )
+
+    XCTAssertEqual(
+      Set(reconciled.credentials.map(\.stationID)),
+      Set(["remote-watch", "relay-current"])
+    )
+    XCTAssertEqual(Set(reconciled.identities.map(\.id)), Set([phoneIdentity.id, watchIdentity.id]))
+    XCTAssertEqual(plan.credentialStationIDsToDelete, ["relay-stale"])
+    XCTAssertFalse(plan.credentialStationIDsToDelete.contains(watchCredential.stationID))
+  }
+
+  func testDuplicateIncomingIdentityIDsUseTheLastValue() throws {
+    let firstPhoneIdentity = makePairingIdentity(id: "default-mobile-device", now: now)
+    var latestPhoneIdentity = firstPhoneIdentity
+    latestPhoneIdentity.displayName = "Latest iPhone"
+    let watchIdentity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID,
+      now: now
+    )
+    let phoneCredential = makePairedStationCredential(
+      stationID: "relay-phone",
+      deviceIdentityID: firstPhoneIdentity.id,
+      now: now
+    )
+    let watchCredential = try makeRemoteCredential(
+      stationID: "remote-watch",
+      identityID: watchIdentity.id,
+      platform: "watchos",
+      token: "watch-token"
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [firstPhoneIdentity, latestPhoneIdentity],
+      credentials: [phoneCredential],
+      exportedAt: now
+    )
+
+    let reconciled = transfer.preservingLocallyPairedRemoteCredentials(
+      for: .watchOS,
+      currentIdentities: [watchIdentity],
+      currentCredentials: [watchCredential]
+    )
+
+    XCTAssertEqual(
+      reconciled.identities.first(where: { $0.id == latestPhoneIdentity.id }),
+      latestPhoneIdentity
+    )
+  }
+}
+
+private func makeRemoteCredential(
+  stationID: String = "remote-daemon-example-com",
+  identityID: String,
+  platform: String,
+  token: String
+) throws -> MobilePairedStationCredential {
+  let endpoint = URL(string: "https://daemon.example.com")!
+  let pin = try MobileRemoteDaemonSPKIPin(
+    validating: "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+  )
+  return MobilePairedStationCredential(
+    stationID: stationID,
+    stationName: "daemon.example.com",
+    endpoint: endpoint,
+    stationPublicKeyFingerprint: pin.value,
+    deviceIdentityID: identityID,
+    snapshotKeyID: "",
+    commandKeyID: "",
+    symmetricKeyRawRepresentation: Data(),
+    pairedAt: Date(timeIntervalSince1970: 1_700_000_000),
+    defaultStation: true,
+    remoteDaemonAccess: MobileRemoteDaemonAccess(
+      endpoint: endpoint,
+      clientID: "\(platform)-client",
+      displayName: platform,
+      platform: platform,
+      role: .operator,
+      scopes: ["read", "write"],
+      bearerToken: token,
+      tokenHint: String(token.suffix(4)),
+      serverSPKISHA256: pin,
+      pairedAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+  )
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileWatchPairingTransferChangesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileWatchPairingTransferChangesTests.swift
@@ -306,6 +306,51 @@ final class MobileWatchPairingTransferChangesTests: XCTestCase {
       latestPhoneIdentity
     )
   }
+
+  func testDuplicateIncomingStationsUseTheLastCredential() throws {
+    let firstPhoneIdentity = makePairingIdentity(id: "phone-first", now: now)
+    let latestPhoneIdentity = makePairingIdentity(id: "phone-latest", now: now)
+    let watchIdentity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID,
+      now: now
+    )
+    let firstPhoneCredential = makePairedStationCredential(
+      stationID: "relay-phone",
+      deviceIdentityID: firstPhoneIdentity.id,
+      now: now
+    )
+    let latestPhoneCredential = makePairedStationCredential(
+      stationID: "relay-phone",
+      deviceIdentityID: latestPhoneIdentity.id,
+      now: now
+    )
+    let watchCredential = try makeRemoteCredential(
+      stationID: "remote-watch",
+      identityID: watchIdentity.id,
+      platform: "watchos",
+      token: "watch-token"
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [firstPhoneIdentity, latestPhoneIdentity],
+      credentials: [firstPhoneCredential, latestPhoneCredential],
+      exportedAt: now
+    )
+
+    let reconciled = transfer.preservingLocallyPairedRemoteCredentials(
+      for: .watchOS,
+      currentIdentities: [watchIdentity],
+      currentCredentials: [watchCredential]
+    )
+
+    XCTAssertEqual(
+      reconciled.credentials.filter { $0.stationID == latestPhoneCredential.stationID },
+      [latestPhoneCredential]
+    )
+    XCTAssertEqual(
+      Set(reconciled.identities.map(\.id)),
+      Set([latestPhoneIdentity.id, watchIdentity.id])
+    )
+  }
 }
 
 private func makeRemoteCredential(

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
@@ -64,6 +64,77 @@ struct HarnessMonitorAppBundleMetadataTests {
     #expect(projectSource.contains("bundleId: \"io.harnessmonitor.app.ios.watch.widgets\""))
   }
 
+  @Test("Watch app claims remote daemon pairing links directly")
+  func watchAppClaimsRemoteDaemonPairingLinksDirectly() throws {
+    let root = monitorAppRoot()
+    let infoPlist = try loadDictionaryPlist(
+      at: root.appendingPathComponent("Resources/HarnessMonitorWatch-Info.plist")
+    )
+    let urlTypes = try #require(infoPlist["CFBundleURLTypes"] as? [[String: Any]])
+    let schemes = Set(
+      urlTypes
+        .compactMap { $0["CFBundleURLSchemes"] as? [String] }
+        .flatMap { $0 }
+    )
+    #expect(schemes.contains("harness"))
+
+    let appSource = try String(
+      contentsOf: root.appendingPathComponent(
+        "Sources/HarnessMonitorWatch/HarnessMonitorWatchApp.swift"
+      ),
+      encoding: .utf8
+    )
+    #expect(appSource.contains("LiveWatchRemoteDaemonCredentialPairer("))
+    #expect(appSource.contains("pairer: remotePairer"))
+    #expect(appSource.contains("let pairingMutationGate = MobilePairingMutationGate()"))
+    #expect(appSource.contains("pairingMutationGate: pairingMutationGate"))
+    #expect(
+      appSource.components(separatedBy: "mutationGate: pairingMutationGate").count == 3
+    )
+    #expect(appSource.contains(".onOpenURL"))
+    #expect(appSource.contains("url.host?.lowercased() == \"remote-pair\""))
+    #expect(appSource.contains("pairingReceiver.start"))
+
+    let rootViewSource = try String(
+      contentsOf: root.appendingPathComponent(
+        "Sources/HarnessMonitorWatch/RootView.swift"
+      ),
+      encoding: .utf8
+    )
+    #expect(rootViewSource.contains("Remove Watch Pairing"))
+    #expect(rootViewSource.contains("removeDirectWatchPairing"))
+
+    let pairingViewSource = try String(
+      contentsOf: root.appendingPathComponent(
+        "Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift"
+      ),
+      encoding: .utf8
+    )
+    #expect(rootViewSource.contains("Pair Remote Daemon"))
+    #expect(rootViewSource.contains("WatchRemoteDaemonPairingView()"))
+    #expect(pairingViewSource.contains("TextField(\"Pairing Link\""))
+    #expect(pairingViewSource.contains(".privacySensitive()"))
+    #expect(pairingViewSource.contains(".lineLimit(1)"))
+    #expect(pairingViewSource.contains(".frame(height: 44)"))
+    #expect(pairingViewSource.contains("pairingLink = \"\""))
+    #expect(pairingViewSource.contains("pairDirectWatchDaemon"))
+
+    let directPairerSource = try String(
+      contentsOf: root.appendingPathComponent(
+        "Sources/HarnessMonitorWatch/LiveWatchRemoteDaemonCredentialPairer.swift"
+      ),
+      encoding: .utf8
+    )
+    let transferReceiverSource = try String(
+      contentsOf: root.appendingPathComponent(
+        "Sources/HarnessMonitorWatch/WatchPairingSessionReceiver.swift"
+      ),
+      encoding: .utf8
+    )
+    #expect(directPairerSource.contains("try await mutationGate.perform"))
+    #expect(transferReceiverSource.contains("try await mutationGate.perform"))
+  }
+
   @Test("Mobile widgets can refresh encrypted mirrors")
   func mobileWidgetsCanRefreshEncryptedMirrors() throws {
     let root = monitorAppRoot()

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
@@ -103,6 +103,8 @@ struct HarnessMonitorAppBundleMetadataTests {
     )
     #expect(rootViewSource.contains("Remove Watch Pairing"))
     #expect(rootViewSource.contains("removeDirectWatchPairing"))
+    #expect(rootViewSource.contains("credential.stationID == store.selectedStationID"))
+    #expect(!rootViewSource.contains("?? directCredentials.first"))
 
     let pairingViewSource = try String(
       contentsOf: root.appendingPathComponent(

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
@@ -116,6 +116,8 @@ struct HarnessMonitorAppBundleMetadataTests {
     #expect(rootViewSource.contains("WatchRemoteDaemonPairingView()"))
     #expect(pairingViewSource.contains("TextField(\"Pairing Link\""))
     #expect(pairingViewSource.contains(".privacySensitive()"))
+    #expect(pairingViewSource.contains(".textInputAutocapitalization(.never)"))
+    #expect(pairingViewSource.contains(".autocorrectionDisabled()"))
     #expect(pairingViewSource.contains(".lineLimit(1)"))
     #expect(pairingViewSource.contains(".frame(height: 44)"))
     #expect(pairingViewSource.contains("pairingLink = \"\""))

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
@@ -119,6 +119,7 @@ struct HarnessMonitorAppBundleMetadataTests {
     #expect(pairingViewSource.contains(".lineLimit(1)"))
     #expect(pairingViewSource.contains(".frame(height: 44)"))
     #expect(pairingViewSource.contains("pairingLink = \"\""))
+    #expect(pairingViewSource.contains("Task { @MainActor in"))
     #expect(pairingViewSource.contains("pairDirectWatchDaemon"))
 
     let directPairerSource = try String(

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingPayloadTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingPayloadTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+import XCTest
+
+@MainActor
+final class WatchRemoteDaemonPairingPayloadTests: XCTestCase {
+  func testWatchPairsDirectlyFromRemotePayload() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identityStore = InMemoryMobileDeviceIdentityStore()
+    let credentialStore = InMemoryMobilePairedStationCredentialStore()
+    let pairer = RecordingWatchCredentialPairer(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      credential: try watchRemoteCredential(now: now)
+    )
+    let store = MirrorStore(
+      demoModeEnabled: true,
+      profile: .watch,
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      syncClientFactory: WatchPairingSyncClientFactory(),
+      pairer: pairer,
+      sharedSnapshotStore: nil
+    )
+    let invitationURL = try watchRemoteInvitationURL(now: now)
+
+    let paired = await store.pairDirectWatchDaemon(
+      payload: invitationURL.absoluteString,
+      deviceName: "Bart's Apple Watch",
+      now: now
+    )
+
+    let capturedRequest = await pairer.lastRequest()
+    let request = try XCTUnwrap(capturedRequest)
+    XCTAssertTrue(paired)
+    XCTAssertEqual(request.invitationURL, invitationURL)
+    XCTAssertEqual(request.deviceName, "Bart's Apple Watch")
+    XCTAssertEqual(request.now, now)
+    XCTAssertFalse(store.demoModeEnabled)
+    XCTAssertTrue(
+      store.pairedCredentials.contains(where: MobileRemoteDaemonPairingDevice.watchOS.owns)
+    )
+  }
+
+  func testWatchRejectsNonRemotePairingPayload() async throws {
+    let pairer = RecordingWatchCredentialPairer(
+      identityStore: InMemoryMobileDeviceIdentityStore(),
+      credentialStore: InMemoryMobilePairedStationCredentialStore(),
+      credential: try watchRemoteCredential(now: .now)
+    )
+    let store = MirrorStore(
+      demoModeEnabled: false,
+      profile: .watch,
+      pairer: pairer,
+      sharedSnapshotStore: nil
+    )
+
+    let paired = await store.pairDirectWatchDaemon(
+      payload: "harness://pair?payload=not-a-remote-invitation",
+      deviceName: "Bart's Apple Watch"
+    )
+
+    XCTAssertFalse(paired)
+    let capturedRequest = await pairer.lastRequest()
+    XCTAssertNil(capturedRequest)
+  }
+
+  func testFailedReplacementDoesNotReportExistingWatchPairingAsSuccess() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identity = MobileDeviceIdentity(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID,
+      displayName: "Bart's Apple Watch",
+      createdAt: now.addingTimeInterval(-60)
+    )
+    let credential = try watchRemoteCredential(now: now.addingTimeInterval(-30))
+    let identityStore = InMemoryMobileDeviceIdentityStore(identities: [identity])
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [credential]
+    )
+    let store = MirrorStore(
+      demoModeEnabled: false,
+      profile: .watch,
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      syncClientFactory: WatchPairingSyncClientFactory(),
+      pairer: FailingWatchCredentialPairer(),
+      sharedSnapshotStore: nil
+    )
+    await store.loadStoredPairings()
+
+    let paired = await store.pairDirectWatchDaemon(
+      payload: try watchRemoteInvitationURL(now: now).absoluteString,
+      deviceName: "Bart's Apple Watch",
+      now: now
+    )
+
+    XCTAssertFalse(paired)
+    XCTAssertEqual(store.pairedCredentials, [credential])
+  }
+}
+
+private struct FailingWatchCredentialPairer: MobileMonitorCredentialPairer {
+  func pair(
+    invitationURL: URL,
+    deviceName: String,
+    now: Date
+  ) async throws -> MobilePairedStationCredential {
+    throw WatchPairingTestError.claimFailed
+  }
+}
+
+private enum WatchPairingTestError: Error {
+  case claimFailed
+}
+
+private actor RecordingWatchCredentialPairer: MobileMonitorCredentialPairer {
+  struct Request: Sendable {
+    var invitationURL: URL
+    var deviceName: String
+    var now: Date
+  }
+
+  private let identityStore: any MobileDeviceIdentityStore
+  private let credentialStore: any MobilePairedStationCredentialStore
+  private let credential: MobilePairedStationCredential
+  private var request: Request?
+
+  init(
+    identityStore: any MobileDeviceIdentityStore,
+    credentialStore: any MobilePairedStationCredentialStore,
+    credential: MobilePairedStationCredential
+  ) {
+    self.identityStore = identityStore
+    self.credentialStore = credentialStore
+    self.credential = credential
+  }
+
+  func pair(
+    invitationURL: URL,
+    deviceName: String,
+    now: Date
+  ) async throws -> MobilePairedStationCredential {
+    request = Request(invitationURL: invitationURL, deviceName: deviceName, now: now)
+    try await identityStore.save(
+      MobileDeviceIdentity(
+        id: credential.deviceIdentityID,
+        displayName: deviceName,
+        createdAt: now
+      )
+    )
+    try await credentialStore.save(credential)
+    return credential
+  }
+
+  func lastRequest() -> Request? {
+    request
+  }
+}
+
+private struct WatchPairingSyncClientFactory: MobileMonitorSyncClientFactory {
+  func makeSyncClient(
+    credential: MobilePairedStationCredential,
+    identity: MobileDeviceIdentity
+  ) -> any MobileMonitorSyncClient {
+    WatchPairingSyncClient()
+  }
+}
+
+private struct WatchPairingSyncClient: MobileMonitorSyncClient {
+  func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot? {
+    MobileMirrorSnapshot(
+      schemaVersion: 1,
+      revision: 1,
+      generatedAt: now,
+      expiresAt: now.addingTimeInterval(60),
+      stations: [],
+      attention: [],
+      sessions: [],
+      reviews: [],
+      commands: []
+    )
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+}
+
+private func watchRemoteCredential(now: Date) throws -> MobilePairedStationCredential {
+  let endpoint = URL(string: "https://daemon.example.com")!
+  let pin = try MobileRemoteDaemonSPKIPin(
+    validating: "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+  )
+  return MobilePairedStationCredential(
+    stationID: "remote-daemon-example-com",
+    stationName: "daemon.example.com",
+    endpoint: endpoint,
+    stationPublicKeyFingerprint: pin.value,
+    deviceIdentityID: MobileRemoteDaemonPairingDevice.watchOS.identityID,
+    snapshotKeyID: "",
+    commandKeyID: "",
+    symmetricKeyRawRepresentation: Data(),
+    pairedAt: now,
+    defaultStation: true,
+    remoteDaemonAccess: MobileRemoteDaemonAccess(
+      endpoint: endpoint,
+      clientID: "watchos-client",
+      displayName: "Bart's Apple Watch",
+      platform: MobileRemoteDaemonPairingDevice.watchOS.platform,
+      role: .operator,
+      scopes: ["read", "write"],
+      bearerToken: "watch-server-token",
+      tokenHint: "watch123",
+      serverSPKISHA256: pin,
+      pairedAt: now
+    )
+  )
+}
+
+private func watchRemoteInvitationURL(now: Date) throws -> URL {
+  let payload: [String: Any] = [
+    "version": 1,
+    "endpoint": "https://daemon.example.com",
+    "code": "watch-one-time-code",
+    "server_spki_sha256": "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY=",
+    "role": "operator",
+    "scopes": ["read", "write"],
+    "expires_at": ISO8601DateFormatter().string(from: now.addingTimeInterval(600)),
+  ]
+  let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+  let encoded =
+    data.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+  return try XCTUnwrap(URL(string: "harness://remote-pair?payload=\(encoded)"))
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+import XCTest
+
+@MainActor
+final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
+  func testRemovingDirectWatchPairingWaitsForPairingMutationGate() async throws {
+    let mutationGate = MobilePairingMutationGate()
+    let fixture = try WatchRemotePairingStoreFixture(
+      device: .watchOS,
+      mutationGate: mutationGate
+    )
+    await fixture.store.loadStoredPairings()
+    let blockerStarted = expectation(description: "blocking mutation started")
+    let releaseBlocker = WatchPairingReleaseGate()
+    let blocker = Task {
+      try await mutationGate.perform {
+        blockerStarted.fulfill()
+        await releaseBlocker.wait()
+      }
+    }
+    await fulfillment(of: [blockerStarted], timeout: 1)
+
+    let removal = Task { @MainActor in
+      await fixture.store.removeDirectWatchPairing(stationID: fixture.credential.stationID)
+    }
+    try await Task.sleep(for: .milliseconds(50))
+
+    let credentialWhileBlocked = try await fixture.credentialStore.load(
+      stationID: fixture.credential.stationID
+    )
+    XCTAssertEqual(credentialWhileBlocked, fixture.credential)
+
+    await releaseBlocker.release()
+    try await blocker.value
+    await removal.value
+    let credentialAfterRemoval = try await fixture.credentialStore.load(
+      stationID: fixture.credential.stationID
+    )
+    XCTAssertNil(credentialAfterRemoval)
+  }
+
+  func testRemovingDirectWatchPairingRequestsIPhoneFallback() async throws {
+    let fixture = try WatchRemotePairingStoreFixture(device: .watchOS)
+    await fixture.store.loadStoredPairings()
+    fixture.store.requestFreshPairingMaterial = { fixture.transferRequests.increment() }
+
+    await fixture.store.removeDirectWatchPairing(stationID: fixture.credential.stationID)
+
+    let storedCredential = try await fixture.credentialStore.load(
+      stationID: fixture.credential.stationID
+    )
+    let storedIdentity = try await fixture.identityStore.load(id: fixture.identity.id)
+    XCTAssertNil(storedCredential)
+    XCTAssertNil(storedIdentity)
+    XCTAssertEqual(fixture.transferRequests.value, 1)
+    XCTAssertEqual(fixture.store.syncStatus, .unpaired)
+  }
+
+  func testRemovingDirectWatchPairingIgnoresIPhoneTransferredCredential() async throws {
+    let fixture = try WatchRemotePairingStoreFixture(device: .iOS)
+    await fixture.store.loadStoredPairings()
+    fixture.store.requestFreshPairingMaterial = { fixture.transferRequests.increment() }
+
+    await fixture.store.removeDirectWatchPairing(stationID: fixture.credential.stationID)
+
+    let storedCredential = try await fixture.credentialStore.load(
+      stationID: fixture.credential.stationID
+    )
+    XCTAssertEqual(storedCredential, fixture.credential)
+    XCTAssertEqual(fixture.transferRequests.value, 0)
+  }
+}
+
+@MainActor
+private struct WatchRemotePairingStoreFixture {
+  let identity: MobileDeviceIdentity
+  let credential: MobilePairedStationCredential
+  let identityStore: InMemoryMobileDeviceIdentityStore
+  let credentialStore: InMemoryMobilePairedStationCredentialStore
+  let transferRequests = WatchPairingCallCounter()
+  let store: MirrorStore
+
+  init(
+    device: MobileRemoteDaemonPairingDevice,
+    mutationGate: MobilePairingMutationGate = MobilePairingMutationGate()
+  ) throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let endpoint = URL(string: "https://daemon.example.com")!
+    let pin = try MobileRemoteDaemonSPKIPin(
+      validating: "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+    )
+    identity = MobileDeviceIdentity(
+      id: device.identityID,
+      displayName: device.platform,
+      signingPrivateKeyRawRepresentation: Data(repeating: 1, count: 32),
+      agreementPrivateKeyRawRepresentation: Data(repeating: 2, count: 32),
+      createdAt: now
+    )
+    credential = MobilePairedStationCredential(
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      endpoint: endpoint,
+      stationPublicKeyFingerprint: pin.value,
+      deviceIdentityID: device.identityID,
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: now,
+      defaultStation: true,
+      remoteDaemonAccess: MobileRemoteDaemonAccess(
+        endpoint: endpoint,
+        clientID: "\(device.platform)-client",
+        displayName: device.platform,
+        platform: device.platform,
+        role: .operator,
+        scopes: ["read", "write"],
+        bearerToken: "server-token",
+        tokenHint: "token123",
+        serverSPKISHA256: pin,
+        pairedAt: now
+      )
+    )
+    identityStore = InMemoryMobileDeviceIdentityStore(identities: [identity])
+    credentialStore = InMemoryMobilePairedStationCredentialStore(credentials: [credential])
+    store = MirrorStore(
+      demoModeEnabled: false,
+      profile: .watch,
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      pairingMutationGate: mutationGate,
+      sharedSnapshotStore: nil
+    )
+  }
+}
+
+private actor WatchPairingReleaseGate {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private var released = false
+
+  func wait() async {
+    guard !released else {
+      return
+    }
+    await withCheckedContinuation { continuation in
+      self.continuation = continuation
+    }
+  }
+
+  func release() {
+    released = true
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
+private final class WatchPairingCallCounter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var count = 0
+
+  var value: Int {
+    lock.withLock { count }
+  }
+
+  func increment() {
+    lock.withLock { count += 1 }
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import HarnessMonitorCrypto
+@testable import HarnessMonitorCrypto
 import HarnessMonitorMirrorStore
 import XCTest
 
@@ -25,7 +25,7 @@ final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
     let removal = Task { @MainActor in
       await fixture.store.removeDirectWatchPairing(stationID: fixture.credential.stationID)
     }
-    try await Task.sleep(for: .milliseconds(50))
+    await mutationGate.waitUntilQueuedOperations(atLeast: 1)
 
     let credentialWhileBlocked = try await fixture.credentialStore.load(
       stationID: fixture.credential.stationID

--- a/docs/agent-guides/monitor-mobile-reference.md
+++ b/docs/agent-guides/monitor-mobile-reference.md
@@ -8,10 +8,10 @@ The macOS app itself is covered by `apps/harness-monitor/AGENTS.md` and `monitor
 
 Harness Monitor on the phone and watch is a mobile control surface with two credential-driven transports:
 
-1. A remote-daemon profile connects directly over pinned HTTPS. The phone claims a one-time remote pairing invitation, stores the bearer credential in its Keychain, fetches authenticated session snapshots, and executes role-scoped commands against daemon HTTP routes. The watch can use the same direct path after the phone transfers that profile through WatchConnectivity.
+1. A remote-daemon profile connects directly over pinned HTTPS. The phone or watch claims a one-time remote pairing invitation, stores the bearer credential in its own Keychain, fetches authenticated session snapshots, and executes role-scoped commands against daemon HTTP routes. The watch can also use the same direct path after the phone transfers its profile through WatchConnectivity.
 2. A local-relay profile uses `HarnessMonitorMacRelay` and `HarnessMonitorCloudMirror`. The Mac redacts and encrypts a full snapshot, CloudKit carries only encrypted records plus routing metadata, and the phone/watch decrypt the mirror. Signed commands return through the same relay for the Mac to validate and execute.
 
-When a credential has both transports, direct snapshot access is tried first. CloudMirror snapshot fallback is used only for reachability/TLS failures or remote 5xx responses; remote `401` and `403` responses fail closed. Commands use direct execution whenever the remote profile has write scope and never fall back after a direct attempt, avoiding duplicate side effects after an ambiguous network failure. A read-only direct profile may still use an independently configured CloudMirror command channel. The phone remains the pairing hub for the watch. The watch does not run either pairing claim itself.
+When a credential has both transports, direct snapshot access is tried first. CloudMirror snapshot fallback is used only for reachability/TLS failures or remote 5xx responses; remote `401` and `403` responses fail closed. Commands use direct execution whenever the remote profile has write scope and never fall back after a direct attempt, avoiding duplicate side effects after an ambiguous network failure. A read-only direct profile may still use an independently configured CloudMirror command channel. Local-relay pairing still runs through the phone. Remote-daemon pairing can run on either the phone or watch.
 
 ## Target and framework map
 
@@ -23,9 +23,9 @@ All Apple targets live in `apps/harness-monitor/Project.swift`. Mobile and watch
 | `HarnessMonitorCrypto` | static framework | mac, iOS, watch | `io.harnessmonitor.crypto` | AEAD cipher (`MobilePayloadCipher`), device identity + Keychain stores, paired-station credential + Keychain stores, the pairing handshake (`MobilePairing*`, invitation codec), and the phone-to-watch transfer bundle. CryptoKit + Security only. |
 | `HarnessMonitorCloudMirror` | static framework | mac, iOS, watch | `io.harnessmonitor.cloudmirror` | The CloudKit transport: schema, record codec, live database, snapshot writer, command queue, subscription registrar, background refresher, privacy service, and the device-side `MobileCloudMirrorSyncClient`. Depends on Core + Crypto. |
 | `HarnessMonitorMacRelay` | framework | mac only | `io.harnessmonitor.mac-relay` | The Mac side: `MobileMacRelayService`, the daemon-backed snapshot source, the command executor, the local-network pairing HTTP server, and the Mac-side identity/trust stores. Embedded in the macOS app. |
-| `HarnessMonitorMobile` | app | iOS | `io.harnessmonitor.app.ios` | The iOS app ("Harness Monitor"). `MobileMonitorStore`, the five-tab UI, QR pairing, command composer, live activity, notifications, and the WatchConnectivity bridge. Embeds the watch app. |
+| `HarnessMonitorMobile` | app | iOS | `io.harnessmonitor.app.ios` | The iOS app ("Harness Monitor"). The shared `MirrorStore`, five-tab UI, QR pairing, command composer, live activity, notifications, and WatchConnectivity bridge. Embeds the watch app. |
 | `HarnessMonitorMobileWidgets` | app extension | iOS | `io.harnessmonitor.app.ios.widgets` | iOS Home Screen widgets (needs-you, command queue, station health) plus the command Live Activity. |
-| `HarnessMonitorWatch` | app | watchOS | `io.harnessmonitor.app.ios.watch` | The watchOS app. `WatchMonitorStore`, root view, command composer, and the pairing-transfer receiver. Embedded inside the iOS app. |
+| `HarnessMonitorWatch` | app | watchOS | `io.harnessmonitor.app.ios.watch` | The watchOS app. The watch-configured `MirrorStore`, root view, command composer, direct remote pairer, and pairing-transfer receiver. Embedded inside the iOS app. |
 | `HarnessMonitorWatchWidgets` | app extension | watchOS | `io.harnessmonitor.app.ios.watch.widgets` | watchOS accessory complications: the legacy NeedsMe count plus the encrypted-mirror timeline. |
 | `HarnessMonitorCloudKit` | static framework | mac, iOS, watch | `io.harnessmonitor.cloudkit` | The older, separate NeedsMe count path (`NeedsMeSnapshot`). Distinct from CloudMirror. See the "NeedsMe vs CloudMirror" section. |
 
@@ -71,9 +71,15 @@ Because the handshake uses the local network, the iOS app surfaces a dedicated `
 
 The daemon returns an opaque per-client bearer token. `MobileRemoteDaemonPairingCoordinator` stores it only inside the existing Keychain-backed `MobilePairedStationCredential`, together with the endpoint, client id, role/scopes, token hint, paired time, and SPKI pin. Invitation endpoints must be plain HTTPS origins with no credentials, query, fragment, or path.
 
+### Watch to remote daemon (internet)
+
+The watch accepts a `harness://remote-pair` value through the privacy-sensitive, single-line Remote Pairing form; the paired iPhone keyboard can paste the full invitation without typing it on the watch. The app also keeps an `onOpenURL` route for watchOS delivery contexts that forward its registered scheme, but direct pairing does not depend on Launch Services opening a custom URL. The form clears the one-time value before starting the claim. `LiveWatchRemoteDaemonCredentialPairer` delegates the claim to the same pinned transport and coordinator as the phone, but selects `MobileRemoteDaemonPairingDevice.watchOS`. That device profile uses a separate `default-watch-device` identity and a `watchos-` client id, so the daemon can audit and revoke the watch independently from the phone.
+
+The direct watch credential takes precedence over an iPhone-transferred credential for the same station. `MobileWatchPairingTransfer.preservingLocallyPairedRemoteCredentials` reconciles each incoming transfer before it reaches the watch Keychain, retaining the watch-owned token and identity while still adding, rotating, and removing other phone-managed stations. The watch status section exposes a destructive removal action only for watch-owned profiles. Successful removal deletes the watch token and private identity, then immediately requests a fresh iPhone transfer as fallback.
+
 ### Phone to watch (WatchConnectivity)
 
-The watch does not run a pairing claim. After the phone pairs, `MobileWatchPairingSessionBridge` serializes the device identities, station credentials, and an optional latest snapshot into a `MobileWatchPairingTransfer` and pushes it to the watch over WatchConnectivity. It uses all three delivery mechanisms for resilience: `sendMessage` when reachable, plus `updateApplicationContext` and `transferUserInfo` for background delivery. The watch can also pull on demand by sending a request payload, which the bridge answers from its cached or stored pairings. Payloads are capped at 60 KB. On the watch, `WatchPairingSessionReceiver` ingests the transfer and writes the same credential/identity material into the watch Keychain. Relay credentials select CloudMirror; remote credentials select the pinned direct client.
+After the phone pairs, `MobileWatchPairingSessionBridge` serializes the device identities, station credentials, and an optional latest snapshot into a `MobileWatchPairingTransfer` and pushes it to the watch over WatchConnectivity. It uses all three delivery mechanisms for resilience: `sendMessage` when reachable, plus `updateApplicationContext` and `transferUserInfo` for background delivery. The watch can also pull on demand by sending a request payload, which the bridge answers from its cached or stored pairings. Payloads are capped at 60 KB. On the watch, `WatchPairingSessionReceiver` reconciles the transfer with any direct watch-owned profile before writing credential/identity material into the watch Keychain. Relay credentials select CloudMirror; remote credentials select the pinned direct client.
 
 ## CloudKit schema
 
@@ -107,15 +113,15 @@ The CloudKit schema must be deployed to the Production environment before TestFl
 - Remote bearer isolation. Each remote client has its own opaque token and client id. The token is persisted only in the device Keychain and redacted from debug descriptions. Authentication and authorization failures never trigger CloudMirror fallback.
 - Secret redaction. The Mac redacts secrets twice: once while building the snapshot (`+Redaction`) and again on command-execution output, via `MobileMirrorSecretRedactor`. Redaction runs before encryption, so a key compromise still does not expose un-redacted secrets that were never put in the payload.
 - Command integrity. CloudMirror commands are signed with a command-signing key distinct from the snapshot key, and the Mac rejects any command whose authored `revision` no longer matches current state. Direct commands use pinned TLS, per-client bearer authentication, route authorization, and authenticated actor rebinding; they execute immediately and never retry through CloudMirror after a direct mutation attempt.
-- Trust is per device. Each phone/watch has its own `MobileDeviceIdentity`; unpairing one device deletes only its credential and, if no sibling credential shares the identity, its identity too.
+- Direct trust is per device. A phone and a directly paired watch have separate `MobileDeviceIdentity`, client id, and bearer token values. An iPhone-transferred watch fallback intentionally mirrors the phone credential until the watch claims its own profile. Removing a direct watch profile deletes only its credential and identity, then asks the phone for that fallback again.
 - Biometric gate. Both apps link `LocalAuthentication` to gate sensitive command actions behind Face ID / Touch ID / wrist-detection.
 - Privacy controls. `MobileCloudMirrorPrivacyService` lets the user inventory and delete the records mirrored for their devices; the iOS Settings tab exposes this when at least one station is mirrored.
 
 ## iOS app structure
 
-Entry point `HarnessMonitorMobileApp` installs a `MobileAppDelegate` (UIKit adaptor) and constructs a single `MobileMonitorStore` with Keychain-backed identity and credential stores, the live pairer, and the WatchConnectivity bridge.
+Entry point `HarnessMonitorMobileApp` installs a `MobileAppDelegate` (UIKit adaptor) and constructs a single `MirrorStore` with Keychain-backed identity and credential stores, the live pairer, and the WatchConnectivity bridge.
 
-- State. `MobileMonitorStore` is a `@MainActor @Observable` class holding the aggregate `snapshot`, `selectedStationID`, `syncStatus`, paired credentials, and notification settings. It builds one `MobileMonitorSyncClient` per paired station through a factory, selecting direct, CloudMirror, or direct-first-with-fallback from the credential. Its extensions split by concern: `+Sync` (refresh/pairing/unpair), `+Commands`, `+Privacy`, `+Internals`.
+- State. `MirrorStore` is a `@MainActor @Observable` class holding the aggregate `snapshot`, `selectedStationID`, `syncStatus`, paired credentials, and notification settings. It builds one `MobileMonitorSyncClient` per paired station through a factory, selecting direct, CloudMirror, or direct-first-with-fallback from the credential. Its extensions split by concern: `+Sync` (refresh/pairing/unpair), `+Commands`, `+Privacy`, `+Internals`.
 - Tabs. `MobileRootView` is a `TabView`: Today, Sessions, Reviews, Commands, Settings. `MobileRootTab` also parses `harness://` deep links to a tab.
 - Sync status. `MobileMonitorSyncStatus` is the single source of UI truth for connection state: `unpaired`, `demo`, `pairing`, `syncing`, `live`, `stale`, `localNetworkDenied`, `paired`, `privacy`, and the command outcomes. Each case carries a title, subtitle, and SF Symbol.
 - Demo mode. On by default in the Simulator (App Review and screenshots get `MobileDemoFixtures` data with no real Mac), off on device. Pairing a real Mac clears demo mode.
@@ -126,7 +132,7 @@ Entry point `HarnessMonitorMobileApp` installs a `MobileAppDelegate` (UIKit adap
 
 ## Watch app structure
 
-The watch app is a separate watchOS product embedded in the iOS app, not a macOS extension. It has its own `WatchMonitorStore` (do not confuse it with the iOS `MobileMonitorStore`) that builds direct and/or CloudMirror clients from credentials transferred by the phone. `RootView`, `WatchCommandComposerView`, and `WatchMonitorStoreRefresh` make up the UI and refresh loop; `WatchPairingSessionReceiver` ingests the WatchConnectivity transfer.
+The watch app is a separate watchOS product embedded in the iOS app, not a macOS extension. It configures the shared `MirrorStore` with the watch profile and builds direct and/or CloudMirror clients from credentials claimed on-watch or transferred by the phone. `HarnessMonitorWatchApp` routes delivered remote pairing links, `WatchRemoteDaemonPairingView` handles in-app link entry, `RootView` and `WatchCommandComposerView` make up the UI, the shared store owns the refresh loop, and `WatchPairingSessionReceiver` ingests reconciled WatchConnectivity transfers.
 
 ### NeedsMe vs CloudMirror
 
@@ -175,7 +181,7 @@ Swap the scheme to `HarnessMonitorWatch` and the destination to `generic/platfor
 
 ## Gotchas
 
-- Two stores, same prefix. `MobileMonitorStore` (iOS) and `WatchMonitorStore` (watchOS) are different types with overlapping shapes. Changes to mirror handling usually need to land in both, plus the shared client in CloudMirror.
+- Shared store, distinct profiles. iOS and watchOS both construct `MirrorStore`, but the watch uses `.watch` profile behavior and its own device identity. Changes to mirror handling belong in the shared store unless the behavior is app-specific.
 - Core is Foundation-only on purpose. Do not add AppKit, UIKit, SwiftData, or CloudKit imports to `HarnessMonitorCore`; doing so breaks the watchOS build. CloudKit belongs in CloudMirror/CloudKit, UI belongs in the app targets.
 - Re-link traps. `HarnessMonitorMacRelay` embeds Core/Crypto/CloudMirror as a dynamic framework; the MacRelay test target depends only on MacRelay and imports the rest transitively. Same pattern for Kit and CloudKit. Adding the embedded static products as direct test dependencies re-links them into the test bundle.
 - Demo mode masks real failures. In the Simulator the iOS app is in demo mode by default, so a broken live sync path can look healthy. Test live paths on device or with demo mode forced off.


### PR DESCRIPTION
## Motivation
watchOS could only consume credentials transferred from the iPhone. That blocked independent watch revocation and audit identity, and made direct remote access depend on the phone.

## Implementation
- Add pinned HTTPS pairing with a watch-owned identity, client token, in-app link entry, and direct removal.
- Preserve direct watch credentials during iPhone transfers and serialize claim, transfer, and removal mutations.
- Harden empty and duplicate transfer payloads, add focused TDD coverage, update the mobile guide, and prove the watch build and simulator flow.