### PR TITLE
fix(daemon): restore perf integration compile

### DIFF
--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -304,7 +304,7 @@ fn recover_poisoned_mutation_lock_map(
 /// Serve the daemon's HTTP API.
 ///
 /// # Errors
-/// Returns `CliError` on listener failures.
+/// Returns `CliError` when serving the HTTP API fails.
 pub async fn serve_tcp(
     listener: TcpListener,
     state: DaemonHttpState,

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -43,6 +43,7 @@ mod core;
 mod improver;
 mod managed_agents;
 mod openrouter_models;
+mod recovery_snapshot_cache;
 mod remote_pairing;
 mod response;
 mod reviews;
@@ -71,6 +72,7 @@ pub(crate) use managed_agents::{
     managed_agent_snapshot_async, run_acp_agent_blocking, run_codex_agent_blocking,
     run_terminal_agent_blocking,
 };
+pub use recovery_snapshot_cache::RecoverySnapshotCache;
 pub(crate) use response::{error_status_and_body, extract_request_id};
 pub(crate) use sessions_adopt::{
     adopt_session, adoption_error_status_and_body, record_adopt_in_db,
@@ -110,7 +112,7 @@ pub(crate) fn require_async_db<'a>(
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct DaemonConnectInfo {
+pub(crate) struct DaemonConnectInfo {
     remote_addr: SocketAddr,
 }
 
@@ -216,37 +218,10 @@ pub struct DaemonHttpState {
     pub recovery_snapshot: Arc<AsyncMutex<RecoverySnapshotCache>>,
 }
 
-pub(crate) fn default_remote_pairing_limiter() -> Arc<Mutex<RemotePairingRateLimiter>> {
+/// Build the default remote pairing rate limiter used by daemon HTTP state.
+#[must_use]
+pub fn default_remote_pairing_limiter() -> Arc<Mutex<RemotePairingRateLimiter>> {
     Arc::new(Mutex::new(RemotePairingRateLimiter::new(5)))
-}
-
-/// Cached global `sessions_updated` recovery snapshot keyed by the change
-/// generation it was built from. A cache hit requires the live change
-/// sequence to still match `change_seq`.
-#[derive(Default)]
-pub struct RecoverySnapshotCache {
-    change_seq: i64,
-    sessions_updated: Option<StreamEvent>,
-}
-
-impl RecoverySnapshotCache {
-    /// Return the cached snapshot when it still matches the live change
-    /// generation, else `None` so the caller rebuilds under the held lock.
-    #[must_use]
-    pub(crate) fn get_fresh(&self, current: i64) -> Option<StreamEvent> {
-        if self.change_seq == current {
-            self.sessions_updated.clone()
-        } else {
-            None
-        }
-    }
-
-    /// Store a freshly built snapshot keyed by the change generation it
-    /// reflects.
-    pub(crate) fn store(&mut self, current: i64, event: StreamEvent) {
-        self.change_seq = current;
-        self.sessions_updated = Some(event);
-    }
 }
 
 impl DaemonHttpState {
@@ -330,7 +305,19 @@ fn recover_poisoned_mutation_lock_map(
 ///
 /// # Errors
 /// Returns `CliError` on listener failures.
-pub async fn serve<L>(
+pub async fn serve_tcp(
+    listener: TcpListener,
+    state: DaemonHttpState,
+    shutdown_rx: watch::Receiver<bool>,
+) -> Result<(), CliError> {
+    serve(listener, state, shutdown_rx).await
+}
+
+/// Serve the daemon's HTTP API.
+///
+/// # Errors
+/// Returns `CliError` on listener failures.
+pub(crate) async fn serve<L>(
     listener: L,
     state: DaemonHttpState,
     mut shutdown_rx: watch::Receiver<bool>,
@@ -454,57 +441,4 @@ fn http_request_span(method: &str, route: &str, request_id: &str) -> tracing::Sp
         duration_ms = Empty,
         trace_id = Empty
     )
-}
-
-#[cfg(test)]
-mod recovery_snapshot_cache_tests {
-    use super::RecoverySnapshotCache;
-    use crate::daemon::protocol::StreamEvent;
-
-    fn sample_event(tag: &str) -> StreamEvent {
-        StreamEvent {
-            event: "sessions_updated".into(),
-            recorded_at: tag.into(),
-            session_id: None,
-            payload: serde_json::Value::Null,
-        }
-    }
-
-    #[test]
-    fn get_fresh_returns_none_until_a_snapshot_is_stored() {
-        let cache = RecoverySnapshotCache::default();
-        assert!(cache.get_fresh(0).is_none());
-    }
-
-    #[test]
-    fn get_fresh_hits_only_on_the_matching_change_generation() {
-        let mut cache = RecoverySnapshotCache::default();
-        cache.store(7, sample_event("first"));
-
-        assert_eq!(
-            cache.get_fresh(7).map(|event| event.recorded_at),
-            Some("first".to_string()),
-            "snapshot stored at generation 7 must be reused at generation 7"
-        );
-        assert!(
-            cache.get_fresh(8).is_none(),
-            "a newer change generation must invalidate the cached snapshot"
-        );
-    }
-
-    #[test]
-    fn store_rekeys_and_replaces_the_previous_snapshot() {
-        let mut cache = RecoverySnapshotCache::default();
-        cache.store(1, sample_event("old"));
-        cache.store(2, sample_event("new"));
-
-        assert!(
-            cache.get_fresh(1).is_none(),
-            "the superseded generation must no longer hit"
-        );
-        assert_eq!(
-            cache.get_fresh(2).map(|event| event.recorded_at),
-            Some("new".to_string())
-        );
-    }
 }

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -110,7 +110,7 @@ pub(crate) fn require_async_db<'a>(
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct DaemonConnectInfo {
+pub struct DaemonConnectInfo {
     remote_addr: SocketAddr,
 }
 
@@ -330,7 +330,7 @@ fn recover_poisoned_mutation_lock_map(
 ///
 /// # Errors
 /// Returns `CliError` on listener failures.
-pub(crate) async fn serve<L>(
+pub async fn serve<L>(
     listener: L,
     state: DaemonHttpState,
     mut shutdown_rx: watch::Receiver<bool>,

--- a/src/daemon/http/recovery_snapshot_cache.rs
+++ b/src/daemon/http/recovery_snapshot_cache.rs
@@ -1,0 +1,83 @@
+use crate::daemon::protocol::StreamEvent;
+
+/// Cached global `sessions_updated` recovery snapshot keyed by the change
+/// generation it was built from. A cache hit requires the live change
+/// sequence to still match `change_seq`.
+#[derive(Default)]
+pub struct RecoverySnapshotCache {
+    change_seq: i64,
+    sessions_updated: Option<StreamEvent>,
+}
+
+impl RecoverySnapshotCache {
+    /// Return the cached snapshot when it still matches the live change
+    /// generation, else `None` so the caller rebuilds under the held lock.
+    #[must_use]
+    pub(crate) fn get_fresh(&self, current: i64) -> Option<StreamEvent> {
+        if self.change_seq == current {
+            self.sessions_updated.clone()
+        } else {
+            None
+        }
+    }
+
+    /// Store a freshly built snapshot keyed by the change generation it
+    /// reflects.
+    pub(crate) fn store(&mut self, current: i64, event: StreamEvent) {
+        self.change_seq = current;
+        self.sessions_updated = Some(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RecoverySnapshotCache;
+    use crate::daemon::protocol::StreamEvent;
+
+    fn sample_event(tag: &str) -> StreamEvent {
+        StreamEvent {
+            event: "sessions_updated".into(),
+            recorded_at: tag.into(),
+            session_id: None,
+            payload: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn get_fresh_returns_none_until_a_snapshot_is_stored() {
+        let cache = RecoverySnapshotCache::default();
+        assert!(cache.get_fresh(0).is_none());
+    }
+
+    #[test]
+    fn get_fresh_hits_only_on_the_matching_change_generation() {
+        let mut cache = RecoverySnapshotCache::default();
+        cache.store(7, sample_event("first"));
+
+        assert_eq!(
+            cache.get_fresh(7).map(|event| event.recorded_at),
+            Some("first".to_string()),
+            "snapshot stored at generation 7 must be reused at generation 7"
+        );
+        assert!(
+            cache.get_fresh(8).is_none(),
+            "a newer change generation must invalidate the cached snapshot"
+        );
+    }
+
+    #[test]
+    fn store_rekeys_and_replaces_the_previous_snapshot() {
+        let mut cache = RecoverySnapshotCache::default();
+        cache.store(1, sample_event("old"));
+        cache.store(2, sample_event("new"));
+
+        assert!(
+            cache.get_fresh(1).is_none(),
+            "the superseded generation must no longer hit"
+        );
+        assert_eq!(
+            cache.get_fresh(2).map(|event| event.recorded_at),
+            Some("new".to_string())
+        );
+    }
+}

--- a/tests/integration/daemon_perf.rs
+++ b/tests/integration/daemon_perf.rs
@@ -11,6 +11,7 @@ use harness::daemon::codex_controller::CodexControllerHandle;
 use harness::daemon::db::DaemonDb;
 use harness::daemon::http::{DaemonHttpState, serve};
 use harness::daemon::protocol::StreamEvent;
+use harness::daemon::remote_pairing::RemotePairingRateLimiter;
 use harness::daemon::service;
 use harness::daemon::state::{self, DaemonManifest, HostBridgeManifest};
 use harness::daemon::websocket::ReplayBuffer;
@@ -96,6 +97,8 @@ async fn start_test_daemon(db: Option<DaemonDb>) -> TestDaemon {
     let state = DaemonHttpState {
         token: token.clone(),
         auth_mode: harness::daemon::http::DaemonHttpAuthMode::Local,
+        remote_domain: None,
+        remote_pairing_limiter: Arc::new(Mutex::new(RemotePairingRateLimiter::new(5))),
         sender: sender.clone(),
         manifest,
         daemon_epoch: harness::workspace::utc_now(),

--- a/tests/integration/daemon_perf.rs
+++ b/tests/integration/daemon_perf.rs
@@ -9,9 +9,8 @@ use tokio::sync::{broadcast, watch};
 use harness::daemon::agent_acp::AcpAgentManagerHandle;
 use harness::daemon::codex_controller::CodexControllerHandle;
 use harness::daemon::db::DaemonDb;
-use harness::daemon::http::{DaemonHttpState, serve};
+use harness::daemon::http::{DaemonHttpState, default_remote_pairing_limiter, serve_tcp};
 use harness::daemon::protocol::StreamEvent;
-use harness::daemon::remote_pairing::RemotePairingRateLimiter;
 use harness::daemon::service;
 use harness::daemon::state::{self, DaemonManifest, HostBridgeManifest};
 use harness::daemon::websocket::ReplayBuffer;
@@ -98,7 +97,7 @@ async fn start_test_daemon(db: Option<DaemonDb>) -> TestDaemon {
         token: token.clone(),
         auth_mode: harness::daemon::http::DaemonHttpAuthMode::Local,
         remote_domain: None,
-        remote_pairing_limiter: Arc::new(Mutex::new(RemotePairingRateLimiter::new(5))),
+        remote_pairing_limiter: default_remote_pairing_limiter(),
         sender: sender.clone(),
         manifest,
         daemon_epoch: harness::workspace::utc_now(),
@@ -115,7 +114,7 @@ async fn start_test_daemon(db: Option<DaemonDb>) -> TestDaemon {
     };
 
     tokio::spawn(async move {
-        let _ = serve(listener, state, shutdown_rx).await;
+        let _ = serve_tcp(listener, state, shutdown_rx).await;
     });
 
     let client = Client::new();


### PR DESCRIPTION
## Summary

Fix the current-main compile break in the `daemon_perf` integration target.

## Root Cause

`tests/integration/daemon_perf.rs` boots an in-process daemon HTTP server as an external integration test. Recent daemon HTTP changes added `remote_domain` plus `remote_pairing_limiter` to `DaemonHttpState`, and the low-level generic HTTP server remained internal, so the external integration test no longer matched the current daemon HTTP surface.

## Changes

- Add a public TCP-only `serve_tcp(...)` wrapper for integration tests while keeping the generic listener-based `serve(...)` crate-private.
- Expose `default_remote_pairing_limiter()` so external integration tests use the same daemon default instead of duplicating the numeric limit.
- Update the perf integration test's `DaemonHttpState` initializer with the current remote pairing fields.
- Move `RecoverySnapshotCache` into its own small module so `src/daemon/http/mod.rs` stays under the Rust file-length gate.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run cargo:local -- test --test integration daemon_perf --no-run`
- `rustfmt --edition 2024 --check src/daemon/http/mod.rs src/daemon/http/recovery_snapshot_cache.rs tests/integration/daemon_perf.rs`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise run harness:check`

Note: full `cargo fmt --check` currently reports unrelated formatting drift in `src/github_api/cache.rs`; the touched files pass direct `rustfmt --check`.

## Versioning

No version bump. This restores test-target compatibility only.
