### PR TITLE
fix(task-board): use global card badge setting

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardCardsSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardCardsSection.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct SettingsTaskBoardCardsSection: View {
+  @AppStorage(TaskBoardCardPreferences.priorityBadgeVisibilityStorageKey)
+  private var showsPriorityBadge = TaskBoardCardPreferences.defaultShowsPriorityBadge
+
+  var body: some View {
+    Section {
+      Toggle("Priority Badge", isOn: $showsPriorityBadge)
+    } header: {
+      Text("Cards")
+        .harnessNativeFormSectionHeader()
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardLaneAppearanceSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardLaneAppearanceSection.swift
@@ -62,14 +62,15 @@ struct SettingsTaskBoardLaneAppearanceSection: View {
   }
 
   private func laneIndicator(for lane: TaskBoardInboxLane) -> some View {
-    ZStack {
-      if let symbolName = appearance.symbolName(for: lane) {
+    let symbolName = appearance.symbolName(for: lane)
+    return ZStack {
+      if let symbolName {
         Image(systemName: symbolName)
           .font(laneIndicatorFont)
           .foregroundStyle(.white)
       }
     }
-    .frame(width: 58, height: 30)
+    .frame(width: 58, height: symbolName == nil ? 18 : 30)
     .background(appearance.color(for: lane), in: .capsule)
     .overlay {
       Capsule(style: .continuous)
@@ -123,8 +124,6 @@ private struct SettingsTaskBoardLaneAppearancePopover: View {
       colorSection
       Divider()
       symbolSection
-      Divider()
-      cardsSection
     }
     .padding(HarnessMonitorTheme.spacingMD)
     .frame(width: 360, alignment: .topLeading)
@@ -210,26 +209,6 @@ private struct SettingsTaskBoardLaneAppearancePopover: View {
     }
   }
 
-  private var cardsSection: some View {
-    VStack(alignment: .leading, spacing: HarnessMonitorTheme.spacingSM) {
-      sectionHeader(title: "Cards") {
-        Button {
-          rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
-            true,
-            for: lane,
-            rawValue: rawValue
-          )
-        } label: {
-          Label("Reset", systemImage: "arrow.counterclockwise")
-        }
-        .buttonStyle(.borderless)
-        .disabled(!appearance.hasPriorityBadgeOverride(for: lane))
-      }
-
-      Toggle("Priority Badge", isOn: priorityBadgeBinding)
-    }
-  }
-
   private func sectionHeader<Actions: View>(
     title: String,
     @ViewBuilder actions: () -> Actions
@@ -282,19 +261,6 @@ private struct SettingsTaskBoardLaneAppearancePopover: View {
       set: { color in
         rawValue = TaskBoardLaneAppearancePreferences.settingCustomColor(
           color,
-          for: lane,
-          rawValue: rawValue
-        )
-      }
-    )
-  }
-
-  private var priorityBadgeBinding: Binding<Bool> {
-    Binding(
-      get: { appearance.showsPriorityBadge(for: lane) },
-      set: { isVisible in
-        rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
-          isVisible,
           for: lane,
           rawValue: rawValue
         )

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardSection.swift
@@ -40,6 +40,7 @@ struct SettingsTaskBoardSection: View, SettingsTaskBoardEditingSurface {
           loadingSection
         } else {
           TaskBoardWorkflowSection(store: store, taskBoardFormState: $taskBoardFormState)
+          SettingsTaskBoardCardsSection()
           SettingsTaskBoardLaneAppearanceSection()
           TaskBoardProjectSection(store: store, taskBoardFormState: $taskBoardFormState)
             .id(SettingsTaskBoardAnchor.githubProject)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardPreferences.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardPreferences.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftUI
+
+enum TaskBoardCardPreferences {
+  static let priorityBadgeVisibilityStorageKey =
+    "harness.task-board.cards.priority-badge-visible.v1"
+  static let defaultShowsPriorityBadge = true
+
+  static func showsPriorityBadge(from userDefaults: UserDefaults = .standard) -> Bool {
+    guard userDefaults.object(forKey: priorityBadgeVisibilityStorageKey) != nil else {
+      return defaultShowsPriorityBadge
+    }
+    return userDefaults.bool(forKey: priorityBadgeVisibilityStorageKey)
+  }
+
+  static func setShowsPriorityBadge(
+    _ isVisible: Bool,
+    in userDefaults: UserDefaults = .standard
+  ) {
+    userDefaults.set(isVisible, forKey: priorityBadgeVisibilityStorageKey)
+  }
+}
+
+extension EnvironmentValues {
+  @Entry var taskBoardShowsPriorityBadge = TaskBoardCardPreferences.defaultShowsPriorityBadge
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneAppearancePreferences.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneAppearancePreferences.swift
@@ -113,14 +113,12 @@ struct TaskBoardLaneAppearanceOverride: Codable, Equatable, Sendable {
   var customColor: TaskBoardLaneCustomColor?
   var symbolName: String?
   var hidesSymbol: Bool?
-  var hidesPriorityBadge: Bool?
 
   var isEmpty: Bool {
     colorToken == nil
       && customColor == nil
       && symbolName == nil
       && hidesSymbol != true
-      && hidesPriorityBadge != true
   }
 }
 
@@ -155,10 +153,6 @@ struct TaskBoardLaneAppearance: Equatable {
     overrides[lane]?.hidesSymbol == true
   }
 
-  func showsPriorityBadge(for lane: TaskBoardInboxLane) -> Bool {
-    overrides[lane]?.hidesPriorityBadge != true
-  }
-
   func hasOverride(for lane: TaskBoardInboxLane) -> Bool {
     overrides[lane]?.isEmpty == false
   }
@@ -171,10 +165,6 @@ struct TaskBoardLaneAppearance: Equatable {
   func hasSymbolOverride(for lane: TaskBoardInboxLane) -> Bool {
     let override = overrides[lane]
     return override?.symbolName != nil || override?.hidesSymbol == true
-  }
-
-  func hasPriorityBadgeOverride(for lane: TaskBoardInboxLane) -> Bool {
-    overrides[lane]?.hidesPriorityBadge == true
   }
 }
 
@@ -289,18 +279,6 @@ enum TaskBoardLaneAppearancePreferences {
     if !isVisible {
       override.symbolName = nil
     }
-    overrides[lane] = override
-    return Self.rawValue(for: overrides)
-  }
-
-  static func settingPriorityBadgeVisibility(
-    _ isVisible: Bool,
-    for lane: TaskBoardInboxLane,
-    rawValue: String
-  ) -> String {
-    var overrides = overrides(from: rawValue)
-    var override = overrides[lane] ?? TaskBoardLaneAppearanceOverride()
-    override.hidesPriorityBadge = isVisible ? nil : true
     overrides[lane] = override
     return Self.rawValue(for: overrides)
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
@@ -165,6 +165,8 @@ struct TaskBoardItemRow: View {
   private var fontScale
   @Environment(\.taskBoardLaneAppearance)
   private var laneAppearance
+  @Environment(\.taskBoardShowsPriorityBadge)
+  private var showsPriorityBadge
 
   private var dragPayload: TaskBoardItemDragPayload {
     TaskBoardItemDragPayload(itemID: item.id, status: item.status)
@@ -239,11 +241,6 @@ struct TaskBoardItemRow: View {
     if let policyTraceCount = item.workflow?.policyTraceIds.count, policyTraceCount > 0 {
       TaskBoardCardPill(label: "\(policyTraceCount) policy", tint: HarnessMonitorTheme.secondaryInk)
     }
-  }
-
-  private var showsPriorityBadge: Bool {
-    TaskBoardInboxLane(status: item.status)
-      .map { laneAppearance.showsPriorityBadge(for: $0) } ?? true
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
@@ -43,6 +43,8 @@ public struct TaskBoardOverviewView: View {
   var laneCollapsePreferencesRawValue = TaskBoardLaneCollapsePreferences.emptyRawValue
   @AppStorage(TaskBoardLaneAppearancePreferences.storageKey)
   var laneAppearancePreferencesRawValue = TaskBoardLaneAppearancePreferences.emptyRawValue
+  @AppStorage(TaskBoardCardPreferences.priorityBadgeVisibilityStorageKey)
+  var showsPriorityBadge = TaskBoardCardPreferences.defaultShowsPriorityBadge
   var captionSemibold: Font {
     HarnessMonitorTextSize.scaledFont(.caption.weight(.semibold), by: fontScale)
   }
@@ -56,13 +58,9 @@ public struct TaskBoardOverviewView: View {
     )
   }
 
-  var metrics: TaskBoardOverviewMetrics {
-    TaskBoardOverviewMetrics(fontScale: fontScale)
-  }
+  var metrics: TaskBoardOverviewMetrics { TaskBoardOverviewMetrics(fontScale: fontScale) }
 
-  var laneMetrics: TaskBoardLaneMetrics {
-    TaskBoardLaneMetrics(fontScale: fontScale)
-  }
+  var laneMetrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
 
   var laneStripSizing: TaskBoardLaneStripSizing {
     TaskBoardLaneStripSizing(
@@ -81,9 +79,7 @@ public struct TaskBoardOverviewView: View {
     )
   }
 
-  var currentPresentation: TaskBoardOverviewPresentation {
-    cachedPresentation
-  }
+  var currentPresentation: TaskBoardOverviewPresentation { cachedPresentation }
 
   public init(
     snapshot: TaskBoardInboxSnapshot,
@@ -165,6 +161,7 @@ public struct TaskBoardOverviewView: View {
       \.taskBoardLaneAppearance,
       TaskBoardLaneAppearance(rawValue: laneAppearancePreferencesRawValue)
     )
+    .environment(\.taskBoardShowsPriorityBadge, showsPriorityBadge)
     .sheet(item: taskBoardManagementSheet) { taskBoardManagementSheet in
       taskBoardManagementSheetContent(taskBoardManagementSheet)
     }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneAppearancePreferencesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneAppearancePreferencesTests.swift
@@ -17,7 +17,6 @@ struct TaskBoardLaneAppearancePreferencesTests {
         == TaskBoardLaneAppearancePreferences.defaultSymbolName(for: .agenticReview)
     )
     #expect(!appearance.hidesSymbol(for: .agenticReview))
-    #expect(appearance.showsPriorityBadge(for: .agenticReview))
     #expect(!appearance.hasOverride(for: .agenticReview))
   }
 
@@ -88,36 +87,6 @@ struct TaskBoardLaneAppearancePreferencesTests {
     #expect(restoredAppearance.hasOverride(for: .planning))
   }
 
-  @Test("Hidden priority badges persist through UserDefaults")
-  func hiddenPriorityBadgesPersistThroughUserDefaults() throws {
-    let suiteName = "TaskBoardLaneAppearancePreferencesTests.\(UUID().uuidString)"
-    let userDefaults = try #require(UserDefaults(suiteName: suiteName))
-    defer {
-      userDefaults.removePersistentDomain(forName: suiteName)
-    }
-
-    let rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
-      false,
-      for: .todo,
-      rawValue: TaskBoardLaneAppearancePreferences.emptyRawValue
-    )
-    TaskBoardLaneAppearancePreferences.save(
-      TaskBoardLaneAppearancePreferences.overrides(from: rawValue),
-      to: userDefaults
-    )
-    userDefaults.synchronize()
-
-    let restartedDefaults = try #require(UserDefaults(suiteName: suiteName))
-    let storedRawValue = try #require(
-      restartedDefaults.string(forKey: TaskBoardLaneAppearancePreferences.storageKey)
-    )
-    let restoredAppearance = TaskBoardLaneAppearance(rawValue: storedRawValue)
-
-    #expect(!restoredAppearance.showsPriorityBadge(for: .todo))
-    #expect(restoredAppearance.hasPriorityBadgeOverride(for: .todo))
-    #expect(restoredAppearance.hasOverride(for: .todo))
-  }
-
   @Test("Custom colors persist through UserDefaults")
   func customColorsPersistThroughUserDefaults() throws {
     let suiteName = "TaskBoardLaneAppearancePreferencesTests.\(UUID().uuidString)"
@@ -143,6 +112,23 @@ struct TaskBoardLaneAppearancePreferencesTests {
 
     #expect(customColor == TaskBoardLaneCustomColor(red: 0.24, green: 0.48, blue: 0.72))
     #expect(TaskBoardLaneAppearance(rawValue: rawValue).hasColorOverride(for: .testing))
+  }
+
+  @Test("Global priority badge preference persists through UserDefaults")
+  func globalPriorityBadgePreferencePersistsThroughUserDefaults() throws {
+    let suiteName = "TaskBoardCardPreferencesTests.\(UUID().uuidString)"
+    let userDefaults = try #require(UserDefaults(suiteName: suiteName))
+    defer {
+      userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    #expect(TaskBoardCardPreferences.showsPriorityBadge(from: userDefaults))
+
+    TaskBoardCardPreferences.setShowsPriorityBadge(false, in: userDefaults)
+    userDefaults.synchronize()
+
+    let restartedDefaults = try #require(UserDefaults(suiteName: suiteName))
+    #expect(!TaskBoardCardPreferences.showsPriorityBadge(from: restartedDefaults))
   }
 
   @Test("Reset and default values remove overrides")
@@ -182,20 +168,6 @@ struct TaskBoardLaneAppearancePreferencesTests {
     #expect(TaskBoardLaneAppearance(rawValue: rawValue).symbolName(for: .testing) == nil)
 
     rawValue = TaskBoardLaneAppearancePreferences.settingSymbolVisibility(
-      true,
-      for: .testing,
-      rawValue: rawValue
-    )
-    #expect(rawValue == TaskBoardLaneAppearancePreferences.emptyRawValue)
-
-    rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
-      false,
-      for: .testing,
-      rawValue: rawValue
-    )
-    #expect(!TaskBoardLaneAppearance(rawValue: rawValue).showsPriorityBadge(for: .testing))
-
-    rawValue = TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(
       true,
       for: .testing,
       rawValue: rawValue
@@ -250,14 +222,10 @@ struct TaskBoardLaneAppearancePreferencesTests {
     )
     #expect(source.contains("Button(\"Customize\")"))
     #expect(source.contains("laneIndicator(for: lane)"))
-    #expect(source.contains("if let symbolName = appearance.symbolName(for: lane)"))
-    #expect(source.contains(".frame(width: 58, height: 30)"))
+    #expect(source.contains("let symbolName = appearance.symbolName(for: lane)"))
+    #expect(source.contains("height: symbolName == nil ? 18 : 30"))
     #expect(source.contains("Label(\"Clear\", systemImage: \"slash.circle\")"))
     #expect(source.contains("Label(\"Reset\", systemImage: \"arrow.counterclockwise\")"))
-    #expect(source.contains("Toggle(\"Priority Badge\", isOn: priorityBadgeBinding)"))
-    #expect(
-      source.contains("TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(")
-    )
     #expect(source.contains("HarnessMonitorTextSize.scaledFont(.body.weight(.medium)"))
     #expect(source.contains("\"terminal\""))
     #expect(source.contains("\"gearshape\""))
@@ -277,20 +245,54 @@ struct TaskBoardLaneAppearancePreferencesTests {
     #expect(!source.contains("import AppKit"))
     #expect(!source.contains("customizeButtonLabel"))
     #expect(!source.contains("?? \"slash.circle\""))
+    #expect(!source.contains("cardsSection"))
+    #expect(!source.contains("priorityBadgeBinding"))
+    #expect(!source.contains("Toggle(\"Priority Badge\""))
+    #expect(
+      !source.contains("TaskBoardLaneAppearancePreferences.settingPriorityBadgeVisibility(")
+    )
 
     let colorRange = try #require(source.range(of: "colorSection"))
     let symbolRange = try #require(source.range(of: "symbolSection"))
-    let cardsRange = try #require(source.range(of: "cardsSection"))
     #expect(colorRange.lowerBound < symbolRange.lowerBound)
-    #expect(symbolRange.lowerBound < cardsRange.lowerBound)
   }
 
-  @Test("Task cards read priority badge visibility from lane appearance")
-  func taskCardsReadPriorityBadgeVisibilityFromLaneAppearance() throws {
-    let source = try sourceFile(named: "Views/TaskBoard/TaskBoardLaneViews.swift")
+  @Test("Task Board settings use global priority badge toggle")
+  func taskBoardSettingsUseGlobalPriorityBadgeToggle() throws {
+    let settingsSource = try sourceFile(named: "Views/Settings/SettingsTaskBoardSection.swift")
+    let cardsSource = try sourceFile(named: "Views/Settings/SettingsTaskBoardCardsSection.swift")
 
-    #expect(source.contains("if showsPriorityBadge"))
-    #expect(source.contains(".map { laneAppearance.showsPriorityBadge(for: $0) } ?? true"))
+    #expect(settingsSource.contains("SettingsTaskBoardCardsSection()"))
+    #expect(
+      cardsSource.contains(
+        "@AppStorage(TaskBoardCardPreferences.priorityBadgeVisibilityStorageKey)"
+      )
+    )
+    #expect(cardsSource.contains("Toggle(\"Priority Badge\", isOn: $showsPriorityBadge)"))
+
+    let cardsRange = try #require(settingsSource.range(of: "SettingsTaskBoardCardsSection()"))
+    let laneRange = try #require(
+      settingsSource.range(of: "SettingsTaskBoardLaneAppearanceSection()")
+    )
+    #expect(cardsRange.lowerBound < laneRange.lowerBound)
+  }
+
+  @Test("Task cards read priority badge visibility from global card preference")
+  func taskCardsReadPriorityBadgeVisibilityFromGlobalCardPreference() throws {
+    let laneSource = try sourceFile(named: "Views/TaskBoard/TaskBoardLaneViews.swift")
+    let overviewSource = try sourceFile(named: "Views/TaskBoard/TaskBoardOverviewView.swift")
+
+    #expect(laneSource.contains("@Environment(\\.taskBoardShowsPriorityBadge)"))
+    #expect(laneSource.contains("if showsPriorityBadge"))
+    #expect(!laneSource.contains("laneAppearance.showsPriorityBadge"))
+    #expect(
+      overviewSource.contains(
+        "@AppStorage(TaskBoardCardPreferences.priorityBadgeVisibilityStorageKey)"
+      )
+    )
+    #expect(
+      overviewSource.contains(".environment(\\.taskBoardShowsPriorityBadge, showsPriorityBadge)")
+    )
   }
 
   private func sourceFile(named relativePath: String) throws -> String {


### PR DESCRIPTION
## Motivation
Task Board card chrome had two settings mismatches: the priority badge was stored per lane even though it is a board-wide card preference, and symbol-less lane appearance rows kept the tall symbol pill.

## Implementation
- Move Priority Badge to a global Task Board Cards setting backed by `@AppStorage` and inject it once from `TaskBoardOverviewView` into task card rows.
- Drop per-lane priority badge overrides from lane appearance storage so old lane JSON keys decode away as empty overrides.
- Shrink symbol-less lane appearance pills while preserving the taller symbol pill for lanes with an icon.
- Validate with `monitor:lint` and focused `TaskBoardLaneAppearancePreferencesTests`.