### PR TITLE
fix(remote): stabilize DNS-01 visibility cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,15 @@ XCODE_ONLY_TESTING=HarnessMonitorKitTests/PolicyGapRuleTests mise run monitor:te
 
 Authoritative DNS-01 visibility uses provider-neutral runtime controls: `HARNESS_REMOTE_ACME_DNS_VISIBILITY_TIMEOUT_SECONDS` (default `300`), `HARNESS_REMOTE_ACME_DNS_VISIBILITY_POLL_SECONDS` (default `5`), and `HARNESS_REMOTE_ACME_DNS_VISIBILITY_STABLE_POLLS` (default `3`). The Aftermarket provider currently uses this check for both challenge presentation and cleanup. A state is accepted only after every authoritative nameserver IP reports the expected result for the configured number of consecutive polls.
 
-`mise run remote-daemon:e2e` runs the self-contained fake-ACME HTTPS/WSS, pairing, authorization, and revocation proof. Its live Aftermarket failure-cleanup case is opt-in: set `HARNESS_TEST_AFTERMARKET_DOMAIN`, `AFTERMARKET_ZONE_NAME`, `AFTERMARKET_API_KEY`, and `AFTERMARKET_API_SECRET`, then run the `remote_daemon_e2e_cleans_aftermarket_dns_after_failed_issuance` test through `mise run cargo:local`. The test presents a real TXT record, waits for authoritative visibility, forces the fake ACME server to reject issuance, and succeeds only after provider cleanup completes. Without `HARNESS_TEST_AFTERMARKET_DOMAIN`, the normal self-contained e2e task skips the external mutation.
+`mise run remote-daemon:e2e` runs the self-contained fake-ACME HTTPS/WSS, pairing, authorization, and revocation proof. Its live Aftermarket failure-cleanup case is opt-in. Set `HARNESS_TEST_AFTERMARKET_DOMAIN`, `AFTERMARKET_ZONE_NAME`, `AFTERMARKET_API_KEY`, and `AFTERMARKET_API_SECRET`, then run:
+
+```bash
+mise run cargo:local -- test --test remote_daemon_e2e \
+  remote_daemon_e2e_cleans_aftermarket_dns_after_failed_issuance -- \
+  --ignored --nocapture
+```
+
+The test presents a real TXT record, waits for authoritative visibility, forces the fake ACME server to reject issuance, and succeeds only after provider cleanup completes. Without `HARNESS_TEST_AFTERMARKET_DOMAIN`, the normal self-contained e2e task skips the external mutation.
 
 The macOS Harness Monitor app lives under `apps/harness-monitor/`. The Xcode project is generated from the Tuist manifests (`Project.swift`, `Tuist/Package.swift`); the generated `HarnessMonitor.xcodeproj` and `HarnessMonitor.xcworkspace` are not tracked. Run `mise run monitor:generate` to materialize them before opening the project in Xcode.
 Its fast lint lane runs `swift format` directly and runs `swiftlint lint` outside the Xcode build graph with a shared cache. Build-based sandbox and daemon validation now live in `mise run monitor:quality-gate`, so routine linting stays off the daemon/Xcode path.

--- a/README.md
+++ b/README.md
@@ -365,6 +365,10 @@ mise run monitor:quality-gate  # slower build-based sandbox + daemon validation 
 XCODE_ONLY_TESTING=HarnessMonitorKitTests/PolicyGapRuleTests mise run monitor:test  # focused macOS XCTest via the shared wrapper
 ```
 
+Authoritative DNS-01 visibility uses provider-neutral runtime controls: `HARNESS_REMOTE_ACME_DNS_VISIBILITY_TIMEOUT_SECONDS` (default `300`), `HARNESS_REMOTE_ACME_DNS_VISIBILITY_POLL_SECONDS` (default `5`), and `HARNESS_REMOTE_ACME_DNS_VISIBILITY_STABLE_POLLS` (default `3`). The Aftermarket provider currently uses this check for both challenge presentation and cleanup. A state is accepted only after every authoritative nameserver IP reports the expected result for the configured number of consecutive polls.
+
+`mise run remote-daemon:e2e` runs the self-contained fake-ACME HTTPS/WSS, pairing, authorization, and revocation proof. Its live Aftermarket failure-cleanup case is opt-in: set `HARNESS_TEST_AFTERMARKET_DOMAIN`, `AFTERMARKET_ZONE_NAME`, `AFTERMARKET_API_KEY`, and `AFTERMARKET_API_SECRET`, then run the `remote_daemon_e2e_cleans_aftermarket_dns_after_failed_issuance` test through `mise run cargo:local`. The test presents a real TXT record, waits for authoritative visibility, forces the fake ACME server to reject issuance, and succeeds only after provider cleanup completes. Without `HARNESS_TEST_AFTERMARKET_DOMAIN`, the normal self-contained e2e task skips the external mutation.
+
 The macOS Harness Monitor app lives under `apps/harness-monitor/`. The Xcode project is generated from the Tuist manifests (`Project.swift`, `Tuist/Package.swift`); the generated `HarnessMonitor.xcodeproj` and `HarnessMonitor.xcworkspace` are not tracked. Run `mise run monitor:generate` to materialize them before opening the project in Xcode.
 Its fast lint lane runs `swift format` directly and runs `swiftlint lint` outside the Xcode build graph with a shared cache. Build-based sandbox and daemon validation now live in `mise run monitor:quality-gate`, so routine linting stays off the daemon/Xcode path.
 

--- a/src/daemon/remote_acme_dns_visibility.rs
+++ b/src/daemon/remote_acme_dns_visibility.rs
@@ -1,19 +1,25 @@
 use std::env;
+use std::fmt;
 use std::net::IpAddr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
-use hickory_resolver::proto::rr::{RData, RecordType};
+use hickory_resolver::proto::rr::RData;
 use hickory_resolver::{Resolver, TokioResolver};
 use tokio::time::{Instant, sleep};
 
+use crate::daemon::remote_redaction::redact_secret_detail;
+
 const TIMEOUT_ENV: &str = "HARNESS_REMOTE_ACME_DNS_VISIBILITY_TIMEOUT_SECONDS";
 const POLL_INTERVAL_ENV: &str = "HARNESS_REMOTE_ACME_DNS_VISIBILITY_POLL_SECONDS";
+const STABLE_POLLS_ENV: &str = "HARNESS_REMOTE_ACME_DNS_VISIBILITY_STABLE_POLLS";
 const DEFAULT_TIMEOUT: Duration = Duration::from_mins(5);
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(5);
+const DEFAULT_STABLE_POLLS: usize = 3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DnsTxtRecordState {
@@ -22,10 +28,10 @@ pub(crate) enum DnsTxtRecordState {
 }
 
 impl DnsTxtRecordState {
-    const fn matches(self, present: bool) -> bool {
+    const fn matches(self, observed: DnsTxtValueState) -> bool {
         match self {
-            Self::Present => present,
-            Self::Absent => !present,
+            Self::Present => matches!(observed, DnsTxtValueState::Matching),
+            Self::Absent => !matches!(observed, DnsTxtValueState::Matching),
         }
     }
 
@@ -33,6 +39,24 @@ impl DnsTxtRecordState {
         match self {
             Self::Present => "appear",
             Self::Absent => "disappear",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DnsTxtValueState {
+    Matching,
+    Different,
+    Absent,
+}
+
+impl DnsTxtValueState {
+    #[cfg(test)]
+    const fn from_present(present: bool) -> Self {
+        if present {
+            Self::Matching
+        } else {
+            Self::Absent
         }
     }
 }
@@ -47,20 +71,70 @@ pub(crate) trait DnsTxtVisibilityWaiter: Send + Sync {
     ) -> Result<(), String>;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct AuthoritativeDnsTxtVisibilityWaiter {
     zone_name: String,
     timeout: Duration,
     poll_interval: Duration,
+    stable_polls: usize,
+    observer: Arc<dyn AuthoritativeDnsTxtObserver>,
+}
+
+impl fmt::Debug for AuthoritativeDnsTxtVisibilityWaiter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthoritativeDnsTxtVisibilityWaiter")
+            .field("zone_name", &self.zone_name)
+            .field("timeout", &self.timeout)
+            .field("poll_interval", &self.poll_interval)
+            .field("stable_polls", &self.stable_polls)
+            .finish_non_exhaustive()
+    }
 }
 
 impl AuthoritativeDnsTxtVisibilityWaiter {
     pub(crate) fn from_environment(zone_name: &str) -> Result<Self, String> {
-        Ok(Self {
+        Ok(Self::new_with_observer(
+            zone_name,
+            duration_from_env(TIMEOUT_ENV, DEFAULT_TIMEOUT)?,
+            duration_from_env(POLL_INTERVAL_ENV, DEFAULT_POLL_INTERVAL)?,
+            positive_usize_from_env(STABLE_POLLS_ENV, DEFAULT_STABLE_POLLS)?,
+            Arc::new(SystemAuthoritativeDnsTxtObserver),
+        ))
+    }
+
+    fn new_with_observer(
+        zone_name: &str,
+        timeout: Duration,
+        poll_interval: Duration,
+        stable_polls: usize,
+        observer: Arc<dyn AuthoritativeDnsTxtObserver>,
+    ) -> Self {
+        Self {
             zone_name: zone_name.to_string(),
-            timeout: duration_from_env(TIMEOUT_ENV, DEFAULT_TIMEOUT)?,
-            poll_interval: duration_from_env(POLL_INTERVAL_ENV, DEFAULT_POLL_INTERVAL)?,
-        })
+            timeout,
+            poll_interval,
+            stable_polls,
+            observer,
+        }
+    }
+
+    async fn observe(
+        &self,
+        endpoints: &[AuthoritativeDnsEndpoint],
+        record_name: &str,
+        record_value: &str,
+    ) -> Vec<AuthoritativeDnsObservation> {
+        let mut observations = Vec::with_capacity(endpoints.len());
+        for endpoint in endpoints {
+            observations.push(AuthoritativeDnsObservation {
+                endpoint: endpoint.clone(),
+                result: self
+                    .observer
+                    .txt_value_state(endpoint, record_name, record_value)
+                    .await,
+            });
+        }
+        observations
     }
 }
 
@@ -72,25 +146,35 @@ impl DnsTxtVisibilityWaiter for AuthoritativeDnsTxtVisibilityWaiter {
         record_value: &str,
         state: DnsTxtRecordState,
     ) -> Result<(), String> {
-        let resolvers = authoritative_resolvers(&self.zone_name).await?;
+        let endpoints = self.observer.discover_endpoints(&self.zone_name).await?;
+        if endpoints.is_empty() {
+            return Err(format!(
+                "authoritative DNS lookup for {} returned no endpoints",
+                self.zone_name
+            ));
+        }
         let fqdn = format!("{}.", record_name.trim_end_matches('.'));
         let deadline = Instant::now() + self.timeout;
+        let mut stable_polls = 0;
         loop {
-            let query_error =
-                match all_authoritative_resolvers_match(&resolvers, &fqdn, record_value, state)
-                    .await
-                {
-                    Ok(true) => return Ok(()),
-                    Ok(_) => None,
-                    Err(error) => Some(error),
-                };
+            let observations = self.observe(&endpoints, &fqdn, record_value).await;
+            if all_authoritative_observations_match(state, &observations) {
+                stable_polls += 1;
+                if stable_polls == self.stable_polls {
+                    return Ok(());
+                }
+            } else {
+                stable_polls = 0;
+            }
             let now = Instant::now();
             if now >= deadline {
                 return Err(visibility_timeout_error(
                     record_name,
                     state,
                     self.timeout,
-                    query_error.as_deref(),
+                    stable_polls,
+                    self.stable_polls,
+                    &observations,
                 ));
             }
             sleep(self.poll_interval.min(deadline - now)).await;
@@ -98,12 +182,68 @@ impl DnsTxtVisibilityWaiter for AuthoritativeDnsTxtVisibilityWaiter {
     }
 }
 
-struct AuthoritativeDnsResolver {
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct AuthoritativeDnsEndpoint {
     name: String,
-    resolver: TokioResolver,
+    address: IpAddr,
 }
 
-async fn authoritative_resolvers(zone_name: &str) -> Result<Vec<AuthoritativeDnsResolver>, String> {
+impl AuthoritativeDnsEndpoint {
+    fn new(name: &str, address: IpAddr) -> Self {
+        Self {
+            name: name.trim_end_matches('.').to_string(),
+            address,
+        }
+    }
+
+    fn label(&self) -> String {
+        format!("{}@{}", self.name, self.address)
+    }
+}
+
+struct AuthoritativeDnsObservation {
+    endpoint: AuthoritativeDnsEndpoint,
+    result: Result<DnsTxtValueState, String>,
+}
+
+#[async_trait]
+trait AuthoritativeDnsTxtObserver: Send + Sync {
+    async fn discover_endpoints(
+        &self,
+        zone_name: &str,
+    ) -> Result<Vec<AuthoritativeDnsEndpoint>, String>;
+
+    async fn txt_value_state(
+        &self,
+        endpoint: &AuthoritativeDnsEndpoint,
+        record_name: &str,
+        record_value: &str,
+    ) -> Result<DnsTxtValueState, String>;
+}
+
+struct SystemAuthoritativeDnsTxtObserver;
+
+#[async_trait]
+impl AuthoritativeDnsTxtObserver for SystemAuthoritativeDnsTxtObserver {
+    async fn discover_endpoints(
+        &self,
+        zone_name: &str,
+    ) -> Result<Vec<AuthoritativeDnsEndpoint>, String> {
+        authoritative_endpoints(zone_name).await
+    }
+
+    async fn txt_value_state(
+        &self,
+        endpoint: &AuthoritativeDnsEndpoint,
+        record_name: &str,
+        record_value: &str,
+    ) -> Result<DnsTxtValueState, String> {
+        let resolver = build_authoritative_resolver(endpoint)?;
+        txt_value_state(&resolver, record_name, record_value).await
+    }
+}
+
+async fn authoritative_endpoints(zone_name: &str) -> Result<Vec<AuthoritativeDnsEndpoint>, String> {
     let system = TokioResolver::builder_tokio()
         .map_err(|error| format!("load system DNS resolver: {error}"))?
         .build()
@@ -128,7 +268,7 @@ async fn authoritative_resolvers(zone_name: &str) -> Result<Vec<AuthoritativeDns
             "authoritative DNS lookup for {zone_name} returned no nameservers"
         ));
     }
-    let mut resolvers = Vec::with_capacity(names.len());
+    let mut endpoints = Vec::with_capacity(names.len());
     for nameserver in names {
         let resolved = system
             .lookup_ip(nameserver.as_str())
@@ -137,88 +277,85 @@ async fn authoritative_resolvers(zone_name: &str) -> Result<Vec<AuthoritativeDns
         let mut addresses = resolved.iter().collect::<Vec<_>>();
         addresses.sort_unstable();
         addresses.dedup();
-        resolvers.push(AuthoritativeDnsResolver {
-            resolver: build_authoritative_resolver(&addresses, &nameserver)?,
-            name: nameserver,
-        });
+        if addresses.is_empty() {
+            return Err(format!(
+                "authoritative DNS server {nameserver} resolved without addresses"
+            ));
+        }
+        endpoints.extend(
+            addresses
+                .into_iter()
+                .map(|address| AuthoritativeDnsEndpoint::new(&nameserver, address)),
+        );
     }
-    Ok(resolvers)
+    endpoints.sort_unstable();
+    endpoints.dedup();
+    Ok(endpoints)
 }
 
 fn build_authoritative_resolver(
-    addresses: &[IpAddr],
-    zone_name: &str,
+    endpoint: &AuthoritativeDnsEndpoint,
 ) -> Result<TokioResolver, String> {
-    if addresses.is_empty() {
-        return Err(format!(
-            "authoritative DNS servers for {zone_name} resolved without addresses"
-        ));
-    }
-    let name_servers = addresses
-        .iter()
-        .copied()
-        .map(|address| {
-            let mut config = NameServerConfig::udp_and_tcp(address);
-            config.trust_negative_responses = false;
-            config
-        })
-        .collect();
+    let mut name_server = NameServerConfig::udp_and_tcp(endpoint.address);
+    name_server.trust_negative_responses = false;
     let mut options = ResolverOpts::default();
     options.attempts = 2;
     options.cache_size = 0;
-    options.num_concurrent_reqs = addresses.len().min(2);
+    options.num_concurrent_reqs = 1;
     options.recursion_desired = false;
     options.timeout = Duration::from_secs(5);
     options.try_tcp_on_error = true;
     Resolver::builder_with_config(
-        ResolverConfig::from_parts(None, Vec::new(), name_servers),
+        ResolverConfig::from_parts(None, Vec::new(), vec![name_server]),
         TokioRuntimeProvider::default(),
     )
     .with_options(options)
     .build()
-    .map_err(|error| format!("build authoritative DNS resolver for {zone_name}: {error}"))
+    .map_err(|error| {
+        format!(
+            "build authoritative DNS resolver for {}: {error}",
+            endpoint.label()
+        )
+    })
 }
 
-async fn txt_value_present(
+async fn txt_value_state(
     resolver: &TokioResolver,
     record_name: &str,
     record_value: &str,
-) -> Result<bool, String> {
+) -> Result<DnsTxtValueState, String> {
     match resolver.txt_lookup(record_name).await {
-        Ok(lookup) => Ok(lookup_contains_txt(&lookup, record_value)),
-        Err(error) if error.is_no_records_found() => Ok(false),
+        Ok(lookup) => Ok(lookup_txt_value_state(&lookup, record_value)),
+        Err(error) if error.is_no_records_found() => Ok(DnsTxtValueState::Absent),
         Err(error) => Err(format!(
             "query authoritative TXT record {record_name}: {error}"
         )),
     }
 }
 
-async fn all_authoritative_resolvers_match(
-    resolvers: &[AuthoritativeDnsResolver],
-    record_name: &str,
-    record_value: &str,
+fn all_authoritative_observations_match(
     state: DnsTxtRecordState,
-) -> Result<bool, String> {
-    let mut states = Vec::with_capacity(resolvers.len());
-    for server in resolvers {
-        server
-            .resolver
-            .clear_lookup_cache(record_name, RecordType::TXT);
-        states.push(
-            txt_value_present(&server.resolver, record_name, record_value)
-                .await
-                .map_err(|error| format!("{error} via {}", server.name))?,
-        );
-    }
-    Ok(all_authoritative_states_match(state, states))
+    observations: &[AuthoritativeDnsObservation],
+) -> bool {
+    !observations.is_empty()
+        && observations.iter().all(|observation| {
+            observation
+                .result
+                .as_ref()
+                .is_ok_and(|present| state.matches(*present))
+        })
 }
 
+#[cfg(test)]
 fn all_authoritative_states_match(
     state: DnsTxtRecordState,
     states: impl IntoIterator<Item = bool>,
 ) -> bool {
-    let mut states = states.into_iter().peekable();
-    states.peek().is_some() && states.all(|present| state.matches(present))
+    let mut states = states
+        .into_iter()
+        .map(DnsTxtValueState::from_present)
+        .peekable();
+    states.peek().is_some() && states.all(|observed| state.matches(observed))
 }
 
 fn lookup_contains_txt(lookup: &Lookup, record_value: &str) -> bool {
@@ -231,6 +368,14 @@ fn lookup_contains_txt(lookup: &Lookup, record_value: &str) -> bool {
             .flat_map(|part| part.iter().copied())
             .eq(record_value.bytes())
     })
+}
+
+fn lookup_txt_value_state(lookup: &Lookup, record_value: &str) -> DnsTxtValueState {
+    if lookup_contains_txt(lookup, record_value) {
+        DnsTxtValueState::Matching
+    } else {
+        DnsTxtValueState::Different
+    }
 }
 
 fn duration_from_env(name: &str, default: Duration) -> Result<Duration, String> {
@@ -250,86 +395,53 @@ fn duration_from_env(name: &str, default: Duration) -> Result<Duration, String> 
     Ok(Duration::from_secs(seconds))
 }
 
+fn positive_usize_from_env(name: &str, default: usize) -> Result<usize, String> {
+    let Ok(value) = env::var(name) else {
+        return Ok(default);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(default);
+    }
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|error| format!("parse {name}: {error}"))?;
+    if parsed == 0 {
+        return Err(format!("{name} must be greater than zero"));
+    }
+    Ok(parsed)
+}
+
 fn visibility_timeout_error(
     record_name: &str,
     state: DnsTxtRecordState,
     timeout: Duration,
-    last_error: Option<&str>,
+    stable_polls: usize,
+    required_stable_polls: usize,
+    observations: &[AuthoritativeDnsObservation],
 ) -> String {
-    let detail = last_error.map_or_else(String::new, |error| format!("; last query: {error}"));
+    let endpoint_states = observations
+        .iter()
+        .map(format_observation)
+        .collect::<Vec<_>>()
+        .join(", ");
     format!(
-        "authoritative DNS TXT record {record_name} did not {} within {} seconds{detail}",
+        "authoritative DNS TXT record {record_name} did not {} within {} seconds; stable polls {stable_polls}/{required_stable_polls}; last authoritative observations: {endpoint_states}",
         state.description(),
         timeout.as_secs(),
     )
 }
 
-#[cfg(test)]
-mod tests {
-    use hickory_resolver::lookup::Lookup;
-    use hickory_resolver::proto::op::Query;
-    use hickory_resolver::proto::rr::rdata::TXT;
-    use hickory_resolver::proto::rr::{Name, RData, RecordType};
-
-    use super::*;
-
-    #[test]
-    fn visibility_config_uses_provider_neutral_environment() {
-        temp_env::with_vars(
-            [(TIMEOUT_ENV, Some("17")), (POLL_INTERVAL_ENV, Some("3"))],
-            || {
-                let waiter = AuthoritativeDnsTxtVisibilityWaiter::from_environment("example.com")
-                    .expect("visibility config");
-                assert_eq!(waiter.timeout, Duration::from_secs(17));
-                assert_eq!(waiter.poll_interval, Duration::from_secs(3));
-            },
-        );
-    }
-
-    #[test]
-    fn visibility_config_rejects_zero_duration() {
-        temp_env::with_var(TIMEOUT_ENV, Some("0"), || {
-            let error = AuthoritativeDnsTxtVisibilityWaiter::from_environment("example.com")
-                .expect_err("reject zero timeout");
-            assert_eq!(
-                error,
-                "HARNESS_REMOTE_ACME_DNS_VISIBILITY_TIMEOUT_SECONDS must be greater than zero"
-            );
-        });
-    }
-
-    #[test]
-    fn txt_matching_joins_segments_and_requires_the_exact_value() {
-        let query = Query::query(
-            Name::from_ascii("_acme-challenge.example.com.").expect("record name"),
-            RecordType::TXT,
-        );
-        let lookup = Lookup::from_rdata(
-            query,
-            RData::TXT(TXT::from_bytes(vec![b"dns-proof-", b"value"])),
-        );
-
-        assert!(lookup_contains_txt(&lookup, "dns-proof-value"));
-        assert!(!lookup_contains_txt(&lookup, "dns-proof"));
-    }
-
-    #[test]
-    fn visibility_requires_every_authoritative_server_to_match() {
-        assert!(all_authoritative_states_match(
-            DnsTxtRecordState::Present,
-            [true, true]
-        ));
-        assert!(!all_authoritative_states_match(
-            DnsTxtRecordState::Present,
-            [true, false]
-        ));
-        assert!(all_authoritative_states_match(
-            DnsTxtRecordState::Absent,
-            [false, false]
-        ));
-        assert!(!all_authoritative_states_match(
-            DnsTxtRecordState::Absent,
-            [false, true]
-        ));
-    }
+fn format_observation(observation: &AuthoritativeDnsObservation) -> String {
+    let state = match &observation.result {
+        Ok(DnsTxtValueState::Matching) => "present".to_string(),
+        Ok(DnsTxtValueState::Different) => "different-value".to_string(),
+        Ok(DnsTxtValueState::Absent) => "absent".to_string(),
+        Err(error) => format!("error({})", redact_secret_detail(error)),
+    };
+    format!("{}={state}", observation.endpoint.label())
 }
+
+#[cfg(test)]
+#[path = "remote_acme_dns_visibility_tests.rs"]
+mod tests;

--- a/src/daemon/remote_acme_dns_visibility.rs
+++ b/src/daemon/remote_acme_dns_visibility.rs
@@ -364,7 +364,7 @@ fn all_authoritative_observations_match(
             observation
                 .result
                 .as_ref()
-                .is_ok_and(|present| state.matches(*present))
+                .is_ok_and(|observed| state.matches(*observed))
         })
 }
 

--- a/src/daemon/remote_acme_dns_visibility.rs
+++ b/src/daemon/remote_acme_dns_visibility.rs
@@ -5,12 +5,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures_util::future::join_all;
 use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::proto::rr::RData;
 use hickory_resolver::{Resolver, TokioResolver};
-use tokio::time::{Instant, sleep};
+use tokio::time::{Instant, sleep, timeout};
 
 use crate::daemon::remote_redaction::redact_secret_detail;
 
@@ -123,18 +124,25 @@ impl AuthoritativeDnsTxtVisibilityWaiter {
         endpoints: &[AuthoritativeDnsEndpoint],
         record_name: &str,
         record_value: &str,
+        query_timeout: Duration,
     ) -> Vec<AuthoritativeDnsObservation> {
-        let mut observations = Vec::with_capacity(endpoints.len());
-        for endpoint in endpoints {
-            observations.push(AuthoritativeDnsObservation {
+        join_all(endpoints.iter().map(|endpoint| async move {
+            let result = match timeout(
+                query_timeout,
+                self.observer
+                    .txt_value_state(endpoint, record_name, record_value),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => Err("query exceeded remaining visibility timeout".to_string()),
+            };
+            AuthoritativeDnsObservation {
                 endpoint: endpoint.clone(),
-                result: self
-                    .observer
-                    .txt_value_state(endpoint, record_name, record_value)
-                    .await,
-            });
-        }
-        observations
+                result,
+            }
+        }))
+        .await
     }
 }
 
@@ -156,8 +164,22 @@ impl DnsTxtVisibilityWaiter for AuthoritativeDnsTxtVisibilityWaiter {
         let fqdn = format!("{}.", record_name.trim_end_matches('.'));
         let deadline = Instant::now() + self.timeout;
         let mut stable_polls = 0;
+        let mut observations = Vec::new();
         loop {
-            let observations = self.observe(&endpoints, &fqdn, record_value).await;
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(visibility_timeout_error(
+                    record_name,
+                    state,
+                    self.timeout,
+                    stable_polls,
+                    self.stable_polls,
+                    &observations,
+                ));
+            }
+            observations = self
+                .observe(&endpoints, &fqdn, record_value, deadline - now)
+                .await;
             if all_authoritative_observations_match(state, &observations) {
                 stable_polls += 1;
                 if stable_polls == self.stable_polls {

--- a/src/daemon/remote_acme_dns_visibility_tests.rs
+++ b/src/daemon/remote_acme_dns_visibility_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::future::pending;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -209,6 +210,46 @@ async fn timeout_distinguishes_a_different_txt_value_from_absence() {
     assert!(!error.contains("never-log-this-digest"));
 }
 
+#[tokio::test(start_paused = true)]
+async fn visibility_deadline_bounds_all_slow_endpoint_queries() {
+    let endpoints = authoritative_test_endpoints();
+    let waiter = AuthoritativeDnsTxtVisibilityWaiter::new_with_observer(
+        "example.com",
+        Duration::from_secs(2),
+        Duration::from_secs(1),
+        3,
+        Arc::new(HangingDnsTxtObserver {
+            endpoints: endpoints.clone(),
+        }),
+    );
+    let started = tokio::time::Instant::now();
+
+    let error = tokio::time::timeout(
+        Duration::from_secs(3),
+        waiter.wait_for(
+            "_acme-challenge.example.com",
+            "never-log-this-digest",
+            DnsTxtRecordState::Present,
+        ),
+    )
+    .await
+    .expect("waiter must honor its two-second deadline")
+    .expect_err("visibility must time out");
+
+    assert_eq!(started.elapsed(), Duration::from_secs(2));
+    assert!(
+        error.contains(
+            "ns1.example.com@192.0.2.1=error(query exceeded remaining visibility timeout)"
+        )
+    );
+    assert!(
+        error.contains(
+            "ns2.example.com@192.0.2.2=error(query exceeded remaining visibility timeout)"
+        )
+    );
+    assert!(!error.contains("never-log-this-digest"));
+}
+
 fn scripted_waiter<const N: usize>(
     observations: [Result<DnsTxtValueState, String>; N],
     stable_polls: usize,
@@ -235,10 +276,7 @@ fn scripted_waiter_with_timing<const N: usize>(
     ScriptedDnsTxtObserver,
     Vec<AuthoritativeDnsEndpoint>,
 ) {
-    let endpoints = vec![
-        AuthoritativeDnsEndpoint::new("ns1.example.com", IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
-        AuthoritativeDnsEndpoint::new("ns2.example.com", IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2))),
-    ];
+    let endpoints = authoritative_test_endpoints();
     let observer = ScriptedDnsTxtObserver::new(endpoints.clone(), observations);
     let waiter = AuthoritativeDnsTxtVisibilityWaiter::new_with_observer(
         "example.com",
@@ -248,6 +286,13 @@ fn scripted_waiter_with_timing<const N: usize>(
         Arc::new(observer.clone()),
     );
     (waiter, observer, endpoints)
+}
+
+fn authoritative_test_endpoints() -> Vec<AuthoritativeDnsEndpoint> {
+    vec![
+        AuthoritativeDnsEndpoint::new("ns1.example.com", IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+        AuthoritativeDnsEndpoint::new("ns2.example.com", IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2))),
+    ]
 }
 
 fn repeat_endpoints(
@@ -313,5 +358,28 @@ impl AuthoritativeDnsTxtObserver for ScriptedDnsTxtObserver {
             .observations
             .pop_front()
             .ok_or_else(|| "scripted DNS observation exhausted".to_string())?
+    }
+}
+
+struct HangingDnsTxtObserver {
+    endpoints: Vec<AuthoritativeDnsEndpoint>,
+}
+
+#[async_trait]
+impl AuthoritativeDnsTxtObserver for HangingDnsTxtObserver {
+    async fn discover_endpoints(
+        &self,
+        _zone_name: &str,
+    ) -> Result<Vec<AuthoritativeDnsEndpoint>, String> {
+        Ok(self.endpoints.clone())
+    }
+
+    async fn txt_value_state(
+        &self,
+        _endpoint: &AuthoritativeDnsEndpoint,
+        _record_name: &str,
+        _record_value: &str,
+    ) -> Result<DnsTxtValueState, String> {
+        pending().await
     }
 }

--- a/src/daemon/remote_acme_dns_visibility_tests.rs
+++ b/src/daemon/remote_acme_dns_visibility_tests.rs
@@ -1,0 +1,317 @@
+use std::collections::VecDeque;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hickory_resolver::lookup::Lookup;
+use hickory_resolver::proto::op::Query;
+use hickory_resolver::proto::rr::rdata::TXT;
+use hickory_resolver::proto::rr::{Name, RData, RecordType};
+
+use super::*;
+
+#[test]
+fn visibility_config_uses_provider_neutral_environment() {
+    temp_env::with_vars(
+        [
+            (TIMEOUT_ENV, Some("17")),
+            (POLL_INTERVAL_ENV, Some("3")),
+            (STABLE_POLLS_ENV, Some("4")),
+        ],
+        || {
+            let waiter = AuthoritativeDnsTxtVisibilityWaiter::from_environment("example.com")
+                .expect("visibility config");
+            assert_eq!(waiter.timeout, Duration::from_secs(17));
+            assert_eq!(waiter.poll_interval, Duration::from_secs(3));
+            assert_eq!(waiter.stable_polls, 4);
+        },
+    );
+}
+
+#[test]
+fn visibility_config_rejects_zero_duration() {
+    temp_env::with_var(TIMEOUT_ENV, Some("0"), || {
+        let error = AuthoritativeDnsTxtVisibilityWaiter::from_environment("example.com")
+            .expect_err("reject zero timeout");
+        assert_eq!(
+            error,
+            "HARNESS_REMOTE_ACME_DNS_VISIBILITY_TIMEOUT_SECONDS must be greater than zero"
+        );
+    });
+}
+
+#[test]
+fn visibility_config_rejects_zero_stable_polls() {
+    temp_env::with_var(STABLE_POLLS_ENV, Some("0"), || {
+        let error = AuthoritativeDnsTxtVisibilityWaiter::from_environment("example.com")
+            .expect_err("reject zero stable polls");
+        assert_eq!(
+            error,
+            "HARNESS_REMOTE_ACME_DNS_VISIBILITY_STABLE_POLLS must be greater than zero"
+        );
+    });
+}
+
+#[test]
+fn txt_matching_joins_segments_and_requires_the_exact_value() {
+    let query = Query::query(
+        Name::from_ascii("_acme-challenge.example.com.").expect("record name"),
+        RecordType::TXT,
+    );
+    let lookup = Lookup::from_rdata(
+        query,
+        RData::TXT(TXT::from_bytes(vec![b"dns-proof-", b"value"])),
+    );
+
+    assert!(lookup_contains_txt(&lookup, "dns-proof-value"));
+    assert!(!lookup_contains_txt(&lookup, "dns-proof"));
+    assert_eq!(
+        lookup_txt_value_state(&lookup, "dns-proof-value"),
+        DnsTxtValueState::Matching
+    );
+    assert_eq!(
+        lookup_txt_value_state(&lookup, "different-value"),
+        DnsTxtValueState::Different
+    );
+}
+
+#[test]
+fn visibility_requires_every_authoritative_endpoint_to_match() {
+    assert!(all_authoritative_states_match(
+        DnsTxtRecordState::Present,
+        [true, true]
+    ));
+    assert!(!all_authoritative_states_match(
+        DnsTxtRecordState::Present,
+        [true, false]
+    ));
+    assert!(all_authoritative_states_match(
+        DnsTxtRecordState::Absent,
+        [false, false]
+    ));
+    assert!(!all_authoritative_states_match(
+        DnsTxtRecordState::Absent,
+        [false, true]
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn visibility_requires_consecutive_fresh_present_observations() {
+    let observations = [
+        true, true, // first matching poll
+        true, false, // mismatch resets stability
+        true, true, // three fresh matching polls
+        true, true, true, true,
+    ];
+    let (waiter, observer, endpoints) = scripted_waiter(
+        observations.map(|present| Ok(DnsTxtValueState::from_present(present))),
+        3,
+    );
+
+    waiter
+        .wait_for(
+            "_acme-challenge.example.com",
+            "dns-proof-value",
+            DnsTxtRecordState::Present,
+        )
+        .await
+        .expect("reach stable authoritative presence");
+
+    assert_eq!(observer.calls(), repeat_endpoints(&endpoints, 5));
+}
+
+#[tokio::test(start_paused = true)]
+async fn cleanup_waits_past_a_transient_absence_and_resurface() {
+    let observations = [
+        false, false, // first absent poll
+        false, true, // record resurfaces and resets stability
+        false, false, // three fresh absent polls
+        false, false, false, false,
+    ];
+    let (waiter, observer, endpoints) = scripted_waiter(
+        observations.map(|present| Ok(DnsTxtValueState::from_present(present))),
+        3,
+    );
+
+    waiter
+        .wait_for(
+            "_acme-challenge.example.com",
+            "dns-proof-value",
+            DnsTxtRecordState::Absent,
+        )
+        .await
+        .expect("reach stable authoritative absence");
+
+    assert_eq!(observer.calls(), repeat_endpoints(&endpoints, 5));
+}
+
+#[tokio::test(start_paused = true)]
+async fn timeout_reports_each_endpoint_state_without_the_txt_value() {
+    let observations = [
+        Ok(DnsTxtValueState::Matching),
+        Err("query refused".to_string()),
+        Ok(DnsTxtValueState::Matching),
+        Err("query refused".to_string()),
+        Ok(DnsTxtValueState::Matching),
+        Err("query refused".to_string()),
+    ];
+    let (waiter, _, _) = scripted_waiter_with_timing(
+        observations,
+        3,
+        Duration::from_secs(2),
+        Duration::from_secs(1),
+    );
+
+    let error = waiter
+        .wait_for(
+            "_acme-challenge.example.com",
+            "never-log-this-digest",
+            DnsTxtRecordState::Present,
+        )
+        .await
+        .expect_err("visibility must time out");
+
+    assert!(error.contains("ns1.example.com@192.0.2.1=present"));
+    assert!(error.contains("ns2.example.com@192.0.2.2=error(query refused)"));
+    assert!(error.contains("stable polls 0/3"));
+    assert!(!error.contains("never-log-this-digest"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn timeout_distinguishes_a_different_txt_value_from_absence() {
+    let observations = [
+        Ok(DnsTxtValueState::Matching),
+        Ok(DnsTxtValueState::Different),
+        Ok(DnsTxtValueState::Matching),
+        Ok(DnsTxtValueState::Different),
+        Ok(DnsTxtValueState::Matching),
+        Ok(DnsTxtValueState::Different),
+    ];
+    let (waiter, _, _) = scripted_waiter_with_timing(
+        observations,
+        3,
+        Duration::from_secs(2),
+        Duration::from_secs(1),
+    );
+
+    let error = waiter
+        .wait_for(
+            "_acme-challenge.example.com",
+            "never-log-this-digest",
+            DnsTxtRecordState::Present,
+        )
+        .await
+        .expect_err("visibility must time out");
+
+    assert!(error.contains("ns1.example.com@192.0.2.1=present"));
+    assert!(error.contains("ns2.example.com@192.0.2.2=different-value"));
+    assert!(!error.contains("never-log-this-digest"));
+}
+
+fn scripted_waiter<const N: usize>(
+    observations: [Result<DnsTxtValueState, String>; N],
+    stable_polls: usize,
+) -> (
+    AuthoritativeDnsTxtVisibilityWaiter,
+    ScriptedDnsTxtObserver,
+    Vec<AuthoritativeDnsEndpoint>,
+) {
+    scripted_waiter_with_timing(
+        observations,
+        stable_polls,
+        Duration::from_secs(30),
+        Duration::from_secs(1),
+    )
+}
+
+fn scripted_waiter_with_timing<const N: usize>(
+    observations: [Result<DnsTxtValueState, String>; N],
+    stable_polls: usize,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> (
+    AuthoritativeDnsTxtVisibilityWaiter,
+    ScriptedDnsTxtObserver,
+    Vec<AuthoritativeDnsEndpoint>,
+) {
+    let endpoints = vec![
+        AuthoritativeDnsEndpoint::new("ns1.example.com", IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+        AuthoritativeDnsEndpoint::new("ns2.example.com", IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2))),
+    ];
+    let observer = ScriptedDnsTxtObserver::new(endpoints.clone(), observations);
+    let waiter = AuthoritativeDnsTxtVisibilityWaiter::new_with_observer(
+        "example.com",
+        timeout,
+        poll_interval,
+        stable_polls,
+        Arc::new(observer.clone()),
+    );
+    (waiter, observer, endpoints)
+}
+
+fn repeat_endpoints(
+    endpoints: &[AuthoritativeDnsEndpoint],
+    count: usize,
+) -> Vec<AuthoritativeDnsEndpoint> {
+    (0..count).flat_map(|_| endpoints.iter().cloned()).collect()
+}
+
+#[derive(Clone)]
+struct ScriptedDnsTxtObserver {
+    inner: Arc<Mutex<ScriptedDnsTxtObserverState>>,
+}
+
+struct ScriptedDnsTxtObserverState {
+    endpoints: Vec<AuthoritativeDnsEndpoint>,
+    observations: VecDeque<Result<DnsTxtValueState, String>>,
+    calls: Vec<AuthoritativeDnsEndpoint>,
+}
+
+impl ScriptedDnsTxtObserver {
+    fn new<const N: usize>(
+        endpoints: Vec<AuthoritativeDnsEndpoint>,
+        observations: [Result<DnsTxtValueState, String>; N],
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ScriptedDnsTxtObserverState {
+                endpoints,
+                observations: observations.into(),
+                calls: Vec::new(),
+            })),
+        }
+    }
+
+    fn calls(&self) -> Vec<AuthoritativeDnsEndpoint> {
+        self.inner.lock().expect("lock observer").calls.clone()
+    }
+}
+
+#[async_trait]
+impl AuthoritativeDnsTxtObserver for ScriptedDnsTxtObserver {
+    async fn discover_endpoints(
+        &self,
+        _zone_name: &str,
+    ) -> Result<Vec<AuthoritativeDnsEndpoint>, String> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|error| error.to_string())?
+            .endpoints
+            .clone())
+    }
+
+    async fn txt_value_state(
+        &self,
+        endpoint: &AuthoritativeDnsEndpoint,
+        _record_name: &str,
+        _record_value: &str,
+    ) -> Result<DnsTxtValueState, String> {
+        let mut state = self.inner.lock().map_err(|error| error.to_string())?;
+        state.calls.push(endpoint.clone());
+        state
+            .observations
+            .pop_front()
+            .ok_or_else(|| "scripted DNS observation exhausted".to_string())?
+    }
+}

--- a/src/daemon/remote_acme_issuer_tests.rs
+++ b/src/daemon/remote_acme_issuer_tests.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use instant_acme::{Account, RetryPolicy};
 use rcgen::KeyPair;
+use tokio::sync::Notify;
 use tokio::time::{sleep, timeout};
 
 #[path = "remote_acme_issuer_test_support.rs"]
@@ -271,6 +272,45 @@ async fn instant_acme_issuer_cleans_challenge_after_rejected_order() {
 }
 
 #[tokio::test]
+async fn instant_acme_issuer_awaits_cleanup_after_readiness_failure() {
+    let http = ScriptedAcmeHttp::new(acme_happy_path());
+    let cleanup_release = Arc::new(Notify::new());
+    let provisioner = RecordingProvisioner::with_wait_ready_error_and_cleanup_gate(
+        "authoritative DNS visibility timed out",
+        Arc::clone(&cleanup_release),
+    );
+    let issuer = test_issuer(http, provisioner.clone());
+    let config = http_serve_config();
+    let account = issuer
+        .create_account(config.acme_email.as_str())
+        .await
+        .expect("create ACME account");
+    let task = tokio::spawn(async move { issuer.issue_certificate(&account, &config, None).await });
+
+    timeout(Duration::from_secs(2), async {
+        while !provisioner.cleanup_started() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("readiness failure did not start cleanup");
+    assert!(
+        !task.is_finished(),
+        "issuance returned before cleanup finished"
+    );
+
+    cleanup_release.notify_one();
+    let error = timeout(Duration::from_secs(2), task)
+        .await
+        .expect("readiness cleanup timeout")
+        .expect("join ACME issuance")
+        .expect_err("readiness failure must fail issuance");
+
+    assert_eq!(error, "authoritative DNS visibility timed out");
+    assert_eq!(provisioner.cleanup_count(), 1);
+}
+
+#[tokio::test]
 async fn instant_acme_issuer_redacts_challenge_cleanup_failure() {
     let http = ScriptedAcmeHttp::new(acme_rejected_order_path());
     let provisioner = RecordingProvisioner::with_cleanup_error(
@@ -349,8 +389,10 @@ struct RecordingProvisionerState {
     materials: Vec<RemoteAcmeChallengeMaterial>,
     cleanup_count: usize,
     cleanup_delay: Duration,
+    cleanup_release: Option<Arc<Notify>>,
     cleanup_started: bool,
     cleanup_error: Option<String>,
+    wait_ready_error: Option<String>,
 }
 
 impl RecordingProvisioner {
@@ -367,6 +409,16 @@ impl RecordingProvisioner {
         Self {
             inner: Arc::new(Mutex::new(RecordingProvisionerState {
                 cleanup_delay: delay,
+                ..RecordingProvisionerState::default()
+            })),
+        }
+    }
+
+    fn with_wait_ready_error_and_cleanup_gate(error: &str, release: Arc<Notify>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RecordingProvisionerState {
+                cleanup_release: Some(release),
+                wait_ready_error: Some(error.to_string()),
                 ..RecordingProvisionerState::default()
             })),
         }
@@ -402,12 +454,24 @@ impl RemoteAcmeChallengeProvisioner for RecordingProvisioner {
         Ok(())
     }
 
+    async fn wait_ready(&self, _lease: &Self::Lease) -> Result<(), String> {
+        self.inner
+            .lock()
+            .map_err(|error| error.to_string())?
+            .wait_ready_error
+            .clone()
+            .map_or(Ok(()), Err)
+    }
+
     async fn cleanup(&self, _lease: Self::Lease) -> Result<(), String> {
-        let delay = {
+        let (delay, release) = {
             let mut state = self.inner.lock().map_err(|error| error.to_string())?;
             state.cleanup_started = true;
-            state.cleanup_delay
+            (state.cleanup_delay, state.cleanup_release.clone())
         };
+        if let Some(release) = release {
+            release.notified().await;
+        }
         sleep(delay).await;
         let mut state = self.inner.lock().map_err(|error| error.to_string())?;
         state.cleanup_count += 1;

--- a/tests/remote_daemon_e2e.rs
+++ b/tests/remote_daemon_e2e.rs
@@ -16,8 +16,10 @@ mod process;
 
 use acme::{AcmeChallenge, AcmeChallengeConfig, FakeAcmeServer};
 use client::RemoteDaemonClient;
-use process::{RemoteDaemonEnvironment, RemoteDaemonProcess};
+use process::{AftermarketDnsEnvironment, RemoteDaemonEnvironment, RemoteDaemonProcess};
 use serde_json::Value;
+use std::env;
+use std::time::Duration;
 
 const DOMAIN: &str = "daemon.example.com";
 
@@ -29,6 +31,70 @@ async fn remote_daemon_e2e_proves_acme_https_wss_pairing_and_revocation() {
             .await
             .unwrap_or_else(|error| panic!("{} e2e failed: {error}", challenge.cli_name()));
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires live Aftermarket credentials and authoritative DNS"]
+async fn remote_daemon_e2e_cleans_aftermarket_dns_after_failed_issuance() {
+    if env::var_os("HARNESS_TEST_AFTERMARKET_DOMAIN").is_none() {
+        return;
+    }
+    run_aftermarket_failed_issuance_case()
+        .await
+        .unwrap_or_else(|error| panic!("live Aftermarket cleanup e2e failed: {error}"));
+}
+
+async fn run_aftermarket_failed_issuance_case() -> Result<(), String> {
+    let domain = required_env("HARNESS_TEST_AFTERMARKET_DOMAIN")?;
+    let zone_name = required_env("AFTERMARKET_ZONE_NAME")?;
+    let api_key = required_env("AFTERMARKET_API_KEY")?;
+    let api_secret = required_env("AFTERMARKET_API_SECRET")?;
+    let environment = RemoteDaemonEnvironment::new(AcmeChallenge::Dns)?;
+    let acme = FakeAcmeServer::start(AcmeChallengeConfig {
+        challenge: AcmeChallenge::Dns,
+        domain: domain.clone(),
+        http_port: environment.http_port(),
+        https_port: environment.https_port(),
+        dns_log: environment.dns_log().to_path_buf(),
+        ca_root: environment.acme_ca_root().to_path_buf(),
+    })
+    .await?;
+    let aftermarket = AftermarketDnsEnvironment {
+        zone_name: &zone_name,
+        api_key: &api_key,
+        api_secret: &api_secret,
+        visibility_timeout_seconds: 300,
+        visibility_poll_seconds: 2,
+        visibility_stable_polls: 3,
+    };
+    let mut daemon = RemoteDaemonProcess::spawn_aftermarket(
+        &environment,
+        &domain,
+        acme.directory_url(),
+        &aftermarket,
+    )?;
+
+    let diagnostics = daemon.wait_for_failure(Duration::from_secs(660)).await?;
+    let validation_error = acme.validation_error()?.ok_or_else(|| {
+        format!("fake ACME server never received the ready DNS challenge; {diagnostics}")
+    })?;
+
+    if !validation_error.contains("DNS-01 hook") {
+        return Err(format!(
+            "fake ACME server failed before DNS validation: {validation_error}"
+        ));
+    }
+    if diagnostics.contains("cleanup also failed") {
+        return Err(format!(
+            "Aftermarket cleanup failed after issuance error: {diagnostics}"
+        ));
+    }
+    for secret in [&api_key, &api_secret] {
+        if diagnostics.contains(secret) {
+            return Err("remote daemon diagnostics exposed an Aftermarket secret".to_string());
+        }
+    }
+    acme.shutdown().await
 }
 
 async fn run_remote_daemon_case(challenge: AcmeChallenge) -> Result<(), String> {
@@ -98,4 +164,11 @@ fn required_string<'a>(value: &'a Value, field: &str) -> Result<&'a str, String>
         .as_str()
         .filter(|value| !value.is_empty())
         .ok_or_else(|| format!("pairing response omitted {field}: {value}"))
+}
+
+fn required_env(name: &str) -> Result<String, String> {
+    env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("live Aftermarket e2e requires {name}"))
 }

--- a/tests/remote_daemon_e2e/acme/mod.rs
+++ b/tests/remote_daemon_e2e/acme/mod.rs
@@ -118,6 +118,14 @@ impl FakeAcmeServer {
         &self.ca_pem
     }
 
+    pub fn validation_error(&self) -> Result<Option<String>, String> {
+        self.state
+            .progress
+            .lock()
+            .map_err(|_| "fake ACME progress lock poisoned".to_string())
+            .map(|progress| progress.validation_error.clone())
+    }
+
     pub async fn assert_complete(&self) -> Result<(), String> {
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {

--- a/tests/remote_daemon_e2e/process.rs
+++ b/tests/remote_daemon_e2e/process.rs
@@ -24,6 +24,15 @@ pub struct RemoteDaemonEnvironment {
     http_port: u16,
 }
 
+pub struct AftermarketDnsEnvironment<'a> {
+    pub zone_name: &'a str,
+    pub api_key: &'a str,
+    pub api_secret: &'a str,
+    pub visibility_timeout_seconds: u64,
+    pub visibility_poll_seconds: u64,
+    pub visibility_stable_polls: usize,
+}
+
 impl RemoteDaemonEnvironment {
     pub fn new(challenge: AcmeChallenge) -> Result<Self, String> {
         let temp = tempfile::Builder::new()
@@ -114,32 +123,50 @@ impl RemoteDaemonProcess {
         challenge: AcmeChallenge,
         directory_url: &str,
     ) -> Result<Self, String> {
+        let dns_provider = (challenge == AcmeChallenge::Dns).then_some("exec");
+        let mut command =
+            remote_daemon_command(environment, super::DOMAIN, challenge, dns_provider);
+        environment.apply(&mut command, directory_url);
+        Self::spawn_command(environment, directory_url, command)
+    }
+
+    pub fn spawn_aftermarket(
+        environment: &RemoteDaemonEnvironment,
+        domain: &str,
+        directory_url: &str,
+        aftermarket: &AftermarketDnsEnvironment<'_>,
+    ) -> Result<Self, String> {
+        let mut command =
+            remote_daemon_command(environment, domain, AcmeChallenge::Dns, Some("aftermarket"));
+        environment.apply(&mut command, directory_url);
+        command
+            .env("AFTERMARKET_ZONE_NAME", aftermarket.zone_name)
+            .env("AFTERMARKET_API_KEY", aftermarket.api_key)
+            .env("AFTERMARKET_API_SECRET", aftermarket.api_secret)
+            .env(
+                "HARNESS_REMOTE_ACME_DNS_VISIBILITY_TIMEOUT_SECONDS",
+                aftermarket.visibility_timeout_seconds.to_string(),
+            )
+            .env(
+                "HARNESS_REMOTE_ACME_DNS_VISIBILITY_POLL_SECONDS",
+                aftermarket.visibility_poll_seconds.to_string(),
+            )
+            .env(
+                "HARNESS_REMOTE_ACME_DNS_VISIBILITY_STABLE_POLLS",
+                aftermarket.visibility_stable_polls.to_string(),
+            );
+        Self::spawn_command(environment, directory_url, command)
+    }
+
+    fn spawn_command(
+        environment: &RemoteDaemonEnvironment,
+        directory_url: &str,
+        mut command: Command,
+    ) -> Result<Self, String> {
         let stdout = File::create(&environment.daemon_stdout)
             .map_err(|error| format!("create daemon stdout log: {error}"))?;
         let stderr = File::create(&environment.daemon_stderr)
             .map_err(|error| format!("create daemon stderr log: {error}"))?;
-        let mut command = Command::new(harness_binary());
-        command.args([
-            "daemon",
-            "remote",
-            "serve",
-            "--domain",
-            super::DOMAIN,
-            "--host",
-            "127.0.0.1",
-            "--https-port",
-            &environment.https_port.to_string(),
-            "--http-port",
-            &environment.http_port.to_string(),
-            "--acme-email",
-            "remote-e2e@example.com",
-            "--acme-challenge",
-            challenge.cli_name(),
-        ]);
-        if challenge == AcmeChallenge::Dns {
-            command.args(["--acme-dns-provider", "exec"]);
-        }
-        environment.apply(&mut command, directory_url);
         let child = command
             .stdin(Stdio::null())
             .stdout(Stdio::from(stdout))
@@ -250,6 +277,31 @@ impl RemoteDaemonProcess {
         }
     }
 
+    pub async fn wait_for_failure(&mut self, wait_timeout: Duration) -> Result<String, String> {
+        let deadline = Instant::now() + wait_timeout;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) if status.success() => {
+                    return Err(format!(
+                        "remote daemon unexpectedly succeeded; {}",
+                        self.diagnostics()
+                    ));
+                }
+                Ok(Some(_)) => return Ok(self.diagnostics()),
+                Ok(None) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                Ok(None) => {
+                    return Err(format!(
+                        "remote daemon did not fail within {wait_timeout:?}; {}",
+                        self.diagnostics()
+                    ));
+                }
+                Err(error) => return Err(format!("wait for remote daemon failure: {error}")),
+            }
+        }
+    }
+
     pub fn diagnostics(&self) -> String {
         let stdout = fs::read_to_string(&self.stdout_path).unwrap_or_default();
         let stderr = fs::read_to_string(&self.stderr_path).unwrap_or_default();
@@ -268,6 +320,36 @@ impl Drop for RemoteDaemonProcess {
 
 fn harness_binary() -> PathBuf {
     assert_cmd::cargo::cargo_bin("harness")
+}
+
+fn remote_daemon_command(
+    environment: &RemoteDaemonEnvironment,
+    domain: &str,
+    challenge: AcmeChallenge,
+    dns_provider: Option<&str>,
+) -> Command {
+    let mut command = Command::new(harness_binary());
+    command.args([
+        "daemon",
+        "remote",
+        "serve",
+        "--domain",
+        domain,
+        "--host",
+        "127.0.0.1",
+        "--https-port",
+        &environment.https_port.to_string(),
+        "--http-port",
+        &environment.http_port.to_string(),
+        "--acme-email",
+        "remote-e2e@example.com",
+        "--acme-challenge",
+        challenge.cli_name(),
+    ]);
+    if let Some(provider) = dns_provider {
+        command.args(["--acme-dns-provider", provider]);
+    }
+    command
 }
 
 fn unused_port() -> Result<u16, String> {


### PR DESCRIPTION
## Motivation

Aftermarket can accept a DNS-01 change while authoritative servers expose transient or inconsistent states. The daemon accepted one observation and timeout diagnostics hid per-server state, so failed-issuance cleanup could not be proven reliably.

## Implementation

- Query each authoritative nameserver IP through a fresh resolver and require configurable consecutive agreement.
- Report redacted per-endpoint absent, different-value, and query-error states with provider-neutral visibility settings.
- Prove readiness failures await cleanup and add an opt-in live Aftermarket failure-path e2e.
- Document the controls and live-test contract.
- Verified provider and issuer unit slices, the self-contained remote daemon e2e, `codegen:check`, `harness:check`, `check`, and a real-server Aftermarket run with 30 clean absence samples over 60 seconds.