### PR TITLE
feat(remote): audit authorization decisions

### DIFF
--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -14,7 +14,8 @@ use crate::daemon::remote_auth::{
 };
 use crate::daemon::remote_identity::RemoteStoredClient;
 
-use super::DaemonHttpState;
+use super::auth_audit::RemoteHttpAuditContext;
+use super::{DaemonHttpState, auth_audit};
 
 const REMOTE_AUTH_STORE_UNAVAILABLE_MESSAGE: &str = "remote authentication store is unavailable";
 
@@ -106,15 +107,56 @@ pub(crate) async fn authorize_remote_http_request(
     let Some(route) = http_route_contract(request.method(), route_path) else {
         return remote_auth_error_response(RemoteAuthError::MissingScopeContract);
     };
-    match verify_and_authorize_http_route(request.headers(), &state, route) {
-        Ok(client) => {
-            let actor = client.control_plane_actor_id();
-            REMOTE_HTTP_CLIENT
-                .scope(client, with_control_plane_actor(actor, next.run(request)))
-                .await
-        }
-        Err(response) => *response,
+    let client = match authenticate_and_audit_remote_http_request(&request, &state, route) {
+        Ok(client) => client,
+        Err(response) => return *response,
+    };
+    let actor = client.control_plane_actor_id();
+    REMOTE_HTTP_CLIENT
+        .scope(client, with_control_plane_actor(actor, next.run(request)))
+        .await
+}
+
+fn authenticate_and_audit_remote_http_request(
+    request: &Request<Body>,
+    state: &DaemonHttpState,
+    route: &HttpApiRouteContract,
+) -> Result<RemoteStoredClient, Box<Response>> {
+    let audit = RemoteHttpAuditContext::from_request(request, route)
+        .map_err(|error| Box::new(remote_auth_error_response(error)))?;
+    let client = verify_remote_client(request.headers(), state)
+        .map_err(|response| Box::new(audit_verification_failure(&audit, state, *response)))?;
+    authorize_and_audit_remote_http_client(&audit, state, route, client)
+}
+
+fn audit_verification_failure(
+    audit: &RemoteHttpAuditContext,
+    state: &DaemonHttpState,
+    response: Response,
+) -> Response {
+    let error_detail = auth_audit::authentication_error_detail(response.status());
+    match audit.record_denied(state, None, error_detail) {
+        Ok(()) => response,
+        Err(error) => auth_audit::unavailable_response(&error),
     }
+}
+
+fn authorize_and_audit_remote_http_client(
+    audit: &RemoteHttpAuditContext,
+    state: &DaemonHttpState,
+    route: &HttpApiRouteContract,
+    client: RemoteStoredClient,
+) -> Result<RemoteStoredClient, Box<Response>> {
+    if let Err(error) = authorize_remote_http_route(&client, route) {
+        return match audit.record_denied(state, Some(&client.client_id), &error.to_string()) {
+            Ok(()) => Err(Box::new(remote_auth_error_response(error))),
+            Err(audit_error) => Err(Box::new(auth_audit::unavailable_response(&audit_error))),
+        };
+    }
+    audit
+        .record_allowed(state, &client.client_id)
+        .map_err(|error| Box::new(auth_audit::unavailable_response(&error)))?;
+    Ok(client)
 }
 
 fn require_local_auth(headers: &HeaderMap, state: &DaemonHttpState) -> Result<(), Box<Response>> {
@@ -166,6 +208,7 @@ fn verify_remote_client(
         })
 }
 
+#[cfg(test)]
 fn verify_and_authorize_http_route(
     headers: &HeaderMap,
     state: &DaemonHttpState,

--- a/src/daemon/http/auth_audit.rs
+++ b/src/daemon/http/auth_audit.rs
@@ -1,0 +1,115 @@
+use axum::Json;
+use axum::body::Body;
+use axum::extract::connect_info::ConnectInfo;
+use axum::http::{HeaderMap, Request, StatusCode};
+use axum::response::{IntoResponse as _, Response};
+
+use crate::daemon::protocol::HttpApiRouteContract;
+use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_auth::{
+    REMOTE_CLIENT_ID_HEADER, RemoteAuthError, remote_http_required_scope,
+};
+use crate::daemon::remote_request_audit::RemoteAuthorizationAudit;
+use crate::errors::CliError;
+
+use super::{DaemonConnectInfo, DaemonHttpState};
+
+const AUDIT_CLIENT_ID_MAX_CHARS: usize = 256;
+const REMOTE_AUDIT_UNAVAILABLE_MESSAGE: &str = "remote authorization audit is unavailable";
+
+pub(super) struct RemoteHttpAuditContext {
+    request_id: String,
+    attempted_client_id: Option<String>,
+    target: String,
+    scope: RemoteAccessScope,
+    remote_addr: Option<String>,
+}
+
+impl RemoteHttpAuditContext {
+    pub(super) fn from_request(
+        request: &Request<Body>,
+        route: &HttpApiRouteContract,
+    ) -> Result<Self, RemoteAuthError> {
+        Ok(Self {
+            request_id: super::extract_request_id(request.headers()),
+            attempted_client_id: attempted_client_id(request.headers()),
+            target: format!("{} {}", request.method(), route.path),
+            scope: remote_http_required_scope(route)?,
+            remote_addr: request
+                .extensions()
+                .get::<ConnectInfo<DaemonConnectInfo>>()
+                .map(|ConnectInfo(info)| info.remote_addr().ip().to_string()),
+        })
+    }
+
+    pub(super) fn record_allowed(
+        &self,
+        state: &DaemonHttpState,
+        client_id: &str,
+    ) -> Result<(), CliError> {
+        RemoteAuthorizationAudit::allowed(
+            &self.request_id,
+            client_id,
+            &self.target,
+            self.scope,
+            self.remote_addr.as_deref(),
+        )
+        .record(state.db.get())
+    }
+
+    pub(super) fn record_denied(
+        &self,
+        state: &DaemonHttpState,
+        client_id: Option<&str>,
+        error_detail: &str,
+    ) -> Result<(), CliError> {
+        RemoteAuthorizationAudit::denied(
+            &self.request_id,
+            client_id.or(self.attempted_client_id.as_deref()),
+            &self.target,
+            self.scope,
+            self.remote_addr.as_deref(),
+            error_detail,
+        )
+        .record(state.db.get())
+    }
+}
+
+pub(super) fn authentication_error_detail(status: StatusCode) -> &'static str {
+    if status == StatusCode::SERVICE_UNAVAILABLE {
+        "remote authentication store is unavailable"
+    } else {
+        "remote authentication denied"
+    }
+}
+
+pub(super) fn unavailable_response(error: &CliError) -> Response {
+    log_unavailable(error);
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": {
+                "code": "REMOTE_AUDIT",
+                "message": REMOTE_AUDIT_UNAVAILABLE_MESSAGE,
+            }
+        })),
+    )
+        .into_response()
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion inflates the score; tokio-rs/tracing#553"
+)]
+fn log_unavailable(error: &CliError) {
+    tracing::error!(error = %error, "remote authorization audit failed");
+}
+
+fn attempted_client_id(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(REMOTE_CLIENT_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.chars().take(AUDIT_CLIENT_ID_MAX_CHARS).collect())
+}

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -39,6 +39,7 @@ use crate::telemetry::{apply_parent_context_from_headers, current_trace_id, with
 mod agents;
 mod audit;
 mod auth;
+mod auth_audit;
 mod core;
 mod improver;
 mod managed_agents;

--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -43,6 +43,7 @@ mod decode_failure_telemetry;
 mod policy_io_route_parity;
 mod remote_actor;
 mod remote_authz;
+mod remote_authz_audit;
 mod remote_pairing;
 mod reviews_policy_writes;
 mod session_archive_tests;

--- a/src/daemon/http/tests/remote_authz_audit.rs
+++ b/src/daemon/http/tests/remote_authz_audit.rs
@@ -112,6 +112,46 @@ async fn remote_authorization_audit_redacts_unauthenticated_attempts() {
 }
 
 #[tokio::test]
+async fn remote_authorization_audit_bounds_client_controlled_request_ids() {
+    const MAX_PERSISTED_REQUEST_ID_BYTES: usize = 256;
+
+    let state = remote_state_with_viewer();
+    let audit_state = state.clone();
+    let (base_url, server) = serve_remote(state).await;
+    let oversized_request_id = "request-id-".repeat(256);
+
+    let response = reqwest::Client::new()
+        .get(format!("{base_url}{}", http_paths::HEALTH))
+        .header("x-request-id", &oversized_request_id)
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .send()
+        .await
+        .expect("send oversized HTTP request id");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let request = remote_ws_request(&base_url, "viewer", "audit-ws-bounded-handshake");
+    let (mut socket, _) = connect_async(request).await.expect("connect websocket");
+    let response = ws_rpc(&mut socket, &oversized_request_id, ws_methods::PING).await;
+    assert_eq!(response["error"], serde_json::Value::Null);
+
+    let events = remote_audits(&audit_state);
+    let http = events
+        .iter()
+        .find(|event| event.route_or_method == format!("GET {}", http_paths::HEALTH))
+        .expect("HTTP audit event");
+    assert_bounded_request_id(http, MAX_PERSISTED_REQUEST_ID_BYTES);
+    let websocket = events
+        .iter()
+        .find(|event| event.route_or_method == ws_methods::PING)
+        .expect("WebSocket audit event");
+    assert_bounded_request_id(websocket, MAX_PERSISTED_REQUEST_ID_BYTES);
+
+    let _ = socket.close(None).await;
+    stop_server(server).await;
+}
+
+#[tokio::test]
 async fn remote_authorization_audit_fails_closed_without_a_store() {
     let state = remote_state_with_viewer();
     drop_remote_audit_table(&state);
@@ -235,6 +275,12 @@ fn audit_for_request<'a>(
         .iter()
         .find(|event| event.request_id.as_deref() == Some(request_id))
         .unwrap_or_else(|| panic!("missing audit for {request_id}: {events:?}"))
+}
+
+fn assert_bounded_request_id(event: &RemoteStoredAuditEvent, max_bytes: usize) {
+    let request_id = event.request_id.as_deref().expect("audit request id");
+    assert!(request_id.len() <= max_bytes, "oversized audit request id");
+    assert!(request_id.ends_with("..."), "missing truncation marker");
 }
 
 fn drop_remote_audit_table(state: &DaemonHttpState) {

--- a/src/daemon/http/tests/remote_authz_audit.rs
+++ b/src/daemon/http/tests/remote_authz_audit.rs
@@ -1,0 +1,326 @@
+use axum::http::{Request, StatusCode};
+use futures_util::{Sink, SinkExt as _, Stream, StreamExt as _};
+use rusqlite::Connection;
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, timeout};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
+use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message};
+
+use crate::daemon::http::{DaemonConnectInfo, DaemonHttpAuthMode, DaemonHttpState};
+use crate::daemon::protocol::{http_paths, ws_methods};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_auth::REMOTE_CLIENT_ID_HEADER;
+use crate::daemon::remote_identity::{
+    RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteClientRegistration, RemoteStoredAuditEvent,
+};
+
+use super::test_http_state_with_db;
+
+#[tokio::test]
+async fn remote_authorization_audit_records_http_allow_and_deny() {
+    let state = remote_state_with_viewer();
+    let audit_state = state.clone();
+    let (base_url, server) = serve_remote(state).await;
+
+    let allowed = reqwest::Client::new()
+        .get(format!("{base_url}{}", http_paths::HEALTH))
+        .header("x-request-id", "audit-http-allowed")
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .send()
+        .await
+        .expect("send allowed request");
+    assert_eq!(allowed.status(), StatusCode::OK);
+
+    let denied = reqwest::Client::new()
+        .post(format!("{base_url}{}", http_paths::DAEMON_TELEMETRY))
+        .header("x-request-id", "audit-http-denied")
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .json(&json!({"kind": "decode_failure"}))
+        .send()
+        .await
+        .expect("send denied request");
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+
+    let events = remote_audits(&audit_state);
+    let allowed = audit_for_request(&events, "audit-http-allowed");
+    assert_eq!(allowed.client_id.as_deref(), Some("viewer"));
+    assert_eq!(
+        allowed.route_or_method,
+        format!("GET {}", http_paths::HEALTH)
+    );
+    assert_eq!(allowed.scope, RemoteAccessScope::Read);
+    assert_eq!(allowed.scope_decision, RemoteAuditScopeDecision::Allowed);
+    assert_eq!(allowed.outcome, RemoteAuditOutcome::Success);
+    assert_eq!(allowed.remote_addr.as_deref(), Some("127.0.0.1"));
+    assert_eq!(allowed.error_detail, None);
+
+    let denied = audit_for_request(&events, "audit-http-denied");
+    assert_eq!(denied.client_id.as_deref(), Some("viewer"));
+    assert_eq!(
+        denied.route_or_method,
+        format!("POST {}", http_paths::DAEMON_TELEMETRY)
+    );
+    assert_eq!(denied.scope, RemoteAccessScope::Write);
+    assert_eq!(denied.scope_decision, RemoteAuditScopeDecision::Denied);
+    assert_eq!(denied.outcome, RemoteAuditOutcome::Failure);
+    assert_eq!(denied.remote_addr.as_deref(), Some("127.0.0.1"));
+    assert_eq!(
+        denied.error_detail.as_deref(),
+        Some("remote client scope is insufficient")
+    );
+
+    stop_server(server).await;
+}
+
+#[tokio::test]
+async fn remote_authorization_audit_redacts_unauthenticated_attempts() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let audit_state = state.clone();
+    let (base_url, server) = serve_remote(state).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{base_url}{}", http_paths::HEALTH))
+        .header("x-request-id", "audit-http-unauthenticated")
+        .bearer_auth("must-not-be-persisted")
+        .send()
+        .await
+        .expect("send unauthenticated request");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let events = remote_audits(&audit_state);
+    let event = audit_for_request(&events, "audit-http-unauthenticated");
+    assert_eq!(event.client_id, None);
+    assert_eq!(event.scope, RemoteAccessScope::Read);
+    assert_eq!(event.scope_decision, RemoteAuditScopeDecision::Denied);
+    assert_eq!(event.outcome, RemoteAuditOutcome::Failure);
+    assert_eq!(event.remote_addr.as_deref(), Some("127.0.0.1"));
+    assert!(
+        !event
+            .error_detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("must-not-be-persisted")
+    );
+
+    stop_server(server).await;
+}
+
+#[tokio::test]
+async fn remote_authorization_audit_fails_closed_without_a_store() {
+    let state = remote_state_with_viewer();
+    drop_remote_audit_table(&state);
+    let (base_url, server) = serve_remote(state).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{base_url}{}", http_paths::HEALTH))
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .send()
+        .await
+        .expect("send request without audit store");
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = response
+        .json::<serde_json::Value>()
+        .await
+        .expect("error json");
+    assert_eq!(body["error"]["code"], "REMOTE_AUDIT");
+
+    stop_server(server).await;
+}
+
+#[tokio::test]
+async fn remote_authorization_audit_records_websocket_methods() {
+    let state = remote_state_with_viewer();
+    let audit_state = state.clone();
+    let (base_url, server) = serve_remote(state).await;
+    let request = remote_ws_request(&base_url, "viewer", "audit-ws-handshake");
+    let (mut socket, _) = connect_async(request).await.expect("connect websocket");
+
+    let ping = ws_rpc(&mut socket, "audit-ws-read", ws_methods::PING).await;
+    assert_eq!(ping["error"], serde_json::Value::Null);
+    let denied = ws_rpc(&mut socket, "audit-ws-write", ws_methods::SESSION_START).await;
+    assert_eq!(denied["error"]["code"], "REMOTE_AUTH");
+
+    let events = remote_audits(&audit_state);
+    let handshake = audit_for_request(&events, "audit-ws-handshake");
+    assert_eq!(handshake.route_or_method, format!("GET {}", http_paths::WS));
+    assert_eq!(handshake.remote_addr.as_deref(), Some("127.0.0.1"));
+
+    let read = audit_for_request(&events, "audit-ws-read");
+    assert_eq!(read.route_or_method, ws_methods::PING);
+    assert_eq!(read.scope, RemoteAccessScope::Read);
+    assert_eq!(read.scope_decision, RemoteAuditScopeDecision::Allowed);
+    assert_eq!(read.outcome, RemoteAuditOutcome::Success);
+    assert_eq!(read.remote_addr.as_deref(), Some("127.0.0.1"));
+
+    let write = audit_for_request(&events, "audit-ws-write");
+    assert_eq!(write.route_or_method, ws_methods::SESSION_START);
+    assert_eq!(write.scope, RemoteAccessScope::Write);
+    assert_eq!(write.scope_decision, RemoteAuditScopeDecision::Denied);
+    assert_eq!(write.outcome, RemoteAuditOutcome::Failure);
+    assert_eq!(write.remote_addr.as_deref(), Some("127.0.0.1"));
+    assert_eq!(
+        write.error_detail.as_deref(),
+        Some("remote client scope is insufficient")
+    );
+
+    let _ = socket.close(None).await;
+    stop_server(server).await;
+}
+
+#[tokio::test]
+async fn remote_authorization_audit_fails_closed_websocket_dispatch() {
+    let state = remote_state_with_viewer();
+    let audit_state = state.clone();
+    let (base_url, server) = serve_remote(state).await;
+    let request = remote_ws_request(&base_url, "viewer", "audit-ws-before-drop");
+    let (mut socket, _) = connect_async(request).await.expect("connect websocket");
+    drop_remote_audit_table(&audit_state);
+
+    let response = ws_rpc(&mut socket, "audit-ws-no-store", ws_methods::PING).await;
+    assert_eq!(response["result"], serde_json::Value::Null);
+    assert_eq!(response["error"]["code"], "REMOTE_AUDIT");
+    assert_eq!(response["error"]["status_code"], 503);
+
+    let _ = socket.close(None).await;
+    stop_server(server).await;
+}
+
+fn remote_state_with_viewer() -> DaemonHttpState {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let registration = RemoteClientRegistration::new_for_tests(
+        "viewer",
+        "Viewer",
+        "macos",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        &remote_token("viewer"),
+        "2026-07-12T08:00:00Z",
+    )
+    .expect("remote registration");
+    state
+        .db
+        .get()
+        .expect("db slot")
+        .lock()
+        .expect("db lock")
+        .register_remote_client(&registration)
+        .expect("register viewer");
+    state
+}
+
+fn remote_audits(state: &DaemonHttpState) -> Vec<RemoteStoredAuditEvent> {
+    state
+        .db
+        .get()
+        .expect("db slot")
+        .lock()
+        .expect("db lock")
+        .load_remote_audit_events(20)
+        .expect("load remote audits")
+}
+
+fn audit_for_request<'a>(
+    events: &'a [RemoteStoredAuditEvent],
+    request_id: &str,
+) -> &'a RemoteStoredAuditEvent {
+    events
+        .iter()
+        .find(|event| event.request_id.as_deref() == Some(request_id))
+        .unwrap_or_else(|| panic!("missing audit for {request_id}: {events:?}"))
+}
+
+fn drop_remote_audit_table(state: &DaemonHttpState) {
+    Connection::open(state.db_path.as_ref().expect("db path"))
+        .expect("open audit db")
+        .execute("DROP TABLE remote_audit_events", [])
+        .expect("drop remote audit table");
+}
+
+fn remote_token(client_id: &str) -> String {
+    format!("remote-token-secret-{client_id}")
+}
+
+fn remote_ws_request(base_url: &str, client_id: &str, request_id: &str) -> Request<()> {
+    let mut request = format!(
+        "{}{}",
+        base_url.replacen("http://", "ws://", 1),
+        http_paths::WS
+    )
+    .into_client_request()
+    .expect("websocket request");
+    request.headers_mut().insert(
+        REMOTE_CLIENT_ID_HEADER,
+        client_id.parse().expect("client id header"),
+    );
+    request.headers_mut().insert(
+        "authorization",
+        format!("Bearer {}", remote_token(client_id))
+            .parse()
+            .expect("authorization header"),
+    );
+    request.headers_mut().insert(
+        "x-request-id",
+        request_id.parse().expect("request id header"),
+    );
+    request
+}
+
+async fn ws_rpc<S>(socket: &mut S, id: &str, method: &str) -> serde_json::Value
+where
+    S: Sink<Message, Error = WebSocketError>
+        + Stream<Item = Result<Message, WebSocketError>>
+        + Unpin,
+{
+    timeout(Duration::from_secs(5), async {
+        socket
+            .send(Message::Text(
+                json!({"id": id, "method": method, "params": {}})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .expect("send websocket request");
+        while let Some(frame) = socket.next().await {
+            let Message::Text(text) = frame.expect("read websocket frame") else {
+                continue;
+            };
+            let value = serde_json::from_str::<serde_json::Value>(&text).expect("websocket json");
+            if value["id"].as_str() == Some(id) {
+                return value;
+            }
+        }
+        panic!("missing websocket response for {id}");
+    })
+    .await
+    .expect("websocket response timeout")
+}
+
+async fn serve_remote(state: DaemonHttpState) -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener address");
+    let app = super::super::daemon_http_router(state);
+    let server = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<DaemonConnectInfo>(),
+        )
+        .await
+        .expect("serve remote router");
+    });
+    (format!("http://{addr}"), server)
+}
+
+async fn stop_server(server: JoinHandle<()>) {
+    server.abort();
+    let _ = server.await;
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -51,6 +51,7 @@ pub(crate) mod remote_crypto;
 pub mod remote_identity;
 pub mod remote_pairing;
 pub(crate) mod remote_redaction;
+pub(crate) mod remote_request_audit;
 pub mod remote_tls;
 pub mod service;
 pub mod snapshot;

--- a/src/daemon/remote_auth.rs
+++ b/src/daemon/remote_auth.rs
@@ -137,7 +137,7 @@ pub fn authorize_remote_http_route(
     client: &RemoteStoredClient,
     route: &HttpApiRouteContract,
 ) -> Result<RemoteAuthDecision, RemoteAuthError> {
-    let required_scope = first_required_scope(remote_http_scopes(route))?;
+    let required_scope = remote_http_required_scope(route)?;
     authorize_client_scope(client, required_scope)?;
     Ok(RemoteAuthDecision {
         client_id: client.client_id.clone(),
@@ -189,7 +189,7 @@ pub fn authorize_remote_ws_method(
     client: &RemoteStoredClient,
     method: &str,
 ) -> Result<RemoteAuthDecision, RemoteAuthError> {
-    let required_scope = first_required_scope(remote_ws_scopes(method))?;
+    let required_scope = remote_ws_required_scope(method)?;
     authorize_client_scope(client, required_scope)?;
     Ok(RemoteAuthDecision {
         client_id: client.client_id.clone(),
@@ -198,6 +198,16 @@ pub fn authorize_remote_ws_method(
         },
         required_scope,
     })
+}
+
+pub(crate) fn remote_http_required_scope(
+    route: &HttpApiRouteContract,
+) -> Result<RemoteAccessScope, RemoteAuthError> {
+    first_required_scope(remote_http_scopes(route))
+}
+
+pub(crate) fn remote_ws_required_scope(method: &str) -> Result<RemoteAccessScope, RemoteAuthError> {
+    first_required_scope(remote_ws_scopes(method))
 }
 
 fn first_required_scope(

--- a/src/daemon/remote_request_audit.rs
+++ b/src/daemon/remote_request_audit.rs
@@ -1,0 +1,91 @@
+use std::sync::{Arc, Mutex};
+
+use uuid::Uuid;
+
+use super::db::DaemonDb;
+use super::remote::RemoteAccessScope;
+use super::remote_identity::{RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision};
+use crate::errors::{CliError, CliErrorKind};
+use crate::workspace::utc_now;
+
+pub(crate) struct RemoteAuthorizationAudit<'a> {
+    request_id: &'a str,
+    client_id: Option<&'a str>,
+    target: &'a str,
+    scope: RemoteAccessScope,
+    decision: RemoteAuditScopeDecision,
+    remote_addr: Option<&'a str>,
+    error_detail: Option<&'a str>,
+}
+
+impl<'a> RemoteAuthorizationAudit<'a> {
+    pub(crate) fn allowed(
+        request_id: &'a str,
+        client_id: &'a str,
+        target: &'a str,
+        scope: RemoteAccessScope,
+        remote_addr: Option<&'a str>,
+    ) -> Self {
+        Self {
+            request_id,
+            client_id: Some(client_id),
+            target,
+            scope,
+            decision: RemoteAuditScopeDecision::Allowed,
+            remote_addr,
+            error_detail: None,
+        }
+    }
+
+    pub(crate) fn denied(
+        request_id: &'a str,
+        client_id: Option<&'a str>,
+        target: &'a str,
+        scope: RemoteAccessScope,
+        remote_addr: Option<&'a str>,
+        error_detail: &'a str,
+    ) -> Self {
+        Self {
+            request_id,
+            client_id,
+            target,
+            scope,
+            decision: RemoteAuditScopeDecision::Denied,
+            remote_addr,
+            error_detail: Some(error_detail),
+        }
+    }
+
+    /// Persist the authorization decision before the request reaches its handler.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the audit store is unavailable or rejects the event.
+    pub(crate) fn record(self, db: Option<&Arc<Mutex<DaemonDb>>>) -> Result<(), CliError> {
+        let db = db.ok_or_else(|| {
+            CliError::from(CliErrorKind::workflow_io(
+                "remote authorization audit store is unavailable",
+            ))
+        })?;
+        let db = db.lock().map_err(|error| {
+            CliError::from(CliErrorKind::workflow_io(format!(
+                "remote authorization audit store lock: {error}"
+            )))
+        })?;
+        let outcome = match self.decision {
+            RemoteAuditScopeDecision::Allowed => RemoteAuditOutcome::Success,
+            RemoteAuditScopeDecision::Denied => RemoteAuditOutcome::Failure,
+        };
+        db.record_remote_audit_event(&RemoteAuditEvent::new(
+            format!("remote-auth-{}", Uuid::new_v4()),
+            utc_now(),
+            Some(self.request_id),
+            self.client_id,
+            self.target,
+            self.scope,
+            self.decision,
+            outcome,
+            self.remote_addr,
+            self.error_detail,
+        ))
+    }
+}

--- a/src/daemon/remote_request_audit.rs
+++ b/src/daemon/remote_request_audit.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
 use uuid::Uuid;
@@ -7,6 +8,9 @@ use super::remote::RemoteAccessScope;
 use super::remote_identity::{RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision};
 use crate::errors::{CliError, CliErrorKind};
 use crate::workspace::utc_now;
+
+const REMOTE_AUDIT_REQUEST_ID_MAX_BYTES: usize = 256;
+const REMOTE_AUDIT_TRUNCATION_MARKER: &str = "...";
 
 pub(crate) struct RemoteAuthorizationAudit<'a> {
     request_id: &'a str,
@@ -75,10 +79,11 @@ impl<'a> RemoteAuthorizationAudit<'a> {
             RemoteAuditScopeDecision::Allowed => RemoteAuditOutcome::Success,
             RemoteAuditScopeDecision::Denied => RemoteAuditOutcome::Failure,
         };
+        let request_id = bounded_request_id(self.request_id);
         db.record_remote_audit_event(&RemoteAuditEvent::new(
             format!("remote-auth-{}", Uuid::new_v4()),
             utc_now(),
-            Some(self.request_id),
+            Some(request_id.as_ref()),
             self.client_id,
             self.target,
             self.scope,
@@ -87,5 +92,35 @@ impl<'a> RemoteAuthorizationAudit<'a> {
             self.remote_addr,
             self.error_detail,
         ))
+    }
+}
+
+fn bounded_request_id(request_id: &str) -> Cow<'_, str> {
+    if request_id.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES {
+        return Cow::Borrowed(request_id);
+    }
+    let mut boundary = REMOTE_AUDIT_REQUEST_ID_MAX_BYTES - REMOTE_AUDIT_TRUNCATION_MARKER.len();
+    while !request_id.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    let mut bounded = String::with_capacity(REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
+    bounded.push_str(&request_id[..boundary]);
+    bounded.push_str(REMOTE_AUDIT_TRUNCATION_MARKER);
+    Cow::Owned(bounded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_authorization_audit_bounds_unicode_request_ids_on_a_character_boundary() {
+        let request_id = "\u{17c}".repeat(256);
+
+        let bounded = bounded_request_id(&request_id);
+
+        assert!(bounded.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
+        assert!(bounded.ends_with(REMOTE_AUDIT_TRUNCATION_MARKER));
+        assert!(bounded.is_char_boundary(bounded.len()));
     }
 }

--- a/src/daemon/websocket/connection.rs
+++ b/src/daemon/websocket/connection.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use axum::extract::State;
+use axum::Extension;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{ConnectInfo, State};
 use axum::http::HeaderMap;
-use axum::http::header::{AUTHORIZATION, ORIGIN, USER_AGENT};
 use axum::response::Response;
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
@@ -15,13 +15,14 @@ use tracing::Instrument as _;
 use tracing::field::{Empty, display};
 use tracing::{debug, info, warn};
 
-use crate::daemon::http::{self, DaemonHttpState};
+use crate::daemon::http::{self, DaemonConnectInfo, DaemonHttpState};
 #[cfg(test)]
 use crate::daemon::protocol::StreamEvent;
 use crate::daemon::remote_identity::RemoteStoredClient;
 use crate::telemetry::{apply_parent_context_from_headers, current_trace_id, with_active_baggage};
 
 use super::config::build_config_push_frame;
+use super::connection_metadata::WebSocketHandshakeMetadata;
 use super::dispatch::handle_message;
 use super::relay::relay_broadcast;
 
@@ -29,6 +30,7 @@ pub(crate) struct ConnectionState {
     pub(crate) global_subscription: bool,
     pub(crate) session_subscriptions: HashSet<String>,
     remote_client: Option<RemoteStoredClient>,
+    remote_addr: Option<String>,
     /// Highest broadcast `seq` this connection has relayed. On a `Lagged`
     /// overflow the relay replays the buffer from here before falling back to a
     /// full recovery snapshot.
@@ -38,25 +40,33 @@ pub(crate) struct ConnectionState {
 impl ConnectionState {
     #[cfg(test)]
     pub(crate) fn new() -> Self {
-        Self::new_with_remote_client(None)
+        Self::new_with_remote_client(None, None)
     }
 
     #[cfg(test)]
     pub(crate) fn new_remote(remote_client: RemoteStoredClient) -> Self {
-        Self::new_with_remote_client(Some(remote_client))
+        Self::new_with_remote_client(Some(remote_client), None)
     }
 
-    fn new_with_remote_client(remote_client: Option<RemoteStoredClient>) -> Self {
+    fn new_with_remote_client(
+        remote_client: Option<RemoteStoredClient>,
+        remote_addr: Option<String>,
+    ) -> Self {
         Self {
             global_subscription: false,
             session_subscriptions: HashSet::new(),
             remote_client,
+            remote_addr,
             last_relayed_seq: 0,
         }
     }
 
     pub(crate) fn remote_client(&self) -> Option<&RemoteStoredClient> {
         self.remote_client.as_ref()
+    }
+
+    pub(crate) fn remote_addr(&self) -> Option<&str> {
+        self.remote_addr.as_deref()
     }
 
     #[cfg(test)]
@@ -77,145 +87,10 @@ impl ConnectionState {
     }
 }
 
-const HEADER_CLIENT_NAME: &str = "x-harness-client-name";
-const HEADER_CLIENT_VERSION: &str = "x-harness-client-version";
-const HEADER_CLIENT_BUNDLE_ID: &str = "x-harness-client-bundle-id";
-const HEADER_CLIENT_PID: &str = "x-harness-client-pid";
-const HEADER_CLIENT_LAUNCH_MODE: &str = "x-harness-client-launch-mode";
-const HEADER_SEC_WEBSOCKET_PROTOCOL: &str = "sec-websocket-protocol";
-const MISSING_METADATA: &str = "<missing>";
-const HEADER_VALUE_LOG_LIMIT: usize = 160;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct WebSocketHandshakeMetadata {
-    client_name: Option<String>,
-    client_version: Option<String>,
-    client_bundle_id: Option<String>,
-    client_pid: Option<String>,
-    client_launch_mode: Option<String>,
-    user_agent: Option<String>,
-    origin: Option<String>,
-    websocket_protocol: Option<String>,
-    auth_state: &'static str,
-}
-
-impl WebSocketHandshakeMetadata {
-    fn from_headers(headers: &HeaderMap) -> Self {
-        Self {
-            client_name: header_summary(headers, HEADER_CLIENT_NAME),
-            client_version: header_summary(headers, HEADER_CLIENT_VERSION),
-            client_bundle_id: header_summary(headers, HEADER_CLIENT_BUNDLE_ID),
-            client_pid: header_summary(headers, HEADER_CLIENT_PID),
-            client_launch_mode: header_summary(headers, HEADER_CLIENT_LAUNCH_MODE),
-            user_agent: header_summary(headers, USER_AGENT.as_str()),
-            origin: header_summary(headers, ORIGIN.as_str()),
-            websocket_protocol: header_summary(headers, HEADER_SEC_WEBSOCKET_PROTOCOL),
-            auth_state: auth_header_state(headers),
-        }
-    }
-
-    fn client_label(&self) -> String {
-        let mut label = self
-            .client_name
-            .clone()
-            .or_else(|| self.user_agent.clone())
-            .unwrap_or_else(|| "unknown".to_string());
-        if self.client_name.is_some()
-            && let Some(version) = &self.client_version
-        {
-            label.push('/');
-            label.push_str(version);
-        }
-        let mut details = Vec::new();
-        if let Some(bundle_id) = &self.client_bundle_id {
-            details.push(format!("bundle={bundle_id}"));
-        }
-        if let Some(pid) = &self.client_pid {
-            details.push(format!("pid={pid}"));
-        }
-        if let Some(launch_mode) = &self.client_launch_mode {
-            details.push(format!("launch={launch_mode}"));
-        }
-        if details.is_empty() {
-            label
-        } else {
-            format!("{label} ({})", details.join("; "))
-        }
-    }
-
-    fn record_on_span(&self, span: &tracing::Span) {
-        let client = self.client_label();
-        span.record("client", display(&client));
-        span.record(
-            "client_name",
-            display(self.client_name.as_deref().unwrap_or(MISSING_METADATA)),
-        );
-        span.record(
-            "client_version",
-            display(self.client_version.as_deref().unwrap_or(MISSING_METADATA)),
-        );
-        span.record(
-            "client_bundle_id",
-            display(self.client_bundle_id.as_deref().unwrap_or(MISSING_METADATA)),
-        );
-        span.record(
-            "client_pid",
-            display(self.client_pid.as_deref().unwrap_or(MISSING_METADATA)),
-        );
-        span.record(
-            "client_launch_mode",
-            display(
-                self.client_launch_mode
-                    .as_deref()
-                    .unwrap_or(MISSING_METADATA),
-            ),
-        );
-        span.record(
-            "user_agent",
-            display(self.user_agent.as_deref().unwrap_or(MISSING_METADATA)),
-        );
-        span.record(
-            "origin",
-            display(self.origin.as_deref().unwrap_or(MISSING_METADATA)),
-        );
-        span.record(
-            "websocket_protocol",
-            display(
-                self.websocket_protocol
-                    .as_deref()
-                    .unwrap_or(MISSING_METADATA),
-            ),
-        );
-        span.record("auth_state", display(self.auth_state));
-    }
-}
-
-fn header_summary(headers: &HeaderMap, name: &str) -> Option<String> {
-    let raw = headers.get(name)?.to_str().ok()?.trim();
-    if raw.is_empty() {
-        return None;
-    }
-    let mut summary = raw.chars().take(HEADER_VALUE_LOG_LIMIT).collect::<String>();
-    if raw.chars().count() > HEADER_VALUE_LOG_LIMIT {
-        summary.push_str("...");
-    }
-    Some(summary)
-}
-
-fn auth_header_state(headers: &HeaderMap) -> &'static str {
-    match headers.get(AUTHORIZATION) {
-        None => "missing",
-        Some(value) => match value.to_str() {
-            Ok(raw) if raw.trim().starts_with("Bearer ") => "bearer-present",
-            Ok(_) => "non-bearer",
-            Err(_) => "invalid-utf8",
-        },
-    }
-}
-
-pub async fn ws_upgrade_handler(
+pub(crate) async fn ws_upgrade_handler(
     headers: HeaderMap,
     State(state): State<DaemonHttpState>,
+    connect_info: Option<Extension<ConnectInfo<DaemonConnectInfo>>>,
     ws: WebSocketUpgrade,
 ) -> Response {
     let request_id = http::extract_request_id(&headers);
@@ -232,10 +107,12 @@ pub async fn ws_upgrade_handler(
             return *response;
         }
     };
+    let remote_addr =
+        connect_info.map(|Extension(ConnectInfo(info))| info.remote_addr().ip().to_string());
     ws.on_upgrade(move |socket| async move {
         with_active_baggage(
             baggage,
-            handle_connection(socket, state, client_label, remote_client)
+            handle_connection(socket, state, client_label, remote_client, remote_addr)
                 .instrument(connection_span.clone()),
         )
         .await;
@@ -289,11 +166,13 @@ async fn handle_connection(
     state: DaemonHttpState,
     client_label: String,
     remote_client: Option<RemoteStoredClient>,
+    remote_addr: Option<String>,
 ) {
     tracing::info!(client = %client_label, "websocket connection opened");
     let (mut sender, mut receiver) = socket.split();
     let connection = Arc::new(Mutex::new(ConnectionState::new_with_remote_client(
         remote_client,
+        remote_addr,
     )));
 
     let (priority_tx, mut priority_rx) = mpsc::channel::<Message>(64);

--- a/src/daemon/websocket/connection/tests.rs
+++ b/src/daemon/websocket/connection/tests.rs
@@ -2,7 +2,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use axum::extract::ws::Message;
-use axum::http::header::{AUTHORIZATION, ORIGIN, USER_AGENT};
 use serde_json::json;
 use tokio::sync::broadcast;
 
@@ -40,71 +39,6 @@ fn connection_state_relay_filtering() {
     state.global_subscription = true;
     assert!(state.should_relay(&global_event));
     assert!(state.should_relay(&session_event));
-}
-
-#[test]
-fn handshake_metadata_extracts_monitor_client_headers() {
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        USER_AGENT,
-        "HarnessMonitor/30.32.0".parse().expect("user agent"),
-    );
-    headers.insert(
-        HEADER_CLIENT_NAME,
-        "harness-monitor".parse().expect("client name"),
-    );
-    headers.insert(
-        HEADER_CLIENT_VERSION,
-        "30.32.0".parse().expect("client version"),
-    );
-    headers.insert(
-        HEADER_CLIENT_BUNDLE_ID,
-        "io.harnessmonitor.app".parse().expect("bundle id"),
-    );
-    headers.insert(HEADER_CLIENT_PID, "70891".parse().expect("client pid"));
-    headers.insert(
-        HEADER_CLIENT_LAUNCH_MODE,
-        "live".parse().expect("launch mode"),
-    );
-    headers.insert(ORIGIN, "app://harness-monitor".parse().expect("origin"));
-    headers.insert(
-        HEADER_SEC_WEBSOCKET_PROTOCOL,
-        "jsonrpc".parse().expect("websocket protocol"),
-    );
-    headers.insert(AUTHORIZATION, "Bearer token".parse().expect("auth header"));
-
-    let metadata = WebSocketHandshakeMetadata::from_headers(&headers);
-    assert_eq!(metadata.client_name.as_deref(), Some("harness-monitor"));
-    assert_eq!(metadata.client_version.as_deref(), Some("30.32.0"));
-    assert_eq!(
-        metadata.client_bundle_id.as_deref(),
-        Some("io.harnessmonitor.app")
-    );
-    assert_eq!(metadata.client_pid.as_deref(), Some("70891"));
-    assert_eq!(metadata.client_launch_mode.as_deref(), Some("live"));
-    assert_eq!(
-        metadata.user_agent.as_deref(),
-        Some("HarnessMonitor/30.32.0")
-    );
-    assert_eq!(metadata.origin.as_deref(), Some("app://harness-monitor"));
-    assert_eq!(metadata.websocket_protocol.as_deref(), Some("jsonrpc"));
-    assert_eq!(metadata.auth_state, "bearer-present");
-    assert_eq!(
-        metadata.client_label(),
-        "harness-monitor/30.32.0 (bundle=io.harnessmonitor.app; pid=70891; launch=live)"
-    );
-}
-
-#[test]
-fn handshake_metadata_tracks_auth_state_without_leaking_tokens() {
-    let missing = WebSocketHandshakeMetadata::from_headers(&HeaderMap::new());
-    assert_eq!(missing.auth_state, "missing");
-
-    let mut non_bearer_headers = HeaderMap::new();
-    non_bearer_headers.insert(AUTHORIZATION, "Basic abc".parse().expect("auth header"));
-    let non_bearer = WebSocketHandshakeMetadata::from_headers(&non_bearer_headers);
-    assert_eq!(non_bearer.auth_state, "non-bearer");
-    assert_eq!(non_bearer.client_label(), "unknown");
 }
 
 #[tokio::test]

--- a/src/daemon/websocket/connection_metadata.rs
+++ b/src/daemon/websocket/connection_metadata.rs
@@ -1,0 +1,142 @@
+use axum::http::HeaderMap;
+use axum::http::header::{AUTHORIZATION, ORIGIN, USER_AGENT};
+use tracing::field::display;
+
+const HEADER_CLIENT_NAME: &str = "x-harness-client-name";
+const HEADER_CLIENT_VERSION: &str = "x-harness-client-version";
+const HEADER_CLIENT_BUNDLE_ID: &str = "x-harness-client-bundle-id";
+const HEADER_CLIENT_PID: &str = "x-harness-client-pid";
+const HEADER_CLIENT_LAUNCH_MODE: &str = "x-harness-client-launch-mode";
+const HEADER_SEC_WEBSOCKET_PROTOCOL: &str = "sec-websocket-protocol";
+const MISSING_METADATA: &str = "<missing>";
+const HEADER_VALUE_LOG_LIMIT: usize = 160;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct WebSocketHandshakeMetadata {
+    client_name: Option<String>,
+    client_version: Option<String>,
+    client_bundle_id: Option<String>,
+    client_pid: Option<String>,
+    client_launch_mode: Option<String>,
+    user_agent: Option<String>,
+    origin: Option<String>,
+    websocket_protocol: Option<String>,
+    auth_state: &'static str,
+}
+
+impl WebSocketHandshakeMetadata {
+    pub(super) fn from_headers(headers: &HeaderMap) -> Self {
+        Self {
+            client_name: header_summary(headers, HEADER_CLIENT_NAME),
+            client_version: header_summary(headers, HEADER_CLIENT_VERSION),
+            client_bundle_id: header_summary(headers, HEADER_CLIENT_BUNDLE_ID),
+            client_pid: header_summary(headers, HEADER_CLIENT_PID),
+            client_launch_mode: header_summary(headers, HEADER_CLIENT_LAUNCH_MODE),
+            user_agent: header_summary(headers, USER_AGENT.as_str()),
+            origin: header_summary(headers, ORIGIN.as_str()),
+            websocket_protocol: header_summary(headers, HEADER_SEC_WEBSOCKET_PROTOCOL),
+            auth_state: auth_header_state(headers),
+        }
+    }
+
+    pub(super) fn client_label(&self) -> String {
+        let mut label = self
+            .client_name
+            .clone()
+            .or_else(|| self.user_agent.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        if self.client_name.is_some()
+            && let Some(version) = &self.client_version
+        {
+            label.push('/');
+            label.push_str(version);
+        }
+        let mut details = Vec::new();
+        if let Some(bundle_id) = &self.client_bundle_id {
+            details.push(format!("bundle={bundle_id}"));
+        }
+        if let Some(pid) = &self.client_pid {
+            details.push(format!("pid={pid}"));
+        }
+        if let Some(launch_mode) = &self.client_launch_mode {
+            details.push(format!("launch={launch_mode}"));
+        }
+        if details.is_empty() {
+            label
+        } else {
+            format!("{label} ({})", details.join("; "))
+        }
+    }
+
+    pub(super) fn record_on_span(&self, span: &tracing::Span) {
+        let client = self.client_label();
+        span.record("client", display(&client));
+        span.record(
+            "client_name",
+            display(self.client_name.as_deref().unwrap_or(MISSING_METADATA)),
+        );
+        span.record(
+            "client_version",
+            display(self.client_version.as_deref().unwrap_or(MISSING_METADATA)),
+        );
+        span.record(
+            "client_bundle_id",
+            display(self.client_bundle_id.as_deref().unwrap_or(MISSING_METADATA)),
+        );
+        span.record(
+            "client_pid",
+            display(self.client_pid.as_deref().unwrap_or(MISSING_METADATA)),
+        );
+        span.record(
+            "client_launch_mode",
+            display(
+                self.client_launch_mode
+                    .as_deref()
+                    .unwrap_or(MISSING_METADATA),
+            ),
+        );
+        span.record(
+            "user_agent",
+            display(self.user_agent.as_deref().unwrap_or(MISSING_METADATA)),
+        );
+        span.record(
+            "origin",
+            display(self.origin.as_deref().unwrap_or(MISSING_METADATA)),
+        );
+        span.record(
+            "websocket_protocol",
+            display(
+                self.websocket_protocol
+                    .as_deref()
+                    .unwrap_or(MISSING_METADATA),
+            ),
+        );
+        span.record("auth_state", display(self.auth_state));
+    }
+}
+
+fn header_summary(headers: &HeaderMap, name: &str) -> Option<String> {
+    let raw = headers.get(name)?.to_str().ok()?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let mut summary = raw.chars().take(HEADER_VALUE_LOG_LIMIT).collect::<String>();
+    if raw.chars().count() > HEADER_VALUE_LOG_LIMIT {
+        summary.push_str("...");
+    }
+    Some(summary)
+}
+
+fn auth_header_state(headers: &HeaderMap) -> &'static str {
+    match headers.get(AUTHORIZATION) {
+        None => "missing",
+        Some(value) => match value.to_str() {
+            Ok(raw) if raw.trim().starts_with("Bearer ") => "bearer-present",
+            Ok(_) => "non-bearer",
+            Err(_) => "invalid-utf8",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/daemon/websocket/connection_metadata/tests.rs
+++ b/src/daemon/websocket/connection_metadata/tests.rs
@@ -1,0 +1,69 @@
+use axum::http::HeaderMap;
+use axum::http::header::{AUTHORIZATION, ORIGIN, USER_AGENT};
+
+use super::*;
+
+#[test]
+fn handshake_metadata_extracts_monitor_client_headers() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        USER_AGENT,
+        "HarnessMonitor/30.32.0".parse().expect("user agent"),
+    );
+    headers.insert(
+        HEADER_CLIENT_NAME,
+        "harness-monitor".parse().expect("client name"),
+    );
+    headers.insert(
+        HEADER_CLIENT_VERSION,
+        "30.32.0".parse().expect("client version"),
+    );
+    headers.insert(
+        HEADER_CLIENT_BUNDLE_ID,
+        "io.harnessmonitor.app".parse().expect("bundle id"),
+    );
+    headers.insert(HEADER_CLIENT_PID, "70891".parse().expect("client pid"));
+    headers.insert(
+        HEADER_CLIENT_LAUNCH_MODE,
+        "live".parse().expect("launch mode"),
+    );
+    headers.insert(ORIGIN, "app://harness-monitor".parse().expect("origin"));
+    headers.insert(
+        HEADER_SEC_WEBSOCKET_PROTOCOL,
+        "jsonrpc".parse().expect("websocket protocol"),
+    );
+    headers.insert(AUTHORIZATION, "Bearer token".parse().expect("auth header"));
+
+    let metadata = WebSocketHandshakeMetadata::from_headers(&headers);
+    assert_eq!(metadata.client_name.as_deref(), Some("harness-monitor"));
+    assert_eq!(metadata.client_version.as_deref(), Some("30.32.0"));
+    assert_eq!(
+        metadata.client_bundle_id.as_deref(),
+        Some("io.harnessmonitor.app")
+    );
+    assert_eq!(metadata.client_pid.as_deref(), Some("70891"));
+    assert_eq!(metadata.client_launch_mode.as_deref(), Some("live"));
+    assert_eq!(
+        metadata.user_agent.as_deref(),
+        Some("HarnessMonitor/30.32.0")
+    );
+    assert_eq!(metadata.origin.as_deref(), Some("app://harness-monitor"));
+    assert_eq!(metadata.websocket_protocol.as_deref(), Some("jsonrpc"));
+    assert_eq!(metadata.auth_state, "bearer-present");
+    assert_eq!(
+        metadata.client_label(),
+        "harness-monitor/30.32.0 (bundle=io.harnessmonitor.app; pid=70891; launch=live)"
+    );
+}
+
+#[test]
+fn handshake_metadata_tracks_auth_state_without_leaking_tokens() {
+    let missing = WebSocketHandshakeMetadata::from_headers(&HeaderMap::new());
+    assert_eq!(missing.auth_state, "missing");
+
+    let mut non_bearer_headers = HeaderMap::new();
+    non_bearer_headers.insert(AUTHORIZATION, "Basic abc".parse().expect("auth header"));
+    let non_bearer = WebSocketHandshakeMetadata::from_headers(&non_bearer_headers);
+    assert_eq!(non_bearer.auth_state, "non-bearer");
+    assert_eq!(non_bearer.client_label(), "unknown");
+}

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -7,8 +7,13 @@ use crate::daemon::http::{DaemonHttpAuthMode, DaemonHttpState};
 use crate::daemon::protocol::{
     WsErrorPayload, WsRequest, WsResponse, with_control_plane_actor, ws_methods,
 };
-use crate::daemon::remote_auth::{RemoteAuthError, authorize_remote_ws_method};
+use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_auth::{
+    RemoteAuthError, authorize_remote_ws_method, remote_ws_required_scope,
+};
 use crate::daemon::remote_identity::RemoteStoredClient;
+use crate::daemon::remote_request_audit::RemoteAuthorizationAudit;
+use crate::errors::CliError;
 use crate::telemetry::{
     TelemetryBaggage, apply_parent_context_from_text_map, current_trace_id, with_active_baggage,
 };
@@ -126,8 +131,8 @@ async fn dispatch_inner(
     state: &DaemonHttpState,
     connection: &Arc<Mutex<ConnectionState>>,
 ) -> WsResponse {
-    if let Some(response) = authorize_remote_ws_request(request, state, connection) {
-        return response;
+    if let Err(response) = authorize_remote_ws_request(request, state, connection) {
+        return *response;
     }
     if let Some(response) = with_connection_actor(
         state,
@@ -165,19 +170,47 @@ fn authorize_remote_ws_request(
     request: &WsRequest,
     state: &DaemonHttpState,
     connection: &Arc<Mutex<ConnectionState>>,
-) -> Option<WsResponse> {
+) -> Result<(), Box<WsResponse>> {
     if state.auth_mode == DaemonHttpAuthMode::Local || !is_declared_ws_method(&request.method) {
-        return None;
+        return Ok(());
     }
-    let Some(client) = remote_client_for_connection(connection) else {
-        return Some(remote_ws_auth_error_response(
-            &request.id,
-            RemoteAuthError::MissingClientId,
-        ));
+    let required_scope = remote_ws_required_scope(&request.method)
+        .map_err(|error| Box::new(remote_ws_auth_error_response(&request.id, error)))?;
+    let (client, remote_addr) = remote_connection_identity(connection);
+    let Some(client) = client else {
+        let error = RemoteAuthError::MissingClientId;
+        record_remote_ws_denial(
+            request,
+            state,
+            None,
+            required_scope,
+            remote_addr.as_deref(),
+            error,
+        )?;
+        return Err(Box::new(remote_ws_auth_error_response(&request.id, error)));
     };
-    authorize_remote_ws_method(&client, &request.method)
-        .err()
-        .map(|error| remote_ws_auth_error_response(&request.id, error))
+    match authorize_remote_ws_method(&client, &request.method) {
+        Ok(decision) => RemoteAuthorizationAudit::allowed(
+            &request.id,
+            &client.client_id,
+            &request.method,
+            decision.required_scope,
+            remote_addr.as_deref(),
+        )
+        .record(state.db.get())
+        .map_err(|error| remote_ws_audit_error_response(request, &error)),
+        Err(error) => {
+            record_remote_ws_denial(
+                request,
+                state,
+                Some(&client.client_id),
+                required_scope,
+                remote_addr.as_deref(),
+                error,
+            )?;
+            Err(Box::new(remote_ws_auth_error_response(&request.id, error)))
+        }
+    }
 }
 
 fn is_declared_ws_method(method: &str) -> bool {
@@ -187,11 +220,64 @@ fn is_declared_ws_method(method: &str) -> bool {
 fn remote_client_for_connection(
     connection: &Arc<Mutex<ConnectionState>>,
 ) -> Option<RemoteStoredClient> {
-    connection
-        .lock()
-        .expect("connection lock")
-        .remote_client()
-        .cloned()
+    remote_connection_identity(connection).0
+}
+
+fn remote_connection_identity(
+    connection: &Arc<Mutex<ConnectionState>>,
+) -> (Option<RemoteStoredClient>, Option<String>) {
+    let connection = connection.lock().expect("connection lock");
+    (
+        connection.remote_client().cloned(),
+        connection.remote_addr().map(ToOwned::to_owned),
+    )
+}
+
+fn record_remote_ws_denial(
+    request: &WsRequest,
+    state: &DaemonHttpState,
+    client_id: Option<&str>,
+    required_scope: RemoteAccessScope,
+    remote_addr: Option<&str>,
+    error: RemoteAuthError,
+) -> Result<(), Box<WsResponse>> {
+    RemoteAuthorizationAudit::denied(
+        &request.id,
+        client_id,
+        &request.method,
+        required_scope,
+        remote_addr,
+        &error.to_string(),
+    )
+    .record(state.db.get())
+    .map_err(|audit_error| remote_ws_audit_error_response(request, &audit_error))
+}
+
+fn remote_ws_audit_error_response(request: &WsRequest, error: &CliError) -> Box<WsResponse> {
+    log_remote_ws_audit_error(request, error);
+    Box::new(error_response_with_payload(
+        &request.id,
+        WsErrorPayload {
+            code: "REMOTE_AUDIT".to_string(),
+            message: "remote authorization audit is unavailable".to_string(),
+            details: Vec::new(),
+            status_code: Some(503),
+            data: None,
+        },
+    ))
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion inflates the score; tokio-rs/tracing#553"
+)]
+fn log_remote_ws_audit_error(request: &WsRequest, error: &CliError) {
+    tracing::error!(
+        error = %error,
+        method = %request.method,
+        request_id = %request.id,
+        "remote websocket authorization audit failed"
+    );
 }
 
 fn remote_ws_auth_error_response(request_id: &str, error: RemoteAuthError) -> WsResponse {

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -22,7 +22,7 @@ fn ws_request_deserialization() {
 
 #[tokio::test]
 async fn remote_ws_dispatch_allows_viewer_read_method() {
-    let mut state = super::super::test_support::test_ws_state();
+    let mut state = super::super::test_support::test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
     let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
         "viewer",
@@ -39,7 +39,7 @@ async fn remote_ws_dispatch_allows_viewer_read_method() {
 
 #[tokio::test]
 async fn remote_ws_dispatch_denies_viewer_write_method() {
-    let mut state = super::super::test_support::test_ws_state();
+    let mut state = super::super::test_support::test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
     let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
         "viewer",
@@ -59,7 +59,7 @@ async fn remote_ws_dispatch_denies_viewer_write_method() {
 
 #[tokio::test]
 async fn remote_ws_dispatch_denies_known_method_without_remote_client() {
-    let mut state = super::super::test_support::test_ws_state();
+    let mut state = super::super::test_support::test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
     let connection = Arc::new(Mutex::new(ConnectionState::new()));
     let request = ws_request("req-missing-client", ws_methods::PING);
@@ -75,7 +75,7 @@ async fn remote_ws_dispatch_denies_known_method_without_remote_client() {
 
 #[tokio::test]
 async fn remote_ws_dispatch_preserves_unknown_method_errors() {
-    let mut state = super::super::test_support::test_ws_state();
+    let mut state = super::super::test_support::test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
     let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
         "admin",

--- a/src/daemon/websocket/mod.rs
+++ b/src/daemon/websocket/mod.rs
@@ -1,6 +1,7 @@
 mod broadcast;
 mod config;
 mod connection;
+mod connection_metadata;
 mod dispatch;
 mod frames;
 mod mutations;
@@ -33,4 +34,4 @@ const WS_CHUNK_DATA_BYTES: usize = 128 * 1024;
 pub(crate) use broadcast::run_broadcast_fanout;
 pub use broadcast::{PreparedBroadcast, ReplayBuffer};
 pub(crate) use config::build_config_payload;
-pub use connection::ws_upgrade_handler;
+pub(crate) use connection::ws_upgrade_handler;


### PR DESCRIPTION
## Motivation

Remote scope enforcement had no durable decision trail for ordinary HTTPS or WebSocket traffic. If the audit table was unavailable, authorized requests still reached handlers, violating the remote daemon's fail-closed security contract.

## Implementation

- Persist allowed and denied remote HTTP route decisions before handler dispatch.
- Persist every declared remote WebSocket method decision before RPC dispatch.
- Record request id, client id, required scope, decision, remote address, and redacted failure detail.
- Return a generic `503 REMOTE_AUDIT` response when audit persistence is unavailable.
- Split WebSocket handshake metadata into its own module while carrying the peer address into connection state.
- Add red-green HTTP/WSS tests plus focused authorization, black-box remote e2e, codegen, and repository gate proof.