### PR TITLE
feat(task-board): polish card hierarchy and refresh feedback

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
@@ -16,6 +16,7 @@ extension HarnessMonitorStore {
     direction: .pull,
     dryRun: false
   )
+  private static let taskBoardDashboardRefreshActivityKey = "task-board-dashboard-refresh"
 
   nonisolated static func loadTaskBoardItemsSnapshot(
     using client: any HarnessMonitorClientProtocol
@@ -84,7 +85,11 @@ extension HarnessMonitorStore {
     defer { isDaemonActionInFlight = false }
     _ = await syncAndRefreshTaskBoardDashboard(
       using: client,
-      request: Self.taskBoardDashboardSyncRequest
+      request: Self.taskBoardDashboardSyncRequest,
+      successMessage: "Task board refreshed",
+      activityKey: Self.taskBoardDashboardRefreshActivityKey,
+      activityTitle: "Refreshing Task Board",
+      feedbackPosition: .bottomTrailing
     )
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
@@ -78,7 +78,7 @@ extension HarnessMonitorStore {
   }
 
   public func refreshTaskBoardDashboard() async {
-    guard let client else {
+    guard let client, !isDaemonActionInFlight else {
       return
     }
     isDaemonActionInFlight = true

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
@@ -98,30 +98,74 @@ extension HarnessMonitorStore {
     using client: any HarnessMonitorClientProtocol,
     request: TaskBoardSyncRequest,
     successMessage: String? = nil,
-    failureMessagePrefix: String? = nil
+    failureMessagePrefix: String? = nil,
+    activityKey: String? = nil,
+    activityTitle: String? = nil,
+    feedbackPosition: ActionFeedback.Position = .topTrailing
   ) async -> Bool {
+    updateTaskBoardRefreshActivity(
+      key: activityKey,
+      title: activityTitle,
+      message: "Syncing task sources",
+      position: feedbackPosition
+    )
     do {
       let measuredSummary = try await Self.measureOperation {
         try await client.syncTaskBoard(request: request)
       }
       recordRequestSuccess()
       globalTaskBoardSyncSummary = measuredSummary.value
+      updateTaskBoardRefreshActivity(
+        key: activityKey,
+        title: activityTitle,
+        message: "Loading refreshed tasks",
+        position: feedbackPosition
+      )
       await refreshTaskBoardDashboardSnapshot(using: client)
+      dismissTaskBoardRefreshActivity(key: activityKey)
       if let successMessage {
-        presentSuccessFeedback(successMessage)
+        presentSuccessFeedback(successMessage, position: feedbackPosition)
       }
       return true
     } catch {
+      updateTaskBoardRefreshActivity(
+        key: activityKey,
+        title: activityTitle,
+        message: "Reloading current tasks",
+        position: feedbackPosition
+      )
       await refreshTaskBoardDashboardSnapshot(using: client)
+      dismissTaskBoardRefreshActivity(key: activityKey)
       let failureDescription =
         if let failureMessagePrefix {
           "\(failureMessagePrefix): \(error.localizedDescription)"
         } else {
           error.localizedDescription
         }
-      presentFailureFeedback(failureDescription)
+      presentFailureFeedback(failureDescription, position: feedbackPosition)
       return false
     }
+  }
+
+  private func updateTaskBoardRefreshActivity(
+    key: String?,
+    title: String?,
+    message: String,
+    position: ActionFeedback.Position
+  ) {
+    guard let key else { return }
+    toast.updateActivity(
+      key: key,
+      message: message,
+      title: title,
+      accessibilityIdentifier: "harness.toast.task-board-refresh",
+      position: position
+    )
+  }
+
+  private func dismissTaskBoardRefreshActivity(key: String?) {
+    guard let key else { return }
+    toast.dismissActivity(key: key)
   }
 
   func mergeTaskBoardItem(_ item: TaskBoardItem) {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
@@ -159,7 +159,6 @@ extension HarnessMonitorStore {
       key: key,
       message: message,
       title: title,
-      accessibilityIdentifier: "harness.toast.task-board-refresh",
       position: position
     )
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
@@ -109,6 +109,7 @@ extension HarnessMonitorStore {
       message: "Syncing task sources",
       position: feedbackPosition
     )
+    defer { dismissTaskBoardRefreshActivity(key: activityKey) }
     do {
       let measuredSummary = try await Self.measureOperation {
         try await client.syncTaskBoard(request: request)
@@ -122,11 +123,12 @@ extension HarnessMonitorStore {
         position: feedbackPosition
       )
       await refreshTaskBoardDashboardSnapshot(using: client)
-      dismissTaskBoardRefreshActivity(key: activityKey)
       if let successMessage {
         presentSuccessFeedback(successMessage, position: feedbackPosition)
       }
       return true
+    } catch is CancellationError {
+      return false
     } catch {
       updateTaskBoardRefreshActivity(
         key: activityKey,
@@ -135,7 +137,6 @@ extension HarnessMonitorStore {
         position: feedbackPosition
       )
       await refreshTaskBoardDashboardSnapshot(using: client)
-      dismissTaskBoardRefreshActivity(key: activityKey)
       let failureDescription =
         if let failureMessagePrefix {
           "\(failureMessagePrefix): \(error.localizedDescription)"

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardInlineCodeText.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardInlineCodeText.swift
@@ -1,0 +1,121 @@
+import Foundation
+import SwiftUI
+
+private struct TaskBoardInlineCodeFragment: Equatable {
+  let text: String
+  let isCode: Bool
+}
+
+enum TaskBoardInlineCodeFormatter {
+  static func displayText(for rawText: String) -> String {
+    fragments(in: rawText).map(\.text).joined()
+  }
+
+  static func attributedText(
+    for rawText: String,
+    codeFont: Font,
+    codeForeground: Color = HarnessMonitorTheme.inlineCodeText,
+    codeBackground: Color = HarnessMonitorTheme.inlineCodeBackground
+  ) -> AttributedString {
+    fragments(in: rawText).reduce(into: AttributedString()) { result, fragment in
+      var attributedFragment = AttributedString(fragment.text)
+      if fragment.isCode {
+        attributedFragment.font = codeFont
+        attributedFragment.foregroundColor = codeForeground
+        attributedFragment.backgroundColor = codeBackground
+      }
+      result += attributedFragment
+    }
+  }
+
+  private static func fragments(in rawText: String) -> [TaskBoardInlineCodeFragment] {
+    guard rawText.contains("`") else {
+      return [.init(text: rawText, isCode: false)]
+    }
+
+    var fragments: [TaskBoardInlineCodeFragment] = []
+    var cursor = rawText.startIndex
+    var index = rawText.startIndex
+
+    while index < rawText.endIndex {
+      guard rawText[index] == "`" else {
+        index = rawText.index(after: index)
+        continue
+      }
+
+      let afterOpen = rawText.index(after: index)
+      guard
+        let close = rawText[afterOpen...].firstIndex(of: "`"),
+        close > afterOpen
+      else {
+        index = afterOpen
+        continue
+      }
+
+      if cursor < index {
+        fragments.append(.init(text: String(rawText[cursor..<index]), isCode: false))
+      }
+      fragments.append(.init(text: String(rawText[afterOpen..<close]), isCode: true))
+      cursor = rawText.index(after: close)
+      index = cursor
+    }
+
+    if cursor < rawText.endIndex {
+      fragments.append(.init(text: String(rawText[cursor...]), isCode: false))
+    }
+
+    return fragments.isEmpty ? [.init(text: rawText, isCode: false)] : fragments
+  }
+}
+
+/// Lightweight backtick-span renderer that consumes fonts scaled by its container.
+struct TaskBoardInlineCodeText: View {
+  let text: String
+  let font: Font
+  let codeFont: Font
+  var foregroundStyle: Color = .primary
+  var codeForeground: Color = HarnessMonitorTheme.inlineCodeText
+  var codeBackground: Color = HarnessMonitorTheme.inlineCodeBackground
+  var lineLimit: Int?
+  var truncationMode: Text.TruncationMode = .tail
+  var multilineTextAlignment: TextAlignment = .leading
+
+  init(
+    _ text: String,
+    font: Font,
+    codeFont: Font,
+    foregroundStyle: Color = .primary,
+    codeForeground: Color = HarnessMonitorTheme.inlineCodeText,
+    codeBackground: Color = HarnessMonitorTheme.inlineCodeBackground,
+    lineLimit: Int? = nil,
+    truncationMode: Text.TruncationMode = .tail,
+    multilineTextAlignment: TextAlignment = .leading
+  ) {
+    self.text = text
+    self.font = font
+    self.codeFont = codeFont
+    self.foregroundStyle = foregroundStyle
+    self.codeForeground = codeForeground
+    self.codeBackground = codeBackground
+    self.lineLimit = lineLimit
+    self.truncationMode = truncationMode
+    self.multilineTextAlignment = multilineTextAlignment
+  }
+
+  var body: some View {
+    Text(
+      TaskBoardInlineCodeFormatter.attributedText(
+        for: text,
+        codeFont: codeFont,
+        codeForeground: codeForeground,
+        codeBackground: codeBackground
+      )
+    )
+    .font(font)
+    .foregroundStyle(foregroundStyle)
+    .lineLimit(lineLimit)
+    .truncationMode(truncationMode)
+    .multilineTextAlignment(multilineTextAlignment)
+    .accessibilityLabel(TaskBoardInlineCodeFormatter.displayText(for: text))
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneSupport.swift
@@ -151,122 +151,19 @@ struct TaskBoardCardPill: View {
   }
 }
 
-private struct TaskBoardInlineCodeFragment: Equatable {
-  let text: String
-  let isCode: Bool
-}
-
-enum TaskBoardInlineCodeFormatter {
-  static func displayText(for rawText: String) -> String {
-    fragments(in: rawText).map(\.text).joined()
-  }
-
-  static func attributedText(
-    for rawText: String,
-    codeFont: Font,
-    codeForeground: Color = HarnessMonitorTheme.inlineCodeText,
-    codeBackground: Color = HarnessMonitorTheme.inlineCodeBackground
-  ) -> AttributedString {
-    fragments(in: rawText).reduce(into: AttributedString()) { result, fragment in
-      var attributedFragment = AttributedString(fragment.text)
-      if fragment.isCode {
-        attributedFragment.font = codeFont
-        attributedFragment.foregroundColor = codeForeground
-        attributedFragment.backgroundColor = codeBackground
-      }
-      result += attributedFragment
-    }
-  }
-
-  private static func fragments(in rawText: String) -> [TaskBoardInlineCodeFragment] {
-    guard rawText.contains("`") else {
-      return [.init(text: rawText, isCode: false)]
-    }
-
-    var fragments: [TaskBoardInlineCodeFragment] = []
-    var cursor = rawText.startIndex
-    var index = rawText.startIndex
-
-    while index < rawText.endIndex {
-      guard rawText[index] == "`" else {
-        index = rawText.index(after: index)
-        continue
-      }
-
-      let afterOpen = rawText.index(after: index)
-      guard
-        let close = rawText[afterOpen...].firstIndex(of: "`"),
-        close > afterOpen
-      else {
-        index = afterOpen
-        continue
-      }
-
-      if cursor < index {
-        fragments.append(.init(text: String(rawText[cursor..<index]), isCode: false))
-      }
-      fragments.append(.init(text: String(rawText[afterOpen..<close]), isCode: true))
-      cursor = rawText.index(after: close)
-      index = cursor
-    }
-
-    if cursor < rawText.endIndex {
-      fragments.append(.init(text: String(rawText[cursor...]), isCode: false))
-    }
-
-    return fragments.isEmpty ? [.init(text: rawText, isCode: false)] : fragments
-  }
-}
-
-/// Lightweight backtick-span renderer so task-board rows avoid the full markdown path.
-struct TaskBoardInlineCodeText: View {
-  let text: String
+struct TaskBoardCardTitleTypography {
   let font: Font
   let codeFont: Font
-  var foregroundStyle: Color = .primary
-  var codeForeground: Color = HarnessMonitorTheme.inlineCodeText
-  var codeBackground: Color = HarnessMonitorTheme.inlineCodeBackground
-  var lineLimit: Int?
-  var truncationMode: Text.TruncationMode = .tail
-  var multilineTextAlignment: TextAlignment = .leading
 
-  init(
-    _ text: String,
-    font: Font,
-    codeFont: Font,
-    foregroundStyle: Color = .primary,
-    codeForeground: Color = HarnessMonitorTheme.inlineCodeText,
-    codeBackground: Color = HarnessMonitorTheme.inlineCodeBackground,
-    lineLimit: Int? = nil,
-    truncationMode: Text.TruncationMode = .tail,
-    multilineTextAlignment: TextAlignment = .leading
-  ) {
-    self.text = text
-    self.font = font
-    self.codeFont = codeFont
-    self.foregroundStyle = foregroundStyle
-    self.codeForeground = codeForeground
-    self.codeBackground = codeBackground
-    self.lineLimit = lineLimit
-    self.truncationMode = truncationMode
-    self.multilineTextAlignment = multilineTextAlignment
-  }
-
-  var body: some View {
-    Text(
-      TaskBoardInlineCodeFormatter.attributedText(
-        for: text,
-        codeFont: codeFont,
-        codeForeground: codeForeground,
-        codeBackground: codeBackground
-      )
+  init(fontScale: CGFloat) {
+    font = HarnessMonitorTextSize.scaledFont(
+      .subheadline.weight(.semibold),
+      by: fontScale
     )
-    .font(font)
-    .foregroundStyle(foregroundStyle)
-    .lineLimit(lineLimit)
-    .truncationMode(truncationMode)
-    .multilineTextAlignment(multilineTextAlignment)
-    .accessibilityLabel(TaskBoardInlineCodeFormatter.displayText(for: text))
+    codeFont = HarnessMonitorTextSize.scaledFont(
+      .subheadline.monospaced().weight(.semibold),
+      by: fontScale
+    )
   }
 }
 
@@ -288,6 +185,14 @@ struct TaskBoardCardFooter<Badges: View>: View {
 
   var body: some View {
     HStack(alignment: .bottom, spacing: metrics.laneBodyTopPadding) {
+      Text(repository)
+        .font(repositoryFont)
+        .foregroundStyle(HarnessMonitorTheme.secondaryInk)
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .multilineTextAlignment(.leading)
+        .layoutPriority(2)
+      Spacer(minLength: metrics.laneBodyTopPadding)
       HarnessMonitorWrapLayout(
         spacing: metrics.laneBodyTopPadding,
         lineSpacing: metrics.laneBodyTopPadding
@@ -295,14 +200,6 @@ struct TaskBoardCardFooter<Badges: View>: View {
         badges
       }
       .layoutPriority(1)
-      Spacer(minLength: metrics.laneBodyTopPadding)
-      Text(repository)
-        .font(repositoryFont)
-        .foregroundStyle(HarnessMonitorTheme.secondaryInk)
-        .lineLimit(1)
-        .truncationMode(.middle)
-        .multilineTextAlignment(.trailing)
-        .layoutPriority(2)
     }
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneUnifiedColumn.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneUnifiedColumn.swift
@@ -8,6 +8,7 @@ struct TaskBoardLaneUnifiedColumn: View {
   let apiItems: [TaskBoardItem]
   let inboxItems: [TaskBoardInboxItem]
   let decisions: [Decision]
+  let titleTypography: TaskBoardCardTitleTypography
   let isCollapsed: Bool
   let onOpenAPIItem: (TaskBoardItem) -> Void
   let onOpenInboxItem: (TaskBoardInboxItem) -> Void
@@ -156,6 +157,7 @@ struct TaskBoardLaneUnifiedColumn: View {
         let cardID = TaskBoardLaneCardHoverID.api(item.id)
         TaskBoardItemRow(
           item: item,
+          titleTypography: titleTypography,
           isHovered: hoveredCardID == cardID,
           onOpenItem: onOpenAPIItem
         )
@@ -168,6 +170,7 @@ struct TaskBoardLaneUnifiedColumn: View {
         )
         TaskBoardInboxItemRow(
           item: item,
+          titleTypography: titleTypography,
           isHovered: hoveredCardID == cardID,
           onOpenItem: onOpenInboxItem
         )

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
@@ -159,6 +159,7 @@ extension UTType {
 
 struct TaskBoardItemRow: View {
   let item: TaskBoardItem
+  let titleTypography: TaskBoardCardTitleTypography
   let isHovered: Bool
   let onOpenItem: (TaskBoardItem) -> Void
   @Environment(\.fontScale)
@@ -173,13 +174,6 @@ struct TaskBoardItemRow: View {
   }
 
   private var metrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
-  private var titleFont: Font {
-    HarnessMonitorTextSize.scaledFont(.subheadline.weight(.semibold), by: fontScale)
-  }
-  private var titleCodeFont: Font {
-    HarnessMonitorTextSize.scaledFont(.subheadline.monospaced().weight(.semibold), by: fontScale)
-  }
-
   var body: some View {
     Button {
       onOpenItem(item)
@@ -188,8 +182,8 @@ struct TaskBoardItemRow: View {
         VStack(alignment: .leading, spacing: metrics.rowTextSpacing) {
           TaskBoardInlineCodeText(
             item.title,
-            font: titleFont,
-            codeFont: titleCodeFont,
+            font: titleTypography.font,
+            codeFont: titleTypography.codeFont,
             foregroundStyle: HarnessMonitorTheme.ink,
             lineLimit: 2
           )
@@ -203,12 +197,6 @@ struct TaskBoardItemRow: View {
         alignment: .topLeading
       )
       .padding(metrics.cardPadding)
-      .taskBoardCardBackgroundGlyph(
-        systemImage: cardGlyph.systemImage,
-        tint: cardGlyph.tint,
-        cornerRadius: metrics.cardCornerRadius,
-        providerSymbol: item.taskBoardBackgroundProviderSymbol
-      )
     }
     .taskBoardCardChrome(tint: cardGlyph.tint, isHovered: isHovered)
     .contentShape(.rect)
@@ -216,7 +204,7 @@ struct TaskBoardItemRow: View {
       dragPayload.itemProvider()
     }
     .draggable(dragPayload) {
-      TaskBoardItemDragPreviewCard(item: item)
+      TaskBoardItemDragPreviewCard(item: item, titleTypography: titleTypography)
     }
     .accessibilityIdentifier("harness.task-board.api-item.\(item.id)")
   }
@@ -246,16 +234,11 @@ struct TaskBoardItemRow: View {
 
 private struct TaskBoardItemDragPreviewCard: View {
   let item: TaskBoardItem
+  let titleTypography: TaskBoardCardTitleTypography
   @Environment(\.fontScale)
   private var fontScale
 
   private var metrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
-  private var titleFont: Font {
-    HarnessMonitorTextSize.scaledFont(.subheadline.weight(.semibold), by: fontScale)
-  }
-  private var titleCodeFont: Font {
-    HarnessMonitorTextSize.scaledFont(.subheadline.monospaced().weight(.semibold), by: fontScale)
-  }
   private var statusFont: Font {
     HarnessMonitorTextSize.scaledFont(.caption.weight(.semibold), by: fontScale)
   }
@@ -264,8 +247,8 @@ private struct TaskBoardItemDragPreviewCard: View {
     VStack(alignment: .leading, spacing: metrics.laneBodyTopPadding) {
       TaskBoardInlineCodeText(
         item.title,
-        font: titleFont,
-        codeFont: titleCodeFont,
+        font: titleTypography.font,
+        codeFont: titleTypography.codeFont,
         lineLimit: 2
       )
       Text(item.status.title)
@@ -280,21 +263,13 @@ private struct TaskBoardItemDragPreviewCard: View {
 
 struct TaskBoardInboxItemRow: View {
   let item: TaskBoardInboxItem
+  let titleTypography: TaskBoardCardTitleTypography
   let isHovered: Bool
   let onOpenItem: (TaskBoardInboxItem) -> Void
   @Environment(\.fontScale)
   private var fontScale
-  @Environment(\.taskBoardLaneAppearance)
-  private var laneAppearance
 
   private var metrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
-  private var titleFont: Font {
-    HarnessMonitorTextSize.scaledFont(.subheadline.weight(.semibold), by: fontScale)
-  }
-  private var titleCodeFont: Font {
-    HarnessMonitorTextSize.scaledFont(.subheadline.monospaced().weight(.semibold), by: fontScale)
-  }
-
   private var dragPayload: TaskBoardInboxItemDragPayload {
     TaskBoardInboxItemDragPayload(
       sessionID: item.session.sessionId,
@@ -312,8 +287,8 @@ struct TaskBoardInboxItemRow: View {
         VStack(alignment: .leading, spacing: metrics.rowTextSpacing) {
           TaskBoardInlineCodeText(
             item.task.title,
-            font: titleFont,
-            codeFont: titleCodeFont,
+            font: titleTypography.font,
+            codeFont: titleTypography.codeFont,
             foregroundStyle: HarnessMonitorTheme.ink,
             lineLimit: 2
           )
@@ -327,11 +302,6 @@ struct TaskBoardInboxItemRow: View {
         alignment: .topLeading
       )
       .padding(metrics.cardPadding)
-      .taskBoardCardBackgroundGlyph(
-        systemImage: statusSymbol,
-        tint: statusTint,
-        cornerRadius: metrics.cardCornerRadius
-      )
     }
     .taskBoardCardChrome(tint: statusTint, isHovered: isHovered)
     .contentShape(.rect)
@@ -339,16 +309,12 @@ struct TaskBoardInboxItemRow: View {
       dragPayload.itemProvider()
     }
     .draggable(dragPayload) {
-      TaskBoardInboxItemDragPreviewCard(item: item)
+      TaskBoardInboxItemDragPreviewCard(item: item, titleTypography: titleTypography)
     }
     .accessibilityIdentifier("harness.task-board.item.\(item.task.taskId)")
   }
 
   private var statusTint: Color { taskStatusColor(for: item.task.status) }
-
-  private var statusSymbol: String? {
-    taskBoardLaneSystemImage(for: item.lane, appearance: laneAppearance)
-  }
 
   @ViewBuilder private var badgeContent: some View {
     TaskBoardCardPill(label: item.task.status.title, tint: statusTint)
@@ -358,16 +324,11 @@ struct TaskBoardInboxItemRow: View {
 
 private struct TaskBoardInboxItemDragPreviewCard: View {
   let item: TaskBoardInboxItem
+  let titleTypography: TaskBoardCardTitleTypography
   @Environment(\.fontScale)
   private var fontScale
 
   private var metrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
-  private var titleFont: Font {
-    HarnessMonitorTextSize.scaledFont(.subheadline.weight(.semibold), by: fontScale)
-  }
-  private var titleCodeFont: Font {
-    HarnessMonitorTextSize.scaledFont(.subheadline.monospaced().weight(.semibold), by: fontScale)
-  }
   private var statusFont: Font {
     HarnessMonitorTextSize.scaledFont(.caption.weight(.semibold), by: fontScale)
   }
@@ -376,8 +337,8 @@ private struct TaskBoardInboxItemDragPreviewCard: View {
     VStack(alignment: .leading, spacing: metrics.laneBodyTopPadding) {
       TaskBoardInlineCodeText(
         item.task.title,
-        font: titleFont,
-        codeFont: titleCodeFont,
+        font: titleTypography.font,
+        codeFont: titleTypography.codeFont,
         lineLimit: 2
       )
       Text(item.task.status.title)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardNeedsYouLaneViews.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardNeedsYouLaneViews.swift
@@ -94,11 +94,6 @@ struct TaskBoardDecisionRow: View {
       alignment: .topLeading
     )
     .padding(metrics.cardPadding)
-    .taskBoardCardBackgroundGlyph(
-      systemImage: severitySystemImage,
-      tint: severityColor,
-      cornerRadius: metrics.cardCornerRadius
-    )
   }
 
   private var headerRow: some View {
@@ -152,15 +147,6 @@ struct TaskBoardDecisionRow: View {
   }
 
   private var severityColor: Color { severity.chipColor }
-
-  private var severitySystemImage: String {
-    switch severity {
-    case .critical: "exclamationmark.octagon.fill"
-    case .needsUser: "person.fill.questionmark"
-    case .warn: "exclamationmark.triangle.fill"
-    case .info: "info.circle.fill"
-    }
-  }
 
   private var ruleDisplayName: String {
     humanizedWorkspaceLabel(decision.ruleID)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
@@ -340,15 +340,16 @@ extension TaskBoardOverviewView {
   }
 
   var taskBoardColumns: some View {
-    ViewThatFits(in: .horizontal) {
+    let titleTypography = TaskBoardCardTitleTypography(fontScale: fontScale)
+    return ViewThatFits(in: .horizontal) {
       TaskBoardLaneStripLayout(sizing: laneStripSizing) {
-        taskBoardLaneColumns
+        taskBoardLaneColumns(titleTypography: titleTypography)
       }
       .padding(.vertical, metrics.boardVerticalPadding)
 
       ScrollView(.horizontal, showsIndicators: true) {
         TaskBoardLaneStripLayout(sizing: laneStripSizing) {
-          taskBoardLaneColumns
+          taskBoardLaneColumns(titleTypography: titleTypography)
         }
         .padding(.vertical, metrics.boardVerticalPadding)
       }
@@ -356,7 +357,8 @@ extension TaskBoardOverviewView {
     }
   }
 
-  @ViewBuilder var taskBoardLaneColumns: some View {
+  @ViewBuilder
+  func taskBoardLaneColumns(titleTypography: TaskBoardCardTitleTypography) -> some View {
     ForEach(TaskBoardInboxLane.allCases) { lane in
       let apiItems = cachedPresentation.apiItems(in: lane)
       let inboxItems = cachedPresentation.inboxItems(in: lane)
@@ -372,6 +374,7 @@ extension TaskBoardOverviewView {
         apiItems: apiItems,
         inboxItems: inboxItems,
         decisions: decisions,
+        titleTypography: titleTypography,
         isCollapsed: isCollapsed,
         onOpenAPIItem: openTaskBoardItem,
         onOpenInboxItem: onOpenItem,

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorActionTestSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorActionTestSupport.swift
@@ -16,6 +16,12 @@ struct RecordedReviewBodyUpdateRequest: Equatable {
   let newBody: String
 }
 
+struct RecordingTaskBoardSyncStub {
+  var importedItems: [TaskBoardItem]?
+  var summary = TaskBoardSyncSummary(total: 0, providers: [])
+  var error: (any Error)?
+}
+
 final class RecordingHarnessClient: HarnessMonitorClientProtocol, @unchecked Sendable {
   enum Call: Equatable {
     case assignTask(sessionID: String, taskID: String, agentID: String, actor: String)
@@ -281,8 +287,7 @@ final class RecordingHarnessClient: HarnessMonitorClientProtocol, @unchecked Sen
     instanceID: "recording-task-board"
   )
   var queuedTaskBoardItemSnapshots: [[TaskBoardItem]] = []
-  var taskBoardItemsAfterSyncStorage: [TaskBoardItem]?
-  var taskBoardSyncSummaryStorage = TaskBoardSyncSummary(total: 0, providers: [])
+  var taskBoardSyncStub = RecordingTaskBoardSyncStub()
   var taskBoardAuditSummaryStorage: TaskBoardAuditSummary?
   var taskBoardProjectSummariesStorage: [TaskBoardProjectSummary]?
   var taskBoardMachineSummariesStorage: [TaskBoardMachineSummary]?

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
@@ -60,4 +60,19 @@ struct HarnessMonitorStoreTaskBoardRefreshFeedbackTests {
     )
     #expect(store.toast.activeFeedback.isEmpty)
   }
+
+  @Test("Successful sync configuration clears a prior fixture error")
+  func successfulSyncConfigurationClearsPriorFixtureError() async throws {
+    let client = RecordingHarnessClient()
+    client.configureTaskBoardSyncError(CancellationError())
+    client.configureTaskBoardSync(
+      summary: TaskBoardSyncSummary(total: 2, providers: [])
+    )
+
+    let summary = try await client.syncTaskBoard(
+      request: TaskBoardSyncRequest(direction: .pull, dryRun: false)
+    )
+
+    #expect(summary.total == 2)
+  }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
@@ -1,0 +1,32 @@
+import Testing
+
+@testable import HarnessMonitorKit
+
+@MainActor
+@Suite("Harness Monitor task-board refresh feedback")
+struct HarnessMonitorStoreTaskBoardRefreshFeedbackTests {
+  @Test("Refresh reports staged progress and completes at the bottom right")
+  func refreshReportsStagedProgressAndCompletesAtBottomRight() async {
+    let client = RecordingHarnessClient()
+    let store = await makeBootstrappedStore(client: client)
+    var toastEvents: [ToastHistoryEvent] = []
+    store.toast.onHistoryEvent = { toastEvents.append($0) }
+
+    await store.refreshTaskBoardDashboard()
+
+    let progressMessages = toastEvents.compactMap { event -> String? in
+      guard event.feedback.severity == .activity else { return nil }
+      switch event.kind {
+      case .presented, .refreshed:
+        return event.feedback.message
+      case .dismissed:
+        return nil
+      }
+    }
+    #expect(progressMessages == ["Syncing task sources", "Loading refreshed tasks"])
+    #expect(store.toast.activeFeedback.count == 1)
+    #expect(store.toast.activeFeedback.first?.message == "Task board refreshed")
+    #expect(store.toast.activeFeedback.first?.severity == .success)
+    #expect(store.toast.activeFeedback.first?.position == .bottomTrailing)
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
@@ -24,6 +24,10 @@ struct HarnessMonitorStoreTaskBoardRefreshFeedbackTests {
       }
     }
     #expect(progressMessages == ["Syncing task sources", "Loading refreshed tasks"])
+    #expect(
+      toastEvents.first?.feedback.accessibilityIdentifier
+        == "harness.toast.activity.task-board-dashboard-refresh"
+    )
     #expect(store.toast.activeFeedback.count == 1)
     #expect(store.toast.activeFeedback.first?.message == "Task board refreshed")
     #expect(store.toast.activeFeedback.first?.severity == .success)

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
@@ -29,4 +29,18 @@ struct HarnessMonitorStoreTaskBoardRefreshFeedbackTests {
     #expect(store.toast.activeFeedback.first?.severity == .success)
     #expect(store.toast.activeFeedback.first?.position == .bottomTrailing)
   }
+
+  @Test("Cancellation dismisses progress without reload or failure feedback")
+  func cancellationDismissesProgressWithoutReloadOrFailureFeedback() async {
+    let client = RecordingHarnessClient()
+    let store = await makeBootstrappedStore(client: client)
+    let baselineItemReads = client.readCallCount(.taskBoardItems(nil))
+    client.configureTaskBoardSyncError(CancellationError())
+
+    await store.refreshTaskBoardDashboard()
+
+    #expect(client.readCallCount(.taskBoardItems(nil)) == baselineItemReads)
+    #expect(store.toast.activeFeedback.isEmpty)
+    #expect(store.currentFailureFeedbackMessage == nil)
+  }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardRefreshFeedbackTests.swift
@@ -43,4 +43,21 @@ struct HarnessMonitorStoreTaskBoardRefreshFeedbackTests {
     #expect(store.toast.activeFeedback.isEmpty)
     #expect(store.currentFailureFeedbackMessage == nil)
   }
+
+  @Test("Refresh is ignored while another daemon action is in flight")
+  func refreshIsIgnoredWhileAnotherDaemonActionIsInFlight() async {
+    let client = RecordingHarnessClient()
+    let store = await makeBootstrappedStore(client: client)
+    store.isDaemonActionInFlight = true
+    defer { store.isDaemonActionInFlight = false }
+
+    await store.refreshTaskBoardDashboard()
+
+    #expect(
+      !client.recordedCalls().contains(
+        .syncTaskBoard(direction: .pull, dryRun: false, status: nil, provider: nil)
+      )
+    )
+    #expect(store.toast.activeFeedback.isEmpty)
+  }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+Config.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+Config.swift
@@ -165,6 +165,7 @@ extension RecordingHarnessClient {
     lock.withLock {
       taskBoardSyncStub.summary = summary
       taskBoardSyncStub.importedItems = importedItems
+      taskBoardSyncStub.error = nil
     }
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+Config.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+Config.swift
@@ -163,8 +163,14 @@ extension RecordingHarnessClient {
     importedItems: [TaskBoardItem]? = nil
   ) {
     lock.withLock {
-      taskBoardSyncSummaryStorage = summary
-      taskBoardItemsAfterSyncStorage = importedItems
+      taskBoardSyncStub.summary = summary
+      taskBoardSyncStub.importedItems = importedItems
+    }
+  }
+
+  func configureTaskBoardSyncError(_ error: any Error) {
+    lock.withLock {
+      taskBoardSyncStub.error = error
     }
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+TaskBoardOrchestrator.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+TaskBoardOrchestrator.swift
@@ -129,11 +129,14 @@ extension RecordingHarnessClient {
         provider: request.provider
       )
     )
+    if let error = lock.withLock({ taskBoardSyncStub.error }) {
+      throw error
+    }
     return lock.withLock {
-      if let importedItems = taskBoardItemsAfterSyncStorage {
+      if let importedItems = taskBoardSyncStub.importedItems {
         taskBoardItemsStorage = importedItems
       }
-      return taskBoardSyncSummaryStorage
+      return taskBoardSyncStub.summary
     }
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+TaskBoardOrchestrator.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+TaskBoardOrchestrator.swift
@@ -129,15 +129,17 @@ extension RecordingHarnessClient {
         provider: request.provider
       )
     )
-    if let error = lock.withLock({ taskBoardSyncStub.error }) {
-      throw error
-    }
-    return lock.withLock {
-      if let importedItems = taskBoardSyncStub.importedItems {
+    let result: (summary: TaskBoardSyncSummary, error: (any Error)?) = lock.withLock {
+      let error = taskBoardSyncStub.error
+      if error == nil, let importedItems = taskBoardSyncStub.importedItems {
         taskBoardItemsStorage = importedItems
       }
-      return taskBoardSyncStub.summary
+      return (taskBoardSyncStub.summary, error)
     }
+    if let error = result.error {
+      throw error
+    }
+    return result.summary
   }
 
   func dispatchTaskBoard(

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardCardPresentationContractTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardCardPresentationContractTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@Suite("Task board card presentation contracts")
+struct TaskBoardCardPresentationContractTests {
+  @Test("Repository leads the footer before card badges")
+  func repositoryLeadsFooterBeforeCardBadges() throws {
+    let source = try taskBoardSource("TaskBoardLaneSupport.swift")
+    let repository = try #require(source.range(of: "Text(repository)"))
+    let badges = try #require(source.range(of: "HarnessMonitorWrapLayout("))
+
+    #expect(repository.lowerBound < badges.lowerBound)
+    #expect(source.contains(".multilineTextAlignment(.leading)"))
+  }
+
+  @Test("Board resolves scaled task-title fonts once and passes them through lanes")
+  func boardPassesScaledTaskTitleFontsThroughLanes() throws {
+    let overviewSource = try taskBoardSource("TaskBoardOverviewView.swift")
+    let laneSource = try taskBoardSource("TaskBoardLaneUnifiedColumn.swift")
+    let rowSource = try taskBoardSource("TaskBoardLaneViews.swift")
+    let textSource = try taskBoardSource("TaskBoardInlineCodeText.swift")
+
+    #expect(
+      overviewSource.contains(
+        "let titleTypography = TaskBoardCardTitleTypography(fontScale: fontScale)"
+      )
+    )
+    #expect(overviewSource.contains("taskBoardLaneColumns(titleTypography: titleTypography)"))
+    #expect(laneSource.components(separatedBy: "titleTypography: titleTypography").count == 3)
+    #expect(laneSource.contains("let titleTypography: TaskBoardCardTitleTypography"))
+    #expect(rowSource.contains("let titleTypography: TaskBoardCardTitleTypography"))
+    #expect(!textSource.contains("@Environment(\\.fontScale)"))
+    #expect(textSource.contains("codeFont: codeFont"))
+    #expect(textSource.contains(".font(font)"))
+  }
+
+  @Test("Cards omit background glyphs while retaining the reusable modifier")
+  func cardsOmitBackgroundGlyphsWhileRetainingModifier() throws {
+    let laneSource = try taskBoardSource("TaskBoardLaneViews.swift")
+    let decisionSource = try taskBoardSource("TaskBoardNeedsYouLaneViews.swift")
+    let glyphSource = try taskBoardSource("TaskBoardCardBackgroundGlyph.swift")
+
+    #expect(!laneSource.contains(".taskBoardCardBackgroundGlyph("))
+    #expect(!decisionSource.contains(".taskBoardCardBackgroundGlyph("))
+    #expect(glyphSource.contains("func taskBoardCardBackgroundGlyph("))
+    #expect(glyphSource.contains(".rotationEffect(glyphRotation)"))
+  }
+
+  private func taskBoardSource(_ fileName: String) throws -> String {
+    let testFile = URL(fileURLWithPath: #filePath)
+    let appRoot =
+      testFile
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let sourceURL =
+      appRoot
+      .appendingPathComponent("Sources/HarnessMonitorUIPreviewable/Views/TaskBoard")
+      .appendingPathComponent(fileName)
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+}


### PR DESCRIPTION
## Motivation

Task Board cards put repository context at the trailing edge, resolve title scaling too low in the view tree, retain visually noisy background glyphs, and provide no visible progress while a manual refresh is running. This makes the board harder to scan and leaves refresh behavior ambiguous.

## Implementation

- Move project and repository context to the leading edge of card footers.
- Resolve scaled task-title typography once for the board and pass it through lanes, cards, and drag previews.
- Remove current tilted background glyph usage while retaining the reusable rendering infrastructure.
- Report refresh sync, reload, completion, and failure states through bottom-right toast feedback.
- Add focused regression coverage for the card presentation and refresh feedback contracts.