### PR TITLE
fix(task-board): route GitHub inbox to Todo

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardInboxSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardInboxSection.swift
@@ -32,7 +32,7 @@ struct SettingsTaskBoardInboxSection: View {
     } footer: {
       Text(
         """
-        Import assigned issues and requested reviews into Needs You. Shared monitored repositories \
+        Import assigned issues and requested reviews into Todo. Shared monitored repositories \
         live in Settings > Repositories. Empty label filters mean all labels are included.
         """
       )

--- a/docs/agent-guides/task-board-workflow.md
+++ b/docs/agent-guides/task-board-workflow.md
@@ -67,11 +67,6 @@ new -> planning -> plan_review -> todo -> in_progress -> in_review -> done
            |                         |          |
            v                         v          v
         blocked                   blocked    blocked
-
-github inbox -> needs_you -> todo
-                   |
-                   v
-                blocked
 ```
 
 `blocked` means the task cannot proceed without new input, an external
@@ -90,10 +85,9 @@ The CLI sets `approved_at` when `--approved-by` is provided.
 Standard GitHub issue sync still imports repo-scoped `todo` items with a
 synthesized planning summary. The separate GitHub inbox flow for selected repos
 imports issues assigned to you and pull requests requesting your review as
-repo-scoped `needs_you` items instead. Inbox items are not dispatch-ready until
-a human moves them into the normal planning/ready flow. Review-request inbox
-items that GitHub no longer reports for you are automatically resolved out of
-the inbox state on the next pull sync.
+repo-scoped `todo` items. Imported items still require planning approval before
+dispatch. Review-request inbox items that GitHub no longer reports for you are
+automatically resolved on the next pull sync.
 
 ## Intake And Planning
 

--- a/src/task_board/external/github.rs
+++ b/src/task_board/external/github.rs
@@ -400,7 +400,7 @@ fn github_inbox_issue_status(state: &str) -> TaskBoardStatus {
     if state.eq_ignore_ascii_case("closed") {
         TaskBoardStatus::Done
     } else {
-        TaskBoardStatus::HumanRequired
+        TaskBoardStatus::Todo
     }
 }
 

--- a/src/task_board/external/github/inbox.rs
+++ b/src/task_board/external/github/inbox.rs
@@ -208,7 +208,7 @@ impl GitHubInboxSyncClient {
                 reference: github_task_ref(repository, item.number, item.url),
                 title: item.title,
                 body: item.body.unwrap_or_default(),
-                status: TaskBoardStatus::HumanRequired,
+                status: TaskBoardStatus::Todo,
                 project_id: Some(project_id.clone()),
                 updated_at: Some(item.updated_at),
             })

--- a/src/task_board/external/github/inbox/tests.rs
+++ b/src/task_board/external/github/inbox/tests.rs
@@ -73,6 +73,29 @@ async fn github_inbox_pull_skips_failed_repository_and_keeps_pullable_tasks() {
     assert!(requests[2].contains("repo:good/repo"));
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].reference.external_id, "good/repo#7");
+    assert_eq!(tasks[0].status, TaskBoardStatus::Todo);
+}
+
+#[tokio::test]
+async fn github_inbox_pull_imports_review_requests_as_todo() {
+    let (endpoint, requests, handle) = spawn_sequence_mock(vec![
+        MockResponse::json(200, viewer_response("octo-user")),
+        MockResponse::json(200, empty_search_response()),
+        MockResponse::json(
+            200,
+            search_response_with_issue("https://example.test/good/pull/7"),
+        ),
+    ]);
+    let client = inbox_client_with_base_uri(endpoint, &["good/repo"]);
+
+    let tasks = client.pull_tasks().await.expect("inbox pull");
+
+    handle.join().expect("mock server");
+    let requests = requests.lock().expect("requests");
+    assert_eq!(requests.len(), 3);
+    assert!(requests[2].contains("review-requested:octo-user"));
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].status, TaskBoardStatus::Todo);
 }
 
 #[tokio::test]

--- a/src/task_board/external/github/review_projection.rs
+++ b/src/task_board/external/github/review_projection.rs
@@ -174,7 +174,7 @@ fn is_github_pull_request(reference: &ExternalRef) -> bool {
 
 fn is_imported_review(item: &TaskBoardItem) -> bool {
     item.imported_from_provider == Some(ExternalRefProvider::GitHub)
-        && item.planning.summary.is_none()
+        && item.external_refs.iter().any(is_github_pull_request)
 }
 
 fn projected_status(
@@ -189,7 +189,7 @@ fn projected_status(
         };
     }
     if snapshot.viewer_review_requested == Some(true) && current == TaskBoardStatus::Done {
-        return TaskBoardStatus::HumanRequired;
+        return TaskBoardStatus::Todo;
     }
     current
 }
@@ -197,7 +197,8 @@ fn projected_status(
 fn is_review_inbox_status(status: TaskBoardStatus) -> bool {
     matches!(
         status,
-        TaskBoardStatus::HumanRequired
+        TaskBoardStatus::Todo
+            | TaskBoardStatus::HumanRequired
             | TaskBoardStatus::AgenticReview
             | TaskBoardStatus::NeedsYou
             | TaskBoardStatus::PlanReview

--- a/src/task_board/external/github/review_projection/tests.rs
+++ b/src/task_board/external/github/review_projection/tests.rs
@@ -13,10 +13,14 @@ fn shared_review_snapshot_completes_imported_review_request() {
         "Body".into(),
         "2026-07-11T10:00:00Z".into(),
     );
-    item.status = TaskBoardStatus::HumanRequired;
+    item.status = TaskBoardStatus::Todo;
     item.project_id = Some("Example/Repo".into());
     item.imported_from_provider = Some(ExternalRefProvider::GitHub);
-    item.planning = PlanningState::default();
+    item.planning = PlanningState {
+        summary: Some("Review the linked pull request.".into()),
+        approved_by: None,
+        approved_at: None,
+    };
     item.external_refs = vec![ExternalRef {
         provider: ExternalRefProvider::GitHub,
         external_id: "example/repo#42".into(),
@@ -147,7 +151,7 @@ fn unknown_viewer_does_not_complete_review_request() {
         "Body".into(),
         "2026-07-11T10:00:00Z".into(),
     );
-    item.status = TaskBoardStatus::HumanRequired;
+    item.status = TaskBoardStatus::Todo;
     item.project_id = Some("example/repo".into());
     item.imported_from_provider = Some(ExternalRefProvider::GitHub);
     item.external_refs = vec![ExternalRef {
@@ -176,7 +180,7 @@ fn unknown_viewer_does_not_complete_review_request() {
             .get("github-example-repo-42")
             .expect("review item")
             .status,
-        TaskBoardStatus::HumanRequired
+        TaskBoardStatus::Todo
     );
 }
 
@@ -233,7 +237,7 @@ fn candidate_projection_reloads_refs_edited_after_listing() {
         "Body".into(),
         "2026-07-11T10:00:00Z".into(),
     );
-    item.status = TaskBoardStatus::HumanRequired;
+    item.status = TaskBoardStatus::Todo;
     item.project_id = Some("example/repo".into());
     item.imported_from_provider = Some(ExternalRefProvider::GitHub);
     item.external_refs = vec![ExternalRef {
@@ -286,7 +290,7 @@ fn aggregate_omission_does_not_complete_imported_review_request() {
         "Body".into(),
         "2026-07-11T10:00:00Z".into(),
     );
-    item.status = TaskBoardStatus::HumanRequired;
+    item.status = TaskBoardStatus::Todo;
     item.imported_from_provider = Some(ExternalRefProvider::GitHub);
     item.external_refs = vec![ExternalRef {
         provider: ExternalRefProvider::GitHub,
@@ -302,7 +306,7 @@ fn aggregate_omission_does_not_complete_imported_review_request() {
             .get("github-example-repo-42")
             .expect("review item")
             .status,
-        TaskBoardStatus::HumanRequired
+        TaskBoardStatus::Todo
     );
 }
 
@@ -316,7 +320,7 @@ fn active_imported_reviews_are_discovered_for_exact_resolution() {
         "Body".into(),
         "2026-07-11T10:00:00Z".into(),
     );
-    active.status = TaskBoardStatus::HumanRequired;
+    active.status = TaskBoardStatus::Todo;
     active.imported_from_provider = Some(ExternalRefProvider::GitHub);
     active.external_refs = vec![ExternalRef {
         provider: ExternalRefProvider::GitHub,

--- a/src/task_board/external/sync/reconcile.rs
+++ b/src/task_board/external/sync/reconcile.rs
@@ -119,7 +119,12 @@ fn reconciliation_patch(item: &TaskBoardItem, task: &ExternalTask) -> TaskBoardI
 }
 
 fn reconciled_status(item: &TaskBoardItem, task: &ExternalTask) -> TaskBoardStatus {
-    if is_active_github_review_request(item, task) && item.status != TaskBoardStatus::Done {
+    if is_active_github_review_request(item, task)
+        && !matches!(
+            item.status,
+            TaskBoardStatus::Done | TaskBoardStatus::HumanRequired | TaskBoardStatus::NeedsYou
+        )
+    {
         return item.status;
     }
     task.status
@@ -128,7 +133,7 @@ fn reconciled_status(item: &TaskBoardItem, task: &ExternalTask) -> TaskBoardStat
 fn is_active_github_review_request(item: &TaskBoardItem, task: &ExternalTask) -> bool {
     item.imported_from_provider == Some(ExternalRefProvider::GitHub)
         && task.reference.provider == ExternalProvider::GitHub
-        && task.status == TaskBoardStatus::HumanRequired
+        && task.status == TaskBoardStatus::Todo
         && task
             .reference
             .url

--- a/src/task_board/external/sync/stale_reviews.rs
+++ b/src/task_board/external/sync/stale_reviews.rs
@@ -52,7 +52,8 @@ fn allows_stale_review_reconcile(options: ExternalSyncOptions) -> bool {
     options.status.is_none_or(|status| {
         matches!(
             status,
-            TaskBoardStatus::HumanRequired
+            TaskBoardStatus::Todo
+                | TaskBoardStatus::HumanRequired
                 | TaskBoardStatus::AgenticReview
                 | TaskBoardStatus::NeedsYou
                 | TaskBoardStatus::PlanReview
@@ -121,10 +122,10 @@ fn is_stale_github_review_request(
     tasks: &[ExternalTask],
 ) -> bool {
     item.imported_from_provider == Some(ExternalRefProvider::GitHub)
-        && item.planning.summary.is_none()
         && matches!(
             item.status,
-            TaskBoardStatus::HumanRequired
+            TaskBoardStatus::Todo
+                | TaskBoardStatus::HumanRequired
                 | TaskBoardStatus::AgenticReview
                 | TaskBoardStatus::NeedsYou
                 | TaskBoardStatus::PlanReview

--- a/src/task_board/external/tests/github.rs
+++ b/src/task_board/external/tests/github.rs
@@ -50,7 +50,7 @@ async fn sync_external_tasks_imports_github_tasks_with_plan_pending_approval() {
 }
 
 #[tokio::test]
-async fn sync_external_tasks_imports_github_human_required_without_planning() {
+async fn sync_external_tasks_imports_github_inbox_items_as_todo_with_plan_pending_approval() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
@@ -59,7 +59,7 @@ async fn sync_external_tasks_imports_github_human_required_without_planning() {
             "owner/repo#19",
             "Review requested",
             "owner/repo",
-            TaskBoardStatus::HumanRequired,
+            TaskBoardStatus::Todo,
         )],
     ))];
 
@@ -80,9 +80,11 @@ async fn sync_external_tasks_imports_github_human_required_without_planning() {
     let item = board
         .get("github-owner-repo-19-983c1507241b6007ac5729cfcea78b64")
         .expect("load imported github inbox task");
-    assert_eq!(item.status, TaskBoardStatus::HumanRequired);
+    assert_eq!(item.status, TaskBoardStatus::Todo);
     assert_eq!(item.project_id.as_deref(), Some("owner/repo"));
-    assert!(item.planning.summary.is_none());
+    assert!(item.planning.summary.is_some());
+    assert!(item.planning.approved_by.is_none());
+    assert!(item.planning.approved_at.is_none());
     assert!(item.external_refs.iter().any(|reference| {
         reference.provider == ExternalRefProvider::GitHub
             && reference.external_id == "owner/repo#19"

--- a/src/task_board/external/tests/support.rs
+++ b/src/task_board/external/tests/support.rs
@@ -13,6 +13,7 @@ pub(super) struct FakeSyncClient {
     tasks: Vec<ExternalTask>,
     pushed: Mutex<Vec<String>>,
     allows_delete: bool,
+    authoritative_review_inbox: bool,
     deleted: Arc<Mutex<Vec<String>>>,
 }
 
@@ -23,12 +24,18 @@ impl FakeSyncClient {
             tasks,
             pushed: Mutex::new(Vec::new()),
             allows_delete: false,
+            authoritative_review_inbox: false,
             deleted: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     pub(super) fn with_delete(mut self) -> Self {
         self.allows_delete = true;
+        self
+    }
+
+    pub(super) fn with_authoritative_review_inbox(mut self) -> Self {
+        self.authoritative_review_inbox = true;
         self
     }
 
@@ -52,6 +59,10 @@ impl ExternalSyncClient for FakeSyncClient {
 
     fn allows_delete(&self) -> bool {
         self.allows_delete
+    }
+
+    fn authoritative_review_inbox(&self) -> bool {
+        self.authoritative_review_inbox
     }
 
     async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {

--- a/src/task_board/external/tests/sync.rs
+++ b/src/task_board/external/tests/sync.rs
@@ -272,7 +272,8 @@ async fn sync_external_tasks_resolves_stale_github_review_requests() {
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
         ExternalProvider::GitHub,
         Vec::new(),
-    ))];
+    )
+    .with_authoritative_review_inbox())];
 
     let operations = sync_external_tasks(
         &board,
@@ -309,13 +310,13 @@ async fn sync_external_tasks_resolves_stale_github_review_requests() {
 }
 
 #[tokio::test]
-async fn sync_external_tasks_dry_run_reports_stale_github_review_requests_without_writing() {
+async fn sync_external_tasks_dry_run_reports_stale_todo_github_review_requests_without_writing() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let item = super::support::github_review_request_item(
         "github-owner-repo-72",
         "owner/repo#72",
-        TaskBoardStatus::HumanRequired,
+        TaskBoardStatus::Todo,
     );
     board
         .create("Review requested", "Please review the pull request.", item)
@@ -324,7 +325,8 @@ async fn sync_external_tasks_dry_run_reports_stale_github_review_requests_withou
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
         ExternalProvider::GitHub,
         Vec::new(),
-    ))];
+    )
+    .with_authoritative_review_inbox())];
 
     let operations = sync_external_tasks(
         &board,
@@ -350,11 +352,11 @@ async fn sync_external_tasks_dry_run_reports_stale_github_review_requests_withou
     let unchanged = board
         .get("github-owner-repo-72")
         .expect("load unchanged review request");
-    assert_eq!(unchanged.status, TaskBoardStatus::HumanRequired);
+    assert_eq!(unchanged.status, TaskBoardStatus::Todo);
 }
 
 #[tokio::test]
-async fn sync_external_tasks_keeps_started_github_review_requests_when_remote_request_disappears() {
+async fn sync_external_tasks_resolves_stale_todo_github_review_requests() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let item = super::support::github_review_request_item(
@@ -364,12 +366,13 @@ async fn sync_external_tasks_keeps_started_github_review_requests_when_remote_re
     );
     board
         .create("Review requested", "Please review the pull request.", item)
-        .expect("create started review request task");
+        .expect("create todo review request task");
 
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
         ExternalProvider::GitHub,
         Vec::new(),
-    ))];
+    )
+    .with_authoritative_review_inbox())];
 
     let operations = sync_external_tasks(
         &board,
@@ -385,11 +388,11 @@ async fn sync_external_tasks_keeps_started_github_review_requests_when_remote_re
     .await
     .expect("sync external tasks");
 
-    assert!(operations.is_empty());
-    let unchanged = board
+    assert_eq!(operations.len(), 1);
+    let resolved = board
         .get("github-owner-repo-73")
-        .expect("load unchanged started review request");
-    assert_eq!(unchanged.status, TaskBoardStatus::Todo);
+        .expect("load resolved review request");
+    assert_eq!(resolved.status, TaskBoardStatus::Done);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation
GitHub inbox items assigned to the user or requesting review were placed in Human Required, hiding active work from the Todo queue and forcing an unnecessary lane transition.

## Implementation
- import open assigned issues and requested-review pull requests into Todo
- retain review-request reconciliation, stale completion, and reopen handling in the Todo lane
- cover Inbox status mapping and update Monitor and workflow guidance