### PR TITLE
perf(check): speed up harness feedback

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -202,7 +202,7 @@ run = "./scripts/version.sh check"
 
 [tasks."harness:check:scripts"]
 hide = true
-run = "mise run check:scripts"
+depends = ["check:scripts"]
 
 [tasks."harness:check:rust"]
 hide = true

--- a/.mise.toml
+++ b/.mise.toml
@@ -138,7 +138,11 @@ run = "./scripts/version.sh check"
 
 [tasks."check:scripts"]
 description = "Run shell and Python script lint plus syntax checks for repo-local helpers"
-run = "./scripts/check-scripts.sh"
+run = "./scripts/check-scripts.sh --lint"
+
+[tasks."test:scripts"]
+description = "Run repo-local helper script regression tests"
+run = "HARNESS_CHECK_SCRIPTS_STEP_TIMEOUT_SECONDS=180 ./scripts/check-scripts.sh --tests"
 
 [tasks."test:unit"]
 description = "Run unit tests"
@@ -181,13 +185,28 @@ run = "./scripts/cargo-local.sh run --quiet -- setup bootstrap"
 
 [tasks."harness:check"]
 description = "Run harness-only quality gates (without aff package checks)"
-run = [
-  "./scripts/check-no-stale-state.sh",
-  "./scripts/version.sh check",
-  "./scripts/check-scripts.sh",
-  "./scripts/cargo-local.sh check -p harness",
-  "./scripts/cargo-local.sh clippy -p harness --lib",
+depends = [
+  "harness:check:stale-state",
+  "harness:check:version",
+  "harness:check:scripts",
+  "harness:check:rust",
 ]
+
+[tasks."harness:check:stale-state"]
+hide = true
+run = "./scripts/check-no-stale-state.sh"
+
+[tasks."harness:check:version"]
+hide = true
+run = "./scripts/version.sh check"
+
+[tasks."harness:check:scripts"]
+hide = true
+run = "mise run check:scripts"
+
+[tasks."harness:check:rust"]
+hide = true
+run = "./scripts/cargo-local.sh clippy -p harness --lib --bins"
 
 [tasks."aff:check"]
 description = "Run aff-only quality gates"

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ If `harness run repair` still leaves blocking findings, start a fresh tracked ru
 mise run version:check
 mise run check                       # default harness quality gates
 mise run harness:check               # harness-only quality gates (same gates as default check)
+mise run test:scripts                # helper-script regression tests (slower; separate from feedback checks)
 mise run aff:check                   # aff-only quality gates (manual; not run by default)
 mise run test                        # default aggregate: harness + aff fast tests
 mise run test:unit                   # harness unit tests (opt-in; not run by default)

--- a/scripts/check-scripts.sh
+++ b/scripts/check-scripts.sh
@@ -133,6 +133,9 @@ if [[ "$mode" != "--tests" ]]; then
   if (( ${#python_scripts[@]} > 0 )); then
     python3 -m py_compile "${python_scripts[@]}"
   fi
+  if (( ${#monitor_python_tests[@]} > 0 )); then
+    python3 -m py_compile "${monitor_python_tests[@]}"
+  fi
 fi
 
 if [[ "$mode" != "--lint" ]] && (( ${#root_python_tests[@]} > 0 )); then
@@ -142,7 +145,6 @@ if [[ "$mode" != "--lint" ]] && (( ${#root_python_tests[@]} > 0 )); then
     python3 -m unittest discover -s "$ROOT/scripts/tests" -p 'test_*.py'
 fi
 if [[ "$mode" != "--lint" ]] && (( ${#monitor_python_tests[@]} > 0 )); then
-  python3 -m py_compile "${monitor_python_tests[@]}"
   for test_path in "${monitor_python_tests[@]}"; do
     case "$(basename -- "$test_path")" in
       test_xcodebuild_with_lock.py|test_test_swift.py)

--- a/scripts/check-scripts.sh
+++ b/scripts/check-scripts.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 
+if (( $# > 1 )); then
+  printf 'usage: %s [--all|--lint|--tests]\n' "${0##*/}" >&2
+  exit 2
+fi
+
 mode="${1:---all}"
 case "$mode" in
   --all|--lint|--tests)

--- a/scripts/check-scripts.sh
+++ b/scripts/check-scripts.sh
@@ -3,6 +3,16 @@ set -euo pipefail
 
 ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 
+mode="${1:---all}"
+case "$mode" in
+  --all|--lint|--tests)
+    ;;
+  *)
+    printf 'usage: %s [--all|--lint|--tests]\n' "${0##*/}" >&2
+    exit 2
+    ;;
+esac
+
 run_quiet_step() {
   local label="$1"
   shift
@@ -68,16 +78,6 @@ PY
   return 1
 }
 
-if ! command -v shellcheck >/dev/null 2>&1; then
-  printf "error: shellcheck is required. Install tools with \`mise install\`.\n" >&2
-  exit 1
-fi
-
-if ! command -v python3 >/dev/null 2>&1; then
-  printf 'error: python3 is required to compile-check scripts/*.py.\n' >&2
-  exit 1
-fi
-
 shopt -s nullglob
 
 shell_scripts=(
@@ -105,30 +105,43 @@ monitor_python_tests_dir="$ROOT/apps/harness-monitor/Scripts/tests"
 monitor_python_tests=("$ROOT"/apps/harness-monitor/Scripts/tests/*.py)
 monitor_python_fast_tests=()
 
-for script_path in "${shell_scripts[@]}"; do
-  bash -n "$script_path"
-done
-for script_path in "${monitor_shell_scripts[@]}"; do
-  bash -n "$script_path"
-done
+if [[ "$mode" != "--tests" ]]; then
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    printf "error: shellcheck is required. Install tools with \`mise install\`.\n" >&2
+    exit 1
+  fi
 
-if (( ${#shell_scripts[@]} > 0 )); then
-  shellcheck -x "${shell_scripts[@]}"
-fi
-if (( ${#monitor_shell_scripts[@]} > 0 )); then
-  shellcheck -x "${monitor_shell_scripts[@]}"
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf 'error: python3 is required to compile-check scripts/*.py.\n' >&2
+    exit 1
+  fi
+
+  for script_path in "${shell_scripts[@]}"; do
+    bash -n "$script_path"
+  done
+  for script_path in "${monitor_shell_scripts[@]}"; do
+    bash -n "$script_path"
+  done
+
+  if (( ${#shell_scripts[@]} > 0 )); then
+    shellcheck -x "${shell_scripts[@]}"
+  fi
+  if (( ${#monitor_shell_scripts[@]} > 0 )); then
+    shellcheck -x "${monitor_shell_scripts[@]}"
+  fi
+
+  if (( ${#python_scripts[@]} > 0 )); then
+    python3 -m py_compile "${python_scripts[@]}"
+  fi
 fi
 
-if (( ${#python_scripts[@]} > 0 )); then
-  python3 -m py_compile "${python_scripts[@]}"
-fi
-if (( ${#root_python_tests[@]} > 0 )); then
+if [[ "$mode" != "--lint" ]] && (( ${#root_python_tests[@]} > 0 )); then
   run_quiet_step \
     "root python script tests" \
     env PYTHONDONTWRITEBYTECODE=1 \
     python3 -m unittest discover -s "$ROOT/scripts/tests" -p 'test_*.py'
 fi
-if (( ${#monitor_python_tests[@]} > 0 )); then
+if [[ "$mode" != "--lint" ]] && (( ${#monitor_python_tests[@]} > 0 )); then
   python3 -m py_compile "${monitor_python_tests[@]}"
   for test_path in "${monitor_python_tests[@]}"; do
     case "$(basename -- "$test_path")" in
@@ -147,21 +160,23 @@ if (( ${#monitor_python_tests[@]} > 0 )); then
   fi
 fi
 
-run_quiet_step "check-scripts shell tests" "$ROOT/scripts/tests/test-check-scripts.sh"
-run_quiet_step "run-step shell tests" "$ROOT/scripts/tests/test-run-step.sh"
-run_quiet_step "clean-build-caches shell tests" "$ROOT/scripts/tests/test-clean-build-caches.sh"
-run_quiet_step "clean-stale-lanes shell tests" "$ROOT/scripts/tests/test-clean-stale-lanes.sh"
-run_quiet_step "mcp shell tests" "$ROOT/scripts/tests/test-mcp-scripts.sh"
-if [[ "${HARNESS_CHECK_SCRIPTS_FULL:-0}" == "1" ]]; then
-  HARNESS_CHECK_SCRIPTS_STEP_TIMEOUT_SECONDS="${HARNESS_CHECK_SCRIPTS_FULL_TIMEOUT_SECONDS:-${HARNESS_CHECK_SCRIPTS_STEP_TIMEOUT_SECONDS:-600}}" \
-    run_quiet_step "stale-scan shell tests" "$ROOT/scripts/tests/test-stale-scan.sh"
-else
-  printf 'ok: stale-scan shell tests (skipped in fast mode; set HARNESS_CHECK_SCRIPTS_FULL=1)\n'
+if [[ "$mode" != "--lint" ]]; then
+  run_quiet_step "check-scripts shell tests" "$ROOT/scripts/tests/test-check-scripts.sh"
+  run_quiet_step "run-step shell tests" "$ROOT/scripts/tests/test-run-step.sh"
+  run_quiet_step "clean-build-caches shell tests" "$ROOT/scripts/tests/test-clean-build-caches.sh"
+  run_quiet_step "clean-stale-lanes shell tests" "$ROOT/scripts/tests/test-clean-stale-lanes.sh"
+  run_quiet_step "mcp shell tests" "$ROOT/scripts/tests/test-mcp-scripts.sh"
+  if [[ "${HARNESS_CHECK_SCRIPTS_FULL:-0}" == "1" ]]; then
+    HARNESS_CHECK_SCRIPTS_STEP_TIMEOUT_SECONDS="${HARNESS_CHECK_SCRIPTS_FULL_TIMEOUT_SECONDS:-${HARNESS_CHECK_SCRIPTS_STEP_TIMEOUT_SECONDS:-600}}" \
+      run_quiet_step "stale-scan shell tests" "$ROOT/scripts/tests/test-stale-scan.sh"
+  else
+    printf 'ok: stale-scan shell tests (skipped in fast mode; set HARNESS_CHECK_SCRIPTS_FULL=1)\n'
+  fi
+  run_quiet_step "swarm e2e contract shell tests" "$ROOT/scripts/tests/test-e2e-swarm-contract.sh"
+  run_quiet_step "e2e triage-run shell tests" "$ROOT/scripts/tests/test-e2e-triage-run.sh"
+  run_quiet_step \
+    "recording triage shell tests" \
+    "$ROOT/scripts/e2e/recording-triage/tests/run-all.sh"
+  run_quiet_step "swarm iterate shell tests" "$ROOT/scripts/swarm-iterate/tests/run-all.sh"
+  run_quiet_step "active ledger shell check" "$ROOT/scripts/swarm-iterate/check-active-ledger.sh"
 fi
-run_quiet_step "swarm e2e contract shell tests" "$ROOT/scripts/tests/test-e2e-swarm-contract.sh"
-run_quiet_step "e2e triage-run shell tests" "$ROOT/scripts/tests/test-e2e-triage-run.sh"
-run_quiet_step \
-  "recording triage shell tests" \
-  "$ROOT/scripts/e2e/recording-triage/tests/run-all.sh"
-run_quiet_step "swarm iterate shell tests" "$ROOT/scripts/swarm-iterate/tests/run-all.sh"
-run_quiet_step "active ledger shell check" "$ROOT/scripts/swarm-iterate/check-active-ledger.sh"

--- a/scripts/check-scripts.sh
+++ b/scripts/check-scripts.sh
@@ -105,14 +105,14 @@ monitor_python_tests_dir="$ROOT/apps/harness-monitor/Scripts/tests"
 monitor_python_tests=("$ROOT"/apps/harness-monitor/Scripts/tests/*.py)
 monitor_python_fast_tests=()
 
+if ! command -v python3 >/dev/null 2>&1; then
+  printf 'error: python3 is required to compile-check or test scripts/*.py.\n' >&2
+  exit 1
+fi
+
 if [[ "$mode" != "--tests" ]]; then
   if ! command -v shellcheck >/dev/null 2>&1; then
     printf "error: shellcheck is required. Install tools with \`mise install\`.\n" >&2
-    exit 1
-  fi
-
-  if ! command -v python3 >/dev/null 2>&1; then
-    printf 'error: python3 is required to compile-check scripts/*.py.\n' >&2
     exit 1
   fi
 

--- a/scripts/tests/test-check-scripts.sh
+++ b/scripts/tests/test-check-scripts.sh
@@ -44,3 +44,9 @@ require_text "scripts/check-scripts.sh" 'clean-stale-lanes shell tests'
 require_text "scripts/check-scripts.sh" 'e2e triage-run shell tests'
 require_text "scripts/check-scripts.sh" 'HARNESS_CHECK_SCRIPTS_FULL_TIMEOUT_SECONDS'
 require_no_text "scripts/check-scripts.sh" 'HARNESS_CHECK_SCRIPTS_STEP_TIMEOUT_SECONDS=180'
+
+set +e
+"$ROOT/scripts/check-scripts.sh" --lint extra >/dev/null 2>&1
+status=$?
+set -e
+[[ "$status" -eq 2 ]] || fail "extra arguments should return usage status 2 (got $status)"


### PR DESCRIPTION
## Motivation
`mise run harness:check` serialized slow script regressions with redundant Rust analysis, delaying routine feedback. Keep the fast quality signal complete while moving full helper regressions to an explicit task.

## Implementation
- run independent harness preflight checks in parallel
- replace duplicate `cargo check` plus library Clippy with one Clippy pass covering library and binaries
- split helper-script linting from regression tests under `check:scripts` and `test:scripts`