### PR TITLE
fix(policy): keep trace IDs wire-compatible

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorPolicyModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorPolicyModels.swift
@@ -48,6 +48,22 @@ public struct PolicyPipelineDocument: Codable, Equatable, Sendable {
     case policyTraceIds = "policy_trace_ids"
   }
 
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    schemaVersion = try container.decode(UInt16.self, forKey: .schemaVersion)
+    revision = try container.decode(UInt64.self, forKey: .revision)
+    mode = try container.decode(PolicyPipelineMode.self, forKey: .mode)
+    nodes = try container.decode([PolicyPipelineNode].self, forKey: .nodes)
+    edges = try container.decode([PolicyPipelineEdge].self, forKey: .edges)
+    groups = try container.decode([PolicyPipelineGroup].self, forKey: .groups)
+    layout = try container.decode(PolicyPipelineLayout.self, forKey: .layout)
+    policyTraceIds =
+      try container.decodeIfPresent(
+        [String].self,
+        forKey: .policyTraceIds
+      ) ?? []
+  }
+
   public func supervisorPolicyOverrides() -> [PolicyConfigOverride] {
     nodes.compactMap { node in
       // The wire model identifies a supervisor rule by the node id (the seed

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/PolicyDocumentDecodingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/PolicyDocumentDecodingTests.swift
@@ -113,4 +113,26 @@ struct PolicyDocumentDecodingTests {
     #expect(document.layout.nodes.first?.nodeId == "risk:merge")
     #expect(document.nodes.first { $0.id == "supervisor:allow" }?.groupId == "terminal")
   }
+
+  @Test("defaults policy trace IDs when the daemon omits an empty list")
+  func defaultsMissingPolicyTraceIDs() throws {
+    let payload = """
+      {
+        "schema_version": 2,
+        "revision": 1,
+        "mode": "draft",
+        "nodes": [],
+        "edges": [],
+        "groups": [],
+        "layout": {}
+      }
+      """
+
+    let document = try PolicyWireCoding.decoder.decode(
+      PolicyPipelineDocument.self,
+      from: Data(payload.utf8)
+    )
+
+    #expect(document.policyTraceIds.isEmpty)
+  }
 }

--- a/src/task_board/policy_graph.rs
+++ b/src/task_board/policy_graph.rs
@@ -105,7 +105,7 @@ pub struct PolicyGraph {
     pub edges: Vec<PolicyGraphEdge>,
     pub groups: Vec<PolicyGraphGroup>,
     pub layout: PolicyGraphLayout,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub policy_trace_ids: Vec<String>,
 }
 

--- a/src/task_board/policy_graph/tests.rs
+++ b/src/task_board/policy_graph/tests.rs
@@ -53,6 +53,16 @@ fn seeded_graph_serializes_as_v2_draft() {
 }
 
 #[test]
+fn graph_serialization_keeps_empty_policy_trace_ids() {
+    let mut graph = PolicyGraph::seeded_v2();
+    graph.policy_trace_ids.clear();
+
+    let encoded = serde_json::to_value(graph).expect("serialize policy graph");
+
+    assert_eq!(encoded["policy_trace_ids"], json!([]));
+}
+
+#[test]
 fn seeded_graph_layout_starts_clear_and_non_overlapping() {
     let graph = PolicyGraph::seeded_v2();
     let node_layouts: HashMap<_, _> = graph


### PR DESCRIPTION
## Motivation
Policy canvases with no trace IDs were valid in Rust but serialized without `policy_trace_ids`. The Monitor hand-written policy decoder required that key, so one such canvas made the entire Policies workspace fail to decode and left the tab on “Loading Policies”.

## Implementation
- always serialize `policy_trace_ids` from the daemon, including an empty array
- default a missing `policy_trace_ids` key to an empty array in Monitor for compatibility with existing rows and older daemons
- add focused Rust serialization and Swift decoding regressions for both sides of the wire contract
- validate with the focused Rust and Swift tests, `mise run codegen:check`, `mise run monitor:lint`, and `mise run harness:check`
