### PR TITLE
fix(remote): invalidate live websocket clients

### DIFF
--- a/src/daemon/db/remote_identity.rs
+++ b/src/daemon/db/remote_identity.rs
@@ -113,6 +113,26 @@ impl DaemonDb {
         Ok(Some(client))
     }
 
+    /// Refresh an authenticated WebSocket identity from persisted state.
+    ///
+    /// A missing/revoked client or changed token hash invalidates the session
+    /// established with `authenticated`.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL or row parsing failures.
+    pub(crate) fn validate_remote_client_session(
+        &self,
+        authenticated: &RemoteStoredClient,
+    ) -> Result<Option<RemoteStoredClient>, CliError> {
+        let Some(current) = self.remote_client(&authenticated.client_id)? else {
+            return Ok(None);
+        };
+        if current.revoked_at.is_some() || current.token_hash != authenticated.token_hash {
+            return Ok(None);
+        }
+        Ok(Some(current))
+    }
+
     /// Revoke a remote client.
     ///
     /// # Errors

--- a/src/daemon/db/tests/remote_identity.rs
+++ b/src/daemon/db/tests/remote_identity.rs
@@ -164,6 +164,56 @@ fn remote_clients_persist_hashed_tokens_and_support_revoke_rotate() {
 }
 
 #[test]
+fn remote_client_session_rejects_revoke_and_token_rotation() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let registration = RemoteClientRegistration::new_for_tests(
+        "session-client",
+        "Session Client",
+        "macos",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        "session-token",
+        "2026-07-12T15:00:00Z",
+    )
+    .expect("registration");
+    let authenticated = db
+        .register_remote_client(&registration)
+        .expect("register client");
+
+    assert!(
+        db.validate_remote_client_session(&authenticated)
+            .expect("validate active session")
+            .is_some()
+    );
+
+    db.rotate_remote_client_token(
+        &authenticated.client_id,
+        "rotated-session-token",
+        "2026-07-12T15:01:00Z",
+    )
+    .expect("rotate token");
+    assert!(
+        db.validate_remote_client_session(&authenticated)
+            .expect("validate rotated session")
+            .is_none(),
+        "a token rotation must invalidate the handshake identity"
+    );
+
+    let rotated = db
+        .verify_remote_client_token(&authenticated.client_id, "rotated-session-token")
+        .expect("verify rotated token")
+        .expect("rotated client");
+    db.revoke_remote_client(&rotated.client_id, "2026-07-12T15:02:00Z")
+        .expect("revoke client");
+    assert!(
+        db.validate_remote_client_session(&rotated)
+            .expect("validate revoked session")
+            .is_none(),
+        "revocation must invalidate the handshake identity"
+    );
+}
+
+#[test]
 fn remote_audit_events_persist_with_redacted_error_detail() {
     let db = DaemonDb::open_in_memory().expect("open db");
     let event = RemoteAuditEvent::new(

--- a/src/daemon/websocket/connection.rs
+++ b/src/daemon/websocket/connection.rs
@@ -253,6 +253,7 @@ fn spawn_inbound_task(
         let mut last_client_message = Instant::now();
         let mut idle_check = tokio_interval(Duration::from_secs(15));
         let mut credential_check = tokio_interval(Duration::from_secs(5));
+        credential_check.tick().await;
 
         loop {
             tokio::select! {

--- a/src/daemon/websocket/connection.rs
+++ b/src/daemon/websocket/connection.rs
@@ -7,6 +7,7 @@ use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{ConnectInfo, State};
 use axum::http::HeaderMap;
 use axum::response::Response;
+use futures_util::stream::SplitStream;
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
 use tokio::task::{JoinHandle, JoinSet};
@@ -15,10 +16,12 @@ use tracing::Instrument as _;
 use tracing::field::{Empty, display};
 use tracing::{debug, info, warn};
 
+use crate::daemon::db::db_error;
 use crate::daemon::http::{self, DaemonConnectInfo, DaemonHttpState};
 #[cfg(test)]
 use crate::daemon::protocol::StreamEvent;
 use crate::daemon::remote_identity::RemoteStoredClient;
+use crate::errors::CliError;
 use crate::telemetry::{apply_parent_context_from_headers, current_trace_id, with_active_baggage};
 
 use super::config::build_config_push_frame;
@@ -67,6 +70,10 @@ impl ConnectionState {
 
     pub(crate) fn remote_addr(&self) -> Option<&str> {
         self.remote_addr.as_deref()
+    }
+
+    fn replace_remote_client(&mut self, client: RemoteStoredClient) {
+        self.remote_client = Some(client);
     }
 
     #[cfg(test)]
@@ -174,7 +181,7 @@ async fn handle_connection(
     remote_addr: Option<String>,
 ) {
     tracing::info!(client = %client_label, "websocket connection opened");
-    let (mut sender, mut receiver) = socket.split();
+    let (mut sender, receiver) = socket.split();
     let connection = Arc::new(Mutex::new(ConnectionState::new_with_remote_client(
         remote_client,
         remote_addr,
@@ -205,59 +212,13 @@ async fn handle_connection(
         relay_state,
     ));
 
-    let priority_tx_dispatch = priority_tx.clone();
-    let connection_dispatch = Arc::clone(&connection);
-    let inbound_client_label = client_label.clone();
-    let inbound_task = tokio::spawn(async move {
-        let mut dispatch_tasks = JoinSet::new();
-        let mut last_client_message = Instant::now();
-        let mut idle_check = tokio_interval(Duration::from_secs(15));
-
-        loop {
-            tokio::select! {
-                message = receiver.next() => {
-                    match message {
-                        Some(Ok(message)) => {
-                            if incoming_message_counts_as_activity(&message) {
-                                last_client_message = Instant::now();
-                            }
-                            match handle_incoming_message(
-                                message,
-                                state.clone(),
-                                Arc::clone(&connection_dispatch),
-                                priority_tx_dispatch.clone(),
-                                &mut dispatch_tasks,
-                            ) {
-                                IncomingMessageAction::ContinueLoop => {}
-                                IncomingMessageAction::CloseConnection => break,
-                                IncomingMessageAction::RespondBatch(frames) => {
-                                    for frame in frames {
-                                        if priority_tx_dispatch.send(frame).await.is_err() {
-                                            return;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        None => break,
-                        Some(Err(error)) => {
-                            debug!(%error, "websocket receive error");
-                            break;
-                        }
-                    }
-                }
-                Some(_) = dispatch_tasks.join_next(), if !dispatch_tasks.is_empty() => {}
-                _ = idle_check.tick() => {
-                    if last_client_message.elapsed() > Duration::from_secs(45) {
-                        info!(client = %inbound_client_label, "websocket idle timeout, closing connection");
-                        break;
-                    }
-                }
-            }
-        }
-        dispatch_tasks.abort_all();
-        while dispatch_tasks.join_next().await.is_some() {}
-    });
+    let inbound_task = spawn_inbound_task(
+        receiver,
+        state,
+        connection,
+        priority_tx,
+        client_label.clone(),
+    );
 
     let writer_task = tokio::spawn(async move {
         loop {
@@ -278,6 +239,101 @@ async fn handle_connection(
 
     await_connection_tasks(relay_task, inbound_task, writer_task).await;
     tracing::info!(client = %client_label, "websocket connection closed");
+}
+
+fn spawn_inbound_task(
+    mut receiver: SplitStream<WebSocket>,
+    state: DaemonHttpState,
+    connection: Arc<Mutex<ConnectionState>>,
+    priority_tx: mpsc::Sender<Message>,
+    client_label: String,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut dispatch_tasks = JoinSet::new();
+        let mut last_client_message = Instant::now();
+        let mut idle_check = tokio_interval(Duration::from_secs(15));
+        let mut credential_check = tokio_interval(Duration::from_secs(5));
+
+        loop {
+            tokio::select! {
+                message = receiver.next() => {
+                    match message {
+                        Some(Ok(message)) => {
+                            if incoming_message_counts_as_activity(&message) {
+                                last_client_message = Instant::now();
+                            }
+                            match handle_incoming_message(
+                                message,
+                                state.clone(),
+                                Arc::clone(&connection),
+                                priority_tx.clone(),
+                                &mut dispatch_tasks,
+                            ) {
+                                IncomingMessageAction::ContinueLoop => {}
+                                IncomingMessageAction::CloseConnection => break,
+                                IncomingMessageAction::RespondBatch(frames) => {
+                                    for frame in frames {
+                                        if priority_tx.send(frame).await.is_err() {
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        None => break,
+                        Some(Err(error)) => {
+                            debug!(%error, "websocket receive error");
+                            break;
+                        }
+                    }
+                }
+                Some(_) = dispatch_tasks.join_next(), if !dispatch_tasks.is_empty() => {}
+                _ = credential_check.tick(), if state.auth_mode == http::DaemonHttpAuthMode::Remote => {
+                    if !matches!(refresh_remote_connection_client(&state, &connection), Ok(Some(_))) {
+                        info!(client = %client_label, "remote websocket credentials invalidated, closing connection");
+                        break;
+                    }
+                }
+                _ = idle_check.tick() => {
+                    if last_client_message.elapsed() > Duration::from_secs(45) {
+                        info!(client = %client_label, "websocket idle timeout, closing connection");
+                        break;
+                    }
+                }
+            }
+        }
+        dispatch_tasks.abort_all();
+        while dispatch_tasks.join_next().await.is_some() {}
+    })
+}
+
+pub(crate) fn refresh_remote_connection_client(
+    state: &DaemonHttpState,
+    connection: &Arc<Mutex<ConnectionState>>,
+) -> Result<Option<RemoteStoredClient>, CliError> {
+    let authenticated = connection
+        .lock()
+        .map_err(|_| db_error("remote websocket connection state is unavailable"))?
+        .remote_client()
+        .cloned();
+    let Some(authenticated) = authenticated else {
+        return Ok(None);
+    };
+    let db = state
+        .db
+        .get()
+        .ok_or_else(|| db_error("remote authentication store is unavailable"))?;
+    let current = db
+        .lock()
+        .map_err(|_| db_error("remote authentication store is unavailable"))?
+        .validate_remote_client_session(&authenticated)?;
+    if let Some(client) = current.as_ref() {
+        connection
+            .lock()
+            .map_err(|_| db_error("remote websocket connection state is unavailable"))?
+            .replace_remote_client(client.clone());
+    }
+    Ok(current)
 }
 
 pub(crate) async fn await_connection_tasks(

--- a/src/daemon/websocket/connection.rs
+++ b/src/daemon/websocket/connection.rs
@@ -289,9 +289,16 @@ fn spawn_inbound_task(
                 }
                 Some(_) = dispatch_tasks.join_next(), if !dispatch_tasks.is_empty() => {}
                 _ = credential_check.tick(), if state.auth_mode == http::DaemonHttpAuthMode::Remote => {
-                    if !matches!(refresh_remote_connection_client(&state, &connection), Ok(Some(_))) {
-                        info!(client = %client_label, "remote websocket credentials invalidated, closing connection");
-                        break;
+                    match refresh_remote_connection_client(&state, &connection) {
+                        Ok(Some(_)) => {}
+                        Ok(None) => {
+                            info!(client = %client_label, "remote websocket credentials invalidated, closing connection");
+                            break;
+                        }
+                        Err(error) => {
+                            warn!(client = %client_label, %error, "remote websocket credential validation failed, closing connection");
+                            break;
+                        }
                     }
                 }
                 _ = idle_check.tick() => {

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -262,7 +262,7 @@ fn authorize_remote_ws_request(
             )?;
             return Err(Box::new(remote_ws_auth_error_response(&request.id, error)));
         }
-        Err(error) => return Err(remote_ws_audit_error_response(request, &error)),
+        Err(error) => return Err(remote_ws_auth_store_error_response(request, &error)),
     };
     match authorize_remote_ws_method(&client, &request.method) {
         Ok(decision) => {
@@ -357,6 +357,33 @@ fn remote_ws_audit_error_response(request: &WsRequest, error: &CliError) -> Box<
             data: None,
         },
     ))
+}
+
+fn remote_ws_auth_store_error_response(request: &WsRequest, error: &CliError) -> Box<WsResponse> {
+    log_remote_ws_auth_store_error(request, error);
+    Box::new(error_response_with_payload(
+        &request.id,
+        WsErrorPayload {
+            code: "REMOTE_AUTH_STORE".to_string(),
+            message: "remote authentication store is unavailable".to_string(),
+            details: Vec::new(),
+            status_code: Some(503),
+            data: None,
+        },
+    ))
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion inflates the score; tokio-rs/tracing#553"
+)]
+fn log_remote_ws_auth_store_error(request: &WsRequest, error: &CliError) {
+    tracing::error!(
+        error = %error,
+        method = %request.method,
+        request_id = %request.id,
+        "remote websocket authentication store refresh failed"
+    );
 }
 
 #[expect(

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -1,4 +1,4 @@
-use super::connection::ConnectionState;
+use super::connection::{ConnectionState, refresh_remote_connection_client};
 use super::frames::{
     error_response, error_response_with_payload, serialize_error_response_frames,
     serialize_response_frames,
@@ -235,8 +235,8 @@ fn authorize_remote_ws_request(
     }
     let required_scope = remote_ws_required_scope(&request.method)
         .map_err(|error| Box::new(remote_ws_auth_error_response(&request.id, error)))?;
-    let (client, remote_addr) = remote_connection_identity(connection);
-    let Some(client) = client else {
+    let (authenticated, remote_addr) = remote_connection_identity(connection);
+    let Some(authenticated) = authenticated else {
         let error = RemoteAuthError::MissingClientId;
         record_remote_ws_denial(
             request,
@@ -247,6 +247,22 @@ fn authorize_remote_ws_request(
             error,
         )?;
         return Err(Box::new(remote_ws_auth_error_response(&request.id, error)));
+    };
+    let client = match refresh_remote_connection_client(state, connection) {
+        Ok(Some(client)) => client,
+        Ok(None) => {
+            let error = RemoteAuthError::InvalidBearerToken;
+            record_remote_ws_denial(
+                request,
+                state,
+                Some(&authenticated.client_id),
+                required_scope,
+                remote_addr.as_deref(),
+                error,
+            )?;
+            return Err(Box::new(remote_ws_auth_error_response(&request.id, error)));
+        }
+        Err(error) => return Err(remote_ws_audit_error_response(request, &error)),
     };
     match authorize_remote_ws_method(&client, &request.method) {
         Ok(decision) => {

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -3,7 +3,10 @@ use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::protocol::ws_methods;
 use crate::daemon::protocol::{WsRequest, current_control_plane_actor_id};
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
-use crate::daemon::remote_identity::{RemoteStoredClient, RemoteTokenHash};
+use crate::daemon::remote_identity::{
+    RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteClientRegistration, RemoteStoredClient,
+    RemoteTokenHash,
+};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -71,6 +74,58 @@ async fn remote_ws_dispatch_denies_known_method_without_remote_client() {
     assert_eq!(error.message, "remote client id is required");
     assert_eq!(error.status_code, Some(401));
     assert!(response.result.is_none());
+}
+
+#[tokio::test]
+async fn remote_ws_dispatch_denies_client_revoked_after_handshake() {
+    let mut state = super::super::test_support::test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let registration = RemoteClientRegistration::new_for_tests(
+        "revoked-viewer",
+        "Revoked Viewer",
+        "macos",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        "revoked-viewer-token-abcdefghijklmnopqrstuvwxyz",
+        "2026-07-12T15:00:00Z",
+    )
+    .expect("remote registration");
+    let authenticated = {
+        let db = state.db.get().expect("db slot").lock().expect("db lock");
+        let client = db
+            .register_remote_client(&registration)
+            .expect("register remote client");
+        db.revoke_remote_client(&client.client_id, "2026-07-12T15:01:00Z")
+            .expect("revoke remote client");
+        client
+    };
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(authenticated)));
+    let request = ws_request("req-revoked", ws_methods::PING);
+
+    let response = dispatch(&request, &state, &connection).await;
+    let error = response.error.expect("remote auth error");
+
+    assert_eq!(error.code, "REMOTE_AUTH");
+    assert_eq!(error.message, "remote bearer token is invalid");
+    assert_eq!(error.status_code, Some(401));
+    let audit = state
+        .db
+        .get()
+        .expect("db slot")
+        .lock()
+        .expect("db lock")
+        .load_remote_audit_events(10)
+        .expect("load remote audits")
+        .into_iter()
+        .find(|event| event.request_id.as_deref() == Some("req-revoked"))
+        .expect("revoked request audit");
+    assert_eq!(audit.client_id.as_deref(), Some("revoked-viewer"));
+    assert_eq!(audit.scope_decision, RemoteAuditScopeDecision::Denied);
+    assert_eq!(audit.outcome, RemoteAuditOutcome::Failure);
+    assert_eq!(
+        audit.error_detail.as_deref(),
+        Some("remote bearer token is invalid")
+    );
 }
 
 #[tokio::test]

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -129,6 +129,25 @@ async fn remote_ws_dispatch_denies_client_revoked_after_handshake() {
 }
 
 #[tokio::test]
+async fn remote_ws_dispatch_reports_auth_store_refresh_failure() {
+    let mut state = super::super::test_support::test_http_state();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
+        "viewer",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+    ))));
+    let request = ws_request("req-auth-store", ws_methods::PING);
+
+    let response = dispatch(&request, &state, &connection).await;
+    let error = response.error.expect("remote auth store error");
+
+    assert_eq!(error.code, "REMOTE_AUTH_STORE");
+    assert_eq!(error.message, "remote authentication store is unavailable");
+    assert_eq!(error.status_code, Some(503));
+}
+
+#[tokio::test]
 async fn remote_ws_dispatch_preserves_unknown_method_errors() {
     let mut state = super::super::test_support::test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;

--- a/tests/remote_daemon_e2e.rs
+++ b/tests/remote_daemon_e2e.rs
@@ -123,13 +123,18 @@ async fn run_remote_daemon_case(challenge: AcmeChallenge) -> Result<(), String> 
     daemon.ensure_running()?;
     expect_untrusted_ca_rejected(environment.https_port()).await?;
 
-    let viewer = pair_client(&daemon, &client, "viewer", "viewer-e2e").await?;
+    let mut viewer = pair_client(&daemon, &client, "viewer", "viewer-e2e").await?;
     client.expect_health(&viewer, 200).await?;
     client.expect_oversized_http_body_rejected(&viewer).await?;
     client
         .expect_oversized_websocket_message_rejected(&viewer)
         .await?;
     client.expect_telemetry(&viewer, 403).await?;
+    let rotated = client
+        .expect_live_websocket_invalidation(&viewer, || daemon.rotate_client(&viewer.client_id))
+        .await?;
+    viewer.token = required_string(&rotated, "token")?.to_string();
+    client.expect_health(&viewer, 200).await?;
 
     let operator = pair_client(&daemon, &client, "operator", "operator-e2e").await?;
     client.expect_telemetry(&operator, 200).await?;
@@ -141,7 +146,11 @@ async fn run_remote_daemon_case(challenge: AcmeChallenge) -> Result<(), String> 
     let admin = pair_client(&daemon, &client, "admin", "admin-e2e").await?;
     client.expect_log_level_update(&admin, 200).await?;
 
-    daemon.revoke_client(&operator.client_id)?;
+    client
+        .expect_live_websocket_invalidation(&operator, || {
+            daemon.revoke_client(&operator.client_id).map(|_| ())
+        })
+        .await?;
     client.expect_health(&operator, 401).await?;
     acme.assert_complete().await?;
 

--- a/tests/remote_daemon_e2e/client.rs
+++ b/tests/remote_daemon_e2e/client.rs
@@ -260,13 +260,13 @@ impl RemoteDaemonClient {
         Mutate: FnOnce() -> Result<Output, String>,
     {
         let mut socket = self.connect_websocket(credentials).await?;
-        let health = websocket_rpc(&mut socket, "e2e-before-revoke", "health").await?;
+        let health = websocket_rpc(&mut socket, "e2e-before-invalidation", "health").await?;
         if !health["error"].is_null() || health["result"].is_null() {
             return Err(format!("WSS health before invalidation failed: {health}"));
         }
 
         let output = mutate()?;
-        let denied = websocket_rpc(&mut socket, "e2e-after-revoke", "health").await?;
+        let denied = websocket_rpc(&mut socket, "e2e-after-invalidation", "health").await?;
         if denied["error"]["status_code"].as_u64() != Some(401) {
             return Err(format!(
                 "live WSS invalidation did not deny the request: {denied}"

--- a/tests/remote_daemon_e2e/client.rs
+++ b/tests/remote_daemon_e2e/client.rs
@@ -251,6 +251,41 @@ impl RemoteDaemonClient {
             .map_err(|error| format!("close WSS connection: {error}"))
     }
 
+    pub async fn expect_live_websocket_invalidation<Mutate, Output>(
+        &self,
+        credentials: &RemoteCredentials,
+        mutate: Mutate,
+    ) -> Result<Output, String>
+    where
+        Mutate: FnOnce() -> Result<Output, String>,
+    {
+        let mut socket = self.connect_websocket(credentials).await?;
+        let health = websocket_rpc(&mut socket, "e2e-before-revoke", "health").await?;
+        if !health["error"].is_null() || health["result"].is_null() {
+            return Err(format!("WSS health before revoke failed: {health}"));
+        }
+
+        let output = mutate()?;
+        let denied = websocket_rpc(&mut socket, "e2e-after-revoke", "health").await?;
+        if denied["error"]["status_code"].as_u64() != Some(401) {
+            return Err(format!(
+                "live WSS revoke did not deny the request: {denied}"
+            ));
+        }
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while let Some(frame) = socket.next().await {
+                match frame {
+                    Ok(Message::Close(_)) | Err(_) => return,
+                    Ok(_) => {}
+                }
+            }
+        })
+        .await
+        .map_err(|_| "invalidated WSS connection remained open".to_string())?;
+        Ok(output)
+    }
+
     #[allow(
         dead_code,
         reason = "used by the public ACME sibling integration target"

--- a/tests/remote_daemon_e2e/client.rs
+++ b/tests/remote_daemon_e2e/client.rs
@@ -262,14 +262,14 @@ impl RemoteDaemonClient {
         let mut socket = self.connect_websocket(credentials).await?;
         let health = websocket_rpc(&mut socket, "e2e-before-revoke", "health").await?;
         if !health["error"].is_null() || health["result"].is_null() {
-            return Err(format!("WSS health before revoke failed: {health}"));
+            return Err(format!("WSS health before invalidation failed: {health}"));
         }
 
         let output = mutate()?;
         let denied = websocket_rpc(&mut socket, "e2e-after-revoke", "health").await?;
         if denied["error"]["status_code"].as_u64() != Some(401) {
             return Err(format!(
-                "live WSS revoke did not deny the request: {denied}"
+                "live WSS invalidation did not deny the request: {denied}"
             ));
         }
 

--- a/tests/remote_daemon_e2e/client.rs
+++ b/tests/remote_daemon_e2e/client.rs
@@ -273,7 +273,7 @@ impl RemoteDaemonClient {
             ));
         }
 
-        tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::time::timeout(Duration::from_secs(7), async {
             while let Some(frame) = socket.next().await {
                 match frame {
                     Ok(Message::Close(_)) | Err(_) => return,

--- a/tests/remote_daemon_e2e/process.rs
+++ b/tests/remote_daemon_e2e/process.rs
@@ -215,6 +215,17 @@ impl RemoteDaemonProcess {
         ])
     }
 
+    pub fn rotate_client(&self, client_id: &str) -> Result<Value, String> {
+        self.run_json(&[
+            "daemon",
+            "remote",
+            "clients",
+            "rotate",
+            "--client-id",
+            client_id,
+        ])
+    }
+
     fn run_json(&self, args: &[&str]) -> Result<Value, String> {
         let mut command = Command::new(harness_binary());
         command.args(args);


### PR DESCRIPTION
## Motivation

Remote WebSockets cached client identity at handshake. Revoked clients and clients whose tokens were rotated could keep an established socket authorized and continue receiving broadcasts.

## Implementation

- Refresh persisted remote-client identity before each declared WS method
- Deny revoked or rotated handshake credentials with an audited 401
- Close idle invalidated remote sockets within five seconds
- Extend the full HTTPS/WSS e2e to prove revoke and rotate invalidation across every ACME challenge mode
- Prove the same e2e on the live Linux server without touching its production daemon