### PR TITLE
fix(monitor): reconnect after leaving remote daemon

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefresh.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefresh.swift
@@ -177,6 +177,7 @@ extension HarnessMonitorStore {
     recordConnectionTelemetry: Bool = true,
     isInitialConnect: Bool = false
   ) async throws {
+    let adoptsLocalManifest = !usesRemoteDaemon
     let refreshSnapshot = try await Self.loadRefreshSnapshot(using: client)
     await applyRefreshSnapshot(
       refreshSnapshot,
@@ -185,7 +186,8 @@ extension HarnessMonitorStore {
         preserveSelection: preserveSelection,
         allowPreviewReadySelection: allowPreviewReadySelection,
         recordConnectionTelemetry: recordConnectionTelemetry,
-        isInitialConnect: isInitialConnect
+        isInitialConnect: isInitialConnect,
+        adoptsLocalManifest: adoptsLocalManifest
       )
     )
   }
@@ -194,6 +196,7 @@ extension HarnessMonitorStore {
     using client: any HarnessMonitorClientProtocol,
     preserveSelection: Bool
   ) async throws {
+    let adoptsLocalManifest = !usesRemoteDaemon
     let refreshSnapshot = try await Self.loadRefreshSnapshot(using: client)
     await applyRefreshSnapshot(
       refreshSnapshot,
@@ -202,7 +205,8 @@ extension HarnessMonitorStore {
         preserveSelection: preserveSelection,
         allowPreviewReadySelection: true,
         recordConnectionTelemetry: false,
-        isInitialConnect: false
+        isInitialConnect: false,
+        adoptsLocalManifest: adoptsLocalManifest
       )
     )
   }
@@ -326,6 +330,7 @@ struct RefreshApplyOptions {
   let allowPreviewReadySelection: Bool
   let recordConnectionTelemetry: Bool
   let isInitialConnect: Bool
+  let adoptsLocalManifest: Bool
 }
 
 struct TaskBoardConfirmationTick {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefreshApply.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefreshApply.swift
@@ -47,7 +47,9 @@ extension HarnessMonitorStore {
         measuredDiagnostics.value.health?.logLevel
         ?? HarnessMonitorLogger.defaultDaemonLogLevel
       lastRefreshTimings = refreshTimings
-      adoptManifestURL(from: measuredDiagnostics.value.workspace.manifestPath)
+      if options.adoptsLocalManifest {
+        adoptManifestURL(from: measuredDiagnostics.value.workspace.manifestPath)
+      }
       globalTaskBoardItems = resolvedTaskBoardSnapshot.items
       globalTaskBoardOrchestratorStatus = resolvedTaskBoardSnapshot.orchestratorStatus
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ManifestLocation.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ManifestLocation.swift
@@ -12,6 +12,10 @@ extension HarnessMonitorStore {
     guard manifestURL == nil else {
       return
     }
+    resetLocalManifestURL()
+  }
+
+  func resetLocalManifestURL() {
     manifestURL = HarnessMonitorPaths.manifestURLWithoutLiveDiscovery()
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+RemoteDaemon.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+RemoteDaemon.swift
@@ -131,7 +131,7 @@ extension HarnessMonitorStore {
   private func completeRemoteDaemonForget() async {
     remoteDaemonProfile = nil
     remoteDaemonActionState = .idle
-    ensureLocalManifestURL()
+    resetLocalManifestURL()
     await reconnect()
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests.swift
@@ -159,6 +159,35 @@ struct HarnessMonitorStoreRemoteConnectionTests {
     #expect(await daemon.recordedWarmUpCallCount() == 1)
   }
 
+  @Test("Forgetting a remote daemon reconnects with the local manifest")
+  func forgettingRemoteDaemonRestoresLocalManifest() async throws {
+    let fixture = try RemoteStoreFixture()
+    let daemon = RecordingDaemonController(
+      warmUpError: DaemonControlError.daemonDidNotStart,
+      usesWarmUpErrorForBootstrap: false
+    )
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      daemonOwnership: .external,
+      remoteDaemonServices: fixture.services
+    )
+    let localManifestURL = URL(fileURLWithPath: "/tmp/harness-local/manifest.json")
+    store.manifestURL = localManifestURL
+
+    await store.bootstrap()
+    #expect(store.manifestURL == localManifestURL)
+
+    store.manifestURL = URL(fileURLWithPath: "/var/lib/harness-remote/manifest.json")
+    store.forgetRemoteDaemon()
+    try await waitUntil {
+      guard case .offline = store.connectionState else { return false }
+      return !store.usesRemoteDaemon && store.remoteDaemonActionState == .idle
+    }
+
+    #expect(store.manifestURL == HarnessMonitorPaths.manifestURLWithoutLiveDiscovery())
+    #expect(await daemon.recordedWarmUpCallCount() == 1)
+  }
+
   private func waitUntil(
     _ condition: @MainActor () -> Bool
   ) async throws {

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingDaemonController.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingDaemonController.swift
@@ -25,13 +25,14 @@ actor RecordingDaemonController: DaemonControlling {
     statusReport: DaemonStatusReport? = nil,
     bootstrapError: (any Error)? = nil,
     warmUpError: (any Error)? = nil,
+    usesWarmUpErrorForBootstrap: Bool = true,
     deferredManagedLaunchAgentRefreshResult: Bool = false
   ) {
     self.client = client
     self.launchAgentInstalled = launchAgentInstalled
     self.registrationStateOverride = registrationState
     self.statusReportOverride = statusReport
-    self.bootstrapError = bootstrapError ?? warmUpError
+    self.bootstrapError = bootstrapError ?? (usesWarmUpErrorForBootstrap ? warmUpError : nil)
     self.warmUpError = warmUpError
     self.deferredManagedLaunchAgentRefreshResult = deferredManagedLaunchAgentRefreshResult
   }


### PR DESCRIPTION
## Motivation
Switching from a remote daemon back to local mode left Monitor watching the remote server manifest path, so it did not reconnect automatically.

## Implementation
- Keep remote diagnostics from replacing the local manifest path, including in-flight refreshes.
- Reset the local manifest path before reconnecting after a remote profile is forgotten.
- Add a regression test covering remote refresh, profile removal, and local reconnect fallback.