### PR TITLE
fix(mobile): clear stale watch pairings

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileWatchPairingTransfer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileWatchPairingTransfer.swift
@@ -38,6 +38,13 @@ public struct MobileWatchPairingTransfer: Codable, Equatable, Sendable {
     return try Self.encode(fallback)
   }
 
+  public func watchConnectivityPayload(maximumBytes: Int) throws -> [String: Any] {
+    [
+      MobileWatchPairingTransferEnvelope.transferKey:
+        try encodedData(maximumBytes: maximumBytes)
+    ]
+  }
+
   private static func encode(_ transfer: Self) throws -> Data {
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .iso8601
@@ -54,12 +61,6 @@ public struct MobileWatchPairingTransfer: Codable, Equatable, Sendable {
   public func replacementPlan(
     replacing currentCredentials: [MobilePairedStationCredential]
   ) -> MobileWatchPairingReplacementPlan {
-    guard !credentials.isEmpty else {
-      return MobileWatchPairingReplacementPlan(
-        credentialStationIDsToDelete: [],
-        identityIDsToDelete: []
-      )
-    }
     var incomingIdentityIDByStation: [String: String] = [:]
     for credential in credentials {
       incomingIdentityIDByStation[credential.stationID] = credential.deviceIdentityID

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileWatchPairingSessionBridge.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileWatchPairingSessionBridge.swift
@@ -39,9 +39,6 @@ final class MobileWatchPairingSessionBridge: NSObject, MobileWatchPairingSyncing
     snapshot: MobileMirrorSnapshot? = nil,
     exportedAt: Date = .now
   ) async {
-    guard !credentials.isEmpty else {
-      return
-    }
     let transfer = MobileWatchPairingTransfer(
       identities: identities,
       credentials: credentials,
@@ -49,13 +46,12 @@ final class MobileWatchPairingSessionBridge: NSObject, MobileWatchPairingSyncing
       exportedAt: exportedAt
     )
     guard
-      let data = try? transfer.encodedData(
+      let payload = try? transfer.watchConnectivityPayload(
         maximumBytes: Self.maximumTransferPayloadBytes
       )
     else {
       return
     }
-    let payload = [MobileWatchPairingTransferEnvelope.transferKey: data]
     cachePayloadForTransfer(payload)
 
     guard let session else {

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobilePairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobilePairingTests.swift
@@ -293,7 +293,7 @@ final class MobilePairingTests: XCTestCase {
     XCTAssertEqual(plan.identityIDsToDelete, ["device-old"])
   }
 
-  func testWatchPairingTransferDoesNotDeleteCredentialsForEmptyTransfer() {
+  func testWatchPairingTransferDeletesCredentialsForEmptyTransfer() {
     let now = Date(timeIntervalSince1970: 1_700_000_000)
     let current = [
       makePairedStationCredential(
@@ -315,8 +315,11 @@ final class MobilePairingTests: XCTestCase {
 
     let plan = transfer.replacementPlan(replacing: current)
 
-    XCTAssertEqual(plan.credentialStationIDsToDelete, [])
-    XCTAssertEqual(plan.identityIDsToDelete, [])
+    XCTAssertEqual(
+      plan.credentialStationIDsToDelete,
+      ["station-laptop", "station-studio"]
+    )
+    XCTAssertEqual(plan.identityIDsToDelete, ["device-phone"])
   }
 
   func testWatchPairingTransferUsesLastDuplicateStationCredential() {

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileWatchPairingTransferChangesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileWatchPairingTransferChangesTests.swift
@@ -224,6 +224,78 @@ final class MobileWatchPairingTransferChangesTests: XCTestCase {
     XCTAssertEqual(reconciled.snapshot, transfer.snapshot)
   }
 
+  func testEmptyPhoneTransferRemovesAllTransferredCredentials() {
+    let phoneIdentity = makePairingIdentity(id: "default-mobile-device", now: now)
+    let phoneCredential = makePairedStationCredential(
+      stationID: "relay-stale",
+      deviceIdentityID: phoneIdentity.id,
+      now: now
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [],
+      credentials: [],
+      exportedAt: now
+    )
+
+    let plan = transfer.replacementPlan(replacing: [phoneCredential])
+
+    XCTAssertEqual(plan.credentialStationIDsToDelete, [phoneCredential.stationID])
+    XCTAssertEqual(plan.identityIDsToDelete, [phoneIdentity.id])
+  }
+
+  func testEmptyPhoneTransferBuildsWatchConnectivityPayload() throws {
+    let transfer = MobileWatchPairingTransfer(
+      identities: [],
+      credentials: [],
+      exportedAt: now
+    )
+
+    let payload = try transfer.watchConnectivityPayload(maximumBytes: 60 * 1024)
+    let data = try XCTUnwrap(
+      payload[MobileWatchPairingTransferEnvelope.transferKey] as? Data
+    )
+
+    XCTAssertEqual(try MobileWatchPairingTransfer.decode(data), transfer)
+  }
+
+  func testEmptyPhoneTransferPreservesWatchOwnedCredentialWhileRemovingPhoneCredential() throws {
+    let phoneIdentity = makePairingIdentity(id: "default-mobile-device", now: now)
+    let watchIdentity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID,
+      now: now
+    )
+    let phoneCredential = makePairedStationCredential(
+      stationID: "relay-stale",
+      deviceIdentityID: phoneIdentity.id,
+      now: now
+    )
+    let watchCredential = try makeRemoteCredential(
+      stationID: "remote-watch",
+      identityID: watchIdentity.id,
+      platform: "watchos",
+      token: "watch-token"
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [],
+      credentials: [],
+      exportedAt: now
+    )
+
+    let reconciled = transfer.preservingLocallyPairedRemoteCredentials(
+      for: .watchOS,
+      currentIdentities: [phoneIdentity, watchIdentity],
+      currentCredentials: [phoneCredential, watchCredential]
+    )
+    let plan = reconciled.replacementPlan(
+      replacing: [phoneCredential, watchCredential]
+    )
+
+    XCTAssertEqual(reconciled.credentials, [watchCredential])
+    XCTAssertEqual(reconciled.identities, [watchIdentity])
+    XCTAssertEqual(plan.credentialStationIDsToDelete, [phoneCredential.stationID])
+    XCTAssertEqual(plan.identityIDsToDelete, [phoneIdentity.id])
+  }
+
   func testPhoneTransferStillReplacesStaleTransferredCredentials() throws {
     let phoneIdentity = makePairingIdentity(id: "default-mobile-device", now: now)
     let watchIdentity = makePairingIdentity(


### PR DESCRIPTION
## Motivation
Removing the final iPhone pairing sent no WatchConnectivity update, and an empty transfer deleted nothing. A watch could retain transferred remote credentials after the phone removed them.

## Implementation
- Publish an explicit empty pairing transfer when the iPhone has no credentials.
- Treat empty transfers as authoritative replacements while preserving watch-owned direct profiles.
- Add focused removal, preservation, and payload round-trip tests.