### PR TITLE
feat(monitor): improve task board management

### DIFF
--- a/apps/harness-monitor/Resources/HarnessMonitor-Info.plist
+++ b/apps/harness-monitor/Resources/HarnessMonitor-Info.plist
@@ -73,6 +73,18 @@
 		</dict>
 		<dict>
 			<key>UTTypeIdentifier</key>
+			<string>io.harnessmonitor.task-board-card</string>
+			<key>UTTypeDescription</key>
+			<string>Harness Monitor Task Board Card</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict/>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
 			<string>io.harnessmonitor.task-board-item</string>
 			<key>UTTypeDescription</key>
 			<string>Harness Monitor Task Board Item</string>

--- a/apps/harness-monitor/Sources/HarnessMonitor/App/HarnessMonitorAppCommands.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitor/App/HarnessMonitorAppCommands.swift
@@ -17,6 +17,8 @@ struct HarnessMonitorAppCommands: Commands {
   private var searchFocusAction
   @FocusedValue(\.harnessSessionSidebarSelection)
   private var sidebarSelectionFocus
+  @FocusedValue(\.harnessTaskBoardSelection)
+  private var taskBoardSelectionFocus
   @FocusedValue(\.dashboardAuditCopyCommand)
   private var dashboardAuditCopyFocus
   @FocusedValue(\.harnessPolicyCanvasCommandFocus)
@@ -73,6 +75,19 @@ struct HarnessMonitorAppCommands: Commands {
 
   private var searchCommandTitle: LocalizedStringKey {
     searchFocusAction?.menuLabel.localizedTitle ?? "Find"
+  }
+
+  private var deleteSelectionCommandTitle: String {
+    taskBoardSelectionFocus == nil
+      ? "Delete Sidebar Selection"
+      : "Delete Task Board Selection"
+  }
+
+  private var canDeleteFocusedSelection: Bool {
+    if let taskBoardSelectionFocus {
+      return taskBoardSelectionFocus.canDelete
+    }
+    return sidebarSelectionFocus?.canDelete == true
   }
 
   var body: some Commands {
@@ -137,12 +152,20 @@ struct HarnessMonitorAppCommands: Commands {
       }
       .keyboardShortcut(.escape, modifiers: [])
       .disabled(sidebarSelectionFocus?.hasMultiSelection != true)
-      Button("Delete Sidebar Selection") {
-        sidebarSelectionFocus?.dispatcher.performDeleteSelection()
+      Button(deleteSelectionCommandTitle) {
+        performDeleteFocusedSelection()
       }
       .keyboardShortcut(.delete, modifiers: [])
-      .disabled(sidebarSelectionFocus?.canDelete != true)
+      .disabled(!canDeleteFocusedSelection)
     }
+  }
+
+  private func performDeleteFocusedSelection() {
+    if let taskBoardSelectionFocus {
+      taskBoardSelectionFocus.performDeleteSelection()
+      return
+    }
+    sidebarSelectionFocus?.dispatcher.performDeleteSelection()
   }
 
   @CommandsBuilder private var dashboardAuditCopyCommands: some Commands {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardMutationModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardMutationModels.swift
@@ -1,5 +1,27 @@
 import Foundation
 
+public struct TaskBoardInboxStatusUpdate: Equatable, Sendable {
+  public let sessionID: String
+  public let taskID: String
+  public let status: TaskStatus
+
+  public init(sessionID: String, taskID: String, status: TaskStatus) {
+    self.sessionID = sessionID
+    self.taskID = taskID
+    self.status = status
+  }
+}
+
+public struct TaskBoardItemStatusUpdate: Equatable, Sendable {
+  public let id: String
+  public let status: TaskBoardStatus
+
+  public init(id: String, status: TaskBoardStatus) {
+    self.id = id
+    self.status = status
+  }
+}
+
 public struct TaskBoardUpdateItemRequest: Codable, Equatable, Sendable {
   public let title: String?
   public let body: String?

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/TaskBoardDeletionTarget.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/TaskBoardDeletionTarget.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public enum TaskBoardDeletionTarget: Equatable, Hashable, Identifiable, Sendable {
+  case taskBoardItem(id: String, title: String)
+  case inboxTask(sessionID: String, taskID: String, title: String)
+
+  public var id: String {
+    switch self {
+    case .taskBoardItem(let id, _):
+      "task-board-item:\(id)"
+    case .inboxTask(let sessionID, let taskID, _):
+      "inbox-task:\(sessionID):\(taskID)"
+    }
+  }
+
+  public var title: String {
+    switch self {
+    case .taskBoardItem(_, let title), .inboxTask(_, _, let title):
+      title
+    }
+  }
+
+  public init(taskBoardItem: TaskBoardItem) {
+    self = .taskBoardItem(id: taskBoardItem.id, title: taskBoardItem.title)
+  }
+
+  public init(inboxTask: TaskBoardInboxItem) {
+    self = .inboxTask(
+      sessionID: inboxTask.session.sessionId,
+      taskID: inboxTask.task.taskId,
+      title: inboxTask.task.title
+    )
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Enums.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Enums.swift
@@ -60,6 +60,7 @@ extension HarnessMonitorStore {
       noteCount: Int
     )
     case deleteTasks(sessionID: String, taskIDs: [String], actorID: String)
+    case deleteTaskBoardTargets(targets: [TaskBoardDeletionTarget])
     case removeAgent(sessionID: String, agentID: String, actorID: String)
     case removeAgents(sessionID: String, agentIDs: [String], actorID: String)
     case interruptCodexRun(sessionID: String, runID: String, runTitle: String)

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Sheets.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Sheets.swift
@@ -231,6 +231,16 @@ extension HarnessMonitorStore {
         ]
       )
       _ = await deleteTasks(sessionID: sessionID, taskIDs: taskIDs, actorID: actorID)
+    case .deleteTaskBoardTargets(let targets):
+      HarnessMonitorUITestTrace.record(
+        component: "store.confirmation",
+        event: "dispatch-delete-task-board-targets",
+        details: [
+          "target_count": String(targets.count),
+          "target_ids": targets.map(\.id).joined(separator: ","),
+        ]
+      )
+      _ = await deleteTaskBoardTargets(targets)
     default:
       return false
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
@@ -95,10 +95,8 @@ extension HarnessMonitorStore {
 
   @discardableResult
   public func updateTaskBoardItemStatus(id: String, status: TaskBoardStatus) async -> Bool {
-    await updateTaskBoardItem(
-      id: id,
-      request: TaskBoardUpdateItemRequest(status: status),
-      successMessage: "Moved task board item"
+    await updateTaskBoardItemStatuses(
+      [TaskBoardItemStatusUpdate(id: id, status: status)]
     )
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
@@ -180,25 +180,7 @@ extension HarnessMonitorStore {
 
   @discardableResult
   public func deleteTaskBoardItem(id: String) async -> Bool {
-    guard let client else {
-      return false
-    }
-    isDaemonActionInFlight = true
-    defer { isDaemonActionInFlight = false }
-
-    do {
-      _ = try await Self.measureOperation {
-        try await client.deleteTaskBoardItem(id: id)
-      }
-      recordRequestSuccess()
-      globalTaskBoardItems.removeAll { $0.id == id }
-      await refreshTaskBoardDashboardSnapshot(using: client)
-      presentSuccessFeedback("Deleted task board item")
-      return true
-    } catch {
-      presentFailureFeedback(error.localizedDescription)
-      return false
-    }
+    await deleteTaskBoardItems(ids: [id])
   }
 
   @discardableResult

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardInboxStatusUpdates.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardInboxStatusUpdates.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+extension HarnessMonitorStore {
+  @discardableResult
+  public func updateTaskBoardInboxStatuses(
+    _ updates: [TaskBoardInboxStatusUpdate],
+    actor: String = "harness-app"
+  ) async -> Bool {
+    let updates = deduplicatedTaskBoardInboxStatusUpdates(updates)
+    guard
+      let client,
+      !updates.isEmpty,
+      !isSessionReadOnly,
+      !isSessionActionInFlight
+    else {
+      return false
+    }
+
+    let actionID = "task-board/inbox-status-batch"
+    isSessionActionInFlight = true
+    inFlightActionID = actionID
+    defer {
+      isSessionActionInFlight = false
+      if inFlightActionID == actionID {
+        inFlightActionID = nil
+      }
+    }
+
+    let actor = controlPlaneActionActor(for: actor)
+    var detailsBySessionID: [String: SessionDetail] = [:]
+    var firstFailure: (sessionID: String, error: any Error)?
+    for update in updates {
+      do {
+        let measuredDetail = try await Self.measureOperation {
+          try await client.updateTask(
+            sessionID: update.sessionID,
+            taskID: update.taskID,
+            request: TaskUpdateRequest(actor: actor, status: update.status, note: nil)
+          )
+        }
+        recordRequestSuccess()
+        detailsBySessionID[update.sessionID] = sessionDetailPreservingFresherSelectedSummary(
+          sessionID: update.sessionID,
+          detail: measuredDetail.value
+        )
+      } catch {
+        if firstFailure == nil {
+          firstFailure = (update.sessionID, error)
+        }
+      }
+    }
+
+    applyTaskBoardInboxStatusDetails(
+      detailsBySessionID,
+      orderedSessionIDs: orderedUniqueSessionIDs(updates.map(\.sessionID)),
+      using: client
+    )
+    if let firstFailure {
+      reportSelectedSessionActionFailure(
+        "Move session tasks",
+        sessionID: firstFailure.sessionID,
+        error: firstFailure.error
+      )
+      presentSelectedSessionMutationFailure(firstFailure.error, actionID: actionID)
+      return false
+    }
+    presentSuccessFeedback(
+      updates.count == 1 ? "Moved session task" : "Moved session tasks"
+    )
+    return true
+  }
+
+  private func applyTaskBoardInboxStatusDetails(
+    _ detailsBySessionID: [String: SessionDetail],
+    orderedSessionIDs: [String],
+    using client: any HarnessMonitorClientProtocol
+  ) {
+    withUISyncBatch {
+      for sessionID in orderedSessionIDs {
+        guard let detail = detailsBySessionID[sessionID] else {
+          continue
+        }
+        applySessionSummaryUpdate(detail.session)
+        guard selectedSessionID == sessionID else {
+          continue
+        }
+        applySelectedSessionSnapshot(
+          sessionID: sessionID,
+          detail: detail,
+          timeline: timeline,
+          timelineWindow: timelineWindow,
+          clearBurstState: false,
+          showingCachedData: isShowingCachedData,
+          cancelPendingTimelineRefresh: false
+        )
+      }
+    }
+    for sessionID in orderedSessionIDs where detailsBySessionID[sessionID] != nil {
+      scheduleSessionPushFallback(using: client, sessionID: sessionID)
+    }
+  }
+
+  private func deduplicatedTaskBoardInboxStatusUpdates(
+    _ updates: [TaskBoardInboxStatusUpdate]
+  ) -> [TaskBoardInboxStatusUpdate] {
+    var seenIDs: Set<TaskBoardCardStatusUpdateID> = []
+    return updates.filter { update in
+      seenIDs.insert(
+        TaskBoardCardStatusUpdateID(sessionID: update.sessionID, taskID: update.taskID)
+      ).inserted
+    }
+  }
+}
+
+private struct TaskBoardCardStatusUpdateID: Hashable {
+  let sessionID: String
+  let taskID: String
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardStatusUpdates.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardStatusUpdates.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+extension HarnessMonitorStore {
+  @discardableResult
+  public func updateTaskBoardItemStatuses(
+    _ updates: [TaskBoardItemStatusUpdate]
+  ) async -> Bool {
+    let updates = deduplicatedTaskBoardItemStatusUpdates(updates)
+    guard let client, !updates.isEmpty, !isDaemonActionInFlight else {
+      return false
+    }
+    isDaemonActionInFlight = true
+    defer { isDaemonActionInFlight = false }
+
+    var firstFailure: (any Error)?
+    var updatedItems: [TaskBoardItem] = []
+    for update in updates {
+      do {
+        let measuredItem = try await Self.measureOperation {
+          try await client.updateTaskBoardItem(
+            id: update.id,
+            request: TaskBoardUpdateItemRequest(status: update.status)
+          )
+        }
+        recordRequestSuccess()
+        updatedItems.append(measuredItem.value)
+      } catch {
+        if firstFailure == nil {
+          firstFailure = error
+        }
+      }
+    }
+
+    withUISyncBatch {
+      for item in updatedItems {
+        mergeTaskBoardItem(item)
+      }
+    }
+    await refreshTaskBoardDashboardSnapshot(using: client)
+    if let firstFailure {
+      presentFailureFeedback(firstFailure.localizedDescription)
+      return false
+    }
+    presentSuccessFeedback(
+      updates.count == 1 ? "Moved task board item" : "Moved task board items"
+    )
+    return true
+  }
+
+  private func deduplicatedTaskBoardItemStatusUpdates(
+    _ updates: [TaskBoardItemStatusUpdate]
+  ) -> [TaskBoardItemStatusUpdate] {
+    var seenIDs: Set<String> = []
+    return updates.filter { seenIDs.insert($0.id).inserted }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskDeletion.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskDeletion.swift
@@ -77,6 +77,108 @@ extension HarnessMonitorStore {
     }
   }
 
+  public func requestTaskBoardDeletionConfirmation(
+    targets: [TaskBoardDeletionTarget]
+  ) {
+    let targets = orderedUniqueTaskBoardDeletionTargets(targets)
+    guard !targets.isEmpty else { return }
+    let actionName = targets.count == 1 ? "Delete task" : "Delete tasks"
+    guard taskBoardDeletionActionIsAvailable(actionName: actionName) else { return }
+    pendingConfirmation = .deleteTaskBoardTargets(targets: targets)
+  }
+
+  @discardableResult
+  func deleteTaskBoardTargets(_ targets: [TaskBoardDeletionTarget]) async -> Bool {
+    let targets = orderedUniqueTaskBoardDeletionTargets(targets)
+    guard !targets.isEmpty else { return false }
+    let actionName = targets.count == 1 ? "Delete task" : "Delete tasks"
+    guard taskBoardDeletionActionIsAvailable(actionName: actionName) else { return false }
+
+    let taskBoardItemIDs = targets.compactMap { target -> String? in
+      guard case .taskBoardItem(let id, _) = target else { return nil }
+      return id
+    }
+    if !taskBoardItemIDs.isEmpty {
+      guard
+        await deleteTaskBoardItems(
+          ids: taskBoardItemIDs,
+          presentsSuccessFeedback: false
+        )
+      else {
+        return false
+      }
+    }
+
+    for group in taskBoardInboxDeletionGroups(targets) {
+      guard
+        await deleteTasks(
+          sessionID: group.sessionID,
+          taskIDs: group.taskIDs,
+          actorID: "harness-app"
+        )
+      else {
+        return false
+      }
+    }
+
+    presentSuccessFeedback(
+      targets.count == 1 ? "Deleted task" : "Deleted \(targets.count) tasks"
+    )
+    return true
+  }
+
+  @discardableResult
+  public func deleteTaskBoardItems(ids: [String]) async -> Bool {
+    await deleteTaskBoardItems(ids: ids, presentsSuccessFeedback: true)
+  }
+
+  private func deleteTaskBoardItems(
+    ids: [String],
+    presentsSuccessFeedback: Bool
+  ) async -> Bool {
+    let ids = orderedUniqueDeletionTaskIDs(ids)
+    guard let client, !ids.isEmpty, !isDaemonActionInFlight else {
+      return false
+    }
+    isDaemonActionInFlight = true
+    defer { isDaemonActionInFlight = false }
+
+    var deletedIDs: Set<String> = []
+    var firstFailure: (index: Int, error: any Error)?
+    for (index, id) in ids.enumerated() {
+      do {
+        _ = try await Self.measureOperation {
+          try await client.deleteTaskBoardItem(id: id)
+        }
+        recordRequestSuccess()
+        deletedIDs.insert(id)
+      } catch {
+        firstFailure = (index, error)
+        break
+      }
+    }
+
+    globalTaskBoardItems.removeAll { deletedIDs.contains($0.id) }
+    await refreshTaskBoardDashboardSnapshot(using: client)
+    if let firstFailure {
+      presentFailureFeedback(
+        taskBoardDeletionFailureMessage(
+          total: ids.count,
+          succeeded: deletedIDs.count,
+          failedIndex: firstFailure.index,
+          error: firstFailure.error
+        )
+      )
+      return false
+    }
+    if presentsSuccessFeedback {
+      presentSuccessFeedback(
+        ids.count == 1 ? "Deleted task board item" : "Deleted \(ids.count) task board items"
+      )
+    }
+    return true
+  }
+
   /// Stop-on-first-failure policy mirrors `removeAgents`: surface where the
   /// boundary fell rather than hammer through. Transient failure on item N
   /// strands items N+1…M; the toast names the unattempted suffix so the user
@@ -116,6 +218,74 @@ extension HarnessMonitorStore {
   private func orderedUniqueDeletionTaskIDs(_ ids: [String]) -> [String] {
     var seen: Set<String> = []
     return ids.filter { seen.insert($0).inserted }
+  }
+
+  private func orderedUniqueTaskBoardDeletionTargets(
+    _ targets: [TaskBoardDeletionTarget]
+  ) -> [TaskBoardDeletionTarget] {
+    var seenIDs: Set<String> = []
+    return targets.filter { seenIDs.insert($0.id).inserted }
+  }
+
+  private func taskBoardInboxDeletionGroups(
+    _ targets: [TaskBoardDeletionTarget]
+  ) -> [(sessionID: String, taskIDs: [String])] {
+    var groups: [(sessionID: String, taskIDs: [String])] = []
+    var groupIndexBySessionID: [String: Int] = [:]
+    for target in targets {
+      guard case .inboxTask(let sessionID, let taskID, _) = target else { continue }
+      if let index = groupIndexBySessionID[sessionID] {
+        groups[index].taskIDs.append(taskID)
+      } else {
+        groupIndexBySessionID[sessionID] = groups.count
+        groups.append((sessionID: sessionID, taskIDs: [taskID]))
+      }
+    }
+    return groups
+  }
+
+  private func taskBoardDeletionActionIsAvailable(actionName: String) -> Bool {
+    if isBusy {
+      presentFailureFeedback(
+        "\(actionName) is unavailable because another action is already in progress. "
+          + "Try again when it finishes"
+      )
+      return false
+    }
+    if isSessionReadOnly {
+      presentFailureFeedback(readOnlySessionAccessMessage)
+      return false
+    }
+    guard client != nil else {
+      presentFailureFeedback(
+        "The daemon action channel is unavailable. Refresh the session and try again"
+      )
+      return false
+    }
+    return true
+  }
+
+  private func taskBoardDeletionFailureMessage(
+    total: Int,
+    succeeded: Int,
+    failedIndex: Int,
+    error: any Error
+  ) -> String {
+    guard total > 1 else {
+      return "Task board item could not be deleted: \(error.localizedDescription)"
+    }
+    let remaining = total - failedIndex - 1
+    let unattemptedSuffix: String
+    if remaining == 0 {
+      unattemptedSuffix = ""
+    } else {
+      let noun = remaining == 1 ? "item was" : "items were"
+      unattemptedSuffix = " \(remaining) \(noun) not attempted."
+    }
+    return """
+      Deleted \(succeeded) of \(total) task board items. Stopped after a failure.\
+      \(unattemptedSuffix) \(error.localizedDescription)
+      """
   }
 
   @discardableResult

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Support/HarnessMonitorUITestTrace.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Support/HarnessMonitorUITestTrace.swift
@@ -169,6 +169,8 @@ extension HarnessMonitorStore.PendingConfirmation {
       "delete-task"
     case .deleteTasks:
       "delete-tasks"
+    case .deleteTaskBoardTargets:
+      "delete-task-board-targets"
     case .removeAgent:
       "remove-agent"
     case .removeAgents:

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRepositoriesSection+Catalog.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRepositoriesSection+Catalog.swift
@@ -86,7 +86,7 @@ extension SettingsRepositoriesSection {
             Spacer()
 
             Button("Add Selected") {
-              addCatalogRepositories(Array(catalogSelection))
+              addCatalogRepositories(catalogRepositories.filter(catalogSelection.contains))
             }
             .harnessActionButtonStyle(variant: .bordered, tint: .secondary)
             .disabled(catalogSelection.isEmpty)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRepositoriesSection+Persistence.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRepositoriesSection+Persistence.swift
@@ -75,7 +75,8 @@ extension SettingsRepositoriesSection {
       ).normalized()
       draft = SettingsSharedRepositoriesDraft(
         reviewsPreferences: reviewsPreferences,
-        taskBoardDraft: taskBoardFormState.draft
+        taskBoardDraft: taskBoardFormState.draft,
+        repositoryCatalog: SettingsRepositoriesCatalog.decode(storedRepositoryCatalog)
       )
       hasLoadedDraft = true
       resetCatalogState()
@@ -145,6 +146,7 @@ extension SettingsRepositoriesSection {
 
     let reviewsRepositories = draft.reviewsRepositories
     let legacyOrganizations = draft.legacyOrganizations
+    let repositoryCatalog = draft.repositoryCatalog
 
     let succeeded = await store.updateTaskBoardGitSettings(
       snapshot: taskBoardDraft.snapshot,
@@ -159,6 +161,7 @@ extension SettingsRepositoriesSection {
     reviewsPreferences.organizationsText = legacyOrganizations.joined(separator: ", ")
     let normalizedPreferences = reviewsPreferences.normalized()
     storedReviewsPreferences = normalizedPreferences.encodedString
+    storedRepositoryCatalog = SettingsRepositoriesCatalog.encode(repositoryCatalog)
 
     do {
       let snapshot = try await store.taskBoardGitSettingsSnapshot()
@@ -167,7 +170,8 @@ extension SettingsRepositoriesSection {
       taskBoardFormState.hasLoadedSettings = true
       draft = SettingsSharedRepositoriesDraft(
         reviewsPreferences: normalizedPreferences,
-        taskBoardDraft: taskBoardFormState.draft
+        taskBoardDraft: taskBoardFormState.draft,
+        repositoryCatalog: repositoryCatalog
       )
       hasLoadedDraft = true
       loadError = nil
@@ -177,7 +181,8 @@ extension SettingsRepositoriesSection {
       taskBoardFormState.hasLoadedSettings = true
       draft = SettingsSharedRepositoriesDraft(
         reviewsPreferences: normalizedPreferences,
-        taskBoardDraft: taskBoardDraft
+        taskBoardDraft: taskBoardDraft,
+        repositoryCatalog: repositoryCatalog
       )
       hasLoadedDraft = true
       loadError = nil

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRepositoriesSection+Table.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRepositoriesSection+Table.swift
@@ -33,8 +33,8 @@ struct RepositoriesMonitoredSection: View {
     } footer: {
       Text(
         """
-        Manage the shared repository scope for Reviews and Task Board here. Turning both \
-        feature toggles off removes the row.
+        Manage the shared repository scope for Reviews and Task Board here. Use the switches \
+        to control each feature independently, or the delete button to remove a repository.
         """
       )
     }
@@ -123,6 +123,7 @@ struct RepositoriesMonitoredSection: View {
       )
       .labelsHidden()
       .toggleStyle(.switch)
+      .harnessNativeFormControl()
       .frame(width: 116, alignment: .center)
       .accessibilityIdentifier(
         HarnessMonitorAccessibility.settingsRepositoriesReviewsToggle(index)
@@ -136,6 +137,7 @@ struct RepositoriesMonitoredSection: View {
       )
       .labelsHidden()
       .toggleStyle(.switch)
+      .harnessNativeFormControl()
       .frame(width: 110, alignment: .center)
       .accessibilityIdentifier(
         HarnessMonitorAccessibility.settingsRepositoriesTaskBoardToggle(index)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRepositoriesSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRepositoriesSection.swift
@@ -7,6 +7,8 @@ struct SettingsRepositoriesSection: View {
   let isActive: Bool
   @AppStorage(DashboardReviewsPreferences.storageKey)
   var storedReviewsPreferences = ""
+  @AppStorage(SettingsRepositoriesCatalog.storageKey)
+  var storedRepositoryCatalog = ""
   @State private var draftStorage = SettingsSharedRepositoriesDraft()
   @State private var isLoadingStorage = false
   @State private var isSavingStorage = false

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsSharedRepositoriesDraft.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsSharedRepositoriesDraft.swift
@@ -1,6 +1,18 @@
 import HarnessMonitorKit
 import SwiftUI
 
+enum SettingsRepositoriesCatalog {
+  static let storageKey = "settings.repositories.catalog"
+
+  static func decode(_ value: String) -> [String] {
+    SettingsGitHubRepositoryNormalization.repositories(from: value)
+  }
+
+  static func encode(_ repositories: [String]) -> String {
+    repositories.joined(separator: "\n")
+  }
+}
+
 struct SettingsSharedRepositoryRow: Identifiable, Equatable {
   let owner: String
   let repository: String
@@ -22,8 +34,14 @@ struct SettingsSharedRepositoriesDraft: Equatable {
 
   init(
     reviewsPreferences: DashboardReviewsPreferences,
-    taskBoardDraft: TaskBoardGitSettingsDraft
+    taskBoardDraft: TaskBoardGitSettingsDraft,
+    repositoryCatalog: [String] = []
   ) {
+    insert(
+      repositories: repositoryCatalog,
+      reviewsEnabled: false,
+      taskBoardEnabled: false
+    )
     insert(
       repositories: reviewsPreferences.normalizedRepositories,
       reviewsEnabled: true,
@@ -51,6 +69,10 @@ struct SettingsSharedRepositoriesDraft: Equatable {
 
   var taskBoardRepositories: [String] {
     rows.filter(\.taskBoardEnabled).map(\.repositoryPath)
+  }
+
+  var repositoryCatalog: [String] {
+    rows.map(\.repositoryPath)
   }
 
   func index(for rowID: String) -> Int? {
@@ -86,13 +108,11 @@ struct SettingsSharedRepositoriesDraft: Equatable {
   mutating func setReviewsEnabled(_ isEnabled: Bool, for rowID: String) {
     guard let index = rowIndexes[rowID] else { return }
     rows[index].reviewsEnabled = isEnabled
-    removeIfDisabled(index: index)
   }
 
   mutating func setTaskBoardEnabled(_ isEnabled: Bool, for rowID: String) {
     guard let index = rowIndexes[rowID] else { return }
     rows[index].taskBoardEnabled = isEnabled
-    removeIfDisabled(index: index)
   }
 
   mutating func remove(rowID: String) {
@@ -143,13 +163,6 @@ struct SettingsSharedRepositoriesDraft: Equatable {
     }
     rowIndexes[candidate.id] = rows.count
     rows.append(candidate)
-  }
-
-  private mutating func removeIfDisabled(index: Int) {
-    guard rows.indices.contains(index) else { return }
-    guard !rows[index].reviewsEnabled, !rows[index].taskBoardEnabled else { return }
-    rows.remove(at: index)
-    rebuildRowIndexes()
   }
 
   private mutating func rebuildRowIndexes() {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardCardsSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardCardsSection.swift
@@ -3,10 +3,15 @@ import SwiftUI
 struct SettingsTaskBoardCardsSection: View {
   @AppStorage(TaskBoardCardPreferences.priorityBadgeVisibilityStorageKey)
   private var showsPriorityBadge = TaskBoardCardPreferences.defaultShowsPriorityBadge
+  @AppStorage(TaskBoardCardPreferences.fullRepositoryNamesStorageKey)
+  private var alwaysShowsFullRepositoryNames =
+    TaskBoardCardPreferences.defaultAlwaysShowsFullRepositoryNames
 
   var body: some View {
     Section {
       Toggle("Priority Badge", isOn: $showsPriorityBadge)
+      Toggle("Full Repository Names", isOn: $alwaysShowsFullRepositoryNames)
+        .help("Always show repository owners on Task Board cards")
     } header: {
       Text("Cards")
         .harnessNativeFormSectionHeader()

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Shared/HarnessMonitorConfirmationDialogModifier.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Shared/HarnessMonitorConfirmationDialogModifier.swift
@@ -45,7 +45,7 @@ public struct HarnessMonitorConfirmationDialogModifier: ViewModifier {
               event: "confirm-tapped",
               details: ["pending_confirmation": pendingConfirmation.uiTestTraceLabel]
             )
-            Task { await store.confirmPendingAction(pendingConfirmation) }
+            dispatchConfirmation(pendingConfirmation)
           }
         } else {
           EmptyView()
@@ -67,6 +67,20 @@ public struct HarnessMonitorConfirmationDialogModifier: ViewModifier {
       }
   }
 
+  private func dispatchConfirmation(
+    _ pendingConfirmation: HarnessMonitorStore.PendingConfirmation
+  ) {
+    if case .deleteTaskBoardTargets(let targets) = pendingConfirmation {
+      HarnessMonitorAsyncWorkQueue.shared.submit(
+        .init(title: targets.count == 1 ? "Deleting task" : "Deleting tasks") {
+          await store.confirmPendingAction(pendingConfirmation)
+        }
+      )
+      return
+    }
+    Task { await store.confirmPendingAction(pendingConfirmation) }
+  }
+
   private var title: String {
     switch shellUI.pendingConfirmation {
     case .endSession: "End Session?"
@@ -76,6 +90,8 @@ public struct HarnessMonitorConfirmationDialogModifier: ViewModifier {
       "Delete Task and \(noteCount) \(noteCount == 1 ? "Note" : "Notes")?"
     case .deleteTask: "Delete Task?"
     case .deleteTasks(_, let taskIDs, _): "Delete \(taskIDs.count) Tasks?"
+    case .deleteTaskBoardTargets(let targets):
+      targets.count == 1 ? "Delete Task?" : "Delete \(targets.count) Tasks?"
     case .removeAgent: "Remove Agent?"
     case .removeAgents(_, let agentIDs, _): "Remove \(agentIDs.count) Agents?"
     case .interruptCodexRun: "Interrupt Whole Run?"
@@ -95,6 +111,8 @@ public struct HarnessMonitorConfirmationDialogModifier: ViewModifier {
       "Delete Task Now"
     case .deleteTasks(_, let taskIDs, _):
       "Delete \(taskIDs.count) Tasks Now"
+    case .deleteTaskBoardTargets(let targets):
+      targets.count == 1 ? "Delete Task Now" : "Delete \(targets.count) Tasks Now"
     case .removeAgent:
       "Remove Agent Now"
     case .removeAgents(_, let agentIDs, _):
@@ -155,6 +173,18 @@ public struct HarnessMonitorConfirmationDialogModifier: ViewModifier {
       This deletes \(taskIDs.count) selected tasks from active task views. \
       Existing task history stays on the timeline as deletion events. Local workspace notes \
       attached to these tasks will be deleted with them.
+      """
+    case .deleteTaskBoardTargets(let targets) where targets.count == 1:
+      """
+      This deletes \(store.confirmationTaskSubject(taskTitle: targets[0].title)) from active \
+      Task Board views. Session task history stays on the timeline when applicable, and local \
+      workspace notes attached to a session task will be deleted with it.
+      """
+    case .deleteTaskBoardTargets(let targets):
+      """
+      This deletes \(targets.count) selected tasks from active Task Board views. Session task \
+      history stays on timelines when applicable, and local workspace notes attached to session \
+      tasks will be deleted with them.
       """
     case .interruptCodexRun(_, _, let runTitle):
       "This interrupts the active Codex run for \"\(runTitle)\". The current turn stops immediately"

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardContextMenu.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardContextMenu.swift
@@ -1,0 +1,75 @@
+import HarnessMonitorKit
+import SwiftUI
+
+struct TaskBoardCardContextMenuActions {
+  let selectedIDs: Set<TaskBoardCardID>
+  let orderedVisibleIDs: [TaskBoardCardID]
+  let isActionInFlight: Bool
+  let canOpen: (TaskBoardCardID) -> Bool
+  let open: (TaskBoardCardID) -> Void
+  let canMove: ([TaskBoardCardID], TaskBoardInboxLane) -> Bool
+  let move: ([TaskBoardCardID], TaskBoardInboxLane) -> Void
+  let deletionTargets: ([TaskBoardCardID]) -> [TaskBoardDeletionTarget]
+  let canDelete: ([TaskBoardCardID]) -> Bool
+  let deleteTargets: (([TaskBoardDeletionTarget]) -> Void)?
+  let primeSelection: ([TaskBoardCardID]) -> Void
+}
+
+struct TaskBoardCardContextMenu: View {
+  let cardID: TaskBoardCardID
+  let actions: TaskBoardCardContextMenuActions
+
+  var body: some View {
+    if let scope = TaskBoardCardContextMenuScope.resolve(
+      menuSelection: [cardID],
+      selectedIDs: actions.selectedIDs,
+      orderedVisibleIDs: actions.orderedVisibleIDs
+    ) {
+      menuContent(scope: scope)
+        .onAppear {
+          actions.primeSelection(scope.cardIDs)
+        }
+    }
+  }
+
+  @ViewBuilder
+  private func menuContent(scope: TaskBoardCardContextMenuScope) -> some View {
+    if scope.isSingle {
+      Button("Open") {
+        actions.open(scope.primaryID)
+      }
+      .disabled(!actions.canOpen(scope.primaryID))
+    }
+    Button(scope.copyIDsLabel) {
+      HarnessMonitorClipboard.copy(scope.clipboardText)
+    }
+    Divider()
+    Menu("Move to...") {
+      ForEach(TaskBoardInboxLane.allCases) { lane in
+        Button {
+          actions.move(scope.cardIDs, lane)
+        } label: {
+          Label(lane.title, systemImage: lane.systemImage)
+        }
+        .disabled(!actions.canMove(scope.cardIDs, lane))
+      }
+    }
+    .disabled(actions.isActionInFlight)
+    Divider()
+    deleteButton(scope: scope)
+  }
+
+  @ViewBuilder
+  private func deleteButton(scope: TaskBoardCardContextMenuScope) -> some View {
+    let targets = actions.deletionTargets(scope.cardIDs)
+    Button(scope.deleteLabel, role: .destructive) {
+      actions.deleteTargets?(targets)
+    }
+    .disabled(
+      actions.isActionInFlight
+        || actions.deleteTargets == nil
+        || !actions.canDelete(scope.cardIDs)
+        || targets.count != scope.count
+    )
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardContextMenuScope.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardContextMenuScope.swift
@@ -1,0 +1,68 @@
+struct TaskBoardCardContextMenuScope: Equatable, Sendable {
+  let primaryID: TaskBoardCardID
+  let cardIDs: [TaskBoardCardID]
+
+  var count: Int { cardIDs.count }
+  var isSingle: Bool { count == 1 }
+
+  var copyIDsLabel: String {
+    isSingle ? "Copy Task ID" : "Copy \(count) Task IDs"
+  }
+
+  var deleteLabel: String {
+    isSingle ? "Delete Task..." : "Delete \(count) Tasks..."
+  }
+
+  var clipboardText: String {
+    cardIDs.map(\.taskID).joined(separator: "\n")
+  }
+
+  static func resolve(
+    menuSelection: Set<TaskBoardCardID>,
+    selectedIDs: Set<TaskBoardCardID>,
+    orderedVisibleIDs: [TaskBoardCardID]
+  ) -> Self? {
+    guard let menuTarget = ordered(menuSelection, using: orderedVisibleIDs).first else {
+      return nil
+    }
+    let scopedIDs = selectedIDs.contains(menuTarget) ? selectedIDs : menuSelection
+    let orderedIDs = ordered(scopedIDs, using: orderedVisibleIDs)
+    guard !orderedIDs.isEmpty else {
+      return nil
+    }
+    return Self(primaryID: menuTarget, cardIDs: orderedIDs)
+  }
+
+  private static func ordered(
+    _ ids: Set<TaskBoardCardID>,
+    using orderedVisibleIDs: [TaskBoardCardID]
+  ) -> [TaskBoardCardID] {
+    let visible = orderedVisibleIDs.filter(ids.contains)
+    guard visible.count < ids.count else {
+      return visible
+    }
+    let visibleSet = Set(visible)
+    let remaining = ids.subtracting(visibleSet).sorted { $0.sortKey < $1.sortKey }
+    return visible + remaining
+  }
+}
+
+extension TaskBoardCardID {
+  fileprivate var taskID: String {
+    switch self {
+    case .api(let itemID):
+      itemID
+    case .inbox(_, let taskID):
+      taskID
+    }
+  }
+
+  fileprivate var sortKey: String {
+    switch self {
+    case .api(let itemID):
+      "api:\(itemID)"
+    case .inbox(let sessionID, let taskID):
+      "inbox:\(sessionID):\(taskID)"
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardDragSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardDragSupport.swift
@@ -1,0 +1,123 @@
+import HarnessMonitorKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+enum TaskBoardCardDragItem: Codable, Equatable, Sendable, Identifiable {
+  case api(itemID: String, status: TaskBoardStatus)
+  case inbox(
+    sessionID: String,
+    taskID: String,
+    status: TaskStatus,
+    sourceLaneRawValue: String
+  )
+
+  var id: TaskBoardCardID {
+    switch self {
+    case .api(let itemID, _):
+      .api(itemID)
+    case .inbox(let sessionID, let taskID, _, _):
+      .inbox(sessionID: sessionID, taskID: taskID)
+    }
+  }
+
+  var sourceLane: TaskBoardInboxLane? {
+    switch self {
+    case .api(_, let status):
+      TaskBoardInboxLane(status: status)
+    case .inbox(_, _, _, let sourceLaneRawValue):
+      TaskBoardInboxLane(rawValue: sourceLaneRawValue)
+    }
+  }
+
+  func accepts(destination: TaskBoardInboxLane) -> Bool {
+    guard let sourceLane, sourceLane != destination else {
+      return false
+    }
+    switch self {
+    case .api:
+      return true
+    case .inbox:
+      return destination.acceptsTaskBoardInboxCardDrop
+    }
+  }
+}
+
+struct TaskBoardCardDragPayload: Codable, Transferable, Identifiable, Sendable {
+  let id: TaskBoardCardID
+  let items: [TaskBoardCardDragItem]
+
+  init(item: TaskBoardCardDragItem) {
+    id = item.id
+    items = [item]
+  }
+
+  init(primaryCardID: TaskBoardCardID, items: [TaskBoardCardDragItem]) {
+    id = primaryCardID
+    self.items = items
+  }
+
+  static var transferRepresentation: some TransferRepresentation {
+    CodableRepresentation(contentType: .harnessMonitorTaskBoardCard)
+  }
+}
+
+extension UTType {
+  static let harnessMonitorTaskBoardCard = UTType(
+    exportedAs: "io.harnessmonitor.task-board-card",
+    conformingTo: .json
+  )
+}
+
+extension TaskBoardInboxLane {
+  fileprivate var acceptsTaskBoardInboxCardDrop: Bool {
+    switch self {
+    case .todo, .inProgress, .inReview, .toReview, .failed:
+      true
+    case .umbrella, .planning, .agenticReview, .testing, .humanRequired:
+      false
+    }
+  }
+}
+
+private struct TaskBoardCardDragContainerModifier: ViewModifier {
+  let isEnabled: Bool
+  let selectedIDs: [TaskBoardCardID]
+  let payloads: ([TaskBoardCardID]) -> [TaskBoardCardDragPayload]
+  let onSessionUpdated: (DragSession) -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .dragContainer(
+        for: TaskBoardCardDragPayload.self,
+        itemID: \.id
+      ) { cardIDs in
+        isEnabled ? payloads(cardIDs) : []
+      }
+      .dragContainerSelection(isEnabled ? selectedIDs : [])
+      .dragConfiguration(.init(allowMove: isEnabled))
+      .dragPreviewsFormation(.pile)
+      .onDragSessionUpdated { session in
+        if isEnabled {
+          onSessionUpdated(session)
+        }
+      }
+  }
+}
+
+extension View {
+  func taskBoardCardDragContainer(
+    isEnabled: Bool,
+    selectedIDs: [TaskBoardCardID],
+    payloads: @escaping ([TaskBoardCardID]) -> [TaskBoardCardDragPayload],
+    onSessionUpdated: @escaping (DragSession) -> Void
+  ) -> some View {
+    modifier(
+      TaskBoardCardDragContainerModifier(
+        isEnabled: isEnabled,
+        selectedIDs: selectedIDs,
+        payloads: payloads,
+        onSessionUpdated: onSessionUpdated
+      )
+    )
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardPreferences.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardPreferences.swift
@@ -4,7 +4,10 @@ import SwiftUI
 enum TaskBoardCardPreferences {
   static let priorityBadgeVisibilityStorageKey =
     "harness.task-board.cards.priority-badge-visible.v1"
+  static let fullRepositoryNamesStorageKey =
+    "harness.task-board.cards.full-repository-names.v1"
   static let defaultShowsPriorityBadge = true
+  static let defaultAlwaysShowsFullRepositoryNames = false
 
   static func showsPriorityBadge(from userDefaults: UserDefaults = .standard) -> Bool {
     guard userDefaults.object(forKey: priorityBadgeVisibilityStorageKey) != nil else {
@@ -19,8 +22,53 @@ enum TaskBoardCardPreferences {
   ) {
     userDefaults.set(isVisible, forKey: priorityBadgeVisibilityStorageKey)
   }
+
+  static func alwaysShowsFullRepositoryNames(
+    from userDefaults: UserDefaults = .standard
+  ) -> Bool {
+    guard userDefaults.object(forKey: fullRepositoryNamesStorageKey) != nil else {
+      return defaultAlwaysShowsFullRepositoryNames
+    }
+    return userDefaults.bool(forKey: fullRepositoryNamesStorageKey)
+  }
+
+  static func setAlwaysShowsFullRepositoryNames(
+    _ alwaysShowsFullRepositoryNames: Bool,
+    in userDefaults: UserDefaults = .standard
+  ) {
+    userDefaults.set(alwaysShowsFullRepositoryNames, forKey: fullRepositoryNamesStorageKey)
+  }
 }
 
 extension EnvironmentValues {
   @Entry var taskBoardShowsPriorityBadge = TaskBoardCardPreferences.defaultShowsPriorityBadge
+  @Entry var taskBoardAlwaysShowsFullRepositoryNames =
+    TaskBoardCardPreferences.defaultAlwaysShowsFullRepositoryNames
+}
+
+private struct TaskBoardCardPreferencesModifier: ViewModifier {
+  let projectLabelResolver: TaskBoardProjectLabelResolver
+  @AppStorage(TaskBoardCardPreferences.priorityBadgeVisibilityStorageKey)
+  private var showsPriorityBadge = TaskBoardCardPreferences.defaultShowsPriorityBadge
+  @AppStorage(TaskBoardCardPreferences.fullRepositoryNamesStorageKey)
+  private var alwaysShowsFullRepositoryNames =
+    TaskBoardCardPreferences.defaultAlwaysShowsFullRepositoryNames
+
+  func body(content: Content) -> some View {
+    content
+      .environment(\.taskBoardShowsPriorityBadge, showsPriorityBadge)
+      .environment(
+        \.taskBoardAlwaysShowsFullRepositoryNames,
+        alwaysShowsFullRepositoryNames
+      )
+      .environment(\.taskBoardProjectLabelResolver, projectLabelResolver)
+  }
+}
+
+extension View {
+  func taskBoardCardPreferences(
+    projectLabelResolver: TaskBoardProjectLabelResolver
+  ) -> some View {
+    modifier(TaskBoardCardPreferencesModifier(projectLabelResolver: projectLabelResolver))
+  }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardSelection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardSelection.swift
@@ -46,6 +46,17 @@ struct TaskBoardCardSelectionState: Equatable {
     return Self(selectedIDs: draggedIDSet, anchorID: first)
   }
 
+  func selectingForContextMenu(_ menuIDs: [TaskBoardCardID]) -> Self {
+    guard let first = menuIDs.first else {
+      return self
+    }
+    let menuIDSet = Set(menuIDs)
+    guard menuIDSet != selectedIDs else {
+      return self
+    }
+    return Self(selectedIDs: menuIDSet, anchorID: first)
+  }
+
   func pruning(orderedVisibleIDs: [TaskBoardCardID]) -> Self {
     let visibleIDs = Set(orderedVisibleIDs)
     let prunedSelection = selectedIDs.intersection(visibleIDs)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardSelection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardSelection.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+enum TaskBoardCardID: Codable, Hashable, Sendable {
+  case api(String)
+  case inbox(sessionID: String, taskID: String)
+}
+
+struct TaskBoardCardSelectionState: Equatable {
+  private(set) var selectedIDs: Set<TaskBoardCardID>
+  private(set) var anchorID: TaskBoardCardID?
+
+  init(
+    selectedIDs: Set<TaskBoardCardID> = [],
+    anchorID: TaskBoardCardID? = nil
+  ) {
+    self.selectedIDs = selectedIDs
+    self.anchorID = anchorID
+  }
+
+  func selecting(
+    _ cardID: TaskBoardCardID,
+    orderedVisibleIDs: [TaskBoardCardID],
+    modifiers: EventModifiers
+  ) -> Self {
+    if !modifiers.contains(.command), !modifiers.contains(.shift) {
+      return Self(selectedIDs: [cardID], anchorID: cardID)
+    }
+    let change = SessionSidebarMultiSelect.resolve(
+      rowID: cardID,
+      orderedVisibleIDs: orderedVisibleIDs,
+      selectedIDs: selectedIDs,
+      anchorID: anchorID,
+      modifiers: modifiers
+    )
+    return Self(selectedIDs: change.selectedIDs, anchorID: change.anchorID)
+  }
+
+  func selectingForDrag(_ draggedIDs: [TaskBoardCardID]) -> Self {
+    guard let first = draggedIDs.first else {
+      return self
+    }
+    let draggedIDSet = Set(draggedIDs)
+    guard draggedIDSet != selectedIDs else {
+      return self
+    }
+    return Self(selectedIDs: draggedIDSet, anchorID: first)
+  }
+
+  func pruning(orderedVisibleIDs: [TaskBoardCardID]) -> Self {
+    let visibleIDs = Set(orderedVisibleIDs)
+    let prunedSelection = selectedIDs.intersection(visibleIDs)
+    let repairedAnchor =
+      if let anchorID, prunedSelection.contains(anchorID) {
+        anchorID
+      } else {
+        orderedVisibleIDs.first { prunedSelection.contains($0) }
+      }
+    return Self(selectedIDs: prunedSelection, anchorID: repairedAnchor)
+  }
+
+  func orderedSelectedIDs(in orderedVisibleIDs: [TaskBoardCardID]) -> [TaskBoardCardID] {
+    orderedVisibleIDs.filter(selectedIDs.contains)
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneChrome.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneChrome.swift
@@ -131,6 +131,7 @@ private struct TaskBoardLaneToggleFeedback: ViewModifier {
 private struct TaskBoardLaneColumnChrome: ViewModifier {
   let lane: TaskBoardInboxLane
   let isCollapsed: Bool
+  let isDropCandidate: Bool
   let isDropTargeted: Bool
   @Environment(\.fontScale)
   private var fontScale
@@ -172,6 +173,8 @@ private struct TaskBoardLaneColumnChrome: ViewModifier {
           metrics: metrics
         )
       }
+      .animation(.easeOut(duration: 0.14), value: isDropCandidate)
+      .animation(.easeOut(duration: 0.1), value: isDropTargeted)
   }
 
   private var laneWidth: CGFloat {
@@ -185,9 +188,16 @@ private struct TaskBoardLaneColumnChrome: ViewModifier {
   @ViewBuilder private var laneBackground: some View {
     let shape = RoundedRectangle(cornerRadius: metrics.cardCornerRadius, style: .continuous)
     shape.fill(laneSurfaceFill)
-    if isDropTargeted {
-      shape.fill(laneColor.opacity(reduceTransparency ? 0.18 : 0.12))
+    if isDropCandidate {
+      shape.fill(laneColor.opacity(dropBackgroundOpacity))
     }
+  }
+
+  private var dropBackgroundOpacity: Double {
+    if isDropTargeted {
+      return reduceTransparency ? 0.18 : 0.12
+    }
+    return reduceTransparency ? 0.1 : 0.055
   }
 
   private var laneSurfaceFill: Color {
@@ -212,6 +222,9 @@ private struct TaskBoardLaneColumnChrome: ViewModifier {
   private var laneStrokeColor: Color {
     if isDropTargeted {
       return laneColor.opacity(colorSchemeContrast == .increased ? 0.84 : 0.62)
+    }
+    if isDropCandidate {
+      return laneColor.opacity(colorSchemeContrast == .increased ? 0.64 : 0.42)
     }
     return HarnessMonitorTheme.controlBorder.opacity(
       colorSchemeContrast == .increased ? 0.78 : 0.54
@@ -339,12 +352,14 @@ extension View {
   func taskBoardLaneColumnChrome(
     lane: TaskBoardInboxLane,
     isCollapsed: Bool = false,
+    isDropCandidate: Bool = false,
     isDropTargeted: Bool = false
   ) -> some View {
     modifier(
       TaskBoardLaneColumnChrome(
         lane: lane,
         isCollapsed: isCollapsed,
+        isDropCandidate: isDropCandidate,
         isDropTargeted: isDropTargeted
       )
     )

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneDropSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneDropSupport.swift
@@ -1,18 +1,22 @@
 import HarnessMonitorKit
 
-enum TaskBoardLaneDropPolicy {
-  static func moveFirstPayload(
-    _ payloads: [TaskBoardItemDragPayload],
-    to destination: TaskBoardInboxLane,
-    move: (String, TaskBoardInboxLane) -> Bool
-  ) -> Bool {
-    guard let payload = payloads.first else {
-      return false
+struct TaskBoardCardDropPlan: Equatable {
+  let items: [TaskBoardCardDragItem]
+  let destination: TaskBoardInboxLane
+
+  static func resolve(
+    _ payloads: [TaskBoardCardDragPayload],
+    to destination: TaskBoardInboxLane
+  ) -> Self? {
+    var seenIDs: Set<TaskBoardCardID> = []
+    let uniqueItems = payloads.flatMap(\.items).filter { item in
+      seenIDs.insert(item.id).inserted
     }
-    guard let sourceLane = payload.sourceLane, sourceLane != destination else {
-      return false
+    let items = uniqueItems.filter { $0.sourceLane != destination }
+    guard !items.isEmpty, items.allSatisfy({ $0.accepts(destination: destination) }) else {
+      return nil
     }
-    return move(payload.itemID, destination)
+    return Self(items: items, destination: destination)
   }
 }
 
@@ -35,29 +39,7 @@ struct TaskBoardDropDeduper<Key: Equatable> {
   }
 }
 
-struct TaskBoardItemDropSignature: Equatable {
-  let itemID: String
+struct TaskBoardCardDropSignature: Equatable {
+  let cardIDs: [TaskBoardCardID]
   let destination: TaskBoardInboxLane
-}
-
-struct TaskBoardInboxItemDropSignature: Equatable {
-  let sessionID: String
-  let taskID: String
-  let destination: TaskBoardInboxLane
-}
-
-enum TaskBoardInboxDropPolicy {
-  static func moveFirstPayload(
-    _ payloads: [TaskBoardInboxItemDragPayload],
-    to destination: TaskBoardInboxLane,
-    move: (TaskBoardInboxItemDragPayload, TaskBoardInboxLane) -> Bool
-  ) -> Bool {
-    guard let payload = payloads.first else {
-      return false
-    }
-    guard let sourceLane = payload.sourceLane, sourceLane != destination else {
-      return false
-    }
-    return move(payload, destination)
-  }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneSupport.swift
@@ -30,7 +30,6 @@ struct TaskBoardLaneMetrics: Equatable {
   let rowTextSpacing: CGFloat
   let pillHorizontalPadding: CGFloat
   let pillVerticalPadding: CGFloat
-  let dragPreviewWidth: CGFloat
 
   init(fontScale: CGFloat) {
     let scale = SessionWindowFontScale.metricsScale(for: fontScale)
@@ -65,7 +64,6 @@ struct TaskBoardLaneMetrics: Equatable {
     rowTextSpacing = HarnessMonitorTheme.spacingXS * denseScale
     pillHorizontalPadding = HarnessMonitorTheme.pillPaddingH * denseScale
     pillVerticalPadding = HarnessMonitorTheme.pillPaddingV * min(scale, 1.2)
-    dragPreviewWidth = 220 * broadScale
   }
 }
 
@@ -229,6 +227,7 @@ struct TaskBoardLaneCardFramePreferenceKey: PreferenceKey {
 private struct TaskBoardCardChrome: ViewModifier {
   let tint: Color
   let isHovered: Bool
+  let isSelected: Bool
   @Environment(\.fontScale)
   private var fontScale
   @Environment(\.accessibilityReduceTransparency)
@@ -251,19 +250,40 @@ private struct TaskBoardCardChrome: ViewModifier {
         extraHoverHint: isHovered,
         respondsToHover: false
       )
-      .background(
-        RoundedRectangle(cornerRadius: metrics.cardCornerRadius, style: .continuous)
-          .fill(cardSurfaceFill)
-      )
+      .background {
+        let shape = RoundedRectangle(
+          cornerRadius: metrics.cardCornerRadius,
+          style: .continuous
+        )
+        shape.fill(cardSurfaceFill)
+        if isSelected {
+          shape.fill(tint.opacity(selectedFillOpacity))
+        }
+      }
       .overlay {
         RoundedRectangle(cornerRadius: metrics.cardCornerRadius, style: .continuous)
           .strokeBorder(
-            HarnessMonitorTheme.controlBorder.opacity(
-              colorSchemeContrast == .increased ? 0.74 : 0.52
-            ),
-            lineWidth: colorSchemeContrast == .increased ? 1.5 : 1
+            cardStrokeColor,
+            lineWidth: cardStrokeWidth
           )
       }
+  }
+
+  private var selectedFillOpacity: Double {
+    reduceTransparency ? 0.2 : 0.12
+  }
+
+  private var cardStrokeColor: Color {
+    if isSelected {
+      return tint.opacity(colorSchemeContrast == .increased ? 1 : 0.86)
+    }
+    return HarnessMonitorTheme.controlBorder.opacity(
+      colorSchemeContrast == .increased ? 0.74 : 0.52
+    )
+  }
+
+  private var cardStrokeWidth: CGFloat {
+    isSelected ? 2 : (colorSchemeContrast == .increased ? 1.5 : 1)
   }
 
   private var cardSurfaceFill: Color {
@@ -285,9 +305,12 @@ private struct TaskBoardCardChrome: ViewModifier {
 extension View {
   func taskBoardCardChrome(
     tint: Color = HarnessMonitorTheme.accent,
-    isHovered: Bool = false
+    isHovered: Bool = false,
+    isSelected: Bool = false
   ) -> some View {
-    modifier(TaskBoardCardChrome(tint: tint, isHovered: isHovered))
+    modifier(
+      TaskBoardCardChrome(tint: tint, isHovered: isHovered, isSelected: isSelected)
+    )
   }
 
   func taskBoardCardFrame(

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneUnifiedColumn.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneUnifiedColumn.swift
@@ -9,12 +9,16 @@ struct TaskBoardLaneUnifiedColumn: View {
   let decisions: [Decision]
   let titleTypography: TaskBoardCardTitleTypography
   let isCollapsed: Bool
+  let isDropEnabled: Bool
+  let isDropCandidate: Bool
   let selectedCardIDs: Set<TaskBoardCardID>
   let onOpenAPIItem: (TaskBoardItem) -> Void
   let onOpenInboxItem: (TaskBoardInboxItem) -> Void
   let onOpenDecision: (Decision) -> Void
   let onToggleCollapse: () -> Void
   let onSelectCard: (TaskBoardCardID, [TaskBoardCardID], EventModifiers) -> Void
+  let contextMenuActions: TaskBoardCardContextMenuActions
+  let dropPlanForCardIDs: ([TaskBoardCardID]) -> TaskBoardCardDropPlan?
   let onMoveCards: ([TaskBoardCardDragItem], TaskBoardInboxLane) -> Bool
   @Environment(\.fontScale)
   private var fontScale
@@ -51,11 +55,16 @@ struct TaskBoardLaneUnifiedColumn: View {
       .taskBoardLaneColumnChrome(
         lane: lane,
         isCollapsed: isCollapsed,
+        isDropCandidate: isDropCandidate,
         isDropTargeted: isDropTargeted
       )
-      .dropDestination(for: TaskBoardCardDragPayload.self, action: handleDrop) { targeted in
-        updateDropTargeted(targeted)
-      }
+      .dropDestination(
+        for: TaskBoardCardDragPayload.self,
+        isEnabled: isDropEnabled,
+        action: handleDrop
+      )
+      .dropConfiguration(dropConfiguration)
+      .onDropSessionUpdated(updateDropSession)
       .accessibilityElement(children: .contain)
       .accessibilityIdentifier("harness.task-board.column.\(lane.rawValue)")
   }
@@ -152,6 +161,9 @@ struct TaskBoardLaneUnifiedColumn: View {
           onOpenItem: onOpenAPIItem
         )
         .taskBoardCardFrame(id: hoverID, in: cardHoverCoordinateSpace)
+        .contextMenu {
+          TaskBoardCardContextMenu(cardID: cardID, actions: contextMenuActions)
+        }
       }
       ForEach(inboxItems) { item in
         let cardID = TaskBoardCardID.inbox(
@@ -173,6 +185,9 @@ struct TaskBoardLaneUnifiedColumn: View {
           onOpenItem: onOpenInboxItem
         )
         .taskBoardCardFrame(id: hoverID, in: cardHoverCoordinateSpace)
+        .contextMenu {
+          TaskBoardCardContextMenu(cardID: cardID, actions: contextMenuActions)
+        }
       }
     }
     .frame(maxWidth: .infinity)
@@ -235,11 +250,15 @@ struct TaskBoardLaneUnifiedColumn: View {
     hoveredCardID = id
   }
 
-  private func handleDrop(_ payloads: [TaskBoardCardDragPayload], _: CGPoint) -> Bool {
-    guard let plan = TaskBoardCardDropPlan.resolve(payloads, to: lane) else {
-      return false
+  private func handleDrop(_ payloads: [TaskBoardCardDragPayload], session: DropSession) {
+    guard
+      dropPlan(for: session) != nil,
+      let plan = TaskBoardCardDropPlan.resolve(payloads, to: lane)
+    else {
+      updateDropTargeted(false)
+      return
     }
-    return performDrop(
+    _ = performDrop(
       signature: TaskBoardCardDropSignature(
         cardIDs: plan.items.map(\.id),
         destination: lane
@@ -247,13 +266,39 @@ struct TaskBoardLaneUnifiedColumn: View {
     ) {
       onMoveCards(plan.items, lane)
     }
+    updateDropTargeted(false)
+  }
+
+  private func dropConfiguration(for session: DropSession) -> DropConfiguration {
+    let operation: DropOperation =
+      isDropEnabled && dropPlan(for: session) != nil ? .move : .forbidden
+    return DropConfiguration(operation: operation)
+  }
+
+  private func updateDropSession(_ session: DropSession) {
+    switch session.phase {
+    case .entering:
+      dropDeduper.reset()
+      updateDropTargeted(dropPlan(for: session) != nil)
+    case .active:
+      updateDropTargeted(dropPlan(for: session) != nil)
+    case .exiting, .ended, .dataTransferCompleted:
+      updateDropTargeted(false)
+    @unknown default:
+      updateDropTargeted(false)
+    }
+  }
+
+  private func dropPlan(for session: DropSession) -> TaskBoardCardDropPlan? {
+    guard isDropEnabled, let localSession = session.localSession else {
+      return nil
+    }
+    let cardIDs = localSession.draggedItemIDs(for: TaskBoardCardID.self)
+    return dropPlanForCardIDs(cardIDs)
   }
 
   private func updateDropTargeted(_ targeted: Bool) {
     isDropTargeted = targeted
-    if !targeted {
-      dropDeduper = TaskBoardDropDeduper()
-    }
   }
 
   private func performDrop(

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneUnifiedColumn.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneUnifiedColumn.swift
@@ -1,7 +1,6 @@
 import Foundation
 import HarnessMonitorKit
 import SwiftUI
-import UniformTypeIdentifiers
 
 struct TaskBoardLaneUnifiedColumn: View {
   let lane: TaskBoardInboxLane
@@ -10,18 +9,17 @@ struct TaskBoardLaneUnifiedColumn: View {
   let decisions: [Decision]
   let titleTypography: TaskBoardCardTitleTypography
   let isCollapsed: Bool
+  let selectedCardIDs: Set<TaskBoardCardID>
   let onOpenAPIItem: (TaskBoardItem) -> Void
   let onOpenInboxItem: (TaskBoardInboxItem) -> Void
   let onOpenDecision: (Decision) -> Void
   let onToggleCollapse: () -> Void
-  let onMoveAPIItem: (String, TaskBoardInboxLane) -> Bool
-  let onMoveInboxItem: (TaskBoardInboxItemDragPayload, TaskBoardInboxLane) -> Bool
+  let onSelectCard: (TaskBoardCardID, [TaskBoardCardID], EventModifiers) -> Void
+  let onMoveCards: ([TaskBoardCardDragItem], TaskBoardInboxLane) -> Bool
   @Environment(\.fontScale)
   private var fontScale
-  @State private var isAPIDropTargeted = false
-  @State private var isInboxDropTargeted = false
-  @State private var apiDropDeduper = TaskBoardDropDeduper<TaskBoardItemDropSignature>()
-  @State private var inboxDropDeduper = TaskBoardDropDeduper<TaskBoardInboxItemDropSignature>()
+  @State private var isDropTargeted = false
+  @State private var dropDeduper = TaskBoardDropDeduper<TaskBoardCardDropSignature>()
   @State private var perfScrollPosition = ScrollPosition()
   @State private var cardHoverLocation: CGPoint?
   @State private var cardHoverFrames: [TaskBoardLaneCardFrame] = []
@@ -37,12 +35,15 @@ struct TaskBoardLaneUnifiedColumn: View {
     apiItems.count + inboxItems.count + decisions.count
   }
 
-  private var isDropTargeted: Bool {
-    isAPIDropTargeted || isInboxDropTargeted
-  }
-
   private var isEmpty: Bool {
     apiItems.isEmpty && inboxItems.isEmpty && decisions.isEmpty
+  }
+
+  private var orderedCardIDs: [TaskBoardCardID] {
+    apiItems.map { .api($0.id) }
+      + inboxItems.map {
+        .inbox(sessionID: $0.session.sessionId, taskID: $0.task.taskId)
+      }
   }
 
   var body: some View {
@@ -52,25 +53,9 @@ struct TaskBoardLaneUnifiedColumn: View {
         isCollapsed: isCollapsed,
         isDropTargeted: isDropTargeted
       )
-      .dropDestination(for: TaskBoardItemDragPayload.self, action: handleAPIDrop) { targeted in
-        updateAPIDropTargeted(targeted)
+      .dropDestination(for: TaskBoardCardDragPayload.self, action: handleDrop) { targeted in
+        updateDropTargeted(targeted)
       }
-      .onDrop(
-        of: [.harnessMonitorTaskBoardItem],
-        isTargeted: nil,
-        perform: handleLegacyAPIDrop
-      )
-      .dropDestination(
-        for: TaskBoardInboxItemDragPayload.self,
-        action: handleInboxDrop
-      ) { targeted in
-        updateInboxDropTargeted(targeted)
-      }
-      .onDrop(
-        of: [.harnessMonitorTaskBoardInboxItem],
-        isTargeted: nil,
-        perform: handleLegacyInboxDrop
-      )
       .accessibilityElement(children: .contain)
       .accessibilityIdentifier("harness.task-board.column.\(lane.rawValue)")
   }
@@ -154,27 +139,40 @@ struct TaskBoardLaneUnifiedColumn: View {
         decisionRows
       }
       ForEach(apiItems) { item in
-        let cardID = TaskBoardLaneCardHoverID.api(item.id)
+        let cardID = TaskBoardCardID.api(item.id)
+        let hoverID = TaskBoardLaneCardHoverID.api(item.id)
         TaskBoardItemRow(
           item: item,
           titleTypography: titleTypography,
-          isHovered: hoveredCardID == cardID,
+          isHovered: hoveredCardID == hoverID,
+          isSelected: selectedCardIDs.contains(cardID),
+          onSelect: { modifiers in
+            onSelectCard(cardID, orderedCardIDs, modifiers)
+          },
           onOpenItem: onOpenAPIItem
         )
-        .taskBoardCardFrame(id: cardID, in: cardHoverCoordinateSpace)
+        .taskBoardCardFrame(id: hoverID, in: cardHoverCoordinateSpace)
       }
       ForEach(inboxItems) { item in
-        let cardID = TaskBoardLaneCardHoverID.inbox(
+        let cardID = TaskBoardCardID.inbox(
+          sessionID: item.session.sessionId,
+          taskID: item.task.taskId
+        )
+        let hoverID = TaskBoardLaneCardHoverID.inbox(
           sessionID: item.session.sessionId,
           taskID: item.task.taskId
         )
         TaskBoardInboxItemRow(
           item: item,
           titleTypography: titleTypography,
-          isHovered: hoveredCardID == cardID,
+          isHovered: hoveredCardID == hoverID,
+          isSelected: selectedCardIDs.contains(cardID),
+          onSelect: { modifiers in
+            onSelectCard(cardID, orderedCardIDs, modifiers)
+          },
           onOpenItem: onOpenInboxItem
         )
-        .taskBoardCardFrame(id: cardID, in: cardHoverCoordinateSpace)
+        .taskBoardCardFrame(id: hoverID, in: cardHoverCoordinateSpace)
       }
     }
     .frame(maxWidth: .infinity)
@@ -237,83 +235,34 @@ struct TaskBoardLaneUnifiedColumn: View {
     hoveredCardID = id
   }
 
-  private func handleAPIDrop(_ payloads: [TaskBoardItemDragPayload], _: CGPoint) -> Bool {
-    guard let payload = payloads.first else {
+  private func handleDrop(_ payloads: [TaskBoardCardDragPayload], _: CGPoint) -> Bool {
+    guard let plan = TaskBoardCardDropPlan.resolve(payloads, to: lane) else {
       return false
     }
-    return performAPIDrop(
-      signature: TaskBoardItemDropSignature(itemID: payload.itemID, destination: lane)
-    ) {
-      TaskBoardLaneDropPolicy.moveFirstPayload(
-        payloads,
-        to: lane,
-        move: onMoveAPIItem
-      )
-    }
-  }
-
-  private func handleInboxDrop(_ payloads: [TaskBoardInboxItemDragPayload], _: CGPoint) -> Bool {
-    guard let payload = payloads.first else {
-      return false
-    }
-    return performInboxDrop(
-      signature: TaskBoardInboxItemDropSignature(
-        sessionID: payload.sessionID,
-        taskID: payload.taskID,
+    return performDrop(
+      signature: TaskBoardCardDropSignature(
+        cardIDs: plan.items.map(\.id),
         destination: lane
       )
     ) {
-      TaskBoardInboxDropPolicy.moveFirstPayload(
-        payloads,
-        to: lane,
-        move: onMoveInboxItem
-      )
+      onMoveCards(plan.items, lane)
     }
   }
 
-  private func handleLegacyAPIDrop(_ providers: [NSItemProvider]) -> Bool {
-    TaskBoardItemDragPayload.loadFirst(from: providers) { payload in
-      _ = handleAPIDrop([payload], .zero)
-    }
-  }
-
-  private func handleLegacyInboxDrop(_ providers: [NSItemProvider]) -> Bool {
-    TaskBoardInboxItemDragPayload.loadFirst(from: providers) { payload in
-      _ = handleInboxDrop([payload], .zero)
-    }
-  }
-
-  private func updateAPIDropTargeted(_ targeted: Bool) {
-    isAPIDropTargeted = targeted
+  private func updateDropTargeted(_ targeted: Bool) {
+    isDropTargeted = targeted
     if !targeted {
-      apiDropDeduper = TaskBoardDropDeduper()
+      dropDeduper = TaskBoardDropDeduper()
     }
   }
 
-  private func updateInboxDropTargeted(_ targeted: Bool) {
-    isInboxDropTargeted = targeted
-    if !targeted {
-      inboxDropDeduper = TaskBoardDropDeduper()
-    }
-  }
-
-  private func performAPIDrop(
-    signature: TaskBoardItemDropSignature,
+  private func performDrop(
+    signature: TaskBoardCardDropSignature,
     action: () -> Bool
   ) -> Bool {
-    var deduper = apiDropDeduper
+    var deduper = dropDeduper
     let handled = deduper.perform(signature, move: action)
-    apiDropDeduper = deduper
-    return handled
-  }
-
-  private func performInboxDrop(
-    signature: TaskBoardInboxItemDropSignature,
-    action: () -> Bool
-  ) -> Bool {
-    var deduper = inboxDropDeduper
-    let handled = deduper.perform(signature, move: action)
-    inboxDropDeduper = deduper
+    dropDeduper = deduper
     return handled
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
@@ -168,6 +168,10 @@ struct TaskBoardItemRow: View {
   private var laneAppearance
   @Environment(\.taskBoardShowsPriorityBadge)
   private var showsPriorityBadge
+  @Environment(\.taskBoardAlwaysShowsFullRepositoryNames)
+  private var alwaysShowsFullRepositoryNames
+  @Environment(\.taskBoardProjectLabelResolver)
+  private var projectLabelResolver
 
   private var dragPayload: TaskBoardItemDragPayload {
     TaskBoardItemDragPayload(itemID: item.id, status: item.status)
@@ -188,7 +192,7 @@ struct TaskBoardItemRow: View {
             lineLimit: 2
           )
         }
-        TaskBoardCardFooter(repository: item.projectId ?? item.agentMode.title) {
+        TaskBoardCardFooter(repository: repositoryLabel) {
           badgeContent
         }
       }
@@ -210,6 +214,16 @@ struct TaskBoardItemRow: View {
   }
 
   private var statusTint: Color { taskBoardStatusColor(for: item.status) }
+
+  private var repositoryLabel: String {
+    guard let projectID = item.projectId else {
+      return item.agentMode.title
+    }
+    return projectLabelResolver.label(
+      for: projectID,
+      alwaysShowFullName: alwaysShowsFullRepositoryNames
+    )
+  }
 
   private var cardGlyph: TaskBoardCardGlyph {
     TaskBoardGitHubCardGlyph.resolve(for: item)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneViews.swift
@@ -1,166 +1,13 @@
-import Foundation
+import AppKit
 import HarnessMonitorKit
 import SwiftUI
-import UniformTypeIdentifiers
-
-struct TaskBoardItemDragPayload: Codable, Transferable, Sendable {
-  let itemID: String
-  let status: TaskBoardStatus
-
-  static var transferRepresentation: some TransferRepresentation {
-    CodableRepresentation(contentType: .harnessMonitorTaskBoardItem)
-  }
-
-  var sourceLane: TaskBoardInboxLane? {
-    TaskBoardInboxLane(status: status)
-  }
-
-  func itemProvider() -> NSItemProvider {
-    let provider = NSItemProvider()
-    guard let encodedPayload = try? JSONEncoder().encode(self) else {
-      return provider
-    }
-    provider.registerDataRepresentation(
-      forTypeIdentifier: UTType.harnessMonitorTaskBoardItem.identifier,
-      visibility: .all
-    ) { completion in
-      completion(encodedPayload, nil)
-      return nil
-    }
-    return provider
-  }
-
-  static func loadFirst(
-    from providers: [NSItemProvider],
-    completion: @escaping @MainActor (Self) -> Void
-  ) -> Bool {
-    guard
-      let provider = providers.first(where: {
-        $0.hasItemConformingToTypeIdentifier(UTType.harnessMonitorTaskBoardItem.identifier)
-      })
-    else {
-      return false
-    }
-    provider.loadDataRepresentation(
-      forTypeIdentifier: UTType.harnessMonitorTaskBoardItem.identifier
-    ) { data, _ in
-      guard
-        let data,
-        let payload = try? JSONDecoder().decode(Self.self, from: data)
-      else {
-        return
-      }
-      Task { @MainActor in
-        completion(payload)
-      }
-    }
-    return true
-  }
-}
-
-struct TaskBoardInboxItemDragPayload: Codable, Transferable, Sendable {
-  let sessionID: String
-  let taskID: String
-  let status: TaskStatus
-  private let laneRawValue: String
-
-  enum CodingKeys: String, CodingKey {
-    case sessionID
-    case taskID
-    case status
-    case laneRawValue
-  }
-
-  init(sessionID: String, taskID: String, status: TaskStatus, lane: TaskBoardInboxLane) {
-    self.sessionID = sessionID
-    self.taskID = taskID
-    self.status = status
-    laneRawValue = lane.rawValue
-  }
-
-  init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    sessionID = try container.decode(String.self, forKey: .sessionID)
-    taskID = try container.decode(String.self, forKey: .taskID)
-    status = try container.decode(TaskStatus.self, forKey: .status)
-    laneRawValue = try container.decode(String.self, forKey: .laneRawValue)
-  }
-
-  func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(sessionID, forKey: .sessionID)
-    try container.encode(taskID, forKey: .taskID)
-    try container.encode(status, forKey: .status)
-    try container.encode(laneRawValue, forKey: .laneRawValue)
-  }
-
-  static var transferRepresentation: some TransferRepresentation {
-    CodableRepresentation(contentType: .harnessMonitorTaskBoardInboxItem)
-  }
-
-  var sourceLane: TaskBoardInboxLane? {
-    TaskBoardInboxLane(rawValue: laneRawValue)
-  }
-
-  func itemProvider() -> NSItemProvider {
-    let provider = NSItemProvider()
-    guard let encodedPayload = try? JSONEncoder().encode(self) else {
-      return provider
-    }
-    provider.registerDataRepresentation(
-      forTypeIdentifier: UTType.harnessMonitorTaskBoardInboxItem.identifier,
-      visibility: .all
-    ) { completion in
-      completion(encodedPayload, nil)
-      return nil
-    }
-    return provider
-  }
-
-  static func loadFirst(
-    from providers: [NSItemProvider],
-    completion: @escaping @MainActor (Self) -> Void
-  ) -> Bool {
-    guard
-      let provider = providers.first(where: {
-        $0.hasItemConformingToTypeIdentifier(UTType.harnessMonitorTaskBoardInboxItem.identifier)
-      })
-    else {
-      return false
-    }
-    provider.loadDataRepresentation(
-      forTypeIdentifier: UTType.harnessMonitorTaskBoardInboxItem.identifier
-    ) { data, _ in
-      guard
-        let data,
-        let payload = try? JSONDecoder().decode(Self.self, from: data)
-      else {
-        return
-      }
-      Task { @MainActor in
-        completion(payload)
-      }
-    }
-    return true
-  }
-}
-
-extension UTType {
-  static let harnessMonitorTaskBoardItem = UTType(
-    exportedAs: "io.harnessmonitor.task-board-item",
-    conformingTo: .json
-  )
-
-  static let harnessMonitorTaskBoardInboxItem = UTType(
-    exportedAs: "io.harnessmonitor.task-board-inbox-item",
-    conformingTo: .json
-  )
-}
 
 struct TaskBoardItemRow: View {
   let item: TaskBoardItem
   let titleTypography: TaskBoardCardTitleTypography
   let isHovered: Bool
+  let isSelected: Bool
+  let onSelect: (EventModifiers) -> Void
   let onOpenItem: (TaskBoardItem) -> Void
   @Environment(\.fontScale)
   private var fontScale
@@ -173,14 +20,14 @@ struct TaskBoardItemRow: View {
   @Environment(\.taskBoardProjectLabelResolver)
   private var projectLabelResolver
 
-  private var dragPayload: TaskBoardItemDragPayload {
-    TaskBoardItemDragPayload(itemID: item.id, status: item.status)
-  }
-
+  private var cardID: TaskBoardCardID { .api(item.id) }
   private var metrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
   var body: some View {
     Button {
-      onOpenItem(item)
+      onSelect(Self.currentEventModifiers)
+      if Self.currentClickCount == 2 {
+        onOpenItem(item)
+      }
     } label: {
       VStack(alignment: .leading, spacing: metrics.laneSpacing) {
         VStack(alignment: .leading, spacing: metrics.rowTextSpacing) {
@@ -202,13 +49,14 @@ struct TaskBoardItemRow: View {
       )
       .padding(metrics.cardPadding)
     }
-    .taskBoardCardChrome(tint: cardGlyph.tint, isHovered: isHovered)
+    .taskBoardCardChrome(tint: cardGlyph.tint, isHovered: isHovered, isSelected: isSelected)
     .contentShape(.rect)
-    .onDrag {
-      dragPayload.itemProvider()
-    }
-    .draggable(dragPayload) {
-      TaskBoardItemDragPreviewCard(item: item, titleTypography: titleTypography)
+    .draggable(containerItemID: cardID)
+    .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    .accessibilityHint("Click to select. Double-click to open.")
+    .accessibilityAddTraits(isSelected ? .isSelected : [])
+    .accessibilityAction(named: Text("Open")) {
+      onOpenItem(item)
     }
     .accessibilityIdentifier("harness.task-board.api-item.\(item.id)")
   }
@@ -244,34 +92,13 @@ struct TaskBoardItemRow: View {
       TaskBoardCardPill(label: "\(policyTraceCount) policy", tint: HarnessMonitorTheme.secondaryInk)
     }
   }
-}
 
-private struct TaskBoardItemDragPreviewCard: View {
-  let item: TaskBoardItem
-  let titleTypography: TaskBoardCardTitleTypography
-  @Environment(\.fontScale)
-  private var fontScale
-
-  private var metrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
-  private var statusFont: Font {
-    HarnessMonitorTextSize.scaledFont(.caption.weight(.semibold), by: fontScale)
+  private static var currentEventModifiers: EventModifiers {
+    EventModifiers(nsModifiers: NSEvent.modifierFlags)
   }
 
-  var body: some View {
-    VStack(alignment: .leading, spacing: metrics.laneBodyTopPadding) {
-      TaskBoardInlineCodeText(
-        item.title,
-        font: titleTypography.font,
-        codeFont: titleTypography.codeFont,
-        lineLimit: 2
-      )
-      Text(item.status.title)
-        .font(statusFont)
-        .foregroundStyle(taskBoardStatusColor(for: item.status))
-    }
-    .frame(width: metrics.dragPreviewWidth, alignment: .leading)
-    .padding(metrics.cardPadding)
-    .background(.background.opacity(0.92), in: .rect(cornerRadius: metrics.cardCornerRadius))
+  private static var currentClickCount: Int {
+    NSApp.currentEvent?.clickCount ?? 1
   }
 }
 
@@ -279,23 +106,23 @@ struct TaskBoardInboxItemRow: View {
   let item: TaskBoardInboxItem
   let titleTypography: TaskBoardCardTitleTypography
   let isHovered: Bool
+  let isSelected: Bool
+  let onSelect: (EventModifiers) -> Void
   let onOpenItem: (TaskBoardInboxItem) -> Void
   @Environment(\.fontScale)
   private var fontScale
 
   private var metrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
-  private var dragPayload: TaskBoardInboxItemDragPayload {
-    TaskBoardInboxItemDragPayload(
-      sessionID: item.session.sessionId,
-      taskID: item.task.taskId,
-      status: item.task.status,
-      lane: item.lane
-    )
+  private var cardID: TaskBoardCardID {
+    .inbox(sessionID: item.session.sessionId, taskID: item.task.taskId)
   }
 
   var body: some View {
     Button {
-      onOpenItem(item)
+      onSelect(Self.currentEventModifiers)
+      if Self.currentClickCount == 2 {
+        onOpenItem(item)
+      }
     } label: {
       VStack(alignment: .leading, spacing: metrics.laneSpacing) {
         VStack(alignment: .leading, spacing: metrics.rowTextSpacing) {
@@ -317,13 +144,14 @@ struct TaskBoardInboxItemRow: View {
       )
       .padding(metrics.cardPadding)
     }
-    .taskBoardCardChrome(tint: statusTint, isHovered: isHovered)
+    .taskBoardCardChrome(tint: statusTint, isHovered: isHovered, isSelected: isSelected)
     .contentShape(.rect)
-    .onDrag {
-      dragPayload.itemProvider()
-    }
-    .draggable(dragPayload) {
-      TaskBoardInboxItemDragPreviewCard(item: item, titleTypography: titleTypography)
+    .draggable(containerItemID: cardID)
+    .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    .accessibilityHint("Click to select. Double-click to open.")
+    .accessibilityAddTraits(isSelected ? .isSelected : [])
+    .accessibilityAction(named: Text("Open")) {
+      onOpenItem(item)
     }
     .accessibilityIdentifier("harness.task-board.item.\(item.task.taskId)")
   }
@@ -334,33 +162,12 @@ struct TaskBoardInboxItemRow: View {
     TaskBoardCardPill(label: item.task.status.title, tint: statusTint)
     TaskBoardCardPill(label: item.task.severity.title, tint: severityColor(for: item.task.severity))
   }
-}
 
-private struct TaskBoardInboxItemDragPreviewCard: View {
-  let item: TaskBoardInboxItem
-  let titleTypography: TaskBoardCardTitleTypography
-  @Environment(\.fontScale)
-  private var fontScale
-
-  private var metrics: TaskBoardLaneMetrics { TaskBoardLaneMetrics(fontScale: fontScale) }
-  private var statusFont: Font {
-    HarnessMonitorTextSize.scaledFont(.caption.weight(.semibold), by: fontScale)
+  private static var currentEventModifiers: EventModifiers {
+    EventModifiers(nsModifiers: NSEvent.modifierFlags)
   }
 
-  var body: some View {
-    VStack(alignment: .leading, spacing: metrics.laneBodyTopPadding) {
-      TaskBoardInlineCodeText(
-        item.task.title,
-        font: titleTypography.font,
-        codeFont: titleTypography.codeFont,
-        lineLimit: 2
-      )
-      Text(item.task.status.title)
-        .font(statusFont)
-        .foregroundStyle(taskStatusColor(for: item.task.status))
-    }
-    .frame(width: metrics.dragPreviewWidth, alignment: .leading)
-    .padding(metrics.cardPadding)
-    .background(.background.opacity(0.92), in: .rect(cornerRadius: metrics.cardCornerRadius))
+  private static var currentClickCount: Int {
+    NSApp.currentEvent?.clickCount ?? 1
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewHost.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewHost.swift
@@ -51,8 +51,8 @@ struct TaskBoardOverviewHost: View {
       isActionInFlight: isActionInFlight,
       onOpenItem: openInboxItem,
       onOpenTaskBoardItem: openTaskBoardItem,
-      onMoveInboxItem: moveInboxItem,
-      onMoveTaskBoardItem: moveTaskBoardItem,
+      onMoveInboxItems: moveInboxItems,
+      onMoveTaskBoardItems: moveTaskBoardItems,
       onOpenDecision: openDecision,
       onCreateTaskBoardItem: createTaskBoardItem,
       onUpdateTaskBoardItem: updateTaskBoardItem,
@@ -133,10 +133,12 @@ struct TaskBoardOverviewHost: View {
     }
   }
 
-  private func moveTaskBoardItem(_ itemID: String, status: TaskBoardStatus) {
-    Task { @MainActor in
-      await store.updateTaskBoardItemStatus(id: itemID, status: status)
-    }
+  private func moveTaskBoardItems(_ updates: [TaskBoardItemStatusUpdate]) {
+    HarnessMonitorAsyncWorkQueue.shared.submit(
+      .init(title: "Moving task board items") {
+        await store.updateTaskBoardItemStatuses(updates)
+      }
+    )
   }
 
   private func createTaskBoardItem(
@@ -160,14 +162,12 @@ struct TaskBoardOverviewHost: View {
     }
   }
 
-  private func moveInboxItem(_ item: TaskBoardInboxItem, status: TaskStatus) {
-    Task { @MainActor in
-      await store.updateTaskStatus(
-        taskID: item.task.taskId,
-        status: status,
-        sessionID: item.session.sessionId
-      )
-    }
+  private func moveInboxItems(_ updates: [TaskBoardInboxStatusUpdate]) {
+    HarnessMonitorAsyncWorkQueue.shared.submit(
+      .init(title: "Moving session tasks") {
+        await store.updateTaskBoardInboxStatuses(updates)
+      }
+    )
   }
 
   private func evaluateTaskBoard() {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewHost.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewHost.swift
@@ -57,6 +57,7 @@ struct TaskBoardOverviewHost: View {
       onCreateTaskBoardItem: createTaskBoardItem,
       onUpdateTaskBoardItem: updateTaskBoardItem,
       onDeleteTaskBoardItem: deleteTaskBoardItem,
+      onDeleteTaskBoardTargets: deleteTaskBoardTargets,
       onEvaluateTaskBoard: evaluateTaskBoard,
       onEvaluateTaskBoardItem: evaluateTaskBoardItem,
       onBeginTaskBoardPlan: beginTaskBoardPlan,
@@ -157,9 +158,11 @@ struct TaskBoardOverviewHost: View {
   }
 
   private func deleteTaskBoardItem(_ item: TaskBoardItem) {
-    Task { @MainActor in
-      await store.deleteTaskBoardItem(id: item.id)
-    }
+    deleteTaskBoardTargets([TaskBoardDeletionTarget(taskBoardItem: item)])
+  }
+
+  private func deleteTaskBoardTargets(_ targets: [TaskBoardDeletionTarget]) {
+    store.requestTaskBoardDeletionConfirmation(targets: targets)
   }
 
   private func moveInboxItems(_ updates: [TaskBoardInboxStatusUpdate]) {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
@@ -13,6 +13,7 @@ struct TaskBoardOverviewPresentation: Equatable, Sendable {
   static let empty = Self(
     taskBoardItems: [],
     taskBoardItemsByID: [:],
+    projectLabelResolver: TaskBoardProjectLabelResolver(projectIDs: []),
     apiItemsByLane: [:],
     inboxItemsByLane: [:],
     decisionIDsByLane: [:],
@@ -25,6 +26,7 @@ struct TaskBoardOverviewPresentation: Equatable, Sendable {
 
   let taskBoardItems: [TaskBoardItem]
   let taskBoardItemsByID: [String: TaskBoardItem]
+  let projectLabelResolver: TaskBoardProjectLabelResolver
   let apiItemsByLane: [TaskBoardInboxLane: [TaskBoardItem]]
   let inboxItemsByLane: [TaskBoardInboxLane: [TaskBoardInboxItem]]
   let decisionIDsByLane: [TaskBoardInboxLane: [String]]
@@ -135,6 +137,9 @@ actor TaskBoardOverviewPresentationWorker {
     return TaskBoardOverviewPresentation(
       taskBoardItems: taskBoardItems,
       taskBoardItemsByID: Dictionary(uniqueKeysWithValues: taskBoardItems.map { ($0.id, $0) }),
+      projectLabelResolver: TaskBoardProjectLabelResolver(
+        projectIDs: taskBoardItems.compactMap(\.projectId)
+      ),
       apiItemsByLane: apiItemsByLane,
       inboxItemsByLane: inboxItemsByLane,
       decisionIDsByLane: decisionIDsByLane,

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
@@ -127,17 +127,13 @@ actor TaskBoardOverviewPresentationWorker {
     let apiItemsByLane = Dictionary(grouping: taskBoardItems) { item in
       TaskBoardInboxLane(status: item.status) ?? .todo
     }
-    let inboxItemsByLane = Dictionary(grouping: input.snapshot.items, by: \.lane)
+    let inboxItems = uniqueInboxItems(input.snapshot.items)
+    let inboxItemsByLane = Dictionary(grouping: inboxItems, by: \.lane)
     let inboxItemsByID = Dictionary(
-      uniqueKeysWithValues: input.snapshot.items.map { item in
-        (
-          TaskBoardCardID.inbox(
-            sessionID: item.session.sessionId,
-            taskID: item.task.taskId
-          ),
-          item
-        )
-      }
+      inboxItems.map { item in
+        (inboxCardID(for: item), item)
+      },
+      uniquingKeysWith: { first, _ in first }
     )
     let decisionIDs = sortedOpenDecisionIDs(input.decisionItems)
     let decisionIDsByLane: [TaskBoardInboxLane: [String]] =
@@ -171,7 +167,7 @@ actor TaskBoardOverviewPresentationWorker {
         + (inboxItemsByLane[.humanRequired]?.count ?? 0)
         + decisionIDs.count,
       aggregateOpenCount: taskBoardOpenCount
-        + input.snapshot.openItemCount
+        + inboxItems.count
         + decisionIDs.count,
       aggregateReviewCount: taskBoardReviewCount
         + reviewLanes.reduce(0) { count, lane in
@@ -189,6 +185,20 @@ actor TaskBoardOverviewPresentationWorker {
     .toReview,
   ]
 
+  private static func uniqueInboxItems(
+    _ items: [TaskBoardInboxItem]
+  ) -> [TaskBoardInboxItem] {
+    var seenIDs: Set<TaskBoardCardID> = []
+    return items.filter { seenIDs.insert(inboxCardID(for: $0)).inserted }
+  }
+
+  private static func inboxCardID(for item: TaskBoardInboxItem) -> TaskBoardCardID {
+    .inbox(
+      sessionID: item.session.sessionId,
+      taskID: item.task.taskId
+    )
+  }
+
   private static func orderedCardIDs(
     apiItemsByLane: [TaskBoardInboxLane: [TaskBoardItem]],
     inboxItemsByLane: [TaskBoardInboxLane: [TaskBoardInboxItem]]
@@ -196,7 +206,7 @@ actor TaskBoardOverviewPresentationWorker {
     TaskBoardInboxLane.allCases.flatMap { lane in
       (apiItemsByLane[lane] ?? []).map { .api($0.id) }
         + (inboxItemsByLane[lane] ?? []).map {
-          .inbox(sessionID: $0.session.sessionId, taskID: $0.task.taskId)
+          inboxCardID(for: $0)
         }
     }
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
@@ -16,6 +16,8 @@ struct TaskBoardOverviewPresentation: Equatable, Sendable {
     projectLabelResolver: TaskBoardProjectLabelResolver(projectIDs: []),
     apiItemsByLane: [:],
     inboxItemsByLane: [:],
+    inboxItemsByID: [:],
+    orderedCardIDs: [],
     decisionIDsByLane: [:],
     aggregateNeedsYouCount: 0,
     aggregateOpenCount: 0,
@@ -29,6 +31,8 @@ struct TaskBoardOverviewPresentation: Equatable, Sendable {
   let projectLabelResolver: TaskBoardProjectLabelResolver
   let apiItemsByLane: [TaskBoardInboxLane: [TaskBoardItem]]
   let inboxItemsByLane: [TaskBoardInboxLane: [TaskBoardInboxItem]]
+  let inboxItemsByID: [TaskBoardCardID: TaskBoardInboxItem]
+  let orderedCardIDs: [TaskBoardCardID]
   let decisionIDsByLane: [TaskBoardInboxLane: [String]]
   let aggregateNeedsYouCount: Int
   let aggregateOpenCount: Int
@@ -64,6 +68,10 @@ struct TaskBoardOverviewPresentation: Equatable, Sendable {
 
   func taskBoardItem(id: String) -> TaskBoardItem? {
     taskBoardItemsByID[id]
+  }
+
+  func inboxItem(id: TaskBoardCardID) -> TaskBoardInboxItem? {
+    inboxItemsByID[id]
   }
 }
 
@@ -120,6 +128,17 @@ actor TaskBoardOverviewPresentationWorker {
       TaskBoardInboxLane(status: item.status) ?? .todo
     }
     let inboxItemsByLane = Dictionary(grouping: input.snapshot.items, by: \.lane)
+    let inboxItemsByID = Dictionary(
+      uniqueKeysWithValues: input.snapshot.items.map { item in
+        (
+          TaskBoardCardID.inbox(
+            sessionID: item.session.sessionId,
+            taskID: item.task.taskId
+          ),
+          item
+        )
+      }
+    )
     let decisionIDs = sortedOpenDecisionIDs(input.decisionItems)
     let decisionIDsByLane: [TaskBoardInboxLane: [String]] =
       decisionIDs.isEmpty ? [:] : [.humanRequired: decisionIDs]
@@ -142,6 +161,11 @@ actor TaskBoardOverviewPresentationWorker {
       ),
       apiItemsByLane: apiItemsByLane,
       inboxItemsByLane: inboxItemsByLane,
+      inboxItemsByID: inboxItemsByID,
+      orderedCardIDs: orderedCardIDs(
+        apiItemsByLane: apiItemsByLane,
+        inboxItemsByLane: inboxItemsByLane
+      ),
       decisionIDsByLane: decisionIDsByLane,
       aggregateNeedsYouCount: taskBoardNeedsYouCount
         + (inboxItemsByLane[.humanRequired]?.count ?? 0)
@@ -164,6 +188,18 @@ actor TaskBoardOverviewPresentationWorker {
     .inReview,
     .toReview,
   ]
+
+  private static func orderedCardIDs(
+    apiItemsByLane: [TaskBoardInboxLane: [TaskBoardItem]],
+    inboxItemsByLane: [TaskBoardInboxLane: [TaskBoardInboxItem]]
+  ) -> [TaskBoardCardID] {
+    TaskBoardInboxLane.allCases.flatMap { lane in
+      (apiItemsByLane[lane] ?? []).map { .api($0.id) }
+        + (inboxItemsByLane[lane] ?? []).map {
+          .inbox(sessionID: $0.session.sessionId, taskID: $0.task.taskId)
+        }
+    }
+  }
 
   private static func sortedTaskBoardItems(_ items: [TaskBoardItem]) -> [TaskBoardItem] {
     items

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+Board.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+Board.swift
@@ -56,6 +56,9 @@ extension TaskBoardOverviewView {
         decisions: decisions,
         titleTypography: titleTypography,
         isCollapsed: isCollapsed,
+        isDropEnabled: !isActionInFlight,
+        isDropCandidate:
+          !isActionInFlight && cardDropPlan(draggedCardIDsValue, to: lane) != nil,
         selectedCardIDs: cardSelectionValue.selectedIDs,
         onOpenAPIItem: openTaskBoardItem,
         onOpenInboxItem: onOpenItem,
@@ -64,6 +67,10 @@ extension TaskBoardOverviewView {
           toggleLaneCollapse(lane, contentCount: contentCount)
         },
         onSelectCard: selectCard,
+        contextMenuActions: taskBoardCardContextMenuActions,
+        dropPlanForCardIDs: { cardIDs in
+          cardDropPlan(cardIDs, to: lane)
+        },
         onMoveCards: moveCards
       )
       .layoutValue(

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+Board.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+Board.swift
@@ -1,0 +1,88 @@
+import HarnessMonitorKit
+import SwiftUI
+
+extension TaskBoardOverviewView {
+  @ViewBuilder var boardContent: some View {
+    if hasBoardContent {
+      taskBoardColumns
+    } else {
+      emptyState
+    }
+  }
+
+  var taskBoardColumns: some View {
+    let titleTypography = TaskBoardCardTitleTypography(fontScale: fontScale)
+    return ViewThatFits(in: .horizontal) {
+      taskBoardLaneStrip(titleTypography: titleTypography)
+
+      ScrollView(.horizontal, showsIndicators: true) {
+        taskBoardLaneStrip(titleTypography: titleTypography)
+      }
+      .scrollClipDisabled()
+    }
+    .taskBoardCardDragContainer(
+      isEnabled: !isActionInFlight,
+      selectedIDs: orderedSelectedCardIDs,
+      payloads: cardDragPayloads,
+      onSessionUpdated: updateCardDragSession
+    )
+  }
+
+  func taskBoardLaneStrip(
+    titleTypography: TaskBoardCardTitleTypography
+  ) -> some View {
+    TaskBoardLaneStripLayout(sizing: laneStripSizing) {
+      taskBoardLaneColumns(titleTypography: titleTypography)
+    }
+    .padding(.vertical, metrics.boardVerticalPadding)
+  }
+
+  @ViewBuilder
+  func taskBoardLaneColumns(titleTypography: TaskBoardCardTitleTypography) -> some View {
+    ForEach(TaskBoardInboxLane.allCases) { lane in
+      let apiItems = currentPresentation.apiItems(in: lane)
+      let inboxItems = currentPresentation.inboxItems(in: lane)
+      let decisions = decisions(in: lane)
+      let contentCount = laneContentCount(
+        apiItems: apiItems,
+        inboxItems: inboxItems,
+        decisions: decisions
+      )
+      let isCollapsed = isLaneCollapsed(lane, contentCount: contentCount)
+      TaskBoardLaneUnifiedColumn(
+        lane: lane,
+        apiItems: apiItems,
+        inboxItems: inboxItems,
+        decisions: decisions,
+        titleTypography: titleTypography,
+        isCollapsed: isCollapsed,
+        selectedCardIDs: cardSelectionValue.selectedIDs,
+        onOpenAPIItem: openTaskBoardItem,
+        onOpenInboxItem: onOpenItem,
+        onOpenDecision: onOpenDecision,
+        onToggleCollapse: {
+          toggleLaneCollapse(lane, contentCount: contentCount)
+        },
+        onSelectCard: selectCard,
+        onMoveCards: moveCards
+      )
+      .layoutValue(
+        key: TaskBoardLanePreferredWidthKey.self,
+        value: isCollapsed ? laneMetrics.laneCollapsedWidth : laneMetrics.laneWidth
+      )
+      .layoutValue(key: TaskBoardLaneCanExpandKey.self, value: !isCollapsed)
+    }
+  }
+
+  var emptyState: some View {
+    ContentUnavailableView("No Open Tasks", systemImage: "tray")
+      .font(bodyFont)
+      .frame(maxWidth: .infinity, minHeight: 180)
+      .background(
+        .background.opacity(0.45), in: .rect(cornerRadius: HarnessMonitorTheme.cornerRadiusSM))
+  }
+
+  func decisions(in lane: TaskBoardInboxLane) -> [Decision] {
+    currentPresentation.decisionIDs(in: lane).compactMap { decisionsByID[$0] }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+CardInteraction.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+CardInteraction.swift
@@ -1,0 +1,124 @@
+import HarnessMonitorKit
+import SwiftUI
+
+extension TaskBoardOverviewView {
+  var orderedSelectedCardIDs: [TaskBoardCardID] {
+    cardSelectionValue.orderedSelectedIDs(
+      in: currentPresentation.orderedCardIDs
+    )
+  }
+
+  func selectCard(
+    _ cardID: TaskBoardCardID,
+    orderedVisibleIDs: [TaskBoardCardID],
+    modifiers: EventModifiers
+  ) {
+    let next = cardSelectionValue.selecting(
+      cardID,
+      orderedVisibleIDs: orderedVisibleIDs,
+      modifiers: modifiers
+    )
+    if cardSelectionValue != next {
+      cardSelectionValue = next
+    }
+  }
+
+  func cardDragPayloads(
+    _ cardIDs: [TaskBoardCardID]
+  ) -> [TaskBoardCardDragPayload] {
+    cardIDs.compactMap(cardDragItem).map(TaskBoardCardDragPayload.init(item:))
+  }
+
+  func updateCardDragSession(_ session: DragSession) {
+    guard case .initial = session.phase else {
+      return
+    }
+    let draggedIDs = session.draggedItemIDs(for: TaskBoardCardID.self)
+    guard !draggedIDs.isEmpty else {
+      return
+    }
+    let next = cardSelectionValue.selectingForDrag(draggedIDs)
+    if cardSelectionValue != next {
+      cardSelectionValue = next
+    }
+  }
+
+  func moveCards(
+    _ items: [TaskBoardCardDragItem],
+    to lane: TaskBoardInboxLane
+  ) -> Bool {
+    guard !isActionInFlight else {
+      return false
+    }
+    var taskBoardUpdates: [TaskBoardItemStatusUpdate] = []
+    var inboxUpdates: [TaskBoardInboxStatusUpdate] = []
+    for item in items {
+      guard item.accepts(destination: lane) else {
+        return false
+      }
+      switch item {
+      case .api(let itemID, let sourceStatus):
+        guard
+          onMoveTaskBoardItems != nil,
+          let current = currentPresentation.taskBoardItem(id: itemID),
+          current.status == sourceStatus
+        else {
+          return false
+        }
+        let destinationStatus = lane.taskBoardDropStatus(for: current)
+        taskBoardUpdates.append(
+          TaskBoardItemStatusUpdate(id: itemID, status: destinationStatus)
+        )
+      case .inbox(_, _, let sourceStatus, let sourceLaneRawValue):
+        guard
+          onMoveInboxItems != nil,
+          let destinationStatus = lane.taskDropStatus,
+          let current = currentPresentation.inboxItem(id: item.id),
+          current.task.status == sourceStatus,
+          current.lane.rawValue == sourceLaneRawValue
+        else {
+          return false
+        }
+        inboxUpdates.append(
+          TaskBoardInboxStatusUpdate(
+            sessionID: current.session.sessionId,
+            taskID: current.task.taskId,
+            status: destinationStatus
+          )
+        )
+      }
+    }
+    guard !taskBoardUpdates.isEmpty || !inboxUpdates.isEmpty else {
+      return false
+    }
+    if !taskBoardUpdates.isEmpty {
+      onMoveTaskBoardItems?(taskBoardUpdates)
+    }
+    if !inboxUpdates.isEmpty {
+      onMoveInboxItems?(inboxUpdates)
+    }
+    return true
+  }
+
+  private func cardDragItem(_ cardID: TaskBoardCardID) -> TaskBoardCardDragItem? {
+    switch cardID {
+    case .api(let itemID):
+      guard let item = currentPresentation.taskBoardItem(id: itemID) else {
+        return nil
+      }
+      return .api(itemID: item.id, status: item.status)
+    case .inbox(let sessionID, let taskID):
+      guard
+        let item = currentPresentation.inboxItem(id: cardID)
+      else {
+        return nil
+      }
+      return .inbox(
+        sessionID: sessionID,
+        taskID: taskID,
+        status: item.task.status,
+        sourceLaneRawValue: item.lane.rawValue
+      )
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+CardInteraction.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+CardInteraction.swift
@@ -29,17 +29,42 @@ extension TaskBoardOverviewView {
     cardIDs.compactMap(cardDragItem).map(TaskBoardCardDragPayload.init(item:))
   }
 
+  func cardDropPlan(
+    _ cardIDs: [TaskBoardCardID],
+    to lane: TaskBoardInboxLane
+  ) -> TaskBoardCardDropPlan? {
+    TaskBoardCardDropPlan.resolve(cardDragPayloads(cardIDs), to: lane)
+  }
+
   func updateCardDragSession(_ session: DragSession) {
-    guard case .initial = session.phase else {
-      return
+    switch session.phase {
+    case .initial, .active:
+      updateActiveCardDrag(session)
+    case .ended, .dataTransferCompleted:
+      updateDraggedCardIDs([])
+    @unknown default:
+      updateDraggedCardIDs([])
     }
+  }
+
+  private func updateActiveCardDrag(_ session: DragSession) {
     let draggedIDs = session.draggedItemIDs(for: TaskBoardCardID.self)
     guard !draggedIDs.isEmpty else {
+      return
+    }
+    updateDraggedCardIDs(draggedIDs)
+    guard case .initial = session.phase else {
       return
     }
     let next = cardSelectionValue.selectingForDrag(draggedIDs)
     if cardSelectionValue != next {
       cardSelectionValue = next
+    }
+  }
+
+  private func updateDraggedCardIDs(_ cardIDs: [TaskBoardCardID]) {
+    if draggedCardIDsValue != cardIDs {
+      draggedCardIDsValue = cardIDs
     }
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+ContextMenu.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+ContextMenu.swift
@@ -1,0 +1,99 @@
+import HarnessMonitorKit
+
+extension TaskBoardOverviewView {
+  var taskBoardCardContextMenuActions: TaskBoardCardContextMenuActions {
+    TaskBoardCardContextMenuActions(
+      selectedIDs: cardSelectionValue.selectedIDs,
+      orderedVisibleIDs: currentPresentation.orderedCardIDs,
+      isActionInFlight: isActionInFlight,
+      canOpen: canOpenCard,
+      open: openCard,
+      canMove: canMoveCardContextMenuSelection,
+      move: moveCardContextMenuSelection,
+      deletionTargets: deletionTargets,
+      canDelete: canDeleteTaskBoardCards,
+      deleteTargets: onDeleteTaskBoardTargets,
+      primeSelection: primeCardSelectionForContextMenu
+    )
+  }
+
+  func primeCardSelectionForContextMenu(_ cardIDs: [TaskBoardCardID]) {
+    let next = cardSelectionValue.selectingForContextMenu(cardIDs)
+    if cardSelectionValue != next {
+      cardSelectionValue = next
+    }
+  }
+
+  private func canMoveCardContextMenuSelection(
+    _ cardIDs: [TaskBoardCardID],
+    to lane: TaskBoardInboxLane
+  ) -> Bool {
+    guard !isActionInFlight, let plan = cardContextMenuMovePlan(cardIDs, to: lane) else {
+      return false
+    }
+    return plan.items.allSatisfy { item in
+      switch item {
+      case .api:
+        onMoveTaskBoardItems != nil
+      case .inbox:
+        onMoveInboxItems != nil
+      }
+    }
+  }
+
+  private func moveCardContextMenuSelection(
+    _ cardIDs: [TaskBoardCardID],
+    to lane: TaskBoardInboxLane
+  ) {
+    guard let plan = cardContextMenuMovePlan(cardIDs, to: lane) else {
+      return
+    }
+    _ = moveCards(plan.items, to: lane)
+  }
+
+  private func cardContextMenuMovePlan(
+    _ cardIDs: [TaskBoardCardID],
+    to lane: TaskBoardInboxLane
+  ) -> TaskBoardCardDropPlan? {
+    TaskBoardCardDropPlan.resolve(cardDragPayloads(cardIDs), to: lane)
+  }
+
+  private func canOpenCard(_ cardID: TaskBoardCardID) -> Bool {
+    switch cardID {
+    case .api(let itemID):
+      currentPresentation.taskBoardItem(id: itemID) != nil
+    case .inbox:
+      currentPresentation.inboxItem(id: cardID) != nil
+    }
+  }
+
+  private func openCard(_ cardID: TaskBoardCardID) {
+    switch cardID {
+    case .api(let itemID):
+      if let item = currentPresentation.taskBoardItem(id: itemID) {
+        openTaskBoardItem(item)
+      }
+    case .inbox:
+      if let item = currentPresentation.inboxItem(id: cardID) {
+        onOpenItem(item)
+      }
+    }
+  }
+
+  func deletionTargets(
+    for cardIDs: [TaskBoardCardID]
+  ) -> [TaskBoardDeletionTarget] {
+    cardIDs.compactMap { cardID in
+      switch cardID {
+      case .api(let itemID):
+        currentPresentation.taskBoardItem(id: itemID).map(
+          TaskBoardDeletionTarget.init(taskBoardItem:)
+        )
+      case .inbox:
+        currentPresentation.inboxItem(id: cardID).map(
+          TaskBoardDeletionTarget.init(inboxTask:)
+        )
+      }
+    }
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+SelectionFocus.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+SelectionFocus.swift
@@ -9,12 +9,6 @@ extension TaskBoardOverviewView {
     )
   }
 
-  func bindTaskBoardSelectionDispatcher() {
-    taskBoardSelectionDispatcherValue.deleteSelection = { [self] in
-      requestDeleteSelectedTaskBoardCards()
-    }
-  }
-
   private var canDeleteSelectedTaskBoardCards: Bool {
     canDeleteTaskBoardCards(orderedSelectedCardIDs)
   }
@@ -36,7 +30,7 @@ extension TaskBoardOverviewView {
     return !store.isBusy && !store.isSessionReadOnly && store.apiClient != nil
   }
 
-  private func requestDeleteSelectedTaskBoardCards() {
+  func requestDeleteSelectedTaskBoardCards() {
     guard canDeleteSelectedTaskBoardCards else {
       return
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+SelectionFocus.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+SelectionFocus.swift
@@ -1,0 +1,45 @@
+import HarnessMonitorKit
+
+extension TaskBoardOverviewView {
+  var taskBoardSelectionFocus: TaskBoardSelectionFocus {
+    TaskBoardSelectionFocus(
+      selectionCount: orderedSelectedCardIDs.count,
+      canDelete: canDeleteSelectedTaskBoardCards,
+      dispatcher: taskBoardSelectionDispatcherValue
+    )
+  }
+
+  func bindTaskBoardSelectionDispatcher() {
+    taskBoardSelectionDispatcherValue.deleteSelection = { [self] in
+      requestDeleteSelectedTaskBoardCards()
+    }
+  }
+
+  private var canDeleteSelectedTaskBoardCards: Bool {
+    canDeleteTaskBoardCards(orderedSelectedCardIDs)
+  }
+
+  func canDeleteTaskBoardCards(_ selectedIDs: [TaskBoardCardID]) -> Bool {
+    guard
+      !selectedIDs.isEmpty,
+      !isActionInFlight,
+      selectedTaskBoardItemIDValue == nil,
+      !isCreatingTaskBoardItemValue,
+      onDeleteTaskBoardTargets != nil,
+      deletionTargets(for: selectedIDs).count == selectedIDs.count
+    else {
+      return false
+    }
+    guard let store else {
+      return true
+    }
+    return !store.isBusy && !store.isSessionReadOnly && store.apiClient != nil
+  }
+
+  private func requestDeleteSelectedTaskBoardCards() {
+    guard canDeleteSelectedTaskBoardCards else {
+      return
+    }
+    onDeleteTaskBoardTargets?(deletionTargets(for: orderedSelectedCardIDs))
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+Support.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+Support.swift
@@ -99,7 +99,7 @@ extension TaskBoardOverviewView {
   }
 
   func moveTaskBoardItem(_ itemID: String, to lane: TaskBoardInboxLane) -> Bool {
-    guard let onMoveTaskBoardItem else {
+    guard let onMoveTaskBoardItems else {
       return false
     }
     guard
@@ -110,25 +110,34 @@ extension TaskBoardOverviewView {
     else {
       return false
     }
-    onMoveTaskBoardItem(itemID, lane.taskBoardDropStatus(for: item))
+    onMoveTaskBoardItems([
+      TaskBoardItemStatusUpdate(id: itemID, status: lane.taskBoardDropStatus(for: item))
+    ])
     return true
   }
 
   func moveInboxItem(
-    _ payload: TaskBoardInboxItemDragPayload,
+    sessionID: String,
+    taskID: String,
     to lane: TaskBoardInboxLane
   ) -> Bool {
     guard
-      let onMoveInboxItem,
+      let onMoveInboxItems,
       let status = lane.taskDropStatus,
       let item = snapshot.items.first(where: {
-        $0.session.sessionId == payload.sessionID && $0.task.taskId == payload.taskID
+        $0.session.sessionId == sessionID && $0.task.taskId == taskID
       }),
       item.lane != lane
     else {
       return false
     }
-    onMoveInboxItem(item, status)
+    onMoveInboxItems([
+      TaskBoardInboxStatusUpdate(
+        sessionID: item.session.sessionId,
+        taskID: item.task.taskId,
+        status: status
+      )
+    ])
     return true
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
@@ -22,6 +22,7 @@ public struct TaskBoardOverviewView: View {
   let onCreateTaskBoardItem: ((TaskBoardCreateItemRequest, TaskBoardStatus) -> Void)?
   let onUpdateTaskBoardItem: ((String, TaskBoardUpdateItemRequest) -> Void)?
   let onDeleteTaskBoardItem: ((TaskBoardItem) -> Void)?
+  let onDeleteTaskBoardTargets: (([TaskBoardDeletionTarget]) -> Void)?
   let onEvaluateTaskBoard: (() -> Void)?
   let onEvaluateTaskBoardItem: ((TaskBoardItem) -> Void)?
   let onBeginTaskBoardPlan: ((TaskBoardItem) -> Void)?
@@ -40,6 +41,8 @@ public struct TaskBoardOverviewView: View {
   @State private var cachedPresentation = TaskBoardOverviewPresentation.empty
   @State private var presentationGeneration: UInt64 = 0
   @State private var cardSelection = TaskBoardCardSelectionState()
+  @State private var draggedCardIDs: [TaskBoardCardID] = []
+  @State private var taskBoardSelectionDispatcher = TaskBoardSelectionDispatcher()
   @AppStorage(TaskBoardLaneCollapsePreferences.storageKey)
   var laneCollapsePreferencesRawValue = TaskBoardLaneCollapsePreferences.emptyRawValue
   @AppStorage(TaskBoardLaneAppearancePreferences.storageKey)
@@ -99,6 +102,7 @@ public struct TaskBoardOverviewView: View {
     onCreateTaskBoardItem: ((TaskBoardCreateItemRequest, TaskBoardStatus) -> Void)? = nil,
     onUpdateTaskBoardItem: ((String, TaskBoardUpdateItemRequest) -> Void)? = nil,
     onDeleteTaskBoardItem: ((TaskBoardItem) -> Void)? = nil,
+    onDeleteTaskBoardTargets: (([TaskBoardDeletionTarget]) -> Void)? = nil,
     onEvaluateTaskBoard: (() -> Void)? = nil,
     onEvaluateTaskBoardItem: ((TaskBoardItem) -> Void)? = nil,
     onBeginTaskBoardPlan: ((TaskBoardItem) -> Void)? = nil,
@@ -132,6 +136,7 @@ public struct TaskBoardOverviewView: View {
     self.onCreateTaskBoardItem = onCreateTaskBoardItem
     self.onUpdateTaskBoardItem = onUpdateTaskBoardItem
     self.onDeleteTaskBoardItem = onDeleteTaskBoardItem
+    self.onDeleteTaskBoardTargets = onDeleteTaskBoardTargets
     self.onEvaluateTaskBoard = onEvaluateTaskBoard
     self.onEvaluateTaskBoardItem = onEvaluateTaskBoardItem
     self.onBeginTaskBoardPlan = onBeginTaskBoardPlan
@@ -160,12 +165,20 @@ public struct TaskBoardOverviewView: View {
       \.taskBoardLaneAppearance,
       TaskBoardLaneAppearance(rawValue: laneAppearancePreferencesRawValue)
     )
+    .harnessFocusedSceneValue(\.harnessTaskBoardSelection, taskBoardSelectionFocus)
+    .taskBoardSelectionForwardDeleteShortcut(taskBoardSelectionFocus)
     .taskBoardCardPreferences(projectLabelResolver: cachedPresentation.projectLabelResolver)
     .sheet(item: taskBoardManagementSheet) { taskBoardManagementSheet in
       taskBoardManagementSheetContent(taskBoardManagementSheet)
     }
     .task(id: presentationInput) {
       await rebuildPresentation(input: presentationInput)
+    }
+    .task {
+      bindTaskBoardSelectionDispatcher()
+    }
+    .onDisappear {
+      taskBoardSelectionDispatcher.deleteSelection = nil
     }
   }
 
@@ -182,6 +195,15 @@ public struct TaskBoardOverviewView: View {
   var cardSelectionValue: TaskBoardCardSelectionState {
     get { cardSelection }
     nonmutating set { cardSelection = newValue }
+  }
+
+  var draggedCardIDsValue: [TaskBoardCardID] {
+    get { draggedCardIDs }
+    nonmutating set { draggedCardIDs = newValue }
+  }
+
+  var taskBoardSelectionDispatcherValue: TaskBoardSelectionDispatcher {
+    taskBoardSelectionDispatcher
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
@@ -174,11 +174,8 @@ public struct TaskBoardOverviewView: View {
     .task(id: presentationInput) {
       await rebuildPresentation(input: presentationInput)
     }
-    .task {
-      bindTaskBoardSelectionDispatcher()
-    }
-    .onDisappear {
-      taskBoardSelectionDispatcher.deleteSelection = nil
+    .onChange(of: taskBoardSelectionDispatcher.deleteRequestGeneration) {
+      requestDeleteSelectedTaskBoardCards()
     }
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
@@ -43,8 +43,6 @@ public struct TaskBoardOverviewView: View {
   var laneCollapsePreferencesRawValue = TaskBoardLaneCollapsePreferences.emptyRawValue
   @AppStorage(TaskBoardLaneAppearancePreferences.storageKey)
   var laneAppearancePreferencesRawValue = TaskBoardLaneAppearancePreferences.emptyRawValue
-  @AppStorage(TaskBoardCardPreferences.priorityBadgeVisibilityStorageKey)
-  var showsPriorityBadge = TaskBoardCardPreferences.defaultShowsPriorityBadge
   var captionSemibold: Font {
     HarnessMonitorTextSize.scaledFont(.caption.weight(.semibold), by: fontScale)
   }
@@ -161,7 +159,7 @@ public struct TaskBoardOverviewView: View {
       \.taskBoardLaneAppearance,
       TaskBoardLaneAppearance(rawValue: laneAppearancePreferencesRawValue)
     )
-    .environment(\.taskBoardShowsPriorityBadge, showsPriorityBadge)
+    .taskBoardCardPreferences(projectLabelResolver: cachedPresentation.projectLabelResolver)
     .sheet(item: taskBoardManagementSheet) { taskBoardManagementSheet in
       taskBoardManagementSheetContent(taskBoardManagementSheet)
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
@@ -16,8 +16,8 @@ public struct TaskBoardOverviewView: View {
   let isActionInFlight: Bool
   let onOpenItem: (TaskBoardInboxItem) -> Void
   let onOpenTaskBoardItem: (TaskBoardItem) -> Void
-  let onMoveInboxItem: ((TaskBoardInboxItem, TaskStatus) -> Void)?
-  let onMoveTaskBoardItem: ((String, TaskBoardStatus) -> Void)?
+  let onMoveInboxItems: (([TaskBoardInboxStatusUpdate]) -> Void)?
+  let onMoveTaskBoardItems: (([TaskBoardItemStatusUpdate]) -> Void)?
   let onOpenDecision: (Decision) -> Void
   let onCreateTaskBoardItem: ((TaskBoardCreateItemRequest, TaskBoardStatus) -> Void)?
   let onUpdateTaskBoardItem: ((String, TaskBoardUpdateItemRequest) -> Void)?
@@ -39,6 +39,7 @@ public struct TaskBoardOverviewView: View {
   @State private var presentationWorker = TaskBoardOverviewPresentationWorker()
   @State private var cachedPresentation = TaskBoardOverviewPresentation.empty
   @State private var presentationGeneration: UInt64 = 0
+  @State private var cardSelection = TaskBoardCardSelectionState()
   @AppStorage(TaskBoardLaneCollapsePreferences.storageKey)
   var laneCollapsePreferencesRawValue = TaskBoardLaneCollapsePreferences.emptyRawValue
   @AppStorage(TaskBoardLaneAppearancePreferences.storageKey)
@@ -92,8 +93,8 @@ public struct TaskBoardOverviewView: View {
     isActionInFlight: Bool = false,
     onOpenItem: @escaping (TaskBoardInboxItem) -> Void = { _ in },
     onOpenTaskBoardItem: @escaping (TaskBoardItem) -> Void = { _ in },
-    onMoveInboxItem: ((TaskBoardInboxItem, TaskStatus) -> Void)? = nil,
-    onMoveTaskBoardItem: ((String, TaskBoardStatus) -> Void)? = nil,
+    onMoveInboxItems: (([TaskBoardInboxStatusUpdate]) -> Void)? = nil,
+    onMoveTaskBoardItems: (([TaskBoardItemStatusUpdate]) -> Void)? = nil,
     onOpenDecision: @escaping (Decision) -> Void = { _ in },
     onCreateTaskBoardItem: ((TaskBoardCreateItemRequest, TaskBoardStatus) -> Void)? = nil,
     onUpdateTaskBoardItem: ((String, TaskBoardUpdateItemRequest) -> Void)? = nil,
@@ -125,8 +126,8 @@ public struct TaskBoardOverviewView: View {
     self.isActionInFlight = isActionInFlight
     self.onOpenItem = onOpenItem
     self.onOpenTaskBoardItem = onOpenTaskBoardItem
-    self.onMoveInboxItem = onMoveInboxItem
-    self.onMoveTaskBoardItem = onMoveTaskBoardItem
+    self.onMoveInboxItems = onMoveInboxItems
+    self.onMoveTaskBoardItems = onMoveTaskBoardItems
     self.onOpenDecision = onOpenDecision
     self.onCreateTaskBoardItem = onCreateTaskBoardItem
     self.onUpdateTaskBoardItem = onUpdateTaskBoardItem
@@ -176,6 +177,11 @@ public struct TaskBoardOverviewView: View {
   var isCreatingTaskBoardItemValue: Bool {
     get { isCreatingTaskBoardItem }
     nonmutating set { isCreatingTaskBoardItem = newValue }
+  }
+
+  var cardSelectionValue: TaskBoardCardSelectionState {
+    get { cardSelection }
+    nonmutating set { cardSelection = newValue }
   }
 }
 
@@ -329,80 +335,6 @@ extension TaskBoardOverviewView {
     .frame(maxHeight: fillsAvailableHeight ? .infinity : nil)
   }
 
-  @ViewBuilder var boardContent: some View {
-    if hasBoardContent {
-      taskBoardColumns
-    } else {
-      emptyState
-    }
-  }
-
-  var taskBoardColumns: some View {
-    let titleTypography = TaskBoardCardTitleTypography(fontScale: fontScale)
-    return ViewThatFits(in: .horizontal) {
-      TaskBoardLaneStripLayout(sizing: laneStripSizing) {
-        taskBoardLaneColumns(titleTypography: titleTypography)
-      }
-      .padding(.vertical, metrics.boardVerticalPadding)
-
-      ScrollView(.horizontal, showsIndicators: true) {
-        TaskBoardLaneStripLayout(sizing: laneStripSizing) {
-          taskBoardLaneColumns(titleTypography: titleTypography)
-        }
-        .padding(.vertical, metrics.boardVerticalPadding)
-      }
-      .scrollClipDisabled()
-    }
-  }
-
-  @ViewBuilder
-  func taskBoardLaneColumns(titleTypography: TaskBoardCardTitleTypography) -> some View {
-    ForEach(TaskBoardInboxLane.allCases) { lane in
-      let apiItems = cachedPresentation.apiItems(in: lane)
-      let inboxItems = cachedPresentation.inboxItems(in: lane)
-      let decisions = decisions(in: lane)
-      let contentCount = laneContentCount(
-        apiItems: apiItems,
-        inboxItems: inboxItems,
-        decisions: decisions
-      )
-      let isCollapsed = isLaneCollapsed(lane, contentCount: contentCount)
-      TaskBoardLaneUnifiedColumn(
-        lane: lane,
-        apiItems: apiItems,
-        inboxItems: inboxItems,
-        decisions: decisions,
-        titleTypography: titleTypography,
-        isCollapsed: isCollapsed,
-        onOpenAPIItem: openTaskBoardItem,
-        onOpenInboxItem: onOpenItem,
-        onOpenDecision: onOpenDecision,
-        onToggleCollapse: {
-          toggleLaneCollapse(lane, contentCount: contentCount)
-        },
-        onMoveAPIItem: moveTaskBoardItem,
-        onMoveInboxItem: moveInboxItem
-      )
-      .layoutValue(
-        key: TaskBoardLanePreferredWidthKey.self,
-        value: isCollapsed ? laneMetrics.laneCollapsedWidth : laneMetrics.laneWidth
-      )
-      .layoutValue(key: TaskBoardLaneCanExpandKey.self, value: !isCollapsed)
-    }
-  }
-
-  var emptyState: some View {
-    ContentUnavailableView("No Open Tasks", systemImage: "tray")
-      .font(bodyFont)
-      .frame(maxWidth: .infinity, minHeight: 180)
-      .background(
-        .background.opacity(0.45), in: .rect(cornerRadius: HarnessMonitorTheme.cornerRadiusSM))
-  }
-
-  func decisions(in lane: TaskBoardInboxLane) -> [Decision] {
-    cachedPresentation.decisionIDs(in: lane).compactMap { decisionsByID[$0] }
-  }
-
   @MainActor
   func rebuildPresentation(input: TaskBoardOverviewPresentationInput) async {
     presentationGeneration &+= 1
@@ -413,6 +345,9 @@ extension TaskBoardOverviewView {
     }
     if cachedPresentation != presentation {
       cachedPresentation = presentation
+      cardSelection = cardSelection.pruning(
+        orderedVisibleIDs: presentation.orderedCardIDs
+      )
     }
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardProjectLabelResolver.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardProjectLabelResolver.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SwiftUI
+
+struct TaskBoardProjectLabelResolver: Equatable, Sendable {
+  private let ambiguousRepositoryNames: Set<String>
+
+  init(projectIDs: [String]) {
+    var projectIDsByRepositoryName: [String: Set<String>] = [:]
+    for projectID in projectIDs {
+      guard let components = Self.components(of: projectID) else {
+        continue
+      }
+      projectIDsByRepositoryName[components.repositoryNameKey, default: []]
+        .insert(components.projectIDKey)
+    }
+    ambiguousRepositoryNames = Set(
+      projectIDsByRepositoryName.compactMap { repositoryName, projectIDs in
+        projectIDs.count > 1 ? repositoryName : nil
+      }
+    )
+  }
+
+  func label(for projectID: String, alwaysShowFullName: Bool = false) -> String {
+    guard
+      !alwaysShowFullName,
+      let components = Self.components(of: projectID),
+      !ambiguousRepositoryNames.contains(components.repositoryNameKey)
+    else {
+      return projectID
+    }
+    return components.repositoryName
+  }
+
+  private static func components(of projectID: String) -> ProjectComponents? {
+    guard projectID == projectID.trimmingCharacters(in: .whitespacesAndNewlines) else {
+      return nil
+    }
+    let components = projectID.split(separator: "/", omittingEmptySubsequences: false)
+    guard
+      components.count == 2,
+      let owner = components.first,
+      let repositoryName = components.last,
+      !owner.isEmpty,
+      !repositoryName.isEmpty
+    else {
+      return nil
+    }
+    return ProjectComponents(
+      repositoryName: String(repositoryName),
+      repositoryNameKey: repositoryName.lowercased(),
+      projectIDKey: projectID.lowercased()
+    )
+  }
+}
+
+private struct ProjectComponents {
+  let repositoryName: String
+  let repositoryNameKey: String
+  let projectIDKey: String
+}
+
+extension EnvironmentValues {
+  @Entry var taskBoardProjectLabelResolver = TaskBoardProjectLabelResolver(projectIDs: [])
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardSelectionFocus.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardSelectionFocus.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 
 @MainActor
+@Observable
 public final class TaskBoardSelectionDispatcher {
-  public var deleteSelection: (() -> Void)?
+  public private(set) var deleteRequestGeneration: UInt64 = 0
 
   public init() {}
 
   public func performDeleteSelection() {
-    deleteSelection?()
+    deleteRequestGeneration &+= 1
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardSelectionFocus.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardSelectionFocus.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+@MainActor
+public final class TaskBoardSelectionDispatcher {
+  public var deleteSelection: (() -> Void)?
+
+  public init() {}
+
+  public func performDeleteSelection() {
+    deleteSelection?()
+  }
+}
+
+public struct TaskBoardSelectionFocus: Equatable {
+  public let selectionCount: Int
+  public let canDelete: Bool
+  public let dispatcher: TaskBoardSelectionDispatcher
+
+  public init(
+    selectionCount: Int,
+    canDelete: Bool,
+    dispatcher: TaskBoardSelectionDispatcher
+  ) {
+    self.selectionCount = selectionCount
+    self.canDelete = canDelete
+    self.dispatcher = dispatcher
+  }
+
+  @MainActor
+  public func performDeleteSelection() {
+    guard canDelete else { return }
+    dispatcher.performDeleteSelection()
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.selectionCount == rhs.selectionCount
+      && lhs.canDelete == rhs.canDelete
+      && lhs.dispatcher === rhs.dispatcher
+  }
+}
+
+extension FocusedValues {
+  @Entry public var harnessTaskBoardSelection: TaskBoardSelectionFocus?
+}
+
+extension View {
+  /// Mount at the Task Board root beside its focused selection value. The Edit
+  /// menu owns Backspace; this hidden button adds Forward Delete without a
+  /// duplicate visible command.
+  public func taskBoardSelectionForwardDeleteShortcut(
+    _ focus: TaskBoardSelectionFocus?
+  ) -> some View {
+    overlay {
+      if let focus {
+        Button("Forward Delete Task Board Selection") {
+          focus.performDeleteSelection()
+        }
+        .keyboardShortcut(.deleteForward, modifiers: [])
+        .disabled(!focus.canDelete)
+        .opacity(0)
+        .frame(width: 0, height: 0)
+        .accessibilityHidden(true)
+      }
+    }
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardDeletionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardDeletionTests.swift
@@ -1,0 +1,226 @@
+import Foundation
+import Testing
+
+@testable import HarnessMonitorKit
+
+@MainActor
+@Suite("Harness Monitor task-board deletion")
+struct HarnessMonitorStoreTaskBoardDeletionTests {
+  @Test("Deletion targets expose stable kind-scoped identities and titles")
+  func deletionTargetsExposeStableIdentityAndTitle() throws {
+    let boardItem = deletionBoardItem(id: "board-1", title: "Board draft")
+    let inboxItem = try #require(
+      TaskBoardInboxItem(session: PreviewFixtures.summary, task: PreviewFixtures.tasks[0])
+    )
+
+    let boardTarget = TaskBoardDeletionTarget(taskBoardItem: boardItem)
+    let inboxTarget = TaskBoardDeletionTarget(inboxTask: inboxItem)
+
+    #expect(boardTarget.id == "task-board-item:board-1")
+    #expect(boardTarget.title == "Board draft")
+    #expect(
+      inboxTarget.id
+        == "inbox-task:\(PreviewFixtures.summary.sessionId):\(PreviewFixtures.tasks[0].taskId)"
+    )
+    #expect(inboxTarget.title == PreviewFixtures.tasks[0].title)
+  }
+
+  @Test("Task Board confirmation submits deletion through the shared work queue")
+  func confirmationUsesSharedWorkQueue() throws {
+    let sourceURL = repoRoot()
+      .appendingPathComponent("apps/harness-monitor/Sources/HarnessMonitorUIPreviewable")
+      .appendingPathComponent("Views/Shared/HarnessMonitorConfirmationDialogModifier.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    #expect(source.contains("if case .deleteTaskBoardTargets(let targets)"))
+    #expect(source.contains("HarnessMonitorAsyncWorkQueue.shared.submit("))
+    #expect(source.contains("await store.confirmPendingAction(pendingConfirmation)"))
+  }
+
+  @Test("Deletion request keeps the first target for each stable identity")
+  func deletionRequestDeduplicatesTargets() async {
+    let store = await makeBootstrappedStore()
+    let first = TaskBoardDeletionTarget.taskBoardItem(id: "board-1", title: "First title")
+    let duplicate = TaskBoardDeletionTarget.taskBoardItem(
+      id: "board-1",
+      title: "Changed title"
+    )
+    let inbox = TaskBoardDeletionTarget.inboxTask(
+      sessionID: "session-1",
+      taskID: "task-1",
+      title: "Session task"
+    )
+
+    store.requestTaskBoardDeletionConfirmation(targets: [first, duplicate, inbox])
+
+    #expect(
+      store.pendingConfirmation
+        == .deleteTaskBoardTargets(targets: [first, inbox])
+    )
+    #expect(
+      store.pendingConfirmation?.uiTestTraceLabel == "delete-task-board-targets"
+    )
+  }
+
+  @Test("Deletion request is gated while another action is in progress")
+  func deletionRequestRejectsBusyStore() async {
+    let store = await makeBootstrappedStore()
+    store.isDaemonActionInFlight = true
+
+    store.requestTaskBoardDeletionConfirmation(
+      targets: [.taskBoardItem(id: "board-1", title: "Board draft")]
+    )
+
+    #expect(store.pendingConfirmation == nil)
+    #expect(store.currentFailureFeedbackMessage?.contains("already in progress") == true)
+  }
+
+  @Test("Deletion request is gated when persisted data is read-only")
+  func deletionRequestRejectsReadOnlyStore() async {
+    let store = await makeBootstrappedStore()
+    store.connectionState = .offline("Unavailable for test")
+
+    store.requestTaskBoardDeletionConfirmation(
+      targets: [.taskBoardItem(id: "board-1", title: "Board draft")]
+    )
+
+    #expect(store.pendingConfirmation == nil)
+    #expect(store.currentFailureFeedbackMessage?.contains("read-only mode") == true)
+  }
+
+  @Test("Deletion request requires a live daemon action channel")
+  func deletionRequestRequiresActionChannel() {
+    let store = HarnessMonitorStore(daemonController: RecordingDaemonController())
+    store.connectionState = .online
+
+    store.requestTaskBoardDeletionConfirmation(
+      targets: [.taskBoardItem(id: "board-1", title: "Board draft")]
+    )
+
+    #expect(store.pendingConfirmation == nil)
+    #expect(store.currentFailureFeedbackMessage?.contains("action channel") == true)
+  }
+
+  @Test("Confirmed board deletion performs sequential writes and one final refresh")
+  func confirmedBoardDeletionUsesOneFinalRefresh() async {
+    let client = RecordingHarnessClient()
+    client.configureTaskBoardItems([
+      deletionBoardItem(id: "board-1", title: "First"),
+      deletionBoardItem(id: "board-2", title: "Second"),
+    ])
+    let store = await makeBootstrappedStore(client: client)
+    let baselineReads = client.readCallCount(.taskBoardItems(nil))
+
+    store.requestTaskBoardDeletionConfirmation(
+      targets: [
+        .taskBoardItem(id: "board-1", title: "First"),
+        .taskBoardItem(id: "board-2", title: "Second"),
+      ]
+    )
+    await store.confirmPendingAction()
+
+    #expect(store.pendingConfirmation == nil)
+    #expect(
+      client.recordedCalls().filter(\.isTaskBoardDeletion)
+        == [
+          .deleteTaskBoardItem(id: "board-1"),
+          .deleteTaskBoardItem(id: "board-2"),
+        ]
+    )
+    #expect(client.readCallCount(.taskBoardItems(nil)) == baselineReads + 1)
+    #expect(store.globalTaskBoardItems.isEmpty)
+    #expect(store.currentSuccessFeedbackMessage == "Deleted 2 tasks")
+  }
+
+  @Test("Board deletion stops honestly after the first failure and still refreshes once")
+  func boardDeletionStopsAfterFirstFailure() async {
+    let client = RecordingHarnessClient()
+    client.configureTaskBoardItems([
+      deletionBoardItem(id: "board-1", title: "First"),
+      deletionBoardItem(id: "board-3", title: "Third"),
+    ])
+    let store = await makeBootstrappedStore(client: client)
+    let baselineReads = client.readCallCount(.taskBoardItems(nil))
+
+    store.requestTaskBoardDeletionConfirmation(
+      targets: [
+        .taskBoardItem(id: "board-1", title: "First"),
+        .taskBoardItem(id: "board-missing", title: "Missing"),
+        .taskBoardItem(id: "board-3", title: "Third"),
+      ]
+    )
+    await store.confirmPendingAction()
+
+    #expect(
+      client.recordedCalls().filter(\.isTaskBoardDeletion)
+        == [
+          .deleteTaskBoardItem(id: "board-1"),
+          .deleteTaskBoardItem(id: "board-missing"),
+        ]
+    )
+    #expect(client.readCallCount(.taskBoardItems(nil)) == baselineReads + 1)
+    #expect(store.globalTaskBoardItems.map(\.id) == ["board-3"])
+    #expect(store.currentFailureFeedbackMessage?.contains("Deleted 1 of 3") == true)
+    #expect(store.currentFailureFeedbackMessage?.contains("1 item was not attempted") == true)
+  }
+
+  @Test("Inbox deletions are grouped by session before reusing task cleanup")
+  func inboxDeletionsAreGroupedBySession() async {
+    let client = RecordingHarnessClient()
+    let store = await makeBootstrappedStore(client: client)
+
+    store.requestTaskBoardDeletionConfirmation(
+      targets: [
+        .inboxTask(sessionID: "session-a", taskID: "task-a1", title: "A one"),
+        .inboxTask(sessionID: "session-b", taskID: "task-b1", title: "B one"),
+        .inboxTask(sessionID: "session-a", taskID: "task-a2", title: "A two"),
+      ]
+    )
+    await store.confirmPendingAction()
+
+    #expect(
+      client.recordedCalls().filter(\.isSessionTaskDeletion)
+        == [
+          .deleteTask(sessionID: "session-a", taskID: "task-a1", actor: "harness-app"),
+          .deleteTask(sessionID: "session-a", taskID: "task-a2", actor: "harness-app"),
+          .deleteTask(sessionID: "session-b", taskID: "task-b1", actor: "harness-app"),
+        ]
+    )
+    #expect(store.currentSuccessFeedbackMessage == "Deleted 3 tasks")
+  }
+
+  private func deletionBoardItem(id: String, title: String) -> TaskBoardItem {
+    TaskBoardItem(
+      schemaVersion: 1,
+      id: id,
+      title: title,
+      body: "Body",
+      status: .todo,
+      priority: .medium,
+      tags: [],
+      projectId: "project-1",
+      agentMode: .interactive,
+      externalRefs: [],
+      planning: TaskBoardPlanningState(),
+      workflow: nil,
+      sessionId: nil,
+      workItemId: nil,
+      usage: TaskBoardUsage(),
+      createdAt: "2026-07-12T10:00:00Z",
+      updatedAt: "2026-07-12T10:00:00Z",
+      deletedAt: nil
+    )
+  }
+}
+
+extension RecordingHarnessClient.Call {
+  fileprivate var isTaskBoardDeletion: Bool {
+    if case .deleteTaskBoardItem = self { return true }
+    return false
+  }
+
+  fileprivate var isSessionTaskDeletion: Bool {
+    if case .deleteTask = self { return true }
+    return false
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardStatusUpdateTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardStatusUpdateTests.swift
@@ -1,0 +1,107 @@
+import Testing
+
+@testable import HarnessMonitorKit
+
+@MainActor
+@Suite("Harness Monitor task-board status updates")
+struct HarnessMonitorStoreTaskBoardStatusUpdateTests {
+  @Test("Moving task board items batches updates before one dashboard refresh")
+  func movingTaskBoardItemsBatchesUpdatesBeforeOneDashboardRefresh() async {
+    let client = RecordingHarnessClient()
+    client.configureTaskBoardItems([
+      taskBoardItem(id: "board-1", status: .todo),
+      taskBoardItem(id: "board-2", status: .planning),
+    ])
+    let store = await makeBootstrappedStore(client: client)
+    let baselineItemReads = client.readCallCount(.taskBoardItems(nil))
+
+    let success = await store.updateTaskBoardItemStatuses([
+      TaskBoardItemStatusUpdate(id: "board-1", status: .inProgress),
+      TaskBoardItemStatusUpdate(id: "board-2", status: .inReview),
+    ])
+
+    let updateCalls = client.recordedCalls().filter {
+      if case .updateTaskBoardItem = $0 { return true }
+      return false
+    }
+    #expect(success)
+    #expect(
+      updateCalls == [
+        .updateTaskBoardItem(id: "board-1", status: .inProgress),
+        .updateTaskBoardItem(id: "board-2", status: .inReview),
+      ]
+    )
+    #expect(client.readCallCount(.taskBoardItems(nil)) == baselineItemReads + 1)
+    #expect(
+      Dictionary(uniqueKeysWithValues: store.globalTaskBoardItems.map { ($0.id, $0.status) })
+        == ["board-1": .inProgress, "board-2": .inReview]
+    )
+    #expect(store.currentSuccessFeedbackMessage == "Moved task board items")
+  }
+
+  @Test("Moving session tasks applies one grouped mutation result")
+  func movingSessionTasksAppliesOneGroupedMutationResult() async {
+    let client = RecordingHarnessClient()
+    let store = await selectedActionStore(client: client)
+    let first = PreviewFixtures.tasks[0]
+    let second = PreviewFixtures.tasks[1]
+
+    let success = await store.updateTaskBoardInboxStatuses([
+      TaskBoardInboxStatusUpdate(
+        sessionID: PreviewFixtures.summary.sessionId,
+        taskID: first.taskId,
+        status: .awaitingReview
+      ),
+      TaskBoardInboxStatusUpdate(
+        sessionID: PreviewFixtures.summary.sessionId,
+        taskID: second.taskId,
+        status: .awaitingReview
+      ),
+    ])
+
+    #expect(success)
+    #expect(
+      client.recordedCalls() == [
+        .updateTask(
+          sessionID: PreviewFixtures.summary.sessionId,
+          taskID: first.taskId,
+          status: .awaitingReview,
+          note: nil,
+          actor: "harness-app"
+        ),
+        .updateTask(
+          sessionID: PreviewFixtures.summary.sessionId,
+          taskID: second.taskId,
+          status: .awaitingReview,
+          note: nil,
+          actor: "harness-app"
+        ),
+      ]
+    )
+    #expect(store.selectedSession?.tasks.allSatisfy { $0.status == .awaitingReview } == true)
+    #expect(store.currentSuccessFeedbackMessage == "Moved session tasks")
+  }
+
+  private func taskBoardItem(id: String, status: TaskBoardStatus) -> TaskBoardItem {
+    TaskBoardItem(
+      schemaVersion: 1,
+      id: id,
+      title: "Board item",
+      body: "Body",
+      status: status,
+      priority: .high,
+      tags: ["automation"],
+      projectId: "project-1",
+      agentMode: .interactive,
+      externalRefs: [],
+      planning: TaskBoardPlanningState(),
+      workflow: nil,
+      sessionId: nil,
+      workItemId: nil,
+      usage: TaskBoardUsage(),
+      createdAt: "2026-05-14T10:00:00Z",
+      updatedAt: "2026-05-14T10:01:00Z",
+      deletedAt: nil
+    )
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
@@ -34,6 +34,7 @@ struct HarnessMonitorAppBundleMetadataTests {
     for identifier in [
       "io.harnessmonitor.task",
       "io.harnessmonitor.session-agent",
+      "io.harnessmonitor.task-board-card",
       "io.harnessmonitor.task-board-item",
       "io.harnessmonitor.task-board-inbox-item",
     ] {

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionWindowRouteContentMetricsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionWindowRouteContentMetricsTests.swift
@@ -89,32 +89,14 @@ struct SessionWindowRouteContentMetricsTests {
     )
   }
 
-  @Test("Task board lane drop policy moves only cross-lane payloads")
-  func taskBoardLaneDropPolicyMovesOnlyCrossLanePayloads() {
-    var moves: [String] = []
-    let readyPayload = TaskBoardItemDragPayload(itemID: "item-1", status: .todo)
+  @Test("Task board card drop plans move only cross-lane payloads")
+  func taskBoardCardDropPlansMoveOnlyCrossLanePayloads() {
+    let item = TaskBoardCardDragItem.api(itemID: "item-1", status: .todo)
+    let payload = TaskBoardCardDragPayload(item: item)
 
-    #expect(
-      !TaskBoardLaneDropPolicy.moveFirstPayload([], to: .todo) { itemID, lane in
-        moves.append("\(itemID):\(lane.rawValue)")
-        return true
-      }
-    )
-    #expect(
-      !TaskBoardLaneDropPolicy.moveFirstPayload([readyPayload], to: .todo) { itemID, lane in
-        moves.append("\(itemID):\(lane.rawValue)")
-        return true
-      }
-    )
-    #expect(moves.isEmpty)
-
-    #expect(
-      TaskBoardLaneDropPolicy.moveFirstPayload([readyPayload], to: .inProgress) { itemID, lane in
-        moves.append("\(itemID):\(lane.rawValue)")
-        return true
-      }
-    )
-    #expect(moves == ["item-1:in_progress"])
+    #expect(TaskBoardCardDropPlan.resolve([], to: .todo) == nil)
+    #expect(TaskBoardCardDropPlan.resolve([payload], to: .todo) == nil)
+    #expect(TaskBoardCardDropPlan.resolve([payload], to: .inProgress)?.items == [item])
   }
 
   @Test("Task selection renders a real detail pane")
@@ -202,7 +184,11 @@ struct SessionWindowRouteContentMetricsTests {
       #expect(source.contains("onStartTaskBoardOrchestrator: startTaskBoardOrchestrator"))
       #expect(source.contains("onStopTaskBoardOrchestrator: stopTaskBoardOrchestrator"))
       #expect(source.contains("onRunTaskBoardOrchestratorOnce: runTaskBoardOrchestratorOnce"))
-      #expect(source.contains("onMoveTaskBoardItem: moveTaskBoardItem"))
+      #expect(source.contains("onMoveTaskBoardItems: moveTaskBoardItems"))
+      #expect(source.contains("onMoveInboxItems: moveInboxItems"))
+      #expect(source.contains("HarnessMonitorAsyncWorkQueue.shared.submit("))
+      #expect(source.contains("await store.updateTaskBoardItemStatuses(updates)"))
+      #expect(source.contains("await store.updateTaskBoardInboxStatuses(updates)"))
       #expect(source.contains("onEvaluateTaskBoardItem: evaluateTaskBoardItem"))
       #expect(source.contains("onBeginTaskBoardPlan: beginTaskBoardPlan"))
       #expect(source.contains("onSubmitTaskBoardPlan: submitTaskBoardPlan"))

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionWindowRouteContentMetricsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionWindowRouteContentMetricsTests.swift
@@ -186,6 +186,7 @@ struct SessionWindowRouteContentMetricsTests {
       #expect(source.contains("onRunTaskBoardOrchestratorOnce: runTaskBoardOrchestratorOnce"))
       #expect(source.contains("onMoveTaskBoardItems: moveTaskBoardItems"))
       #expect(source.contains("onMoveInboxItems: moveInboxItems"))
+      #expect(source.contains("onDeleteTaskBoardTargets: deleteTaskBoardTargets"))
       #expect(source.contains("HarnessMonitorAsyncWorkQueue.shared.submit("))
       #expect(source.contains("await store.updateTaskBoardItemStatuses(updates)"))
       #expect(source.contains("await store.updateTaskBoardInboxStatuses(updates)"))

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SettingsSharedRepositoriesDraftTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SettingsSharedRepositoriesDraftTests.swift
@@ -1,0 +1,83 @@
+import Testing
+
+@testable import HarnessMonitorUIPreviewable
+
+@Suite("Settings shared repositories draft")
+struct SettingsSharedRepositoriesDraftTests {
+  @Test("Feature toggles preserve order and retain a fully disabled row")
+  func featureTogglesPreserveOrderAndRetainFullyDisabledRow() throws {
+    var draft = makeDraft(
+      reviewsRepositories: ["example/alpha", "example/shared"],
+      taskBoardRepositories: ["example/shared", "example/omega"]
+    )
+    let originalIDs = draft.rows.map(\.id)
+
+    draft.setReviewsEnabled(false, for: "example/shared")
+    draft.setTaskBoardEnabled(false, for: "example/shared")
+
+    #expect(draft.rows.map(\.id) == originalIDs)
+    let disabled = try #require(draft.rows.first { $0.id == "example/shared" })
+    #expect(!disabled.reviewsEnabled)
+    #expect(!disabled.taskBoardEnabled)
+    #expect(draft.reviewsRepositories == ["example/alpha"])
+    #expect(draft.taskBoardRepositories == ["example/omega"])
+
+    draft.setTaskBoardEnabled(true, for: "example/shared")
+    #expect(draft.rows.map(\.id) == originalIDs)
+    #expect(draft.index(for: "example/shared") == 1)
+  }
+
+  @Test("Repository catalog preserves disabled rows and order across reloads")
+  func repositoryCatalogPreservesDisabledRowsAndOrderAcrossReloads() throws {
+    let catalog = ["example/omega", "example/disabled", "example/alpha"]
+    let draft = makeDraft(
+      reviewsRepositories: ["example/alpha"],
+      taskBoardRepositories: ["example/omega"],
+      repositoryCatalog: catalog
+    )
+
+    #expect(draft.rows.map(\.repositoryPath) == catalog)
+    let disabled = try #require(draft.rows.first { $0.id == "example/disabled" })
+    #expect(!disabled.reviewsEnabled)
+    #expect(!disabled.taskBoardEnabled)
+
+    let storedCatalog = SettingsRepositoriesCatalog.encode(draft.repositoryCatalog)
+    let reloaded = makeDraft(
+      reviewsRepositories: draft.reviewsRepositories,
+      taskBoardRepositories: draft.taskBoardRepositories,
+      repositoryCatalog: SettingsRepositoriesCatalog.decode(storedCatalog)
+    )
+    #expect(reloaded.rows == draft.rows)
+  }
+
+  @Test("Explicit removal preserves survivor order and rebuilds indexes")
+  func explicitRemovalPreservesSurvivorOrderAndRebuildsIndexes() {
+    var draft = makeDraft(
+      reviewsRepositories: ["example/alpha", "example/shared"],
+      taskBoardRepositories: ["example/shared", "example/omega"]
+    )
+
+    draft.remove(rowID: "example/shared")
+
+    #expect(draft.rows.map(\.id) == ["example/alpha", "example/omega"])
+    #expect(draft.index(for: "example/alpha") == 0)
+    #expect(draft.index(for: "example/omega") == 1)
+    #expect(draft.index(for: "example/shared") == nil)
+  }
+
+  private func makeDraft(
+    reviewsRepositories: [String],
+    taskBoardRepositories: [String],
+    repositoryCatalog: [String] = []
+  ) -> SettingsSharedRepositoriesDraft {
+    var reviews = DashboardReviewsPreferences()
+    reviews.repositoriesText = reviewsRepositories.joined(separator: ", ")
+    var taskBoard = TaskBoardGitSettingsDraft()
+    taskBoard.githubInboxRepositoriesText = taskBoardRepositories.joined(separator: "\n")
+    return SettingsSharedRepositoriesDraft(
+      reviewsPreferences: reviews,
+      taskBoardDraft: taskBoard,
+      repositoryCatalog: repositoryCatalog
+    )
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SettingsTaskBoardDraftTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SettingsTaskBoardDraftTests.swift
@@ -285,6 +285,23 @@ struct SettingsRepositoriesPerformanceSourceTests {
     #expect(source.contains("func index(for rowID: String) -> Int?"))
   }
 
+  @Test("Repository switches use native sizing and explicit deletion")
+  func repositorySwitchesUseNativeSizingAndExplicitDeletion() throws {
+    let tableSource = try settingsSourceFile("SettingsRepositoriesSection+Table.swift")
+    let source = try settingsSourceFiles([
+      "SettingsRepositoriesSection.swift",
+      "SettingsRepositoriesSection+Persistence.swift",
+      "SettingsSharedRepositoriesDraft.swift",
+    ])
+
+    let nativeSwitchChain = ".toggleStyle(.switch)\n      .harnessNativeFormControl()"
+    #expect(tableSource.components(separatedBy: nativeSwitchChain).count - 1 == 2)
+    #expect(source.contains("@AppStorage(SettingsRepositoriesCatalog.storageKey)"))
+    #expect(source.contains("SettingsRepositoriesCatalog.decode(storedRepositoryCatalog)"))
+    #expect(source.contains("SettingsRepositoriesCatalog.encode(repositoryCatalog)"))
+    #expect(!source.contains("removeIfDisabled"))
+  }
+
   @Test("Supervisor panes are retained without hidden scroll or MCP work")
   func supervisorPanesAreRetainedWithoutHiddenScrollOrMCPWork() throws {
     let source = try settingsSourceFile("Supervisor/SettingsSupervisorSection.swift")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardCardContextMenuScopeTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardCardContextMenuScopeTests.swift
@@ -1,0 +1,67 @@
+import Testing
+
+@testable import HarnessMonitorUIPreviewable
+
+@Suite("Task board card context menu scope")
+struct TaskBoardCardContextMenuScopeTests {
+  private let first = TaskBoardCardID.api("board-a")
+  private let second = TaskBoardCardID.api("board-b")
+  private let third = TaskBoardCardID.inbox(sessionID: "session-a", taskID: "task-c")
+
+  @Test("Right-clicking a selected card keeps the full selection")
+  func selectedCardKeepsFullSelection() throws {
+    let scope = try #require(
+      TaskBoardCardContextMenuScope.resolve(
+        menuSelection: [second],
+        selectedIDs: [first, second],
+        orderedVisibleIDs: [second, first, third]
+      )
+    )
+
+    #expect(scope.cardIDs == [second, first])
+    #expect(scope.copyIDsLabel == "Copy 2 Task IDs")
+    #expect(scope.deleteLabel == "Delete 2 Tasks...")
+  }
+
+  @Test("Right-clicking an unselected card scopes actions to that card")
+  func unselectedCardUsesSingleCardScope() throws {
+    let scope = try #require(
+      TaskBoardCardContextMenuScope.resolve(
+        menuSelection: [third],
+        selectedIDs: [first, second],
+        orderedVisibleIDs: [first, second, third]
+      )
+    )
+
+    #expect(scope.primaryID == third)
+    #expect(scope.cardIDs == [third])
+    #expect(scope.copyIDsLabel == "Copy Task ID")
+    #expect(scope.deleteLabel == "Delete Task...")
+    #expect(scope.clipboardText == "task-c")
+  }
+
+  @Test("Native multi-selection is preserved in visible order")
+  func nativeMultiSelectionKeepsVisibleOrder() throws {
+    let scope = try #require(
+      TaskBoardCardContextMenuScope.resolve(
+        menuSelection: [first, second],
+        selectedIDs: [first, second],
+        orderedVisibleIDs: [second, first, third]
+      )
+    )
+
+    #expect(scope.cardIDs == [second, first])
+    #expect(scope.clipboardText == "board-b\nboard-a")
+  }
+
+  @Test("An empty native selection has no actions")
+  func emptySelectionHasNoActions() {
+    #expect(
+      TaskBoardCardContextMenuScope.resolve(
+        menuSelection: [],
+        selectedIDs: [first],
+        orderedVisibleIDs: [first]
+      ) == nil
+    )
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardCardSelectionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardCardSelectionTests.swift
@@ -106,4 +106,14 @@ struct TaskBoardCardSelectionTests {
     #expect(next.anchorID == second)
     #expect(next.orderedSelectedIDs(in: [second, first, third]) == [second, first])
   }
+
+  @Test("Context menu priming replaces selection with its action scope")
+  func contextMenuPrimingUsesActionScope() {
+    let state = TaskBoardCardSelectionState(selectedIDs: [first, second], anchorID: first)
+
+    let next = state.selectingForContextMenu([third])
+
+    #expect(next.selectedIDs == [third])
+    #expect(next.anchorID == third)
+  }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardCardSelectionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardCardSelectionTests.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import Testing
+
+@testable import HarnessMonitorUIPreviewable
+
+@Suite("Task board card selection")
+struct TaskBoardCardSelectionTests {
+  private let first = TaskBoardCardID.api("task-a")
+  private let second = TaskBoardCardID.api("task-b")
+  private let third = TaskBoardCardID.inbox(sessionID: "session-a", taskID: "task-c")
+
+  @Test("Plain click replaces selection with an unselected card")
+  func plainClickReplacesSelectionWithUnselectedCard() {
+    let state = TaskBoardCardSelectionState(selectedIDs: [first, second], anchorID: first)
+
+    let next = state.selecting(
+      third,
+      orderedVisibleIDs: [first, second, third],
+      modifiers: []
+    )
+
+    #expect(next.selectedIDs == [third])
+    #expect(next.anchorID == third)
+  }
+
+  @Test("Plain click collapses a selected group to the clicked card")
+  func plainClickCollapsesSelectedGroup() {
+    let state = TaskBoardCardSelectionState(selectedIDs: [first, second], anchorID: first)
+
+    let next = state.selecting(
+      second,
+      orderedVisibleIDs: [first, second, third],
+      modifiers: []
+    )
+
+    #expect(next.selectedIDs == [second])
+    #expect(next.anchorID == second)
+  }
+
+  @Test("Starting a group drag preserves every selected card")
+  func startingGroupDragPreservesEverySelectedCard() {
+    let state = TaskBoardCardSelectionState(selectedIDs: [first, second], anchorID: first)
+
+    let next = state.selectingForDrag([first, second])
+
+    #expect(next == state)
+  }
+
+  @Test("Command click toggles cards across lanes")
+  func commandClickTogglesCardsAcrossLanes() {
+    let state = TaskBoardCardSelectionState(selectedIDs: [first], anchorID: first)
+
+    let selected = state.selecting(
+      third,
+      orderedVisibleIDs: [third],
+      modifiers: .command
+    )
+    let deselected = selected.selecting(
+      first,
+      orderedVisibleIDs: [first, second],
+      modifiers: .command
+    )
+
+    #expect(selected.selectedIDs == [first, third])
+    #expect(deselected.selectedIDs == [third])
+  }
+
+  @Test("Shift click extends through one lane")
+  func shiftClickExtendsThroughOneLane() {
+    let state = TaskBoardCardSelectionState(selectedIDs: [first], anchorID: first)
+
+    let next = state.selecting(
+      third,
+      orderedVisibleIDs: [first, second, third],
+      modifiers: .shift
+    )
+
+    #expect(next.selectedIDs == [first, second, third])
+    #expect(next.anchorID == first)
+  }
+
+  @Test("Shift click with an anchor from another lane starts a new selection")
+  func shiftClickAcrossLanesStartsNewSelection() {
+    let state = TaskBoardCardSelectionState(selectedIDs: [first], anchorID: first)
+
+    let next = state.selecting(
+      third,
+      orderedVisibleIDs: [third],
+      modifiers: .shift
+    )
+
+    #expect(next.selectedIDs == [third])
+    #expect(next.anchorID == third)
+  }
+
+  @Test("Pruning removes hidden cards and repairs the anchor")
+  func pruningRemovesHiddenCardsAndRepairsAnchor() {
+    let state = TaskBoardCardSelectionState(
+      selectedIDs: [first, second, third],
+      anchorID: third
+    )
+
+    let next = state.pruning(orderedVisibleIDs: [second, first])
+
+    #expect(next.selectedIDs == [first, second])
+    #expect(next.anchorID == second)
+    #expect(next.orderedSelectedIDs(in: [second, first, third]) == [second, first])
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneAppearancePreferencesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneAppearancePreferencesTests.swift
@@ -131,6 +131,23 @@ struct TaskBoardLaneAppearancePreferencesTests {
     #expect(!TaskBoardCardPreferences.showsPriorityBadge(from: restartedDefaults))
   }
 
+  @Test("Full repository name preference persists through UserDefaults")
+  func fullRepositoryNamePreferencePersistsThroughUserDefaults() throws {
+    let suiteName = "TaskBoardCardPreferencesTests.\(UUID().uuidString)"
+    let userDefaults = try #require(UserDefaults(suiteName: suiteName))
+    defer {
+      userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    #expect(!TaskBoardCardPreferences.alwaysShowsFullRepositoryNames(from: userDefaults))
+
+    TaskBoardCardPreferences.setAlwaysShowsFullRepositoryNames(true, in: userDefaults)
+    userDefaults.synchronize()
+
+    let restartedDefaults = try #require(UserDefaults(suiteName: suiteName))
+    #expect(TaskBoardCardPreferences.alwaysShowsFullRepositoryNames(from: restartedDefaults))
+  }
+
   @Test("Reset and default values remove overrides")
   func resetAndDefaultValuesRemoveOverrides() {
     var rawValue = TaskBoardLaneAppearancePreferences.settingColorToken(
@@ -269,6 +286,16 @@ struct TaskBoardLaneAppearancePreferencesTests {
       )
     )
     #expect(cardsSource.contains("Toggle(\"Priority Badge\", isOn: $showsPriorityBadge)"))
+    #expect(
+      cardsSource.contains(
+        "@AppStorage(TaskBoardCardPreferences.fullRepositoryNamesStorageKey)"
+      )
+    )
+    #expect(
+      cardsSource.contains(
+        "Toggle(\"Full Repository Names\", isOn: $alwaysShowsFullRepositoryNames)"
+      )
+    )
 
     let cardsRange = try #require(settingsSource.range(of: "SettingsTaskBoardCardsSection()"))
     let laneRange = try #require(
@@ -281,18 +308,35 @@ struct TaskBoardLaneAppearancePreferencesTests {
   func taskCardsReadPriorityBadgeVisibilityFromGlobalCardPreference() throws {
     let laneSource = try sourceFile(named: "Views/TaskBoard/TaskBoardLaneViews.swift")
     let overviewSource = try sourceFile(named: "Views/TaskBoard/TaskBoardOverviewView.swift")
+    let preferencesSource = try sourceFile(
+      named: "Views/TaskBoard/TaskBoardCardPreferences.swift"
+    )
 
     #expect(laneSource.contains("@Environment(\\.taskBoardShowsPriorityBadge)"))
     #expect(laneSource.contains("if showsPriorityBadge"))
     #expect(!laneSource.contains("laneAppearance.showsPriorityBadge"))
     #expect(
-      overviewSource.contains(
+      preferencesSource.contains(
         "@AppStorage(TaskBoardCardPreferences.priorityBadgeVisibilityStorageKey)"
       )
     )
     #expect(
-      overviewSource.contains(".environment(\\.taskBoardShowsPriorityBadge, showsPriorityBadge)")
+      preferencesSource.contains(
+        ".environment(\\.taskBoardShowsPriorityBadge, showsPriorityBadge)"
+      )
     )
+    #expect(laneSource.contains("@Environment(\\.taskBoardAlwaysShowsFullRepositoryNames)"))
+    #expect(laneSource.contains("projectLabelResolver.label("))
+    #expect(
+      preferencesSource.contains(
+        "@AppStorage(TaskBoardCardPreferences.fullRepositoryNamesStorageKey)"
+      )
+    )
+    #expect(
+      preferencesSource.contains("\\.taskBoardAlwaysShowsFullRepositoryNames,")
+    )
+    #expect(preferencesSource.contains("\\.taskBoardProjectLabelResolver,"))
+    #expect(overviewSource.contains(".taskBoardCardPreferences(projectLabelResolver:"))
   }
 
   private func sourceFile(named relativePath: String) throws -> String {

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests+Presentation.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests+Presentation.swift
@@ -321,13 +321,14 @@ extension TaskBoardOverviewBehaviorTests {
 extension TaskBoardOverviewBehaviorTests {
   func inboxItem(
     taskID: String,
-    status: TaskStatus = .inProgress
+    status: TaskStatus = .inProgress,
+    title: String = "Linked task"
   ) -> TaskBoardInboxItem {
     let item = TaskBoardInboxItem(
       session: PreviewFixtures.summary,
       task: WorkItem(
         taskId: taskID,
-        title: "Linked task",
+        title: title,
         context: nil,
         severity: .medium,
         status: status,

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests+SourceContracts.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests+SourceContracts.swift
@@ -75,6 +75,43 @@ extension TaskBoardOverviewBehaviorTests {
     #expect(laneColumn.contains(titleFontSource))
   }
 
+  @Test("Lane drops use the modern session plan for acceptance and action")
+  func laneDropsUseModernSessionPlanForAcceptanceAndAction() throws {
+    let board = try taskBoardSourceFile(named: "TaskBoardOverviewView+Board.swift")
+    let laneColumn = try taskBoardSourceFile(named: "TaskBoardLaneUnifiedColumn.swift")
+    let interaction = try taskBoardSourceFile(
+      named: "TaskBoardOverviewView+CardInteraction.swift"
+    )
+
+    #expect(board.contains("dropPlanForCardIDs: { cardIDs in"))
+    #expect(board.contains("cardDropPlan(cardIDs, to: lane)"))
+    #expect(laneColumn.contains("localSession.draggedItemIDs(for: TaskBoardCardID.self)"))
+    #expect(laneColumn.contains("DropConfiguration(operation: operation)"))
+    #expect(laneColumn.contains("? .move : .forbidden"))
+    #expect(laneColumn.contains("dropPlan(for: session) != nil"))
+    #expect(laneColumn.contains("TaskBoardCardDropPlan.resolve(payloads, to: lane)"))
+    #expect(!laneColumn.contains("_: CGPoint"))
+    #expect(interaction.contains("TaskBoardCardDropPlan.resolve(cardDragPayloads(cardIDs)"))
+  }
+
+  @Test("Lifted cards highlight only lanes with valid drop plans")
+  func liftedCardsHighlightOnlyValidDropDestinations() throws {
+    let board = try taskBoardSourceFile(named: "TaskBoardOverviewView+Board.swift")
+    let interaction = try taskBoardSourceFile(
+      named: "TaskBoardOverviewView+CardInteraction.swift"
+    )
+    let laneColumn = try taskBoardSourceFile(named: "TaskBoardLaneUnifiedColumn.swift")
+    let laneChrome = try taskBoardSourceFile(named: "TaskBoardLaneChrome.swift")
+
+    #expect(board.contains("cardDropPlan(draggedCardIDsValue, to: lane) != nil"))
+    #expect(interaction.contains("case .initial, .active:"))
+    #expect(interaction.contains("updateDraggedCardIDs(draggedIDs)"))
+    #expect(interaction.contains("case .ended, .dataTransferCompleted:"))
+    #expect(laneColumn.contains("isDropCandidate: isDropCandidate"))
+    #expect(laneChrome.contains("if isDropCandidate"))
+    #expect(laneChrome.contains("value: isDropCandidate"))
+  }
+
   private func taskBoardSourceFile(named relativePath: String) throws -> String {
     let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
     let repoRoot =

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests.swift
@@ -144,6 +144,36 @@ struct TaskBoardOverviewBehaviorTests {
     #expect(evaluation.dryRun == false)
   }
 
+  @Test("Overview presentation collapses duplicate inbox identities")
+  func overviewPresentationCollapsesDuplicateInboxIdentities() async {
+    let worker = TaskBoardOverviewPresentationWorker()
+    let first = inboxItem(taskID: "duplicate-task", title: "First duplicate")
+    let second = inboxItem(taskID: "duplicate-task", title: "Second duplicate")
+    let snapshot = TaskBoardInboxSnapshot(items: [first, second])
+    let expectedItem = snapshot.items[0]
+
+    let presentation = await worker.compute(
+      input: TaskBoardOverviewPresentationInput(
+        snapshot: snapshot,
+        taskBoardItems: [],
+        decisionItems: [],
+        scopeSessionID: nil
+      )
+    )
+    let cardID = TaskBoardCardID.inbox(
+      sessionID: expectedItem.session.sessionId,
+      taskID: expectedItem.task.taskId
+    )
+    let laneItemCount = TaskBoardInboxLane.allCases.reduce(0) { count, lane in
+      count + presentation.inboxItems(in: lane).count
+    }
+
+    #expect(presentation.inboxItem(id: cardID)?.task.title == expectedItem.task.title)
+    #expect(laneItemCount == 1)
+    #expect(presentation.orderedCardIDs == [cardID])
+    #expect(presentation.aggregateOpenCount == 1)
+  }
+
   @Test("Collapsed lane titles keep a consistent font size")
   func collapsedLaneTitlesKeepConsistentFontSize() throws {
     let source = try taskBoardSource("TaskBoardLaneUnifiedColumn.swift")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests.swift
@@ -7,52 +7,50 @@ import Testing
 
 @Suite("Task board overview behavior")
 struct TaskBoardOverviewBehaviorTests {
-  @Test("Lane drop policy ignores empty and same-lane payloads")
-  func laneDropPolicyIgnoresEmptyAndSameLanePayloads() {
-    var moves: [(String, TaskBoardInboxLane)] = []
-    let payload = TaskBoardItemDragPayload(itemID: "board-1", status: .todo)
+  @Test("Card drop plan rejects empty and same-lane payloads")
+  func cardDropPlanRejectsEmptyAndSameLanePayloads() {
+    let item = TaskBoardCardDragItem.api(itemID: "board-1", status: .todo)
+    let payload = TaskBoardCardDragPayload(item: item)
 
-    #expect(
-      !TaskBoardLaneDropPolicy.moveFirstPayload([], to: .inProgress) { itemID, lane in
-        moves.append((itemID, lane))
-        return true
-      }
-    )
-    #expect(
-      !TaskBoardLaneDropPolicy.moveFirstPayload([payload], to: .todo) { itemID, lane in
-        moves.append((itemID, lane))
-        return true
-      }
-    )
-    #expect(moves.isEmpty)
+    #expect(TaskBoardCardDropPlan.resolve([], to: .inProgress) == nil)
+    #expect(TaskBoardCardDropPlan.resolve([payload], to: .todo) == nil)
   }
 
-  @Test("Lane drop policy forwards first cross-lane payload only")
-  func laneDropPolicyForwardsFirstCrossLanePayloadOnly() {
-    var moves: [(String, TaskBoardInboxLane)] = []
-    let first = TaskBoardItemDragPayload(itemID: "board-1", status: .todo)
-    let second = TaskBoardItemDragPayload(itemID: "board-2", status: .failed)
+  @Test("Card drop plan keeps every selected card in visible order")
+  func cardDropPlanKeepsEverySelectedCardInVisibleOrder() throws {
+    let first = TaskBoardCardDragItem.api(itemID: "board-1", status: .todo)
+    let second = TaskBoardCardDragItem.api(itemID: "board-2", status: .failed)
+    let payload = TaskBoardCardDragPayload(primaryCardID: first.id, items: [first, second])
 
-    #expect(
-      TaskBoardLaneDropPolicy.moveFirstPayload([first, second], to: .inProgress) { itemID, lane in
-        moves.append((itemID, lane))
-        return true
-      }
-    )
-    #expect(moves.count == 1)
-    #expect(moves.first?.0 == "board-1")
-    #expect(moves.first?.1 == .inProgress)
+    let plan = try #require(TaskBoardCardDropPlan.resolve([payload], to: .inProgress))
+
+    #expect(plan.items.map(\.id) == [first.id, second.id])
   }
 
-  @Test("Lane drop policy returns move result")
-  func laneDropPolicyReturnsMoveResult() {
-    let payload = TaskBoardItemDragPayload(itemID: "board-1", status: .todo)
-
-    #expect(
-      !TaskBoardLaneDropPolicy.moveFirstPayload([payload], to: .inProgress) { _, _ in
-        false
-      }
+  @Test("Card drop plan skips cards already in the destination")
+  func cardDropPlanSkipsCardsAlreadyInDestination() throws {
+    let stationary = TaskBoardCardDragItem.api(itemID: "board-1", status: .inProgress)
+    let moving = TaskBoardCardDragItem.api(itemID: "board-2", status: .todo)
+    let payload = TaskBoardCardDragPayload(
+      primaryCardID: stationary.id,
+      items: [stationary, moving]
     )
+
+    let plan = try #require(TaskBoardCardDropPlan.resolve([payload], to: .inProgress))
+
+    #expect(plan.items == [moving])
+  }
+
+  @Test("Card drop plan deduplicates repeated payloads")
+  func cardDropPlanDeduplicatesRepeatedPayloads() throws {
+    let item = TaskBoardCardDragItem.api(itemID: "board-1", status: .todo)
+    let payload = TaskBoardCardDragPayload(item: item)
+
+    let plan = try #require(
+      TaskBoardCardDropPlan.resolve([payload, payload], to: .inProgress)
+    )
+
+    #expect(plan.items == [item])
   }
 
   @Test("Board-only items select management surface instead of opening linked task")
@@ -97,54 +95,37 @@ struct TaskBoardOverviewBehaviorTests {
     #expect(confirmation.message.contains("current filter"))
   }
 
-  @Test("Inbox drop policy ignores unknown source lane payloads")
-  func inboxDropPolicyIgnoresUnknownSourceLanePayloads() throws {
-    let payload = try JSONDecoder().decode(
-      TaskBoardInboxItemDragPayload.self,
-      from: Data(
-        """
-        {
-          "sessionID": "sess-1",
-          "taskID": "task-1",
-          "status": "open",
-          "laneRawValue": "unknown"
-        }
-        """.utf8
-      )
+  @Test("Card drop plan rejects unknown inbox source lanes")
+  func cardDropPlanRejectsUnknownInboxSourceLanes() {
+    let item = TaskBoardCardDragItem.inbox(
+      sessionID: "session-1",
+      taskID: "task-1",
+      status: .open,
+      sourceLaneRawValue: "unknown"
     )
 
     #expect(
-      !TaskBoardInboxDropPolicy.moveFirstPayload([payload], to: .inProgress) { _, _ in
-        true
-      }
+      TaskBoardCardDropPlan.resolve([TaskBoardCardDragPayload(item: item)], to: .inProgress)
+        == nil
     )
   }
 
-  @Test("Inbox drop policy forwards first cross-lane payload only")
-  func inboxDropPolicyForwardsFirstCrossLanePayloadOnly() {
-    var moves: [(String, TaskBoardInboxLane)] = []
-    let first = TaskBoardInboxItemDragPayload(
-      sessionID: "sess-1",
+  @Test("Card drop plan rejects a destination unsupported by one selected card")
+  func cardDropPlanRejectsDestinationUnsupportedByOneSelectedCard() {
+    let boardItem = TaskBoardCardDragItem.api(itemID: "board-1", status: .todo)
+    let inboxItem = TaskBoardCardDragItem.inbox(
+      sessionID: "session-1",
       taskID: "task-1",
       status: .open,
-      lane: .todo
+      sourceLaneRawValue: TaskBoardInboxLane.todo.rawValue
     )
-    let second = TaskBoardInboxItemDragPayload(
-      sessionID: "sess-2",
-      taskID: "task-2",
-      status: .blocked,
-      lane: .failed
+    let payload = TaskBoardCardDragPayload(
+      primaryCardID: boardItem.id,
+      items: [boardItem, inboxItem]
     )
 
-    #expect(
-      TaskBoardInboxDropPolicy.moveFirstPayload([first, second], to: .inProgress) { payload, lane in
-        moves.append((payload.taskID, lane))
-        return true
-      }
-    )
-    #expect(moves.count == 1)
-    #expect(moves.first?.0 == "task-1")
-    #expect(moves.first?.1 == .inProgress)
+    #expect(TaskBoardCardDropPlan.resolve([payload], to: .planning) == nil)
+    #expect(TaskBoardCardDropPlan.resolve([payload], to: .inProgress) != nil)
   }
 
   @Test("Board-only Run Once and Evaluate requests carry board item identity")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardProjectLabelTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardProjectLabelTests.swift
@@ -1,0 +1,56 @@
+import Testing
+
+@testable import HarnessMonitorUIPreviewable
+
+@Suite("Task board project labels")
+struct TaskBoardProjectLabelTests {
+  @Test("Unique repository names omit their owner")
+  func uniqueRepositoryNamesOmitTheirOwner() {
+    let resolver = TaskBoardProjectLabelResolver(
+      projectIDs: ["alpha/widget", "beta/control-plane"]
+    )
+
+    #expect(resolver.label(for: "alpha/widget") == "widget")
+    #expect(resolver.label(for: "beta/control-plane") == "control-plane")
+  }
+
+  @Test("Ambiguous repository names retain every owner")
+  func ambiguousRepositoryNamesRetainEveryOwner() {
+    let resolver = TaskBoardProjectLabelResolver(
+      projectIDs: ["alpha/console", "beta/CONSOLE", "gamma/worker"]
+    )
+
+    #expect(resolver.label(for: "alpha/console") == "alpha/console")
+    #expect(resolver.label(for: "beta/CONSOLE") == "beta/CONSOLE")
+    #expect(resolver.label(for: "gamma/worker") == "worker")
+  }
+
+  @Test("Repeated cards from one repository remain unambiguous")
+  func repeatedCardsFromOneRepositoryRemainUnambiguous() {
+    let resolver = TaskBoardProjectLabelResolver(
+      projectIDs: ["alpha/console", "alpha/console", "ALPHA/CONSOLE"]
+    )
+
+    #expect(resolver.label(for: "alpha/console") == "console")
+    #expect(resolver.label(for: "ALPHA/CONSOLE") == "CONSOLE")
+  }
+
+  @Test("Non repository project identifiers remain unchanged")
+  func nonRepositoryProjectIdentifiersRemainUnchanged() {
+    let projectIDs = ["project-1", "owner/repo/extra", "/repo", "owner/"]
+    let resolver = TaskBoardProjectLabelResolver(projectIDs: projectIDs)
+
+    for projectID in projectIDs {
+      #expect(resolver.label(for: projectID) == projectID)
+    }
+  }
+
+  @Test("Full repository names can be forced")
+  func fullRepositoryNamesCanBeForced() {
+    let resolver = TaskBoardProjectLabelResolver(projectIDs: ["alpha/widget"])
+
+    #expect(
+      resolver.label(for: "alpha/widget", alwaysShowFullName: true) == "alpha/widget"
+    )
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardRouteContentSourceTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardRouteContentSourceTests.swift
@@ -28,7 +28,7 @@ struct TaskBoardRouteContentSourceTests {
     #expect(overviewSource.contains("onEvaluateTaskBoardItem(item)"))
     #expect(!overviewSource.contains("if !item.hasLinkedSessionTask"))
     #expect(overviewSource.contains("TaskBoardOverviewItemBehavior.selectionAction("))
-    #expect(overviewSource.contains("inboxItems: cachedPresentation.inboxItems(in: lane)"))
+    #expect(overviewSource.contains("let inboxItems = currentPresentation.inboxItems(in: lane)"))
     #expect(managementPanelSource.contains("Session Task"))
     #expect(managementPanelSource.contains("Board Only"))
     #expect(managementPanelSource.contains("TaskBoardManagementFacts("))
@@ -72,23 +72,36 @@ struct TaskBoardRouteContentSourceTests {
     let overviewSource = try taskBoardOverviewSource()
     let laneSource = try taskBoardSourceFile(named: "TaskBoardLaneViews.swift")
     let laneDropSource = try taskBoardSourceFile(named: "TaskBoardLaneDropSupport.swift")
+    let dragSource = try taskBoardSourceFile(named: "TaskBoardCardDragSupport.swift")
     let unifiedSource = try taskBoardSourceFile(named: "TaskBoardLaneUnifiedColumn.swift")
 
     #expect(overviewSource.contains("lane.taskBoardDropStatus"))
-    #expect(laneSource.contains("TaskBoardItemDragPayload"))
-    #expect(laneSource.contains("TaskBoardInboxItemDragPayload"))
-    #expect(laneSource.contains("let status: TaskBoardStatus"))
-    #expect(unifiedSource.contains("TaskBoardLaneDropPolicy.moveFirstPayload("))
-    #expect(unifiedSource.contains("TaskBoardInboxDropPolicy.moveFirstPayload("))
-    #expect(laneDropSource.contains("TaskBoardInboxDropPolicy"))
-    #expect(laneDropSource.contains("sourceLane != destination"))
-    #expect(laneSource.contains(".draggable(dragPayload)"))
-    #expect(laneSource.contains(".onDrag {"))
+    #expect(dragSource.contains("TaskBoardCardDragPayload"))
+    #expect(laneDropSource.contains("TaskBoardCardDropPlan"))
+    #expect(laneDropSource.contains("items.allSatisfy"))
+    #expect(laneSource.contains(".draggable(containerItemID: cardID)"))
+    #expect(!laneSource.contains(".onDrag {"))
     #expect(!laneSource.contains("TaskBoardCardPill(label: item.status.title"))
-    #expect(laneSource.contains("Text(item.status.title)"))
-    #expect(unifiedSource.contains(".dropDestination(for: TaskBoardItemDragPayload.self"))
-    #expect(unifiedSource.contains(".dropDestination(for: TaskBoardInboxItemDragPayload.self"))
-    #expect(unifiedSource.contains(".onDrop("))
+    #expect(!laneSource.contains("DragPreviewCard"))
+    #expect(unifiedSource.contains(".dropDestination(for: TaskBoardCardDragPayload.self"))
+    #expect(!unifiedSource.contains(".onDrop("))
+    #expect(!unifiedSource.contains("let dragPayload:"))
+    #expect(dragSource.contains(".dragContainerSelection("))
+    #expect(dragSource.contains(".dragContainer("))
+    #expect(!laneSource.contains("TaskBoardItemDragPayload"))
+    #expect(!laneSource.contains("TaskBoardInboxItemDragPayload"))
+  }
+
+  @Test("Task board task cards select on click and open on double click")
+  func taskBoardTaskCardsSelectOnClickAndOpenOnDoubleClick() throws {
+    let laneSource = try taskBoardSourceFile(named: "TaskBoardLaneViews.swift")
+    let supportSource = try taskBoardSourceFile(named: "TaskBoardCardSelection.swift")
+
+    #expect(laneSource.contains("onSelect(Self.currentEventModifiers)"))
+    #expect(laneSource.contains("Self.currentClickCount == 2"))
+    #expect(!laneSource.contains("TapGesture(count: 2)"))
+    #expect(laneSource.contains(".accessibilityAddTraits(isSelected ? .isSelected : [])"))
+    #expect(supportSource.contains("SessionSidebarMultiSelect.resolve("))
   }
 
   @Test("Task board lanes keep board column chrome")
@@ -99,7 +112,7 @@ struct TaskBoardRouteContentSourceTests {
 
     #expect(unifiedSource.contains(".taskBoardLaneColumnChrome("))
     #expect(laneChromeSource.contains("private struct TaskBoardLaneColumnChrome"))
-    #expect(laneChromeSource.contains("private var laneFill: AnyShapeStyle"))
+    #expect(laneChromeSource.contains("private var laneSurfaceFill: Color"))
     #expect(laneChromeSource.contains("RoundedRectangle(cornerRadius: metrics.cardCornerRadius"))
     #expect(laneChromeSource.contains(".strokeBorder(laneStrokeColor, lineWidth: laneStrokeWidth)"))
     #expect(laneChromeSource.contains("private var laneStrokeColor: Color"))
@@ -186,6 +199,8 @@ struct TaskBoardRouteContentSourceTests {
     try [
       taskBoardSourceFile(named: "TaskBoardOverviewView.swift"),
       taskBoardSourceFile(named: "TaskBoardOverviewView+Support.swift"),
+      taskBoardSourceFile(named: "TaskBoardOverviewView+Board.swift"),
+      taskBoardSourceFile(named: "TaskBoardOverviewView+CardInteraction.swift"),
     ].joined(separator: "\n")
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardRouteContentSourceTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardRouteContentSourceTests.swift
@@ -83,7 +83,14 @@ struct TaskBoardRouteContentSourceTests {
     #expect(!laneSource.contains(".onDrag {"))
     #expect(!laneSource.contains("TaskBoardCardPill(label: item.status.title"))
     #expect(!laneSource.contains("DragPreviewCard"))
-    #expect(unifiedSource.contains(".dropDestination(for: TaskBoardCardDragPayload.self"))
+    #expect(unifiedSource.contains("for: TaskBoardCardDragPayload.self"))
+    #expect(unifiedSource.contains("isEnabled: isDropEnabled"))
+    #expect(unifiedSource.contains("session: DropSession"))
+    #expect(unifiedSource.contains(".dropConfiguration(dropConfiguration)"))
+    #expect(unifiedSource.contains(".onDropSessionUpdated(updateDropSession)"))
+    #expect(unifiedSource.contains("? .move : .forbidden"))
+    #expect(unifiedSource.contains("dropPlan(for: session) != nil"))
+    #expect(unifiedSource.contains("TaskBoardCardDropPlan.resolve(payloads, to: lane)"))
     #expect(!unifiedSource.contains(".onDrop("))
     #expect(!unifiedSource.contains("let dragPayload:"))
     #expect(dragSource.contains(".dragContainerSelection("))
@@ -102,6 +109,32 @@ struct TaskBoardRouteContentSourceTests {
     #expect(!laneSource.contains("TapGesture(count: 2)"))
     #expect(laneSource.contains(".accessibilityAddTraits(isSelected ? .isSelected : [])"))
     #expect(supportSource.contains("SessionSidebarMultiSelect.resolve("))
+  }
+
+  @Test("Task board cards expose one selection-aware context menu per card")
+  func taskBoardCardsExposeSelectionAwareContextMenus() throws {
+    let boardSource = try taskBoardSourceFile(named: "TaskBoardOverviewView+Board.swift")
+    let contextMenuSource = try taskBoardSourceFile(
+      named: "TaskBoardCardContextMenu.swift"
+    )
+    let laneSource = try taskBoardSourceFile(named: "TaskBoardLaneViews.swift")
+    let unifiedSource = try taskBoardSourceFile(named: "TaskBoardLaneUnifiedColumn.swift")
+
+    #expect(
+      !boardSource.contains(".contextMenu(forSelectionType: TaskBoardCardID.self)")
+    )
+    #expect(unifiedSource.contains(".contextMenu {"))
+    #expect(unifiedSource.contains("TaskBoardCardContextMenu(cardID: cardID"))
+    #expect(contextMenuSource.contains("TaskBoardCardContextMenuScope.resolve("))
+    #expect(contextMenuSource.contains(".onAppear {"))
+    #expect(contextMenuSource.contains("actions.primeSelection(scope.cardIDs)"))
+    #expect(!contextMenuSource.contains("let _: Task"))
+    #expect(contextMenuSource.contains("Menu(\"Move to...\")"))
+    #expect(contextMenuSource.contains("ForEach(TaskBoardInboxLane.allCases)"))
+    #expect(contextMenuSource.contains("Button(scope.deleteLabel, role: .destructive)"))
+    #expect(contextMenuSource.contains("!actions.canDelete(scope.cardIDs)"))
+    #expect(contextMenuSource.contains("actions.deleteTargets?(targets)"))
+    #expect(!laneSource.contains(".contextMenu"))
   }
 
   @Test("Task board lanes keep board column chrome")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSelectionFocusTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSelectionFocusTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+
+@testable import HarnessMonitorUIPreviewable
+
+@MainActor
+@Suite("Task board selection focus")
+struct TaskBoardSelectionFocusTests {
+  @Test("Equivalent values retain dispatcher identity")
+  func equivalentValuesRetainDispatcherIdentity() {
+    let dispatcher = TaskBoardSelectionDispatcher()
+    let first = TaskBoardSelectionFocus(
+      selectionCount: 2,
+      canDelete: true,
+      dispatcher: dispatcher
+    )
+    let second = TaskBoardSelectionFocus(
+      selectionCount: 2,
+      canDelete: true,
+      dispatcher: dispatcher
+    )
+
+    #expect(first == second)
+  }
+
+  @Test("Different dispatcher references are not equivalent")
+  func differentDispatcherReferencesAreNotEquivalent() {
+    let first = TaskBoardSelectionFocus(
+      selectionCount: 1,
+      canDelete: true,
+      dispatcher: TaskBoardSelectionDispatcher()
+    )
+    let second = TaskBoardSelectionFocus(
+      selectionCount: 1,
+      canDelete: true,
+      dispatcher: TaskBoardSelectionDispatcher()
+    )
+
+    #expect(first != second)
+  }
+
+  @Test("Delete forwards only while enabled")
+  func deleteForwardsOnlyWhileEnabled() {
+    let dispatcher = TaskBoardSelectionDispatcher()
+    var callCount = 0
+    dispatcher.deleteSelection = { callCount += 1 }
+
+    TaskBoardSelectionFocus(
+      selectionCount: 0,
+      canDelete: false,
+      dispatcher: dispatcher
+    ).performDeleteSelection()
+    TaskBoardSelectionFocus(
+      selectionCount: 3,
+      canDelete: true,
+      dispatcher: dispatcher
+    ).performDeleteSelection()
+
+    #expect(callCount == 1)
+  }
+
+  @Test("Task board command owns Delete whenever its focus is mounted")
+  func taskBoardCommandOwnsDeleteWheneverMounted() throws {
+    let commandsSource = try sourceFile(
+      at: "Sources/HarnessMonitor/App/HarnessMonitorAppCommands.swift"
+    )
+    let focusSource = try sourceFile(
+      at: "Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardSelectionFocus.swift"
+    )
+    let overviewSource = try sourceFile(
+      at: "Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift"
+    )
+
+    #expect(commandsSource.contains("@FocusedValue(\\.harnessTaskBoardSelection)"))
+    #expect(commandsSource.contains("if let taskBoardSelectionFocus"))
+    #expect(commandsSource.contains("return taskBoardSelectionFocus.canDelete"))
+    #expect(commandsSource.contains("taskBoardSelectionFocus.performDeleteSelection()"))
+    #expect(commandsSource.contains(".keyboardShortcut(.delete, modifiers: [])"))
+    #expect(!commandsSource.contains(".keyboardShortcut(.deleteForward"))
+    #expect(focusSource.contains(".keyboardShortcut(.deleteForward, modifiers: [])"))
+    #expect(focusSource.contains(".opacity(0)"))
+    #expect(focusSource.contains(".accessibilityHidden(true)"))
+    #expect(
+      overviewSource.contains(
+        ".harnessFocusedSceneValue(\\.harnessTaskBoardSelection, taskBoardSelectionFocus)"
+      )
+    )
+    #expect(
+      overviewSource.contains(
+        ".taskBoardSelectionForwardDeleteShortcut(taskBoardSelectionFocus)"
+      )
+    )
+  }
+
+  private func sourceFile(at relativePath: String) throws -> String {
+    let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let monitorRoot =
+      testsDirectory
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    return try String(
+      contentsOf: monitorRoot.appendingPathComponent(relativePath),
+      encoding: .utf8
+    )
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSelectionFocusTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSelectionFocusTests.swift
@@ -42,8 +42,6 @@ struct TaskBoardSelectionFocusTests {
   @Test("Delete forwards only while enabled")
   func deleteForwardsOnlyWhileEnabled() {
     let dispatcher = TaskBoardSelectionDispatcher()
-    var callCount = 0
-    dispatcher.deleteSelection = { callCount += 1 }
 
     TaskBoardSelectionFocus(
       selectionCount: 0,
@@ -56,7 +54,7 @@ struct TaskBoardSelectionFocusTests {
       dispatcher: dispatcher
     ).performDeleteSelection()
 
-    #expect(callCount == 1)
+    #expect(dispatcher.deleteRequestGeneration == 1)
   }
 
   @Test("Task board command owns Delete whenever its focus is mounted")
@@ -78,6 +76,9 @@ struct TaskBoardSelectionFocusTests {
     #expect(commandsSource.contains(".keyboardShortcut(.delete, modifiers: [])"))
     #expect(!commandsSource.contains(".keyboardShortcut(.deleteForward"))
     #expect(focusSource.contains(".keyboardShortcut(.deleteForward, modifiers: [])"))
+    #expect(focusSource.contains("@Observable"))
+    #expect(focusSource.contains("deleteRequestGeneration &+= 1"))
+    #expect(!focusSource.contains("deleteSelection: (() -> Void)?"))
     #expect(focusSource.contains(".opacity(0)"))
     #expect(focusSource.contains(".accessibilityHidden(true)"))
     #expect(
@@ -90,6 +91,12 @@ struct TaskBoardSelectionFocusTests {
         ".taskBoardSelectionForwardDeleteShortcut(taskBoardSelectionFocus)"
       )
     )
+    #expect(
+      overviewSource.contains(
+        ".onChange(of: taskBoardSelectionDispatcher.deleteRequestGeneration)"
+      )
+    )
+    #expect(!overviewSource.contains("bindTaskBoardSelectionDispatcher"))
   }
 
   private func sourceFile(at relativePath: String) throws -> String {

--- a/apps/harness-monitor/Tests/HarnessMonitorUITests/HarnessMonitorUITests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorUITests/HarnessMonitorUITests.swift
@@ -107,7 +107,7 @@ final class HarnessMonitorUITests: HarnessMonitorUITestCase {
     XCTAssertFalse(feedback.exists)
   }
 
-  func testTaskBoardBoardOnlyItemOpensManagementSheet() throws {
+  func testTaskBoardBoardOnlyItemSelectsThenDoubleClickOpensManagementSheet() throws {
     let itemID = "preview-board-only"
     let app = launch(
       mode: "preview",
@@ -121,12 +121,16 @@ final class HarnessMonitorUITests: HarnessMonitorUITestCase {
     XCTAssertTrue(boardRoot.waitForExistence(timeout: Self.actionTimeout))
     XCTAssertTrue(boardItem.waitForExistence(timeout: Self.actionTimeout))
 
-    tapButton(in: app, identifier: "harness.task-board.api-item.\(itemID)")
-
     let managementPanel = element(
       in: app,
       identifier: "harness.task-board.manage-item.\(itemID)"
     )
+
+    boardItem.click()
+    XCTAssertEqual(boardItem.value as? String, "Selected")
+    XCTAssertFalse(managementPanel.exists)
+
+    boardItem.doubleClick()
     XCTAssertTrue(managementPanel.waitForExistence(timeout: Self.actionTimeout))
     XCTAssertTrue(app.staticTexts["Manage Board Item"].exists)
     XCTAssertTrue(app.textFields["Title"].exists)


### PR DESCRIPTION
## Motivation
Task Board refreshes could retain tasks from repositories no longer enabled for Task Board, repository settings could reorder or disappear based on feature toggles, and card workflows lacked concise project labels, native multi-selection, durable group moves, contextual actions, and clear drop feedback.

## Implementation
- keep repository settings stable and visible, use compact switches, and scope Task Board synchronization to enabled repositories
- add persistent compact project labels with automatic owner disambiguation for duplicate repository names
- add natural multi-selection, double-click opening, group dragging, persistent batched moves, and valid-lane lift/drop feedback
- add selection-aware card menus, gated bulk deletion, lane moves, copy actions, and Delete shortcuts
- cover synchronization, settings, selection, drag/drop, context-menu, and deletion contracts with focused tests