### PR TITLE
feat(remote): pair review query profiles

### DIFF
--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -24,15 +24,18 @@ use crate::daemon::remote_pairing::{
     validate_pairing_domain,
 };
 
+mod metadata;
+use metadata::{decode_remote_pairing_metadata, encode_remote_pairing_metadata};
+
 const INSERT_REMOTE_PAIRING_SQL: &str = "
 INSERT INTO remote_pairing_codes (
     pairing_id, code_hash, role, scopes_json, created_at, expires_at,
     claimed_at, claimed_client_id, claim_remote_addr, metadata_json
-) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, NULL, '{}')";
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, NULL, ?7)";
 
 const SELECT_REMOTE_PAIRING_BY_HASH_SQL: &str = "
 SELECT pairing_id, code_hash, role, scopes_json, created_at, expires_at,
-       claimed_at, claimed_client_id, claim_remote_addr
+       claimed_at, claimed_client_id, claim_remote_addr, metadata_json
 FROM remote_pairing_codes
 WHERE code_hash = ?1";
 
@@ -103,6 +106,7 @@ impl DaemonDb {
         validate_pairing_audit_event_id(audit_event_id)
             .map_err(|error| db_error(error.to_string()))?;
         let scopes_json = scopes_to_json(&record.scopes)?;
+        let metadata_json = encode_remote_pairing_metadata(record.reviews_query.as_ref())?;
         let transaction = self
             .conn
             .unchecked_transaction()
@@ -117,6 +121,7 @@ impl DaemonDb {
                     scopes_json,
                     record.created_at.as_str(),
                     record.expires_at.as_str(),
+                    metadata_json,
                 ],
             )
             .map_err(|error| {
@@ -323,6 +328,7 @@ impl DaemonDb {
         Ok(RemotePairingClaimedClient {
             client,
             bearer_token,
+            reviews_query: pairing.reviews_query.clone(),
         })
     }
 
@@ -449,6 +455,9 @@ fn remote_pairing_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteSt
         .map_err(|error| rusqlite::Error::FromSqlConversionFailure(3, Type::Text, error.into()))?;
     let code_hash = RemotePairingCodeHash::try_from_storage_value(row.get::<_, String>(1)?)
         .map_err(|error| rusqlite::Error::FromSqlConversionFailure(1, Type::Text, error.into()))?;
+    let metadata_json = row.get::<_, String>(9)?;
+    let reviews_query = decode_remote_pairing_metadata(&metadata_json)
+        .map_err(|error| rusqlite::Error::FromSqlConversionFailure(9, Type::Text, error.into()))?;
     Ok(RemoteStoredPairing {
         pairing_id: row.get(0)?,
         code_hash,
@@ -459,6 +468,7 @@ fn remote_pairing_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteSt
         claimed_at: row.get(6)?,
         claimed_client_id: row.get(7)?,
         claim_remote_addr: row.get(8)?,
+        reviews_query,
     })
 }
 

--- a/src/daemon/db/remote_pairing/metadata.rs
+++ b/src/daemon/db/remote_pairing/metadata.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+use crate::daemon::db::{CliError, db_error};
+use crate::daemon::remote_pairing::normalize_remote_reviews_query;
+use crate::reviews::ReviewsQueryRequest;
+
+#[derive(Default, Deserialize, Serialize)]
+struct RemotePairingMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reviews_query: Option<ReviewsQueryRequest>,
+}
+
+pub(super) fn encode_remote_pairing_metadata(
+    reviews_query: Option<&ReviewsQueryRequest>,
+) -> Result<String, CliError> {
+    serde_json::to_string(&RemotePairingMetadata {
+        reviews_query: reviews_query.cloned(),
+    })
+    .map_err(|error| db_error(format!("serialize remote pairing metadata: {error}")))
+}
+
+pub(super) fn decode_remote_pairing_metadata(
+    value: &str,
+) -> Result<Option<ReviewsQueryRequest>, String> {
+    serde_json::from_str::<RemotePairingMetadata>(value)
+        .map(|metadata| metadata.reviews_query)
+        .map_err(|error| format!("parse remote pairing metadata: {error}"))
+        .and_then(|query| {
+            query
+                .as_ref()
+                .map(normalize_remote_reviews_query)
+                .transpose()
+                .map_err(|error| error.to_string())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_remote_pairing_metadata;
+
+    #[test]
+    fn invalid_reviews_query_metadata_is_rejected() {
+        let error =
+            decode_remote_pairing_metadata(r#"{"reviews_query":{"authors":["renovate[bot]"]}}"#)
+                .expect_err("unscoped Reviews query must fail");
+
+        assert!(error.contains("organization or repository"));
+    }
+}

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -21,6 +21,7 @@ mod remote_acme;
 mod remote_acme_providers;
 mod remote_identity;
 mod remote_pairing;
+mod remote_pairing_reviews;
 mod runtime;
 mod schema;
 mod schema_backfill;

--- a/src/daemon/db/tests/remote_pairing_reviews.rs
+++ b/src/daemon/db/tests/remote_pairing_reviews.rs
@@ -1,0 +1,61 @@
+use super::*;
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_pairing::{
+    RemotePairingClaimRequest, RemotePairingCode, RemotePairingRecord,
+};
+use crate::reviews::ReviewsQueryRequest;
+
+#[test]
+fn remote_pairing_reviews_query_survives_persistence_and_claim() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let code = RemotePairingCode::from_value_for_tests("reviews-pairing-secret");
+    let query = ReviewsQueryRequest {
+        organizations: vec!["smykla-skalski".into()],
+        repositories: vec!["smykla-skalski/harness".into()],
+        cache_max_age_seconds: 45,
+        ..ReviewsQueryRequest::default()
+    };
+    let record = RemotePairingRecord::new_with_reviews_query_for_tests(
+        "pairing-reviews",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        code.expose(),
+        "2026-07-12T18:00:00Z",
+        "2026-07-12T18:10:00Z",
+        Some(query.clone()),
+    )
+    .expect("pairing record");
+
+    db.create_remote_pairing_code(&record, "audit-create-reviews")
+        .expect("persist pairing");
+    let metadata: serde_json::Value = db
+        .connection()
+        .query_row(
+            "SELECT metadata_json FROM remote_pairing_codes WHERE pairing_id = 'pairing-reviews'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .map(|value| serde_json::from_str(&value).expect("decode metadata"))
+        .expect("load metadata");
+    assert_eq!(
+        metadata["reviews_query"]["repositories"],
+        serde_json::json!(["smykla-skalski/harness"])
+    );
+    assert!(!metadata.to_string().contains(code.expose()));
+
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "reviews-iphone",
+        "Bart iPhone",
+        "ios",
+        Some("203.0.113.44"),
+        "audit-claim-reviews",
+    )
+    .expect("claim request");
+    let claimed = db
+        .claim_remote_pairing_code(code.expose(), &claim, "2026-07-12T18:01:00Z")
+        .expect("claim pairing");
+
+    assert_eq!(claimed.reviews_query, Some(query));
+}

--- a/src/daemon/http/remote_pairing.rs
+++ b/src/daemon/http/remote_pairing.rs
@@ -20,6 +20,7 @@ use crate::daemon::remote_pairing::{
     RemotePairingError,
 };
 use crate::errors::{CliError, CliErrorKind};
+use crate::reviews::ReviewsQueryRequest;
 use crate::workspace::utc_now;
 
 use super::response::{extract_request_id, timed_json, timed_response};
@@ -48,6 +49,8 @@ pub(crate) struct RemotePairClaimHttpResponse {
     token: String,
     token_hint: String,
     paired_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reviews_query: Option<ReviewsQueryRequest>,
 }
 
 async fn post_remote_pair_claim(
@@ -181,6 +184,7 @@ fn remote_pair_claim_response(claimed: RemotePairingClaimedClient) -> RemotePair
         token: claimed.bearer_token.expose().to_string(),
         token_hint: claimed.client.token_hint,
         paired_at: claimed.client.created_at,
+        reviews_query: claimed.reviews_query,
     }
 }
 
@@ -311,6 +315,7 @@ fn pairing_error_status(error: &RemotePairingError) -> StatusCode {
         | RemotePairingError::EmptyPlatform
         | RemotePairingError::EmptyAuditEventId
         | RemotePairingError::InvalidStoredCodeHash
+        | RemotePairingError::InvalidReviewsQuery(_)
         | RemotePairingError::UnknownCode
         | RemotePairingError::Identity(_) => StatusCode::BAD_REQUEST,
     }
@@ -330,6 +335,7 @@ fn pairing_error_message(error: &RemotePairingError) -> &'static str {
         RemotePairingError::EmptyPlatform => "remote pairing platform is required",
         RemotePairingError::EmptyAuditEventId => "remote pairing audit event id is required",
         RemotePairingError::InvalidStoredCodeHash => "remote pairing code is invalid",
+        RemotePairingError::InvalidReviewsQuery(_) => "remote pairing reviews query is invalid",
         RemotePairingError::UnknownCode => "remote pairing code is unknown",
         RemotePairingError::Identity(_) => "remote pairing client identity is invalid",
     }

--- a/src/daemon/http/tests/remote_pairing.rs
+++ b/src/daemon/http/tests/remote_pairing.rs
@@ -11,6 +11,7 @@ use crate::daemon::remote_identity::{RemoteBearerToken, RemoteClientRegistration
 use crate::daemon::remote_pairing::{
     RemotePairingCode, RemotePairingRateLimiter, RemotePairingRecord,
 };
+use crate::reviews::ReviewsQueryRequest;
 
 use super::test_http_state_with_db;
 
@@ -51,6 +52,7 @@ async fn remote_pair_claim_is_public_and_returns_one_time_client_token() {
     assert_eq!(body["client_id"], "iphone-1");
     assert_eq!(body["role"], "operator");
     assert_eq!(body["scopes"], serde_json::json!(["read", "write"]));
+    assert!(body.get("reviews_query").is_none());
     let token = body["token"].as_str().expect("paired token");
     assert!(!token.is_empty());
     assert!(!body.to_string().contains(code.expose()));
@@ -70,6 +72,56 @@ async fn remote_pair_claim_is_public_and_returns_one_time_client_token() {
         .find(|event| event.route_or_method == "remote.pair.claim")
         .expect("claim audit event");
     assert_eq!(claim_event.remote_addr.as_deref(), Some("127.0.0.1"));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn remote_pair_claim_returns_server_owned_reviews_query() {
+    let state = remote_pairing_state();
+    let query = ReviewsQueryRequest {
+        organizations: vec!["smykla-skalski".into()],
+        repositories: vec!["smykla-skalski/harness".into()],
+        cache_max_age_seconds: 45,
+        ..ReviewsQueryRequest::default()
+    };
+    let code = seed_pairing_code_with_reviews_query(
+        &state,
+        "pairing-http-reviews",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        "http-reviews-secret",
+        "2026-07-12T18:00:00Z",
+        "2099-07-12T18:10:00Z",
+        Some(query),
+    );
+    let (base_url, server) = serve_http(state).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM))
+        .json(&serde_json::json!({
+            "code": code.expose(),
+            "domain": "daemon.example.com",
+            "client_id": "reviews-iphone",
+            "display_name": "Bart iPhone",
+            "platform": "ios",
+        }))
+        .send()
+        .await
+        .expect("send claim request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response
+        .json::<serde_json::Value>()
+        .await
+        .expect("json body");
+    assert_eq!(
+        body["reviews_query"]["repositories"],
+        serde_json::json!(["smykla-skalski/harness"])
+    );
+    assert_eq!(body["reviews_query"]["cache_max_age_seconds"], 45);
+    assert!(!body.to_string().contains(code.expose()));
 
     server.abort();
     let _ = server.await;
@@ -339,14 +391,34 @@ fn seed_pairing_code(
     created_at: &str,
     expires_at: &str,
 ) -> RemotePairingCode {
+    seed_pairing_code_with_reviews_query(
+        state, pairing_id, role, scopes, code, created_at, expires_at, None,
+    )
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "pairing fixture mirrors the persisted record"
+)]
+fn seed_pairing_code_with_reviews_query(
+    state: &crate::daemon::http::DaemonHttpState,
+    pairing_id: &str,
+    role: RemoteRole,
+    scopes: &[RemoteAccessScope],
+    code: &str,
+    created_at: &str,
+    expires_at: &str,
+    reviews_query: Option<ReviewsQueryRequest>,
+) -> RemotePairingCode {
     let code = RemotePairingCode::from_value_for_tests(code);
-    let record = RemotePairingRecord::new_for_tests(
+    let record = RemotePairingRecord::new_with_reviews_query_for_tests(
         pairing_id,
         role,
         scopes,
         code.expose(),
         created_at,
         expires_at,
+        reviews_query,
     )
     .expect("pairing record");
     state

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -10,9 +10,11 @@ use super::remote::{RemoteAccessScope, RemoteRole};
 use super::remote_crypto::{
     parse_sha256_storage_digest, sha256_storage_value, verify_sha256_storage_value,
 };
-use super::remote_identity::{
-    RemoteBearerToken, RemoteIdentityError, RemoteStoredClient, expand_client_scopes,
-};
+use super::remote_identity::{RemoteBearerToken, RemoteIdentityError, RemoteStoredClient};
+use crate::reviews::ReviewsQueryRequest;
+
+mod reviews;
+pub(crate) use reviews::normalize_remote_reviews_query;
 
 #[cfg(test)]
 #[path = "remote_pairing_tests.rs"]
@@ -36,6 +38,7 @@ pub enum RemotePairingError {
     Expired,
     AlreadyClaimed,
     UnknownCode,
+    InvalidReviewsQuery(String),
     Identity(RemoteIdentityError),
 }
 
@@ -58,6 +61,9 @@ impl fmt::Display for RemotePairingError {
             Self::Expired => write!(f, "remote pairing code expired"),
             Self::AlreadyClaimed => write!(f, "remote pairing code already claimed"),
             Self::UnknownCode => write!(f, "remote pairing code is unknown"),
+            Self::InvalidReviewsQuery(detail) => {
+                write!(f, "remote pairing reviews query is invalid: {detail}")
+            }
             Self::Identity(error) => write!(f, "{error}"),
         }
     }
@@ -79,7 +85,8 @@ impl Error for RemotePairingError {
             | Self::RateLimited
             | Self::Expired
             | Self::AlreadyClaimed
-            | Self::UnknownCode => None,
+            | Self::UnknownCode
+            | Self::InvalidReviewsQuery(_) => None,
         }
     }
 }
@@ -181,6 +188,7 @@ pub struct RemotePairingRecord {
     pub scopes: Vec<RemoteAccessScope>,
     pub created_at: String,
     pub expires_at: String,
+    pub reviews_query: Option<ReviewsQueryRequest>,
 }
 
 impl RemotePairingRecord {
@@ -197,18 +205,15 @@ impl RemotePairingRecord {
         created_at: impl Into<String>,
         expires_at: impl Into<String>,
     ) -> Result<Self, RemotePairingError> {
-        let pairing_id = pairing_id.into();
-        if pairing_id.trim().is_empty() {
-            return Err(RemotePairingError::EmptyPairingId);
-        }
-        Ok(Self {
+        Self::new_with_reviews_query(
             pairing_id,
-            code_hash: RemotePairingCodeHash::from_code(code)?,
             role,
-            scopes: expand_client_scopes(role, requested_scopes)?,
-            created_at: created_at.into(),
-            expires_at: expires_at.into(),
-        })
+            requested_scopes,
+            code,
+            created_at,
+            expires_at,
+            None,
+        )
     }
 
     #[cfg(test)]
@@ -242,6 +247,7 @@ pub struct RemoteStoredPairing {
     pub claimed_at: Option<String>,
     pub claimed_client_id: Option<String>,
     pub claim_remote_addr: Option<String>,
+    pub reviews_query: Option<ReviewsQueryRequest>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -329,6 +335,7 @@ impl RemotePairingClaimRequest {
 pub struct RemotePairingClaimedClient {
     pub client: RemoteStoredClient,
     pub bearer_token: RemoteBearerToken,
+    pub reviews_query: Option<ReviewsQueryRequest>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/daemon/remote_pairing/reviews.rs
+++ b/src/daemon/remote_pairing/reviews.rs
@@ -1,0 +1,78 @@
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::expand_client_scopes;
+use crate::reviews::ReviewsQueryRequest;
+
+use super::{RemotePairingCodeHash, RemotePairingError, RemotePairingRecord};
+
+impl RemotePairingRecord {
+    /// Build a pairing record carrying an optional server-owned Reviews query.
+    ///
+    /// # Errors
+    /// Returns [`RemotePairingError`] when pairing identity, scopes, or the
+    /// Reviews query is invalid.
+    pub fn new_with_reviews_query(
+        pairing_id: impl Into<String>,
+        role: RemoteRole,
+        requested_scopes: &[RemoteAccessScope],
+        code: &str,
+        created_at: impl Into<String>,
+        expires_at: impl Into<String>,
+        reviews_query: Option<&ReviewsQueryRequest>,
+    ) -> Result<Self, RemotePairingError> {
+        let pairing_id = pairing_id.into();
+        if pairing_id.trim().is_empty() {
+            return Err(RemotePairingError::EmptyPairingId);
+        }
+        Ok(Self {
+            pairing_id,
+            code_hash: RemotePairingCodeHash::from_code(code)?,
+            role,
+            scopes: expand_client_scopes(role, requested_scopes)?,
+            created_at: created_at.into(),
+            expires_at: expires_at.into(),
+            reviews_query: reviews_query
+                .map(normalize_remote_reviews_query)
+                .transpose()?,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn new_with_reviews_query_for_tests(
+        pairing_id: impl Into<String>,
+        role: RemoteRole,
+        requested_scopes: &[RemoteAccessScope],
+        code: &str,
+        created_at: impl Into<String>,
+        expires_at: impl Into<String>,
+        reviews_query: Option<ReviewsQueryRequest>,
+    ) -> Result<Self, RemotePairingError> {
+        Self::new_with_reviews_query(
+            pairing_id,
+            role,
+            requested_scopes,
+            code,
+            created_at,
+            expires_at,
+            reviews_query.as_ref(),
+        )
+    }
+}
+
+pub(crate) fn normalize_remote_reviews_query(
+    query: &ReviewsQueryRequest,
+) -> Result<ReviewsQueryRequest, RemotePairingError> {
+    let normalized = ReviewsQueryRequest {
+        authors: query.normalized_authors(),
+        organizations: query.normalized_organizations(),
+        repositories: query.normalized_repositories(),
+        exclude_repositories: query.normalized_exclude_repositories(),
+        force_refresh: false,
+        cache_max_age_seconds: query.cache_max_age_seconds(),
+        backport_detection_enabled: query.backport_detection_enabled,
+        backport_patterns: query.normalized_backport_patterns(),
+    };
+    normalized
+        .validate()
+        .map_err(|error| RemotePairingError::InvalidReviewsQuery(error.to_string()))?;
+    Ok(normalized)
+}

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -3,6 +3,7 @@ use super::{
     RemotePairingRateLimiter, RemotePairingRecord, validate_pairing_domain,
 };
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::reviews::ReviewsQueryRequest;
 
 #[test]
 fn remote_pairing_code_hashes_secret_and_redacts_debug() {
@@ -43,6 +44,62 @@ fn remote_pairing_code_hash_normalizes_surrounding_whitespace() {
         trimmed_hash.as_storage_value()
     );
     assert!(trimmed_hash.verify(" \tpairing-secret-value\n"));
+}
+
+#[test]
+fn remote_pairing_record_normalizes_reviews_query_profile() {
+    let query = ReviewsQueryRequest {
+        authors: vec![" renovate[bot] ".into(), "renovate[bot]".into()],
+        organizations: vec![" smykla-skalski ".into()],
+        repositories: vec![
+            "smykla-skalski/harness".into(),
+            "smykla-skalski/harness".into(),
+        ],
+        exclude_repositories: vec![" smykla-skalski/archive ".into()],
+        force_refresh: true,
+        cache_max_age_seconds: 0,
+        ..ReviewsQueryRequest::default()
+    };
+
+    let record = RemotePairingRecord::new_with_reviews_query_for_tests(
+        "pairing-reviews",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        "pairing-secret",
+        "2026-07-12T18:00:00Z",
+        "2026-07-12T18:10:00Z",
+        Some(query),
+    )
+    .expect("pairing record with reviews query");
+    let query = record.reviews_query.expect("reviews query");
+
+    assert_eq!(query.authors, vec!["renovate[bot]"]);
+    assert_eq!(query.organizations, vec!["smykla-skalski"]);
+    assert_eq!(query.repositories, vec!["smykla-skalski/harness"]);
+    assert_eq!(query.exclude_repositories, vec!["smykla-skalski/archive"]);
+    assert!(!query.force_refresh);
+    assert_eq!(query.cache_max_age_seconds, 1);
+}
+
+#[test]
+fn remote_pairing_record_rejects_author_only_reviews_query() {
+    let query = ReviewsQueryRequest {
+        authors: vec!["renovate[bot]".into()],
+        ..ReviewsQueryRequest::default()
+    };
+
+    let error = RemotePairingRecord::new_with_reviews_query_for_tests(
+        "pairing-reviews-invalid",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        "pairing-secret",
+        "2026-07-12T18:00:00Z",
+        "2026-07-12T18:10:00Z",
+        Some(query),
+    )
+    .expect_err("author-only reviews query must fail");
+
+    assert!(error.to_string().contains("organization or repository"));
 }
 
 #[test]

--- a/src/daemon/transport/mod.rs
+++ b/src/daemon/transport/mod.rs
@@ -4,6 +4,7 @@ mod remote;
 mod remote_acme;
 mod remote_clients;
 mod remote_doctor;
+mod remote_pair_reviews;
 mod remote_pairing_invitation;
 mod remote_serve;
 mod remote_serve_startup;

--- a/src/daemon/transport/remote.rs
+++ b/src/daemon/transport/remote.rs
@@ -17,10 +17,12 @@ use crate::daemon::remote_pairing::{RemotePairingCode, RemotePairingRecord};
 use crate::daemon::service::DaemonServeConfig;
 use crate::daemon::state;
 use crate::errors::{CliError, CliErrorKind};
+use crate::reviews::ReviewsQueryRequest;
 use crate::workspace::utc_now;
 
 use super::control::{adopt_daemon_root_for_transport_command, print_json};
 use super::remote_doctor::execute_remote_doctor;
+use super::remote_pair_reviews::DaemonRemotePairReviewsArgs;
 use super::remote_pairing_invitation::build_remote_pairing_invitation;
 use super::remote_serve::execute_remote_serve;
 use super::remote_systemd::{DaemonRemoteSystemdArgs, DaemonRemoteSystemdInstallArgs};
@@ -161,6 +163,8 @@ pub struct DaemonRemotePairCreateArgs {
     /// Pairing code time-to-live.
     #[arg(long, default_value = "10m")]
     pub ttl: DaemonRemotePairTtl,
+    #[command(flatten)]
+    pub(super) reviews: DaemonRemotePairReviewsArgs,
 }
 
 impl Execute for DaemonRemotePairCreateArgs {
@@ -206,13 +210,15 @@ impl DaemonRemotePairCreateArgs {
             .map(RemoteAccessScope::from)
             .collect::<Vec<_>>();
         let expires_at = expires_at_from_ttl(created_at, self.ttl.as_secs())?;
-        let record = RemotePairingRecord::new(
+        let reviews_query = self.reviews_query()?;
+        let record = RemotePairingRecord::new_with_reviews_query(
             pairing_id,
             role,
             &requested_scopes,
             code.expose(),
             created_at,
             expires_at.as_str(),
+            reviews_query.as_ref(),
         )
         .map_err(|error| CliErrorKind::workflow_parse(error.to_string()))?;
         let role = record.role.as_str().to_string();
@@ -240,6 +246,7 @@ impl DaemonRemotePairCreateArgs {
             endpoint: invitation.endpoint,
             server_spki_sha256: invitation.server_spki_sha256,
             pairing_url: invitation.pairing_url,
+            reviews_query: stored.reviews_query,
         })
     }
 }
@@ -256,6 +263,8 @@ pub(crate) struct DaemonRemotePairCreateResponse {
     pub endpoint: String,
     pub server_spki_sha256: String,
     pub pairing_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reviews_query: Option<ReviewsQueryRequest>,
 }
 
 pub(super) fn open_remote_daemon_db() -> Result<DaemonDb, CliError> {

--- a/src/daemon/transport/remote_pair_reviews.rs
+++ b/src/daemon/transport/remote_pair_reviews.rs
@@ -1,0 +1,53 @@
+use clap::Args;
+
+use crate::daemon::remote_pairing::normalize_remote_reviews_query;
+use crate::errors::{CliError, CliErrorKind};
+use crate::reviews::ReviewsQueryRequest;
+
+use super::remote::DaemonRemotePairCreateArgs;
+
+#[derive(Debug, Clone, Args)]
+pub(super) struct DaemonRemotePairReviewsArgs {
+    /// Optional GitHub authors included in the paired client's Reviews query.
+    #[arg(long = "reviews-authors", value_delimiter = ',')]
+    authors: Vec<String>,
+    /// GitHub organizations included in the paired client's Reviews query.
+    #[arg(long = "reviews-organizations", value_delimiter = ',')]
+    organizations: Vec<String>,
+    /// GitHub owner/repository scopes included in the paired client's Reviews query.
+    #[arg(long = "reviews-repositories", value_delimiter = ',')]
+    repositories: Vec<String>,
+    /// GitHub owner/repository scopes excluded from the paired client's Reviews query.
+    #[arg(long = "reviews-exclude-repositories", value_delimiter = ',')]
+    exclude_repositories: Vec<String>,
+    /// Maximum age of cached Reviews data returned to the paired client.
+    #[arg(long = "reviews-cache-max-age-seconds")]
+    cache_max_age_seconds: Option<u64>,
+}
+
+impl DaemonRemotePairCreateArgs {
+    pub(crate) fn reviews_query(&self) -> Result<Option<ReviewsQueryRequest>, CliError> {
+        let configured = !self.reviews.authors.is_empty()
+            || !self.reviews.organizations.is_empty()
+            || !self.reviews.repositories.is_empty()
+            || !self.reviews.exclude_repositories.is_empty()
+            || self.reviews.cache_max_age_seconds.is_some();
+        if !configured {
+            return Ok(None);
+        }
+        normalize_remote_reviews_query(&ReviewsQueryRequest {
+            authors: self.reviews.authors.clone(),
+            organizations: self.reviews.organizations.clone(),
+            repositories: self.reviews.repositories.clone(),
+            exclude_repositories: self.reviews.exclude_repositories.clone(),
+            force_refresh: false,
+            cache_max_age_seconds: self
+                .reviews
+                .cache_max_age_seconds
+                .unwrap_or_else(|| ReviewsQueryRequest::default().cache_max_age_seconds),
+            ..ReviewsQueryRequest::default()
+        })
+        .map(Some)
+        .map_err(|error| CliErrorKind::workflow_parse(error.to_string()).into())
+    }
+}

--- a/src/daemon/transport/tests/mod.rs
+++ b/src/daemon/transport/tests/mod.rs
@@ -5,6 +5,7 @@ mod remote_cli;
 mod remote_clients;
 mod remote_doctor;
 mod remote_pairing_contract;
+mod remote_pairing_reviews;
 mod remote_serve;
 mod remote_systemd;
 mod remote_systemd_lifecycle;

--- a/src/daemon/transport/tests/remote_cli.rs
+++ b/src/daemon/transport/tests/remote_cli.rs
@@ -478,7 +478,7 @@ fn daemon_remote_pair_create_execute_persists_pairing_in_daemon_db() {
     });
 }
 
-fn seed_remote_tls_identity(db: &DaemonDb) -> String {
+pub(super) fn seed_remote_tls_identity(db: &DaemonDb) -> String {
     let config = RemoteDaemonServeConfig {
         domain: "daemon.example.com".to_string(),
         host: "0.0.0.0".to_string(),

--- a/src/daemon/transport/tests/remote_pairing_reviews.rs
+++ b/src/daemon/transport/tests/remote_pairing_reviews.rs
@@ -1,0 +1,139 @@
+use clap::Parser;
+
+use crate::daemon::db::DaemonDb;
+use crate::daemon::remote_pairing::RemotePairingCode;
+
+use super::super::{DaemonRemoteCommand, DaemonRemotePairCommand};
+use super::remote_cli::seed_remote_tls_identity;
+
+#[derive(Debug, Parser)]
+struct DaemonRemoteCommandTestHarness {
+    #[command(subcommand)]
+    command: DaemonRemoteCommand,
+}
+
+#[test]
+fn daemon_remote_pair_create_builds_normalized_reviews_query() {
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "pair",
+        "create",
+        "--reviews-authors",
+        " renovate[bot] ,renovate[bot]",
+        "--reviews-organizations",
+        " smykla-skalski ",
+        "--reviews-repositories",
+        "smykla-skalski/harness,smykla-skalski/harness",
+        "--reviews-exclude-repositories",
+        " smykla-skalski/archive ",
+        "--reviews-cache-max-age-seconds",
+        "45",
+    ])
+    .expect("parse pair create reviews query")
+    .command;
+    let DaemonRemoteCommand::Pair {
+        command: DaemonRemotePairCommand::Create(args),
+    } = parsed
+    else {
+        panic!("expected pair create");
+    };
+
+    let query = args
+        .reviews_query()
+        .expect("valid reviews query")
+        .expect("configured reviews query");
+
+    assert_eq!(query.authors, vec!["renovate[bot]"]);
+    assert_eq!(query.organizations, vec!["smykla-skalski"]);
+    assert_eq!(query.repositories, vec!["smykla-skalski/harness"]);
+    assert_eq!(query.exclude_repositories, vec!["smykla-skalski/archive"]);
+    assert_eq!(query.cache_max_age_seconds, 45);
+}
+
+#[test]
+fn daemon_remote_pair_create_returns_persisted_reviews_query() {
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "pair",
+        "create",
+        "--reviews-repositories",
+        " smykla-skalski/harness ",
+        "--reviews-cache-max-age-seconds",
+        "45",
+    ])
+    .expect("parse pair create reviews query")
+    .command;
+    let DaemonRemoteCommand::Pair {
+        command: DaemonRemotePairCommand::Create(args),
+    } = parsed
+    else {
+        panic!("expected pair create");
+    };
+    let db = DaemonDb::open_in_memory().expect("open db");
+    seed_remote_tls_identity(&db);
+    let code = RemotePairingCode::from_value_for_tests("reviews-pairing-secret");
+
+    let response = args
+        .create_pairing_with(
+            &db,
+            "pairing-reviews-response",
+            "audit-pairing-reviews-response",
+            &code,
+            "2026-07-12T18:00:00Z",
+        )
+        .expect("create pairing");
+    let query = response.reviews_query.expect("Reviews query response");
+
+    assert_eq!(query.repositories, vec!["smykla-skalski/harness"]);
+    assert_eq!(query.cache_max_age_seconds, 45);
+}
+
+#[test]
+fn daemon_remote_pair_create_rejects_unscoped_reviews_authors() {
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "pair",
+        "create",
+        "--reviews-authors",
+        "renovate[bot]",
+    ])
+    .expect("parse pair create")
+    .command;
+    let DaemonRemoteCommand::Pair {
+        command: DaemonRemotePairCommand::Create(args),
+    } = parsed
+    else {
+        panic!("expected pair create");
+    };
+
+    let error = args
+        .reviews_query()
+        .expect_err("unscoped authors must fail");
+
+    assert!(error.to_string().contains("organization or repository"));
+}
+
+#[test]
+fn daemon_remote_pair_create_rejects_unscoped_reviews_cache_setting() {
+    let parsed = DaemonRemoteCommandTestHarness::try_parse_from([
+        "test",
+        "pair",
+        "create",
+        "--reviews-cache-max-age-seconds",
+        "45",
+    ])
+    .expect("parse pair create")
+    .command;
+    let DaemonRemoteCommand::Pair {
+        command: DaemonRemotePairCommand::Create(args),
+    } = parsed
+    else {
+        panic!("expected pair create");
+    };
+
+    let error = args
+        .reviews_query()
+        .expect_err("unscoped cache setting must fail");
+
+    assert!(error.to_string().contains("organization or repository"));
+}


### PR DESCRIPTION
## Motivation
Remote mobile clients cannot query Reviews without a server-authoritative repository scope. Pairing currently transfers identity but no Reviews filter, so an Apple client would have to guess repositories or send an invalid empty request. This follows the direct task-board snapshot support from #230.

## Implementation
- Add optional --reviews-* filters to harness daemon remote pair create, normalize and validate them, and reject unscoped review settings.
- Persist the profile in pairing metadata, validate it again on load, and return it only from pair-create and a successful one-time claim.
- Preserve existing pairing behavior by omitting reviews_query when no profile is configured.
- Add focused red-to-green coverage for CLI parsing, persistence, claim transport, malformed metadata, and compatibility.
- Proof: mise run cargo:local -- test remote_pairing, mise run cargo:local -- test daemon_remote_pair_create, mise run cargo:local -- test remote_pair_claim, and mise run harness:check.