### PR TITLE
feat(mobile): sync direct remote reviews

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
@@ -60,6 +60,7 @@ public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStri
   public var tokenHint: String
   public var serverSPKISHA256: MobileRemoteDaemonSPKIPin
   public var pairedAt: Date
+  public var reviewsQuery: MobileRemoteDaemonReviewsQuery?
 
   public init(
     endpoint: URL,
@@ -71,7 +72,8 @@ public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStri
     bearerToken: String,
     tokenHint: String,
     serverSPKISHA256: MobileRemoteDaemonSPKIPin,
-    pairedAt: Date
+    pairedAt: Date,
+    reviewsQuery: MobileRemoteDaemonReviewsQuery? = nil
   ) {
     self.endpoint = endpoint
     self.clientID = clientID
@@ -83,12 +85,14 @@ public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStri
     self.tokenHint = tokenHint
     self.serverSPKISHA256 = serverSPKISHA256
     self.pairedAt = pairedAt
+    self.reviewsQuery = reviewsQuery
   }
 
   public var description: String {
     "MobileRemoteDaemonAccess(endpoint: \(endpoint.absoluteString), clientID: \(clientID), "
       + "platform: \(platform), role: \(role.rawValue), scopes: \(scopes), "
-      + "tokenHint: \(tokenHint), bearerToken: <redacted>)"
+      + "tokenHint: \(tokenHint), reviewsQuery: \(reviewsQuery == nil ? "none" : "configured"), "
+      + "bearerToken: <redacted>)"
   }
 
   public var canRead: Bool {

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
@@ -9,6 +9,7 @@ public struct MobileRemoteDaemonPairingClaim: Equatable, Sendable {
   public var token: String
   public var tokenHint: String
   public var pairedAt: Date
+  public var reviewsQuery: MobileRemoteDaemonReviewsQuery?
 
   public init(
     clientID: String,
@@ -18,7 +19,8 @@ public struct MobileRemoteDaemonPairingClaim: Equatable, Sendable {
     scopes: [String],
     token: String,
     tokenHint: String,
-    pairedAt: Date
+    pairedAt: Date,
+    reviewsQuery: MobileRemoteDaemonReviewsQuery? = nil
   ) {
     self.clientID = clientID
     self.displayName = displayName
@@ -28,6 +30,7 @@ public struct MobileRemoteDaemonPairingClaim: Equatable, Sendable {
     self.token = token
     self.tokenHint = tokenHint
     self.pairedAt = pairedAt
+    self.reviewsQuery = reviewsQuery
   }
 }
 
@@ -117,6 +120,9 @@ public struct URLSessionMobileRemoteDaemonPairingTransport:
     else {
       throw MobileRemoteDaemonPairingError.claimMismatch
     }
+    guard wire.reviewsQuery?.isValidProfile != false else {
+      throw MobileRemoteDaemonPairingError.invalidResponse
+    }
     return wire.claim
   }
 
@@ -171,7 +177,8 @@ public actor MobileRemoteDaemonPairingCoordinator<Transport: MobileRemoteDaemonP
       bearerToken: claim.token,
       tokenHint: claim.tokenHint,
       serverSPKISHA256: invitation.serverSPKISHA256,
-      pairedAt: claim.pairedAt
+      pairedAt: claim.pairedAt,
+      reviewsQuery: claim.reviewsQuery
     )
     let stationID = MobileRemoteDaemonStationID.make(endpoint: invitation.endpoint)
     let existing = try await credentialStore.loadAll()
@@ -265,6 +272,7 @@ private struct MobileRemoteDaemonPairingClaimResponse: Decodable {
   var token: String
   var tokenHint: String
   var pairedAt: Date
+  var reviewsQuery: MobileRemoteDaemonReviewsQuery?
 
   var claim: MobileRemoteDaemonPairingClaim {
     MobileRemoteDaemonPairingClaim(
@@ -275,7 +283,8 @@ private struct MobileRemoteDaemonPairingClaimResponse: Decodable {
       scopes: scopes,
       token: token,
       tokenHint: tokenHint,
-      pairedAt: pairedAt
+      pairedAt: pairedAt,
+      reviewsQuery: reviewsQuery
     )
   }
 
@@ -288,5 +297,6 @@ private struct MobileRemoteDaemonPairingClaimResponse: Decodable {
     case token
     case tokenHint = "token_hint"
     case pairedAt = "paired_at"
+    case reviewsQuery = "reviews_query"
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonReviewsQuery.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonReviewsQuery.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+public struct MobileRemoteDaemonReviewsQuery: Codable, Equatable, Sendable {
+  public var authors: [String]
+  public var organizations: [String]
+  public var repositories: [String]
+  public var excludeRepositories: [String]
+  public var forceRefresh: Bool
+  public var cacheMaxAgeSeconds: UInt64
+  public var backportDetectionEnabled: Bool
+  public var backportPatterns: [String]
+
+  public init(
+    authors: [String] = [],
+    organizations: [String] = [],
+    repositories: [String] = [],
+    excludeRepositories: [String] = [],
+    forceRefresh: Bool = false,
+    cacheMaxAgeSeconds: UInt64 = 600,
+    backportDetectionEnabled: Bool = true,
+    backportPatterns: [String] = []
+  ) {
+    self.authors = authors
+    self.organizations = organizations
+    self.repositories = repositories
+    self.excludeRepositories = excludeRepositories
+    self.forceRefresh = forceRefresh
+    self.cacheMaxAgeSeconds = cacheMaxAgeSeconds
+    self.backportDetectionEnabled = backportDetectionEnabled
+    self.backportPatterns = backportPatterns
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      authors: try container.decodeIfPresent([String].self, forKey: .authors) ?? [],
+      organizations: try container.decodeIfPresent([String].self, forKey: .organizations) ?? [],
+      repositories: try container.decodeIfPresent([String].self, forKey: .repositories) ?? [],
+      excludeRepositories: try container.decodeIfPresent(
+        [String].self,
+        forKey: .excludeRepositories
+      ) ?? [],
+      forceRefresh: try container.decodeIfPresent(Bool.self, forKey: .forceRefresh) ?? false,
+      cacheMaxAgeSeconds: try container.decodeIfPresent(
+        UInt64.self,
+        forKey: .cacheMaxAgeSeconds
+      ) ?? 600,
+      backportDetectionEnabled: try container.decodeIfPresent(
+        Bool.self,
+        forKey: .backportDetectionEnabled
+      ) ?? true,
+      backportPatterns: try container.decodeIfPresent(
+        [String].self,
+        forKey: .backportPatterns
+      ) ?? []
+    )
+  }
+
+  var isValidProfile: Bool {
+    let scopes = organizations + repositories
+    return cacheMaxAgeSeconds > 0
+      && scopes.contains { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case authors
+    case organizations
+    case repositories
+    case excludeRepositories = "exclude_repositories"
+    case forceRefresh = "force_refresh"
+    case cacheMaxAgeSeconds = "cache_max_age_seconds"
+    case backportDetectionEnabled = "backport_detection_enabled"
+    case backportPatterns = "backport_patterns"
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewsSnapshot.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewsSnapshot.swift
@@ -29,7 +29,11 @@ extension MobileRemoteDaemonSyncClient {
       $0.mobileSummary(stationID: stationID, now: now, redactor: redactor)
     }
     let attention = reviews.filter(\.needsYou).map {
-      $0.mobileAttention(stationID: stationID, redactor: redactor)
+      $0.mobileAttention(
+        stationID: stationID,
+        canExecuteCommands: access.canWrite,
+        redactor: redactor
+      )
     }
     return MobileRemoteReviewsSnapshot(reviews: reviews, attention: attention)
   }
@@ -165,9 +169,31 @@ private struct MobileRemoteReviewCheckWire: Decodable, Sendable {
 extension MobileReviewSummary {
   fileprivate func mobileAttention(
     stationID: String,
+    canExecuteCommands: Bool,
     redactor: MobileMirrorSecretRedactor
   ) -> MobileAttentionItem {
-    MobileAttentionItem(
+    let exposesCommand = canExecuteCommands && viewerCanUpdate
+    let commandKind: MobileCommandKind? =
+      exposesCommand
+      ? (checkStatus == "failure" ? .pullRequestRerunChecks : .pullRequestApprove)
+      : nil
+    let target =
+      exposesCommand
+      ? MobileCommandTarget(
+        stationID: stationID,
+        reviewID: id,
+        targetRevision: 0
+      )
+      : nil
+    let commandPayload =
+      exposesCommand
+      ? [
+        "repository": repository,
+        "number": String(number),
+        "headSha": headSha ?? "",
+      ]
+      : [:]
+    return MobileAttentionItem(
       id: "review-\(id)",
       stationID: stationID,
       kind: .pullRequest,
@@ -175,17 +201,9 @@ extension MobileReviewSummary {
       title: redactor.redact("\(repository) #\(number) needs you"),
       subtitle: title,
       updatedAt: updatedAt,
-      commandKind: checkStatus == "failure" ? .pullRequestRerunChecks : .pullRequestApprove,
-      target: MobileCommandTarget(
-        stationID: stationID,
-        reviewID: id,
-        targetRevision: 0
-      ),
-      commandPayload: [
-        "repository": repository,
-        "number": String(number),
-        "headSha": headSha ?? "",
-      ]
+      commandKind: commandKind,
+      target: target,
+      commandPayload: commandPayload
     )
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewsSnapshot.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewsSnapshot.swift
@@ -1,0 +1,191 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+
+struct MobileRemoteReviewsSnapshot: Sendable {
+  var reviews: [MobileReviewSummary]
+  var attention: [MobileAttentionItem]
+
+  static let empty = Self(reviews: [], attention: [])
+}
+
+extension MobileRemoteDaemonSyncClient {
+  func fetchReviewsSnapshot(now: Date) async throws -> MobileRemoteReviewsSnapshot {
+    guard let query = access.reviewsQuery else {
+      return .empty
+    }
+    var request = authenticatedRequest(path: "/v1/reviews/query")
+    request.httpMethod = "POST"
+    request.httpBody = try JSONEncoder().encode(query)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+    try validate(response)
+    let wire = try JSONDecoder().decode(MobileRemoteReviewsResponseWire.self, from: data)
+    let redactor = MobileMirrorSecretRedactor()
+    let reviews = wire.items.map {
+      $0.mobileSummary(stationID: stationID, now: now, redactor: redactor)
+    }
+    let attention = reviews.filter(\.needsYou).map {
+      $0.mobileAttention(stationID: stationID, redactor: redactor)
+    }
+    return MobileRemoteReviewsSnapshot(reviews: reviews, attention: attention)
+  }
+}
+
+private struct MobileRemoteReviewsResponseWire: Decodable, Sendable {
+  var items: [MobileRemoteReviewWire]
+}
+
+private struct MobileRemoteReviewWire: Decodable, Sendable {
+  var pullRequestID: String
+  var repositoryID: String
+  var repository: String
+  var number: Int
+  var title: String
+  var url: String
+  var authorLogin: String
+  var state: String
+  var mergeable: String
+  var reviewStatus: String
+  var checkStatus: String
+  var isDraft: Bool?
+  var policyBlocked: Bool?
+  var viewerCanUpdate: Bool?
+  var viewerCanMergeAsAdmin: Bool?
+  var headSHA: String
+  var labels: [String]?
+  var checks: [MobileRemoteReviewCheckWire]?
+  var additions: UInt64
+  var deletions: UInt64
+  var updatedAt: String
+  var requiredFailedCheckNames: [String]?
+
+  func mobileSummary(
+    stationID: String,
+    now: Date,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileReviewSummary {
+    MobileReviewSummary(
+      id: pullRequestID,
+      stationID: stationID,
+      repositoryID: repositoryID,
+      repository: repository,
+      number: number,
+      url: redactor.redact(url),
+      title: redactor.redact(title),
+      author: redactor.redact(authorLogin),
+      state: state,
+      checksSummary: checkStatus,
+      headSha: headSHA,
+      mergeable: mergeable,
+      reviewStatus: reviewStatus,
+      checkStatus: checkStatus,
+      policyBlocked: policyBlocked ?? false,
+      isDraft: isDraft ?? false,
+      labels: (labels ?? []).map(redactor.redact),
+      checks: (checks ?? []).prefix(6).enumerated().map { index, check in
+        check.mobileSnippet(reviewID: pullRequestID, index: index, redactor: redactor)
+      },
+      additions: additions,
+      deletions: deletions,
+      requiredFailedCheckNames: (requiredFailedCheckNames ?? []).map(redactor.redact),
+      viewerCanUpdate: viewerCanUpdate ?? true,
+      viewerCanMergeAsAdmin: viewerCanMergeAsAdmin ?? false,
+      needsYou: needsAttention,
+      updatedAt: MobileRemoteSessionDate.parse(updatedAt) ?? now
+    )
+  }
+
+  private var needsAttention: Bool {
+    reviewStatus == "review_required"
+      || policyBlocked == true
+      || checkStatus == "failure"
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case pullRequestID = "pull_request_id"
+    case repositoryID = "repository_id"
+    case repository
+    case number
+    case title
+    case url
+    case authorLogin = "author_login"
+    case state
+    case mergeable
+    case reviewStatus = "review_status"
+    case checkStatus = "check_status"
+    case isDraft = "is_draft"
+    case policyBlocked = "policy_blocked"
+    case viewerCanUpdate = "viewer_can_update"
+    case viewerCanMergeAsAdmin = "viewer_can_merge_as_admin"
+    case headSHA = "head_sha"
+    case labels
+    case checks
+    case additions
+    case deletions
+    case updatedAt = "updated_at"
+    case requiredFailedCheckNames = "required_failed_check_names"
+  }
+}
+
+private struct MobileRemoteReviewCheckWire: Decodable, Sendable {
+  var name: String
+  var status: String
+  var conclusion: String
+  var checkSuiteID: String?
+  var detailsURL: String?
+
+  func mobileSnippet(
+    reviewID: String,
+    index: Int,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileReviewCheckSnippet {
+    MobileReviewCheckSnippet(
+      id: "\(reviewID)-check-\(index)",
+      name: redactor.redact(name),
+      status: status,
+      conclusion: conclusion,
+      checkSuiteID: checkSuiteID,
+      detailsURL: detailsURL.map(redactor.redact)
+    )
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case name
+    case status
+    case conclusion
+    case checkSuiteID = "check_suite_id"
+    case detailsURL = "details_url"
+  }
+}
+
+extension MobileReviewSummary {
+  fileprivate func mobileAttention(
+    stationID: String,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileAttentionItem {
+    MobileAttentionItem(
+      id: "review-\(id)",
+      stationID: stationID,
+      kind: .pullRequest,
+      severity: policyBlocked == true || checkStatus == "failure" ? .critical : .warning,
+      title: redactor.redact("\(repository) #\(number) needs you"),
+      subtitle: title,
+      updatedAt: updatedAt,
+      commandKind: checkStatus == "failure" ? .pullRequestRerunChecks : .pullRequestApprove,
+      target: MobileCommandTarget(
+        stationID: stationID,
+        reviewID: id,
+        targetRevision: 0
+      ),
+      commandPayload: [
+        "repository": repository,
+        "number": String(number),
+        "headSha": headSha ?? "",
+      ]
+    )
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
@@ -54,9 +54,11 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
     }
     async let sessions = fetchSessions()
     async let taskBoardItems = fetchTaskBoardItems()
+    async let reviewsSnapshot = fetchReviewsSnapshot(now: now)
     return try await makeSnapshot(
       sessions: sessions,
       taskBoardItems: taskBoardItems,
+      reviewsSnapshot: reviewsSnapshot,
       now: now
     )
   }
@@ -99,6 +101,7 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
   private func makeSnapshot(
     sessions: [MobileRemoteSessionWire],
     taskBoardItems: [MobileRemoteTaskBoardWire],
+    reviewsSnapshot: MobileRemoteReviewsSnapshot,
     now: Date
   ) -> MobileMirrorSnapshot {
     let redactor = MobileMirrorSecretRedactor()
@@ -110,7 +113,10 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
     }
     let activeSessions = sessions.filter { $0.status != "ended" }
     let sessionNeedsYouCount = sessions.count(where: { $0.metrics.awaitingReviewAgentCount > 0 })
-    let needsYouCount = sessionNeedsYouCount + mobileTaskBoardItems.count(where: \.needsYou)
+    let needsYouCount =
+      sessionNeedsYouCount
+      + mobileTaskBoardItems.count(where: \.needsYou)
+      + reviewsSnapshot.reviews.count(where: \.needsYou)
     let station = MobileStationSummary(
       id: stationID,
       displayName: stationName,
@@ -126,9 +132,9 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
       generatedAt: now,
       expiresAt: now.addingTimeInterval(60),
       stations: [station],
-      attention: [],
+      attention: reviewsSnapshot.attention,
       sessions: mobileSessions,
-      reviews: [],
+      reviews: reviewsSnapshot.reviews,
       taskBoardItems: mobileTaskBoardItems,
       commands: [],
       trustedDevices: []

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
@@ -57,7 +57,8 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
         scopes: ["read", "write"],
         token: "server-issued-token",
         tokenHint: "abcd1234",
-        pairedAt: now.addingTimeInterval(5)
+        pairedAt: now.addingTimeInterval(5),
+        reviewsQuery: remoteReviewsQuery()
       )
     )
     let coordinator = MobileRemoteDaemonPairingCoordinator(
@@ -80,6 +81,7 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
     XCTAssertTrue(request.clientID.hasPrefix("ios-"))
     XCTAssertEqual(credential.remoteDaemonAccess?.bearerToken, "server-issued-token")
     XCTAssertEqual(credential.remoteDaemonAccess?.serverSPKISHA256.value, testSPKIPin)
+    XCTAssertEqual(credential.remoteDaemonAccess?.reviewsQuery, remoteReviewsQuery())
     XCTAssertTrue(credential.symmetricKeyRawRepresentation.isEmpty)
     XCTAssertTrue(credential.snapshotKeyID.isEmpty)
     let storedCredential = try await credentialStore.load(stationID: credential.stationID)
@@ -151,6 +153,21 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
     XCTAssertTrue(description.contains("abcd1234"))
   }
 
+  func testRemoteAccessDecodesLegacyCredentialWithoutReviewsQuery() throws {
+    var access = try remoteAccess()
+    access.reviewsQuery = nil
+    let encoded = try JSONEncoder().encode(access)
+    var object = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+    )
+    object.removeValue(forKey: "reviewsQuery")
+    let legacyPayload = try JSONSerialization.data(withJSONObject: object)
+
+    let decoded = try JSONDecoder().decode(MobileRemoteDaemonAccess.self, from: legacyPayload)
+
+    XCTAssertNil(decoded.reviewsQuery)
+  }
+
   func testAdminRoleCanReadBeforeScopeExpansion() throws {
     var access = try remoteAccess()
     access.role = .admin
@@ -200,6 +217,7 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
     try await store.save(credential)
     let stored = try await store.load(stationID: stationID)
     XCTAssertEqual(stored?.remoteDaemonAccess?.bearerToken, "server-issued-token")
+    XCTAssertEqual(stored?.remoteDaemonAccess?.reviewsQuery, remoteReviewsQuery())
 
     credential.remoteDaemonAccess?.bearerToken = "rotated-server-token"
     try await store.save(credential)
@@ -328,7 +346,16 @@ private func remoteAccess() throws -> MobileRemoteDaemonAccess {
     bearerToken: "server-issued-token",
     tokenHint: "abcd1234",
     serverSPKISHA256: try MobileRemoteDaemonSPKIPin(validating: testSPKIPin),
-    pairedAt: Date(timeIntervalSince1970: 1_752_124_405)
+    pairedAt: Date(timeIntervalSince1970: 1_752_124_405),
+    reviewsQuery: remoteReviewsQuery()
+  )
+}
+
+private func remoteReviewsQuery() -> MobileRemoteDaemonReviewsQuery {
+  MobileRemoteDaemonReviewsQuery(
+    organizations: ["smykla-skalski"],
+    repositories: ["smykla-skalski/harness"],
+    cacheMaxAgeSeconds: 45
   )
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTransportTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTransportTests.swift
@@ -63,6 +63,63 @@ final class MobileRemoteDaemonPairingTransportTests: XCTestCase {
     XCTAssertEqual(claim.token, "server-issued-token")
     XCTAssertEqual(claim.role, .operator)
     XCTAssertEqual(claim.scopes, ["read", "write"])
+    XCTAssertNil(claim.reviewsQuery)
+  }
+
+  func testClaimDecodesServerOwnedReviewsQuery() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    RemotePairingURLProtocol.respond(
+      statusCode: 201,
+      body: """
+        {
+          "client_id": "ios-device-fingerprint",
+          "display_name": "Bart's iPhone",
+          "platform": "ios",
+          "role": "viewer",
+          "scopes": ["read"],
+          "token": "server-issued-token",
+          "token_hint": "abcd1234",
+          "paired_at": "2025-07-10T14:33:25Z",
+          "reviews_query": {
+            "authors": ["renovate[bot]"],
+            "organizations": ["smykla-skalski"],
+            "repositories": ["smykla-skalski/harness"],
+            "exclude_repositories": ["smykla-skalski/archive"],
+            "force_refresh": false,
+            "cache_max_age_seconds": 45,
+            "backport_detection_enabled": true,
+            "backport_patterns": ["backport"]
+          }
+        }
+        """
+    )
+    let session = makeSession()
+    let transport = URLSessionMobileRemoteDaemonPairingTransport { _ in session }
+    let invitation = try MobileRemoteDaemonPairingInvitation.decode(
+      remoteInvitationURL(now: now),
+      now: now
+    )
+
+    let claim = try await transport.claim(
+      invitation: invitation,
+      clientID: "ios-device-fingerprint",
+      displayName: "Bart's iPhone",
+      platform: "ios"
+    )
+
+    XCTAssertEqual(
+      claim.reviewsQuery,
+      MobileRemoteDaemonReviewsQuery(
+        authors: ["renovate[bot]"],
+        organizations: ["smykla-skalski"],
+        repositories: ["smykla-skalski/harness"],
+        excludeRepositories: ["smykla-skalski/archive"],
+        forceRefresh: false,
+        cacheMaxAgeSeconds: 45,
+        backportDetectionEnabled: true,
+        backportPatterns: ["backport"]
+      )
+    )
   }
 
   func testClaimRejectsServerIdentityMismatch() async throws {
@@ -99,6 +156,44 @@ final class MobileRemoteDaemonPairingTransportTests: XCTestCase {
       XCTFail("expected claim mismatch")
     } catch let error as MobileRemoteDaemonPairingError {
       XCTAssertEqual(error, .claimMismatch)
+    }
+  }
+
+  func testClaimRejectsUnscopedReviewsQuery() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    RemotePairingURLProtocol.respond(
+      statusCode: 200,
+      body: """
+        {
+          "client_id": "ios-device-fingerprint",
+          "display_name": "Bart's iPhone",
+          "platform": "ios",
+          "role": "viewer",
+          "scopes": ["read"],
+          "token": "server-issued-token",
+          "token_hint": "abcd1234",
+          "paired_at": "2025-07-10T14:33:25Z",
+          "reviews_query": {"authors": ["renovate[bot]"]}
+        }
+        """
+    )
+    let session = makeSession()
+    let transport = URLSessionMobileRemoteDaemonPairingTransport { _ in session }
+    let invitation = try MobileRemoteDaemonPairingInvitation.decode(
+      remoteInvitationURL(now: now),
+      now: now
+    )
+
+    do {
+      _ = try await transport.claim(
+        invitation: invitation,
+        clientID: "ios-device-fingerprint",
+        displayName: "Bart's iPhone",
+        platform: "ios"
+      )
+      XCTFail("expected invalid Reviews profile")
+    } catch let error as MobileRemoteDaemonPairingError {
+      XCTAssertEqual(error, .invalidResponse)
     }
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonWatchPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonWatchPairingTests.swift
@@ -40,6 +40,10 @@ final class MobileRemoteDaemonWatchPairingTests: XCTestCase {
     XCTAssertEqual(credential.deviceIdentityID, MobileRemoteDaemonPairingDevice.watchOS.identityID)
     XCTAssertEqual(credential.remoteDaemonAccess?.platform, "watchos")
     XCTAssertEqual(credential.remoteDaemonAccess?.clientID, request.clientID)
+    XCTAssertEqual(
+      credential.remoteDaemonAccess?.reviewsQuery?.repositories,
+      ["smykla-skalski/harness"]
+    )
     let storedWatchIdentity = try await identityStore.load(
       id: MobileRemoteDaemonPairingDevice.watchOS.identityID
     )
@@ -112,7 +116,11 @@ private actor RecordingWatchRemotePairingTransport: MobileRemoteDaemonPairingTra
       scopes: ["read", "write"],
       token: "watch-server-token",
       tokenHint: "watch123",
-      pairedAt: pairedAt
+      pairedAt: pairedAt,
+      reviewsQuery: MobileRemoteDaemonReviewsQuery(
+        repositories: ["smykla-skalski/harness"],
+        cacheMaxAgeSeconds: 45
+      )
     )
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileWatchPairingTransferChangesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileWatchPairingTransferChangesTests.swift
@@ -133,6 +133,32 @@ final class MobileWatchPairingTransferChangesTests: XCTestCase {
     XCTAssertTrue(changed, "a rotated symmetric key must trigger a reload")
   }
 
+  func testChangedRemoteReviewsQueryIsAChange() throws {
+    let identity = makePairingIdentity(id: "default-mobile-device", now: now)
+    let current = try makeRemoteCredential(
+      identityID: identity.id,
+      platform: "ios",
+      token: "phone-token"
+    )
+    var incoming = current
+    incoming.remoteDaemonAccess?.reviewsQuery = MobileRemoteDaemonReviewsQuery(
+      repositories: ["smykla-skalski/harness"],
+      cacheMaxAgeSeconds: 45
+    )
+    let transfer = MobileWatchPairingTransfer(
+      identities: [identity],
+      credentials: [incoming],
+      exportedAt: now
+    )
+
+    let changed = transfer.changesPairingMaterial(
+      currentIdentities: [identity],
+      currentCredentials: [current]
+    )
+
+    XCTAssertTrue(changed, "a changed remote Reviews profile must trigger a reload")
+  }
+
   func testRotatedIdentityKeyIsAChange() {
     var current = makePairingIdentity(id: "device-watch", now: now)
     current.signingPrivateKeyRawRepresentation = Data(repeating: 7, count: 32)

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonReviewsSyncTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonReviewsSyncTests.swift
@@ -107,6 +107,65 @@ final class MobileRemoteDaemonReviewsSyncTests: XCTestCase {
     XCTAssertEqual(fallbackFetchCount, 0)
   }
 
+  func testReadOnlyReviewAttentionDoesNotExposeCommand() async throws {
+    var response = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: Data(reviewsResponse.utf8)) as? [String: Any]
+    )
+    var items = try XCTUnwrap(response["items"] as? [[String: Any]])
+    items[0]["viewer_can_update"] = false
+    response["items"] = items
+    let responseData = try JSONSerialization.data(withJSONObject: response)
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/sessions", body: "[]")
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/task-board/items", body: #"{"items":[]}"#)
+    ReviewsRemoteDaemonURLProtocol.respond(
+      path: "/v1/reviews/query",
+      body: String(decoding: responseData, as: UTF8.self)
+    )
+    let client = MobileRemoteDaemonSyncClient(
+      access: try reviewsRemoteAccess(),
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      defaultStation: true,
+      session: makeReviewsSession()
+    )
+
+    let fetchedSnapshot = try await client.fetchLatestSnapshot(
+      stationID: "remote-daemon-example-com",
+      now: .now
+    )
+    let attention = try XCTUnwrap(fetchedSnapshot?.attention.first)
+
+    XCTAssertNil(attention.commandKind)
+    XCTAssertNil(attention.target)
+    XCTAssertTrue(attention.commandPayload.isEmpty)
+  }
+
+  func testReadOnlyRemoteProfileDoesNotExposeReviewCommand() async throws {
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/sessions", body: "[]")
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/task-board/items", body: #"{"items":[]}"#)
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/reviews/query", body: reviewsResponse)
+    var access = try reviewsRemoteAccess()
+    access.role = .viewer
+    access.scopes = ["read"]
+    let client = MobileRemoteDaemonSyncClient(
+      access: access,
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      defaultStation: true,
+      session: makeReviewsSession()
+    )
+
+    let fetchedSnapshot = try await client.fetchLatestSnapshot(
+      stationID: "remote-daemon-example-com",
+      now: .now
+    )
+    let attention = try XCTUnwrap(fetchedSnapshot?.attention.first)
+
+    XCTAssertNil(attention.commandKind)
+    XCTAssertNil(attention.target)
+    XCTAssertTrue(attention.commandPayload.isEmpty)
+  }
+
   func testReviewsServerFailureUsesCloudFallback() async throws {
     ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/sessions", body: "[]")
     ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/task-board/items", body: #"{"items":[]}"#)
@@ -240,8 +299,8 @@ private func reviewsRemoteAccess() throws -> MobileRemoteDaemonAccess {
     clientID: "ios-device",
     displayName: "Phone",
     platform: "ios",
-    role: .viewer,
-    scopes: ["read"],
+    role: .operator,
+    scopes: ["read", "write"],
     bearerToken: "server-token",
     tokenHint: "abcd1234",
     serverSPKISHA256: try MobileRemoteDaemonSPKIPin(

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonReviewsSyncTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonReviewsSyncTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+import XCTest
+
+final class MobileRemoteDaemonReviewsSyncTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    ReviewsRemoteDaemonURLProtocol.reset()
+  }
+
+  override func tearDown() {
+    ReviewsRemoteDaemonURLProtocol.reset()
+    super.tearDown()
+  }
+
+  func testFetchPostsPairedQueryAndBuildsReviewsAndAttention() async throws {
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/sessions", body: "[]")
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/task-board/items", body: #"{"items":[]}"#)
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/reviews/query", body: reviewsResponse)
+    let client = MobileRemoteDaemonSyncClient(
+      access: try reviewsRemoteAccess(),
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      defaultStation: true,
+      session: makeReviewsSession()
+    )
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+
+    let fetchedSnapshot = try await client.fetchLatestSnapshot(
+      stationID: "remote-daemon-example-com",
+      now: now
+    )
+    let snapshot = try XCTUnwrap(fetchedSnapshot)
+
+    let request = try XCTUnwrap(
+      ReviewsRemoteDaemonURLProtocol.requests.first { $0.url?.path == "/v1/reviews/query" }
+    )
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer server-token")
+    XCTAssertEqual(
+      request.value(forHTTPHeaderField: "x-harness-remote-client-id"),
+      "ios-device"
+    )
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    let body = try XCTUnwrap(request.httpBody)
+    let query = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    XCTAssertEqual(query["organizations"] as? [String], ["smykla-skalski"])
+    XCTAssertEqual(query["repositories"] as? [String], ["smykla-skalski/harness"])
+    XCTAssertEqual(query["cache_max_age_seconds"] as? Int, 45)
+    XCTAssertEqual(query["force_refresh"] as? Bool, false)
+
+    let review = try XCTUnwrap(snapshot.reviews.first)
+    XCTAssertEqual(review.id, "pr-232")
+    XCTAssertEqual(review.stationID, "remote-daemon-example-com")
+    XCTAssertEqual(review.repository, "smykla-skalski/harness")
+    XCTAssertEqual(review.number, 232)
+    XCTAssertEqual(review.title, "Fix api_key=[redacted]")
+    XCTAssertEqual(review.author, "bart api_key=[redacted]")
+    XCTAssertEqual(review.reviewStatus, "review_required")
+    XCTAssertEqual(review.checkStatus, "failure")
+    XCTAssertEqual(review.checks.first?.name, "CI api_key=[redacted]")
+    XCTAssertEqual(review.requiredFailedCheckNames, ["CI"])
+    XCTAssertTrue(review.needsYou)
+    let attention = try XCTUnwrap(snapshot.attention.first)
+    XCTAssertEqual(attention.id, "review-pr-232")
+    XCTAssertEqual(attention.kind, .pullRequest)
+    XCTAssertEqual(attention.severity, .critical)
+    XCTAssertEqual(attention.commandKind, .pullRequestRerunChecks)
+    XCTAssertEqual(attention.target?.reviewID, "pr-232")
+    XCTAssertEqual(attention.commandPayload["repository"], "smykla-skalski/harness")
+    XCTAssertEqual(attention.commandPayload["number"], "232")
+    XCTAssertEqual(snapshot.stations.first?.needsYouCount, 1)
+    XCTAssertEqual(snapshot.needsYouCount, 1)
+  }
+
+  func testReviewsUnauthorizedFailsClosedWithoutCloudFallback() async throws {
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/sessions", body: "[]")
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/task-board/items", body: #"{"items":[]}"#)
+    ReviewsRemoteDaemonURLProtocol.respond(
+      path: "/v1/reviews/query",
+      statusCode: 401,
+      body: #"{"error":"unauthorized"}"#
+    )
+    let direct = MobileRemoteDaemonSyncClient(
+      access: try reviewsRemoteAccess(),
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      defaultStation: true,
+      session: makeReviewsSession()
+    )
+    let fallback = RecordingReviewsFallback()
+    let client = DirectFirstMobileMonitorSyncClient(direct: direct, cloudFallback: fallback)
+
+    do {
+      _ = try await client.fetchLatestSnapshot(
+        stationID: "remote-daemon-example-com",
+        now: .now
+      )
+      XCTFail("expected unauthorized response")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .unauthorized)
+    }
+
+    let fallbackFetchCount = await fallback.fetchCount()
+    XCTAssertEqual(fallbackFetchCount, 0)
+  }
+
+  func testReviewsServerFailureUsesCloudFallback() async throws {
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/sessions", body: "[]")
+    ReviewsRemoteDaemonURLProtocol.respond(path: "/v1/task-board/items", body: #"{"items":[]}"#)
+    ReviewsRemoteDaemonURLProtocol.respond(
+      path: "/v1/reviews/query",
+      statusCode: 503,
+      body: #"{"error":"unavailable"}"#
+    )
+    let direct = MobileRemoteDaemonSyncClient(
+      access: try reviewsRemoteAccess(),
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      defaultStation: true,
+      session: makeReviewsSession()
+    )
+    let fallback = RecordingReviewsFallback()
+    let client = DirectFirstMobileMonitorSyncClient(direct: direct, cloudFallback: fallback)
+
+    let snapshot = try await client.fetchLatestSnapshot(
+      stationID: "remote-daemon-example-com",
+      now: .now
+    )
+
+    XCTAssertNotNil(snapshot)
+    let fallbackFetchCount = await fallback.fetchCount()
+    XCTAssertEqual(fallbackFetchCount, 1)
+  }
+}
+
+private actor RecordingReviewsFallback: MobileMonitorSyncClient {
+  private var fetches = 0
+
+  func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot? {
+    fetches += 1
+    return .empty(now: now)
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    MobileCommandSubmission(command: command)
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func fetchCount() -> Int { fetches }
+}
+
+private final class ReviewsRemoteDaemonURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var responses: [String: (Int, Data)] = [:]
+  nonisolated(unsafe) private static var capturedRequests: [URLRequest] = []
+
+  static var requests: [URLRequest] {
+    lock.withLock { capturedRequests }
+  }
+
+  static func reset() {
+    lock.withLock {
+      responses = [:]
+      capturedRequests = []
+    }
+  }
+
+  static func respond(path: String, statusCode: Int = 200, body: String) {
+    lock.withLock {
+      responses[path] = (statusCode, Data(body.utf8))
+    }
+  }
+
+  override static func canInit(with request: URLRequest) -> Bool { true }
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    var capturedRequest = request
+    capturedRequest.httpBody = request.httpBody ?? request.httpBodyStream.flatMap(Self.readBodyStream)
+    let response = Self.lock.withLock { () -> (Int, Data) in
+      Self.capturedRequests.append(capturedRequest)
+      return Self.responses[request.url?.path ?? ""] ?? (404, Data())
+    }
+    guard let url = request.url,
+      let httpResponse = HTTPURLResponse(
+        url: url,
+        statusCode: response.0,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+    client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: response.1)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+
+  private static func readBodyStream(_ stream: InputStream) -> Data? {
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 1_024)
+    while stream.hasBytesAvailable {
+      let count = stream.read(&buffer, maxLength: buffer.count)
+      guard count >= 0 else { return nil }
+      if count == 0 { break }
+      data.append(buffer, count: count)
+    }
+    return data
+  }
+}
+
+private func makeReviewsSession() -> URLSession {
+  let configuration = URLSessionConfiguration.ephemeral
+  configuration.protocolClasses = [ReviewsRemoteDaemonURLProtocol.self]
+  return URLSession(configuration: configuration)
+}
+
+private func reviewsRemoteAccess() throws -> MobileRemoteDaemonAccess {
+  MobileRemoteDaemonAccess(
+    endpoint: URL(string: "https://daemon.example.com")!,
+    clientID: "ios-device",
+    displayName: "Phone",
+    platform: "ios",
+    role: .viewer,
+    scopes: ["read"],
+    bearerToken: "server-token",
+    tokenHint: "abcd1234",
+    serverSPKISHA256: try MobileRemoteDaemonSPKIPin(
+      validating: "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+    ),
+    pairedAt: .now,
+    reviewsQuery: MobileRemoteDaemonReviewsQuery(
+      organizations: ["smykla-skalski"],
+      repositories: ["smykla-skalski/harness"],
+      cacheMaxAgeSeconds: 45
+    )
+  )
+}
+
+private let reviewsResponse = """
+  {
+    "fetched_at": "2026-07-12T18:00:00Z",
+    "from_cache": false,
+    "summary": {
+      "total": 1,
+      "review_required": 1,
+      "ready_to_merge": 0,
+      "auto_approvable": 0,
+      "waiting_on_checks": 0,
+      "blocked": 1
+    },
+    "items": [
+      {
+        "pull_request_id": "pr-232",
+        "repository_id": "R_harness",
+        "repository": "smykla-skalski/harness",
+        "number": 232,
+        "title": "Fix api_key=super-secret",
+        "url": "https://github.com/smykla-skalski/harness/pull/232",
+        "author_login": "bart api_key=super-secret",
+        "state": "open",
+        "mergeable": "mergeable",
+        "review_status": "review_required",
+        "check_status": "failure",
+        "is_draft": false,
+        "policy_blocked": false,
+        "viewer_can_update": true,
+        "viewer_is_requested_reviewer": true,
+        "viewer_can_merge_as_admin": true,
+        "head_sha": "abc123",
+        "labels": ["bug"],
+        "checks": [
+          {
+            "name": "CI api_key=super-secret",
+            "status": "completed",
+            "conclusion": "failure",
+            "check_suite_id": "42",
+            "details_url": "https://ci.example.com/run/42"
+          }
+        ],
+        "reviews": [],
+        "additions": 12,
+        "deletions": 4,
+        "created_at": "2026-07-12T17:00:00Z",
+        "updated_at": "2026-07-12T18:01:00.250Z",
+        "required_failed_check_names": ["CI"]
+      }
+    ]
+  }
+  """


### PR DESCRIPTION
## Motivation
Remote iPhone and watch clients can fetch sessions and task-board items, but they still cannot consume Reviews because the paired server query from #232 is not stored or executed. That leaves the Reviews tab and review attention empty on the direct internet path.

## Implementation
- Decode and validate the optional server-owned Reviews query during remote claim, then persist it in the Keychain-backed credential.
- Carry the profile through direct watch pairing and WatchConnectivity, including query-only change detection.
- POST the paired query to /v1/reviews/query with pinned authenticated transport and project reviews into the shared mobile snapshot.
- Build review attention, station counts, redacted display fields, and fresh command targets while preserving 401/403 fail-closed and 5xx CloudMirror fallback behavior.
- Preserve credentials and claims created before Reviews profiles existed.
- Proof: 31 focused Crypto pairing and watch tests, 12 focused direct-sync tests, monitor:lint, HarnessMonitorMobile iOS Simulator build, HarnessMonitorWatch watchOS Simulator build, and monitor:quality-gate.