### PR TITLE
feat(mobile): sync remote managed agents

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonAgentWire.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonAgentWire.swift
@@ -1,0 +1,276 @@
+import Foundation
+import HarnessMonitorCore
+
+struct MobileRemoteManagedAgentListWire: Decodable, Sendable {
+  var agents: [MobileRemoteManagedAgentWire]
+}
+
+enum MobileRemoteManagedAgentWire: Decodable, Sendable {
+  case terminal(MobileRemoteTerminalAgentWire)
+  case codex(MobileRemoteCodexAgentWire)
+  case acp(MobileRemoteAcpAgentWire)
+
+  var managedAgentID: String {
+    switch self {
+    case .terminal(let agent): agent.id
+    case .codex(let agent): agent.id
+    case .acp(let agent): agent.id
+    }
+  }
+
+  var permissionBatches: [MobileRemoteAcpPermissionBatchWire] {
+    guard case .acp(let agent) = self else {
+      return []
+    }
+    return agent.permissionBatches
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    switch try container.decode(String.self, forKey: .kind) {
+    case "terminal":
+      self = .terminal(try container.decode(MobileRemoteTerminalAgentWire.self, forKey: .snapshot))
+    case "codex":
+      self = .codex(try container.decode(MobileRemoteCodexAgentWire.self, forKey: .snapshot))
+    case "acp":
+      self = .acp(try container.decode(MobileRemoteAcpAgentWire.self, forKey: .snapshot))
+    case let kind:
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "unknown remote managed-agent kind \(kind)"
+      )
+    }
+  }
+
+  func mobileSummary(
+    stationID: String,
+    now: Date,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileAgentSummary {
+    switch self {
+    case .terminal(let agent):
+      agent.mobileSummary(stationID: stationID, now: now, redactor: redactor)
+    case .codex(let agent):
+      agent.mobileSummary(stationID: stationID, now: now, redactor: redactor)
+    case .acp(let agent):
+      agent.mobileSummary(stationID: stationID, now: now, redactor: redactor)
+    }
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case kind
+    case snapshot
+  }
+}
+
+struct MobileRemoteTerminalAgentWire: Decodable, Sendable {
+  var id: String
+  var sessionID: String
+  var agentID: String
+  var runtime: String
+  var status: String
+  var projectDir: String
+  var error: String?
+  var updatedAt: String
+
+  func mobileSummary(
+    stationID: String,
+    now: Date,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileAgentSummary {
+    MobileAgentSummary(
+      id: id,
+      stationID: stationID,
+      sessionID: sessionID,
+      displayName: redactor.redact("\(runtime) \(agentID)"),
+      family: .terminal,
+      status: status.remoteAgentStatusTitle,
+      isActive: ["starting", "running"].contains(status),
+      isBlocked: status == "failed",
+      lastActivityAt: MobileRemoteSessionDate.parse(updatedAt) ?? now,
+      summary: redactor.redact(error ?? projectDir)
+    )
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id = "tui_id"
+    case sessionID = "session_id"
+    case agentID = "agent_id"
+    case runtime
+    case status
+    case projectDir = "project_dir"
+    case error
+    case updatedAt = "updated_at"
+  }
+}
+
+struct MobileRemoteCodexAgentWire: Decodable, Sendable {
+  var id: String
+  var sessionID: String
+  var displayName: String?
+  var projectDir: String
+  var status: String
+  var prompt: String
+  var latestSummary: String?
+  var finalMessage: String?
+  var error: String?
+  var pendingApprovalCount: Int
+  var updatedAt: String
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    sessionID = try container.decode(String.self, forKey: .sessionID)
+    displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
+    projectDir = try container.decode(String.self, forKey: .projectDir)
+    status = try container.decode(String.self, forKey: .status)
+    prompt = try container.decode(String.self, forKey: .prompt)
+    latestSummary = try container.decodeIfPresent(String.self, forKey: .latestSummary)
+    finalMessage = try container.decodeIfPresent(String.self, forKey: .finalMessage)
+    error = try container.decodeIfPresent(String.self, forKey: .error)
+    pendingApprovalCount =
+      try container.decodeIfPresent(
+        [MobileRemoteIgnoredWire].self,
+        forKey: .pendingApprovals
+      )?.count ?? 0
+    updatedAt = try container.decode(String.self, forKey: .updatedAt)
+  }
+
+  func mobileSummary(
+    stationID: String,
+    now: Date,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileAgentSummary {
+    MobileAgentSummary(
+      id: id,
+      stationID: stationID,
+      sessionID: sessionID,
+      displayName: redactor.redact(displayName ?? id),
+      family: .codex,
+      status: status.remoteAgentStatusTitle,
+      isActive: ["queued", "running", "waiting_approval"].contains(status),
+      isBlocked: status == "waiting_approval" || pendingApprovalCount > 0 || status == "failed",
+      pendingApprovalCount: pendingApprovalCount,
+      lastActivityAt: MobileRemoteSessionDate.parse(updatedAt) ?? now,
+      summary: redactor.redact(latestSummary ?? finalMessage ?? error ?? prompt)
+    )
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id = "run_id"
+    case sessionID = "session_id"
+    case displayName = "display_name"
+    case projectDir = "project_dir"
+    case status
+    case prompt
+    case latestSummary = "latest_summary"
+    case finalMessage = "final_message"
+    case error
+    case pendingApprovals = "pending_approvals"
+    case updatedAt = "updated_at"
+  }
+}
+
+struct MobileRemoteAcpAgentWire: Decodable, Sendable {
+  var id: String
+  var sessionID: String
+  var displayName: String
+  var status: MobileRemoteAcpStatusWire
+  var projectDir: String
+  var pendingPermissions: Int
+  var permissionBatches: [MobileRemoteAcpPermissionBatchWire]
+  var updatedAt: String
+
+  func mobileSummary(
+    stationID: String,
+    now: Date,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileAgentSummary {
+    MobileAgentSummary(
+      id: id,
+      stationID: stationID,
+      sessionID: sessionID,
+      displayName: redactor.redact(displayName),
+      family: .acp,
+      status: status.value.remoteAgentStatusTitle,
+      isActive: status.value == "active",
+      isBlocked: pendingPermissions > 0 || status.value == "awaiting_review",
+      pendingPermissionCount: pendingPermissions,
+      lastActivityAt: MobileRemoteSessionDate.parse(updatedAt) ?? now,
+      summary: redactor.redact(status.stderrTail ?? projectDir)
+    )
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id = "managed_agent_id"
+    case sessionID = "session_id"
+    case displayName = "display_name"
+    case status
+    case projectDir = "project_dir"
+    case pendingPermissions = "pending_permissions"
+    case permissionBatches = "pending_permission_batches"
+    case updatedAt = "updated_at"
+  }
+}
+
+struct MobileRemoteAcpPermissionBatchWire: Decodable, Sendable {
+  var batchID: String
+  var managedAgentID: String
+  var sessionID: String
+  var requestCount: Int
+  var createdAt: String
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    batchID = try container.decode(String.self, forKey: .batchID)
+    managedAgentID = try container.decode(String.self, forKey: .managedAgentID)
+    sessionID = try container.decode(String.self, forKey: .sessionID)
+    requestCount =
+      try container.decodeIfPresent(
+        [MobileRemoteIgnoredWire].self,
+        forKey: .requests
+      )?.count ?? 0
+    createdAt = try container.decode(String.self, forKey: .createdAt)
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case batchID = "batch_id"
+    case managedAgentID = "managed_agent_id"
+    case sessionID = "session_id"
+    case requests
+    case createdAt = "created_at"
+  }
+}
+
+struct MobileRemoteAcpStatusWire: Decodable, Sendable {
+  var value: String
+  var stderrTail: String?
+
+  init(from decoder: any Decoder) throws {
+    let single = try decoder.singleValueContainer()
+    if let value = try? single.decode(String.self) {
+      self.value = value
+      stderrTail = nil
+      return
+    }
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    value = try container.decode(String.self, forKey: .value)
+    stderrTail = try container.decodeIfPresent(String.self, forKey: .stderrTail)
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case value = "state"
+    case stderrTail = "stderr_tail"
+  }
+}
+
+private struct MobileRemoteIgnoredWire: Decodable, Sendable {
+  init(from _: any Decoder) throws {}
+}
+
+extension String {
+  fileprivate var remoteAgentStatusTitle: String {
+    replacingOccurrences(of: "_", with: " ").capitalized
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonAgentsSnapshot.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonAgentsSnapshot.swift
@@ -51,9 +51,10 @@ extension MobileRemoteDaemonSyncClient {
   private func fetchManagedAgentWires(
     for sessions: [MobileRemoteManagedAgentsSession]
   ) async throws -> [String: [MobileRemoteManagedAgentWire]] {
+    let batchSize = 6
     var agentsBySessionID: [String: [MobileRemoteManagedAgentWire]] = [:]
-    for startIndex in stride(from: 0, to: sessions.count, by: 6) {
-      let endIndex = min(startIndex + 6, sessions.count)
+    for startIndex in stride(from: 0, to: sessions.count, by: batchSize) {
+      let endIndex = min(startIndex + batchSize, sessions.count)
       let batch = sessions[startIndex..<endIndex]
       try await withThrowingTaskGroup(of: MobileRemoteManagedAgentsFetchResult.self) { group in
         for session in batch {

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonAgentsSnapshot.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonAgentsSnapshot.swift
@@ -1,0 +1,199 @@
+import Foundation
+import HarnessMonitorCore
+
+struct MobileRemoteManagedAgentsSnapshot: Sendable {
+  var agentsBySessionID: [String: [MobileAgentSummary]]
+  var attention: [MobileAttentionItem]
+}
+
+struct MobileRemoteManagedAgentsSession: Sendable {
+  var id: String
+  var title: String
+}
+
+private struct MobileRemoteManagedAgentsFetchResult: Sendable {
+  var sessionID: String
+  var agents: [MobileRemoteManagedAgentWire]
+}
+
+extension MobileRemoteDaemonSyncClient {
+  func fetchManagedAgentsSnapshot(
+    for sessions: [MobileRemoteManagedAgentsSession],
+    now: Date
+  ) async throws -> MobileRemoteManagedAgentsSnapshot {
+    let wiresBySessionID = try await fetchManagedAgentWires(for: sessions)
+    let redactor = MobileMirrorSecretRedactor()
+    var agentsBySessionID: [String: [MobileAgentSummary]] = [:]
+    var attention: [MobileAttentionItem] = []
+    for session in sessions {
+      let wires = wiresBySessionID[session.id] ?? []
+      let agents = wires.map {
+        $0.mobileSummary(stationID: stationID, now: now, redactor: redactor)
+      }
+      .sorted(by: Self.sortManagedAgents)
+      agentsBySessionID[session.id] = agents
+      attention.append(
+        contentsOf: managedAgentAttention(
+          wires: wires,
+          agents: agents,
+          session: session,
+          now: now,
+          redactor: redactor
+        )
+      )
+    }
+    return MobileRemoteManagedAgentsSnapshot(
+      agentsBySessionID: agentsBySessionID,
+      attention: attention
+    )
+  }
+
+  private func fetchManagedAgentWires(
+    for sessions: [MobileRemoteManagedAgentsSession]
+  ) async throws -> [String: [MobileRemoteManagedAgentWire]] {
+    var agentsBySessionID: [String: [MobileRemoteManagedAgentWire]] = [:]
+    for startIndex in stride(from: 0, to: sessions.count, by: 6) {
+      let endIndex = min(startIndex + 6, sessions.count)
+      let batch = sessions[startIndex..<endIndex]
+      try await withThrowingTaskGroup(of: MobileRemoteManagedAgentsFetchResult.self) { group in
+        for session in batch {
+          group.addTask {
+            MobileRemoteManagedAgentsFetchResult(
+              sessionID: session.id,
+              agents: try await fetchManagedAgents(sessionID: session.id)
+            )
+          }
+        }
+        for try await result in group {
+          agentsBySessionID[result.sessionID] = result.agents
+        }
+      }
+    }
+    return agentsBySessionID
+  }
+
+  private func fetchManagedAgents(
+    sessionID: String
+  ) async throws -> [MobileRemoteManagedAgentWire] {
+    let path = "/v1/sessions/\(try sessionID.remotePathComponent())/managed-agents"
+    var request = try authenticatedRequest(path: path, method: "GET")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw MobileRemoteDaemonSyncError.invalidResponse
+    }
+    guard response.statusCode != 404 else {
+      return []
+    }
+    try validate(response)
+    return try JSONDecoder().decode(MobileRemoteManagedAgentListWire.self, from: data).agents
+  }
+
+  private func managedAgentAttention(
+    wires: [MobileRemoteManagedAgentWire],
+    agents: [MobileAgentSummary],
+    session: MobileRemoteManagedAgentsSession,
+    now: Date,
+    redactor: MobileMirrorSecretRedactor
+  ) -> [MobileAttentionItem] {
+    var agentsByID: [String: MobileAgentSummary] = [:]
+    for agent in agents {
+      agentsByID[agent.id] = agent
+    }
+    return wires.flatMap { wire -> [MobileAttentionItem] in
+      guard let agent = agentsByID[wire.managedAgentID] else {
+        return []
+      }
+      let permissions = wire.permissionBatches
+      if !permissions.isEmpty {
+        return permissions.map {
+          permissionAttention(
+            batch: $0,
+            agent: agent,
+            session: session,
+            now: now,
+            redactor: redactor
+          )
+        }
+      }
+      return agent.isBlocked
+        ? [blockedAgentAttention(agent: agent, session: session, redactor: redactor)]
+        : []
+    }
+  }
+
+  private func permissionAttention(
+    batch: MobileRemoteAcpPermissionBatchWire,
+    agent: MobileAgentSummary,
+    session: MobileRemoteManagedAgentsSession,
+    now: Date,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileAttentionItem {
+    let exposesCommand = access.canWrite
+    let requestLabel = batch.requestCount == 1 ? "request" : "requests"
+    return MobileAttentionItem(
+      id: "acp-\(batch.batchID)",
+      stationID: stationID,
+      kind: .acpDecision,
+      severity: .critical,
+      title: redactor.redact("Permission requested by \(agent.displayName)"),
+      subtitle: redactor.redact(
+        "\(batch.requestCount) \(requestLabel) waiting in \(session.title)."
+      ),
+      updatedAt: MobileRemoteSessionDate.parse(batch.createdAt) ?? now,
+      commandKind: exposesCommand ? .acpPermissionDecision : nil,
+      target: MobileCommandTarget(
+        stationID: stationID,
+        sessionID: batch.sessionID,
+        agentID: batch.managedAgentID,
+        targetRevision: 0
+      ),
+      commandPayload: exposesCommand
+        ? ["batchID": batch.batchID, "decision": "approve_all"]
+        : [:]
+    )
+  }
+
+  private func blockedAgentAttention(
+    agent: MobileAgentSummary,
+    session: MobileRemoteManagedAgentsSession,
+    redactor: MobileMirrorSecretRedactor
+  ) -> MobileAttentionItem {
+    let exposesCommand = access.canWrite && agent.isActive
+    return MobileAttentionItem(
+      id: "blocked-\(agent.id)",
+      stationID: stationID,
+      kind: .blockedAgent,
+      severity: .warning,
+      title: redactor.redact("\(agent.displayName) is waiting"),
+      subtitle: redactor.redact(session.title),
+      updatedAt: agent.lastActivityAt,
+      commandKind: exposesCommand ? .agentPrompt : nil,
+      target: MobileCommandTarget(
+        stationID: stationID,
+        sessionID: agent.sessionID,
+        agentID: agent.id,
+        targetRevision: 0
+      ),
+      commandPayload: exposesCommand
+        ? ["prompt": "Please summarize what you need from me."]
+        : [:]
+    )
+  }
+
+  private static func sortManagedAgents(
+    _ lhs: MobileAgentSummary,
+    _ rhs: MobileAgentSummary
+  ) -> Bool {
+    if lhs.isBlocked != rhs.isBlocked {
+      return lhs.isBlocked && !rhs.isBlocked
+    }
+    if lhs.isActive != rhs.isActive {
+      return lhs.isActive && !rhs.isActive
+    }
+    if lhs.lastActivityAt != rhs.lastActivityAt {
+      return lhs.lastActivityAt > rhs.lastActivityAt
+    }
+    return lhs.id < rhs.id
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewsSnapshot.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonReviewsSnapshot.swift
@@ -177,14 +177,11 @@ extension MobileReviewSummary {
       exposesCommand
       ? (checkStatus == "failure" ? .pullRequestRerunChecks : .pullRequestApprove)
       : nil
-    let target =
-      exposesCommand
-      ? MobileCommandTarget(
-        stationID: stationID,
-        reviewID: id,
-        targetRevision: 0
-      )
-      : nil
+    let target = MobileCommandTarget(
+      stationID: stationID,
+      reviewID: id,
+      targetRevision: 0
+    )
     let commandPayload =
       exposesCommand
       ? [

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
@@ -52,13 +52,18 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
     guard stationID == self.stationID else {
       throw MobileRemoteDaemonSyncError.stationMismatch
     }
-    async let sessions = fetchSessions()
     async let taskBoardItems = fetchTaskBoardItems()
     async let reviewsSnapshot = fetchReviewsSnapshot(now: now)
+    let sessions = try await fetchSessions()
+    async let managedAgentsSnapshot = fetchManagedAgentsSnapshot(
+      for: sessions.compactMap(\.managedAgentsSession),
+      now: now
+    )
     return try await makeSnapshot(
       sessions: sessions,
       taskBoardItems: taskBoardItems,
       reviewsSnapshot: reviewsSnapshot,
+      managedAgentsSnapshot: managedAgentsSnapshot,
       now: now
     )
   }
@@ -102,43 +107,46 @@ public struct MobileRemoteDaemonSyncClient: MobileMonitorSyncClient, Sendable {
     sessions: [MobileRemoteSessionWire],
     taskBoardItems: [MobileRemoteTaskBoardWire],
     reviewsSnapshot: MobileRemoteReviewsSnapshot,
+    managedAgentsSnapshot: MobileRemoteManagedAgentsSnapshot,
     now: Date
   ) -> MobileMirrorSnapshot {
     let redactor = MobileMirrorSecretRedactor()
     let mobileSessions = sessions.map {
-      $0.mobileSummary(stationID: stationID, now: now, redactor: redactor)
+      $0.mobileSummary(
+        stationID: stationID,
+        agents: managedAgentsSnapshot.agentsBySessionID[$0.sessionID] ?? [],
+        now: now,
+        redactor: redactor
+      )
     }
     let mobileTaskBoardItems = taskBoardItems.map {
       $0.mobileSummary(stationID: stationID, now: now, redactor: redactor)
     }
     let activeSessions = sessions.filter { $0.status != "ended" }
-    let sessionNeedsYouCount = sessions.count(where: { $0.metrics.awaitingReviewAgentCount > 0 })
-    let needsYouCount =
-      sessionNeedsYouCount
-      + mobileTaskBoardItems.count(where: \.needsYou)
-      + reviewsSnapshot.reviews.count(where: \.needsYou)
     let station = MobileStationSummary(
       id: stationID,
       displayName: stationName,
       state: .online,
       lastSeenAt: now,
       activeSessionCount: activeSessions.count,
-      needsYouCount: needsYouCount,
+      needsYouCount: 0,
       commandQueueCount: 0,
       defaultStation: defaultStation
     )
-    return MobileMirrorSnapshot(
+    var snapshot = MobileMirrorSnapshot(
       revision: 0,
       generatedAt: now,
       expiresAt: now.addingTimeInterval(60),
       stations: [station],
-      attention: reviewsSnapshot.attention,
+      attention: managedAgentsSnapshot.attention + reviewsSnapshot.attention,
       sessions: mobileSessions,
       reviews: reviewsSnapshot.reviews,
       taskBoardItems: mobileTaskBoardItems,
       commands: [],
       trustedDevices: []
     )
+    snapshot.stations[0].needsYouCount = snapshot.needsYouCount
+    return snapshot
   }
 }
 
@@ -154,6 +162,7 @@ private struct MobileRemoteSessionWire: Decodable, Sendable {
 
   func mobileSummary(
     stationID: String,
+    agents: [MobileAgentSummary],
     now: Date,
     redactor: MobileMirrorSecretRedactor
   ) -> MobileSessionSummary {
@@ -167,8 +176,16 @@ private struct MobileRemoteSessionWire: Decodable, Sendable {
       activeAgentCount: metrics.activeAgentCount,
       blockedAgentCount: metrics.awaitingReviewAgentCount,
       lastActivityAt: MobileRemoteSessionDate.parse(lastActivityAt ?? updatedAt) ?? now,
-      summary: MobileRemoteSessionSummaryText.make(metrics: metrics)
+      summary: MobileRemoteSessionSummaryText.make(metrics: metrics),
+      agents: agents
     )
+  }
+
+  var managedAgentsSession: MobileRemoteManagedAgentsSession? {
+    guard status != "ended" else {
+      return nil
+    }
+    return MobileRemoteManagedAgentsSession(id: sessionID, title: title)
   }
 
   enum CodingKeys: String, CodingKey {

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonSyncClient.swift
@@ -170,7 +170,7 @@ private struct MobileRemoteSessionWire: Decodable, Sendable {
       id: sessionID,
       stationID: stationID,
       projectName: redactor.redact(projectName),
-      title: title.isEmpty ? "(untitled)" : redactor.redact(title),
+      title: redactor.redact(displayTitle),
       branch: redactor.redact(branchRef),
       status: MobileRemoteSessionStatus.title(for: status),
       activeAgentCount: metrics.activeAgentCount,
@@ -185,8 +185,10 @@ private struct MobileRemoteSessionWire: Decodable, Sendable {
     guard status != "ended" else {
       return nil
     }
-    return MobileRemoteManagedAgentsSession(id: sessionID, title: title)
+    return MobileRemoteManagedAgentsSession(id: sessionID, title: displayTitle)
   }
+
+  private var displayTitle: String { title.isEmpty ? "(untitled)" : title }
 
   enum CodingKeys: String, CodingKey {
     case projectName = "project_name"

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonAgentsSyncTestSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonAgentsSyncTestSupport.swift
@@ -1,0 +1,201 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+
+let agentsStationID = "remote-daemon-example-com"
+
+func configureAgentsBaseResponses() {
+  AgentsRemoteDaemonURLProtocol.respond(path: "/v1/sessions", body: agentsSessionsResponse)
+  AgentsRemoteDaemonURLProtocol.respond(
+    path: "/v1/task-board/items",
+    body: #"{"items":[]}"#
+  )
+}
+
+func makeAgentsRemoteClient(canWrite: Bool) throws -> MobileRemoteDaemonSyncClient {
+  let access = MobileRemoteDaemonAccess(
+    endpoint: URL(string: "https://daemon.example.com")!,
+    clientID: "ios-device",
+    displayName: "Phone",
+    platform: "ios",
+    role: canWrite ? .operator : .viewer,
+    scopes: canWrite ? ["read", "write"] : ["read"],
+    bearerToken: "server-token",
+    tokenHint: "abcd1234",
+    serverSPKISHA256: try MobileRemoteDaemonSPKIPin(
+      validating: "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+    ),
+    pairedAt: .now
+  )
+  let configuration = URLSessionConfiguration.ephemeral
+  configuration.protocolClasses = [AgentsRemoteDaemonURLProtocol.self]
+  return MobileRemoteDaemonSyncClient(
+    access: access,
+    stationID: agentsStationID,
+    stationName: "daemon.example.com",
+    defaultStation: true,
+    session: URLSession(configuration: configuration)
+  )
+}
+
+actor RecordingAgentsFallback: MobileMonitorSyncClient {
+  private var fetches = 0
+
+  func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot? {
+    fetches += 1
+    return .empty(now: now)
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    MobileCommandSubmission(command: command)
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func fetchCount() -> Int { fetches }
+}
+
+final class AgentsRemoteDaemonURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var responses: [String: (Int, Data)] = [:]
+  nonisolated(unsafe) private static var capturedRequests: [URLRequest] = []
+
+  static var requests: [URLRequest] {
+    lock.withLock { capturedRequests }
+  }
+
+  static func reset() {
+    lock.withLock {
+      responses = [:]
+      capturedRequests = []
+    }
+  }
+
+  static func respond(path: String, statusCode: Int = 200, body: String) {
+    lock.withLock {
+      responses[path] = (statusCode, Data(body.utf8))
+    }
+  }
+
+  override static func canInit(with request: URLRequest) -> Bool { true }
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let response = Self.lock.withLock { () -> (Int, Data) in
+      Self.capturedRequests.append(request)
+      return Self.responses[request.url?.path ?? ""] ?? (404, Data())
+    }
+    guard let url = request.url,
+      let httpResponse = HTTPURLResponse(
+        url: url,
+        statusCode: response.0,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+    client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: response.1)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
+let agentsSessionsResponse = """
+  [
+    {
+      "project_name": "Harness",
+      "session_id": "session-1",
+      "title": "Remote session api_key=super-secret",
+      "branch_ref": "main",
+      "status": "active",
+      "updated_at": "2026-07-10T13:00:00Z",
+      "last_activity_at": "2026-07-10T13:01:00.250Z",
+      "metrics": {
+        "active_agent_count": 3,
+        "awaiting_review_agent_count": 2
+      }
+    },
+    {
+      "project_name": "Harness",
+      "session_id": "session-ended",
+      "title": "Ended session",
+      "branch_ref": "done",
+      "status": "ended",
+      "updated_at": "2026-07-09T13:00:00Z",
+      "metrics": {}
+    }
+  ]
+  """
+
+let managedAgentsResponse = """
+  {
+    "agents": [
+      {
+        "kind": "terminal",
+        "snapshot": {
+          "tui_id": "terminal-1",
+          "session_id": "session-1",
+          "agent_id": "worker-1",
+          "runtime": "codex",
+          "status": "running",
+          "project_dir": "/tmp/api_key=super-secret",
+          "error": null,
+          "updated_at": "2026-07-10T13:01:00Z"
+        }
+      },
+      {
+        "kind": "codex",
+        "snapshot": {
+          "run_id": "codex-1",
+          "session_id": "session-1",
+          "display_name": "Reviewer api_key=super-secret",
+          "project_dir": "/tmp/project",
+          "status": "waiting_approval",
+          "prompt": "api_key=super-secret review this",
+          "latest_summary": "Waiting for api_key=super-secret",
+          "final_message": null,
+          "error": null,
+          "pending_approvals": [{ "approval_id": "approval-1" }],
+          "updated_at": "2026-07-10T13:02:00Z"
+        }
+      },
+      {
+        "kind": "acp",
+        "snapshot": {
+          "managed_agent_id": "acp-1",
+          "session_id": "session-1",
+          "session_agent_id": "worker-2",
+          "display_name": "ACP api_key=super-secret",
+          "status": "active",
+          "project_dir": "/tmp/api_key=super-secret",
+          "pending_permissions": 2,
+          "pending_permission_batches": [
+            {
+              "batch_id": "batch-1",
+              "managed_agent_id": "acp-1",
+              "session_id": "session-1",
+              "requests": [{ "request_id": "one" }, { "request_id": "two" }],
+              "created_at": "2026-07-10T13:03:00Z"
+            }
+          ],
+          "updated_at": "2026-07-10T13:03:00Z"
+        }
+      }
+    ]
+  }
+  """

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonAgentsSyncTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonAgentsSyncTests.swift
@@ -122,6 +122,44 @@ final class MobileRemoteDaemonAgentsSyncTests: XCTestCase {
     XCTAssertEqual(snapshot.sortedAttention.count, 2)
   }
 
+  func testEmptySessionTitleUsesUntitledAttentionLabel() async throws {
+    var sessions = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: Data(agentsSessionsResponse.utf8))
+        as? [[String: Any]]
+    )
+    sessions[0]["title"] = ""
+    let sessionsData = try JSONSerialization.data(withJSONObject: sessions)
+    AgentsRemoteDaemonURLProtocol.respond(
+      path: "/v1/sessions",
+      body: String(decoding: sessionsData, as: UTF8.self)
+    )
+    AgentsRemoteDaemonURLProtocol.respond(
+      path: "/v1/task-board/items",
+      body: #"{"items":[]}"#
+    )
+    AgentsRemoteDaemonURLProtocol.respond(
+      path: "/v1/sessions/session-1/managed-agents",
+      body: managedAgentsResponse
+    )
+    let client = try makeAgentsRemoteClient(canWrite: true)
+
+    let fetchedSnapshot = try await client.fetchLatestSnapshot(
+      stationID: agentsStationID,
+      now: Date(timeIntervalSince1970: 1_752_124_400)
+    )
+    let snapshot = try XCTUnwrap(fetchedSnapshot)
+
+    XCTAssertEqual(snapshot.sessions.first?.title, "(untitled)")
+    XCTAssertEqual(
+      snapshot.attention.first { $0.kind == .acpDecision }?.subtitle,
+      "2 requests waiting in (untitled)."
+    )
+    XCTAssertEqual(
+      snapshot.attention.first { $0.kind == .blockedAgent }?.subtitle,
+      "(untitled)"
+    )
+  }
+
   func testMissingManagedAgentsRouteKeepsRemoteSessionsAvailable() async throws {
     configureAgentsBaseResponses()
     AgentsRemoteDaemonURLProtocol.respond(

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonAgentsSyncTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonAgentsSyncTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorMirrorStore
+import XCTest
+
+final class MobileRemoteDaemonAgentsSyncTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    AgentsRemoteDaemonURLProtocol.reset()
+  }
+
+  override func tearDown() {
+    AgentsRemoteDaemonURLProtocol.reset()
+    super.tearDown()
+  }
+
+  func testFetchIncludesAuthenticatedManagedAgentsAndAttention() async throws {
+    configureAgentsBaseResponses()
+    AgentsRemoteDaemonURLProtocol.respond(
+      path: "/v1/sessions/session-1/managed-agents",
+      body: managedAgentsResponse
+    )
+    let client = try makeAgentsRemoteClient(canWrite: true)
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+
+    let fetchedSnapshot = try await client.fetchLatestSnapshot(
+      stationID: agentsStationID,
+      now: now
+    )
+    let snapshot = try XCTUnwrap(fetchedSnapshot)
+
+    let paths = AgentsRemoteDaemonURLProtocol.requests.compactMap(\.url?.path).sorted()
+    XCTAssertEqual(paths, [
+      "/v1/sessions",
+      "/v1/sessions/session-1/managed-agents",
+      "/v1/task-board/items",
+    ])
+    XCTAssertFalse(paths.contains("/v1/sessions/session-ended/managed-agents"))
+    for request in AgentsRemoteDaemonURLProtocol.requests {
+      XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer server-token")
+      XCTAssertEqual(
+        request.value(forHTTPHeaderField: "x-harness-remote-client-id"),
+        "ios-device"
+      )
+    }
+
+    let session = try XCTUnwrap(snapshot.sessions.first { $0.id == "session-1" })
+    XCTAssertEqual(session.agents.map(\.id), ["acp-1", "codex-1", "terminal-1"])
+    let terminal = try XCTUnwrap(session.agents.first { $0.family == .terminal })
+    XCTAssertEqual(terminal.displayName, "codex worker-1")
+    XCTAssertEqual(terminal.status, "Running")
+    XCTAssertTrue(terminal.isActive)
+    XCTAssertFalse(terminal.isBlocked)
+    XCTAssertTrue(terminal.summary.contains("[redacted]"))
+
+    let codex = try XCTUnwrap(session.agents.first { $0.family == .codex })
+    XCTAssertEqual(codex.displayName, "Reviewer api_key=[redacted]")
+    XCTAssertEqual(codex.status, "Waiting Approval")
+    XCTAssertTrue(codex.isActive)
+    XCTAssertTrue(codex.isBlocked)
+    XCTAssertEqual(codex.pendingApprovalCount, 1)
+    XCTAssertTrue(codex.summary.contains("[redacted]"))
+
+    let acp = try XCTUnwrap(session.agents.first { $0.family == .acp })
+    XCTAssertEqual(acp.displayName, "ACP api_key=[redacted]")
+    XCTAssertEqual(acp.status, "Active")
+    XCTAssertTrue(acp.isActive)
+    XCTAssertTrue(acp.isBlocked)
+    XCTAssertEqual(acp.pendingPermissionCount, 2)
+    XCTAssertTrue(acp.summary.contains("[redacted]"))
+
+    XCTAssertFalse(
+      session.agents.contains {
+        $0.displayName.contains("super-secret") || $0.summary.contains("super-secret")
+      }
+    )
+    let permission = try XCTUnwrap(
+      snapshot.attention.first { $0.kind == .acpDecision }
+    )
+    XCTAssertEqual(permission.commandKind, .acpPermissionDecision)
+    XCTAssertEqual(permission.target?.sessionID, "session-1")
+    XCTAssertEqual(permission.target?.agentID, "acp-1")
+    XCTAssertEqual(permission.commandPayload, [
+      "batchID": "batch-1",
+      "decision": "approve_all",
+    ])
+    XCTAssertFalse(permission.title.contains("super-secret"))
+    XCTAssertFalse(permission.subtitle.contains("super-secret"))
+
+    let blocked = try XCTUnwrap(
+      snapshot.attention.first { $0.kind == .blockedAgent }
+    )
+    XCTAssertEqual(blocked.commandKind, .agentPrompt)
+    XCTAssertEqual(blocked.target?.agentID, "codex-1")
+    XCTAssertEqual(
+      blocked.commandPayload,
+      ["prompt": "Please summarize what you need from me."]
+    )
+    XCTAssertEqual(snapshot.stations.first?.needsYouCount, 2)
+    XCTAssertEqual(snapshot.needsYouCount, 2)
+  }
+
+  func testReadOnlyProfileDoesNotExposeManagedAgentActions() async throws {
+    configureAgentsBaseResponses()
+    AgentsRemoteDaemonURLProtocol.respond(
+      path: "/v1/sessions/session-1/managed-agents",
+      body: managedAgentsResponse
+    )
+    let client = try makeAgentsRemoteClient(canWrite: false)
+
+    let fetchedSnapshot = try await client.fetchLatestSnapshot(
+      stationID: agentsStationID,
+      now: Date(timeIntervalSince1970: 1_752_124_400)
+    )
+    let snapshot = try XCTUnwrap(fetchedSnapshot)
+
+    XCTAssertEqual(snapshot.attention.count, 2)
+    XCTAssertTrue(snapshot.attention.allSatisfy { $0.commandKind == nil })
+    XCTAssertTrue(snapshot.attention.allSatisfy { $0.commandPayload.isEmpty })
+    XCTAssertTrue(snapshot.attention.allSatisfy { $0.target?.sessionID == "session-1" })
+    XCTAssertTrue(snapshot.sortedAttention.allSatisfy { $0.commandKind == nil })
+    XCTAssertEqual(snapshot.sortedAttention.count, 2)
+  }
+
+  func testMissingManagedAgentsRouteKeepsRemoteSessionsAvailable() async throws {
+    configureAgentsBaseResponses()
+    AgentsRemoteDaemonURLProtocol.respond(
+      path: "/v1/sessions/session-1/managed-agents",
+      statusCode: 404,
+      body: #"{"error":"not found"}"#
+    )
+    let client = try makeAgentsRemoteClient(canWrite: true)
+
+    let fetchedSnapshot = try await client.fetchLatestSnapshot(
+      stationID: agentsStationID,
+      now: Date(timeIntervalSince1970: 1_752_124_400)
+    )
+    let snapshot = try XCTUnwrap(fetchedSnapshot)
+
+    XCTAssertEqual(snapshot.sessions.count, 2)
+    XCTAssertTrue(snapshot.sessions.allSatisfy { $0.agents.isEmpty })
+    XCTAssertTrue(snapshot.attention.isEmpty)
+  }
+
+  func testManagedAgentsUnauthorizedFailsClosed() async throws {
+    configureAgentsBaseResponses()
+    AgentsRemoteDaemonURLProtocol.respond(
+      path: "/v1/sessions/session-1/managed-agents",
+      statusCode: 401,
+      body: #"{"error":"unauthorized"}"#
+    )
+    let client = try makeAgentsRemoteClient(canWrite: true)
+
+    do {
+      _ = try await client.fetchLatestSnapshot(stationID: agentsStationID, now: .now)
+      XCTFail("expected unauthorized error")
+    } catch let error as MobileRemoteDaemonSyncError {
+      XCTAssertEqual(error, .unauthorized)
+    }
+  }
+
+  func testManagedAgentsServerFailureUsesCloudFallback() async throws {
+    configureAgentsBaseResponses()
+    AgentsRemoteDaemonURLProtocol.respond(
+      path: "/v1/sessions/session-1/managed-agents",
+      statusCode: 503,
+      body: #"{"error":"unavailable"}"#
+    )
+    let direct = try makeAgentsRemoteClient(canWrite: true)
+    let fallback = RecordingAgentsFallback()
+    let client = DirectFirstMobileMonitorSyncClient(direct: direct, cloudFallback: fallback)
+
+    let snapshot = try await client.fetchLatestSnapshot(stationID: agentsStationID, now: .now)
+
+    XCTAssertNotNil(snapshot)
+    let fallbackFetchCount = await fallback.fetchCount()
+    XCTAssertEqual(fallbackFetchCount, 1)
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonReviewsSyncTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonReviewsSyncTests.swift
@@ -133,11 +133,14 @@ final class MobileRemoteDaemonReviewsSyncTests: XCTestCase {
       stationID: "remote-daemon-example-com",
       now: .now
     )
-    let attention = try XCTUnwrap(fetchedSnapshot?.attention.first)
+    let snapshot = try XCTUnwrap(fetchedSnapshot)
+    let attention = try XCTUnwrap(snapshot.attention.first)
 
     XCTAssertNil(attention.commandKind)
-    XCTAssertNil(attention.target)
+    XCTAssertEqual(attention.target?.reviewID, "pr-232")
     XCTAssertTrue(attention.commandPayload.isEmpty)
+    XCTAssertEqual(snapshot.sortedAttention.count, 1)
+    XCTAssertEqual(snapshot.stations.first?.needsYouCount, 1)
   }
 
   func testReadOnlyRemoteProfileDoesNotExposeReviewCommand() async throws {
@@ -159,11 +162,14 @@ final class MobileRemoteDaemonReviewsSyncTests: XCTestCase {
       stationID: "remote-daemon-example-com",
       now: .now
     )
-    let attention = try XCTUnwrap(fetchedSnapshot?.attention.first)
+    let snapshot = try XCTUnwrap(fetchedSnapshot)
+    let attention = try XCTUnwrap(snapshot.attention.first)
 
     XCTAssertNil(attention.commandKind)
-    XCTAssertNil(attention.target)
+    XCTAssertEqual(attention.target?.reviewID, "pr-232")
     XCTAssertTrue(attention.commandPayload.isEmpty)
+    XCTAssertEqual(snapshot.sortedAttention.count, 1)
+    XCTAssertEqual(snapshot.stations.first?.needsYouCount, 1)
   }
 
   func testReviewsServerFailureUsesCloudFallback() async throws {

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
@@ -91,9 +91,11 @@ final class MobileRemoteDaemonSyncClientTests: XCTestCase {
     let snapshot = try XCTUnwrap(fetchedSnapshot)
 
     let requests = RemoteDaemonSessionsURLProtocol.requests
-    XCTAssertEqual(requests.count, 2)
+    XCTAssertEqual(requests.count, 3)
     XCTAssertEqual(requests.compactMap(\.url?.path).sorted(), [
-      "/v1/sessions", "/v1/task-board/items",
+      "/v1/sessions",
+      "/v1/sessions/session-1/managed-agents",
+      "/v1/task-board/items",
     ])
     for request in requests {
       XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer server-token")

--- a/docs/agent-guides/monitor-mobile-reference.md
+++ b/docs/agent-guides/monitor-mobile-reference.md
@@ -41,7 +41,7 @@ The macOS app, the iOS app, and the watch app all share the same iCloud containe
 
 On a relay-paired device, `MobileCloudMirrorSyncClient.fetchLatestSnapshot(stationID:now:)` fetches the record(s), checks the `expiresAt` TTL (a stale record raises `MobileCloudMirrorSyncError.staleSnapshot`), decrypts and verifies the envelope with the per-station symmetric key, reassembles chunks, and returns a `MobileMirrorSnapshot`.
 
-On a remote-paired device, `MobileRemoteDaemonSyncClient.fetchLatestSnapshot(stationID:now:)` sends an authenticated `GET /v1/sessions` to the pinned endpoint and maps the daemon's secret-free session fields into the shared snapshot model. `DirectFirstMobileMonitorSyncClient` applies the fail-closed fallback policy described above. The shared `MirrorStore.refresh()` aggregates every paired station through the same `MobileMonitorSyncClient` protocol.
+On a remote-paired device, `MobileRemoteDaemonSyncClient.fetchLatestSnapshot(stationID:now:)` sends authenticated requests through the pinned endpoint for sessions, active-session managed agents, task-board items, and the paired Reviews query. It maps terminal, Codex, and ACP agents into redacted mobile session details, including role-gated ACP permission and blocked-agent attention. A missing managed-agent or task-board route remains compatible with older servers; authentication failures fail closed, while reachability and server failures follow the CloudMirror fallback policy described above. The shared `MirrorStore.refresh()` aggregates every paired station through the same `MobileMonitorSyncClient` protocol.
 
 ### Device command paths
 


### PR DESCRIPTION
## Motivation
After #233, direct remote clients can see sessions, task-board items, and Reviews, but session details still contain no managed agents. That leaves the existing iPhone and watch agent, blocked-work, and ACP permission workflows without live remote state.

## Implementation
- Fetch active-session managed-agent lists over the existing pinned authenticated transport in bounded batches.
- Map terminal, Codex, and ACP wire subsets into redacted mobile agent summaries.
- Surface ACP permission and blocked-agent attention with write-scoped actions and read-only-safe metadata.
- Keep older servers compatible on missing routes while preserving fail-closed auth and CloudMirror server-failure fallback.
- Add red-to-green tests for mapping, redaction, role gating, fallback behavior, and the expanded request contract.
- Proof: 19 focused direct-sync tests, monitor:lint, iOS Simulator build, watchOS Simulator build, and monitor:quality-gate.