### PR TITLE
fix(task-board): preserve local status during review sync

### DIFF
--- a/src/daemon/service/reviews_tests/projection.rs
+++ b/src/daemon/service/reviews_tests/projection.rs
@@ -7,8 +7,8 @@ use crate::reviews::{
     ReviewsRefreshRequest,
 };
 use crate::task_board::{
-    ExternalRef, ExternalRefProvider, TaskBoardGitHubInboxConfig, TaskBoardItem,
-    TaskBoardOrchestratorSettings, TaskBoardStatus,
+    ExternalRef, ExternalRefProvider, ExternalRefSyncState, TaskBoardGitHubInboxConfig,
+    TaskBoardItem, TaskBoardOrchestratorSettings, TaskBoardStatus,
 };
 
 use super::super::{
@@ -207,6 +207,7 @@ async fn cached_reviews_query_creates_only_matching_task_board_reviews_idempoten
     assert_eq!(revision_after_second, revision_after_first);
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].title, "Review acme/api#17");
+    assert_eq!(items[0].status, TaskBoardStatus::Todo);
     assert_eq!(items[0].project_id.as_deref(), Some("acme/api"));
     assert_eq!(
         items[0].external_refs[0].external_id, "acme/api#17",
@@ -215,7 +216,7 @@ async fn cached_reviews_query_creates_only_matching_task_board_reviews_idempoten
 }
 
 #[tokio::test]
-async fn cached_reviews_projection_preserves_active_task_status() {
+async fn cached_reviews_projection_preserves_user_selected_status() {
     let _github_guard = crate::github_api::acquire_global_budget_test_lock().await;
     let dir = tempdir().expect("tempdir");
     let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
@@ -237,21 +238,36 @@ async fn cached_reviews_projection_preserves_active_task_status() {
         .await
         .expect("initial cached projection");
     let item = db.list_task_board_items(None).await.expect("list board")[0].clone();
-    db.update_task_board_item(&item.id, |current| {
-        current.status = TaskBoardStatus::AgenticReview;
-        current.planning.summary = Some("Review the dependency update".to_owned());
-        Ok(true)
-    })
-    .await
-    .expect("mark task in progress");
-
-    let projected = query_reviews_with_database(&request, Some(&db))
+    for status in [
+        TaskBoardStatus::Umbrella,
+        TaskBoardStatus::Todo,
+        TaskBoardStatus::Planning,
+        TaskBoardStatus::InProgress,
+        TaskBoardStatus::AgenticReview,
+        TaskBoardStatus::Testing,
+        TaskBoardStatus::InReview,
+        TaskBoardStatus::ToReview,
+        TaskBoardStatus::HumanRequired,
+        TaskBoardStatus::Failed,
+        TaskBoardStatus::Done,
+    ] {
+        db.update_task_board_item(&item.id, |current| {
+            current.status = status;
+            current.planning.summary = Some("Review the dependency update".to_owned());
+            Ok(true)
+        })
         .await
-        .expect("repeat cached projection");
-    let updated = db.task_board_item(&item.id).await.expect("load task");
+        .expect("select local task status");
 
-    assert!(projected.from_cache);
-    assert_eq!(updated.status, TaskBoardStatus::AgenticReview);
+        let projected = query_reviews_with_database(&request, Some(&db))
+            .await
+            .expect("repeat cached projection");
+        let updated = db.task_board_item(&item.id).await.expect("load task");
+
+        assert!(projected.from_cache);
+        assert_eq!(updated.status, status, "sync must preserve the local lane");
+    }
+    let updated = db.task_board_item(&item.id).await.expect("load task");
     assert_eq!(
         updated.planning.summary.as_deref(),
         Some("Review the dependency update")
@@ -267,26 +283,29 @@ async fn cached_reviews_projection_reopens_done_task_when_review_is_requested_ag
         .expect("open database");
     configure_review_inbox(&db, &["status/reopened"], &[]).await;
     let request = cached_projection_request("status/reopened");
-    let response = ReviewsQueryResponse::new(
-        vec![requested_review_item(
-            "status/reopened",
-            "pr_status_reopened",
-            32,
-            &[],
-        )],
-        "2026-07-11T12:00:00Z".into(),
-    );
+    let review = requested_review_item("status/reopened", "pr_status_reopened", 32, &[]);
+    let refresh_request = ReviewsRefreshRequest {
+        targets: vec![review.target()],
+        ..ReviewsRefreshRequest::default()
+    };
+    let response = ReviewsQueryResponse::new(vec![review], "2026-07-11T12:00:00Z".into());
     store_cached_query_response(request.cache_key(), &response);
     query_reviews_with_database(&request, Some(&db))
         .await
         .expect("initial cached projection");
     let item = db.list_task_board_items(None).await.expect("list board")[0].clone();
-    db.update_task_board_item(&item.id, |current| {
-        current.status = TaskBoardStatus::Done;
-        Ok(true)
-    })
-    .await
-    .expect("complete task");
+    assert!(
+        reconcile_targeted_missing_task_board_reviews(
+            Some(&db),
+            &refresh_request,
+            &["pr_status_reopened".into()],
+            crate::github_api::GitHubProtectedClient::data_revision(),
+        )
+        .await
+        .expect("record external review completion")
+    );
+    let completed = db.task_board_item(&item.id).await.expect("load task");
+    assert_eq!(completed.status, TaskBoardStatus::Done);
 
     let projected = query_reviews_with_database(&request, Some(&db))
         .await
@@ -294,7 +313,7 @@ async fn cached_reviews_projection_reopens_done_task_when_review_is_requested_ag
     let updated = db.task_board_item(&item.id).await.expect("load task");
 
     assert!(projected.from_cache);
-    assert_eq!(updated.status, TaskBoardStatus::HumanRequired);
+    assert_eq!(updated.status, TaskBoardStatus::Todo);
 }
 
 #[tokio::test]
@@ -386,7 +405,13 @@ async fn targeted_missing_refresh_completes_only_matching_imported_review() {
         Some(TaskBoardStatus::Done)
     );
     assert_eq!(unrelated.status, TaskBoardStatus::HumanRequired);
-    assert!(unrelated.external_refs[0].sync_state.is_none());
+    assert_eq!(
+        unrelated.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::HumanRequired)
+    );
 }
 
 async fn create_imported_review(db: &AsyncDaemonDb, item_id: &str, repository: &str, number: u64) {
@@ -403,7 +428,11 @@ async fn create_imported_review(db: &AsyncDaemonDb, item_id: &str, repository: &
         provider: ExternalRefProvider::GitHub,
         external_id: format!("{repository}#{number}"),
         url: Some(format!("https://github.com/{repository}/pull/{number}")),
-        sync_state: None,
+        sync_state: Some(ExternalRefSyncState {
+            status: Some(TaskBoardStatus::HumanRequired),
+            updated_at: Some("2026-07-11T12:00:00Z".into()),
+            ..ExternalRefSyncState::default()
+        }),
     }];
     db.create_task_board_item(item)
         .await

--- a/src/daemon/service/reviews_tests/projection/eligibility.rs
+++ b/src/daemon/service/reviews_tests/projection/eligibility.rs
@@ -53,7 +53,7 @@ async fn observed_label_and_repository_eligibility_loss_completes_only_matching_
     );
     assert_eq!(
         status_for_repository(&after_label_loss, "eligibility/web"),
-        TaskBoardStatus::HumanRequired,
+        TaskBoardStatus::Todo,
         "a per-repository observation must not globally stale unrelated tasks"
     );
 

--- a/src/daemon/service/task_board_db/reviews_sync.rs
+++ b/src/daemon/service/task_board_db/reviews_sync.rs
@@ -209,7 +209,7 @@ fn review_external_task(item: &ReviewItem) -> ExternalTask {
         .with_url(item.url.clone()),
         title: item.title.clone(),
         body: String::new(),
-        status: TaskBoardStatus::HumanRequired,
+        status: TaskBoardStatus::Todo,
         project_id: Some(item.repository.clone()),
         updated_at: Some(item.updated_at.to_rfc3339_opts(SecondsFormat::Secs, true)),
     }

--- a/src/task_board/external/github.rs
+++ b/src/task_board/external/github.rs
@@ -28,6 +28,7 @@ use errors::{github_sync_error_with_context, warn_github_message};
 pub use inbox::GitHubInboxSyncClient;
 pub(crate) use review_projection::{
     imported_review_references_from_items, reconcile_review_item_from_snapshots,
+    reconciled_review_status,
 };
 #[derive(Clone)]
 pub struct GitHubSyncClient {

--- a/src/task_board/external/github/review_projection.rs
+++ b/src/task_board/external/github/review_projection.rs
@@ -201,8 +201,10 @@ pub(crate) fn reconciled_review_status(
     last_synced: Option<TaskBoardStatus>,
     observed: TaskBoardStatus,
 ) -> TaskBoardStatus {
+    let current = current.canonical_persisted_status();
+    let observed = observed.canonical_persisted_status();
     last_synced.map_or(current, |last_synced| {
-        if current == last_synced {
+        if current == last_synced.canonical_persisted_status() {
             observed
         } else {
             current
@@ -212,10 +214,7 @@ pub(crate) fn reconciled_review_status(
 
 fn is_active_github_review_reference(reference: &ExternalRef) -> bool {
     is_github_pull_request(reference)
-        && reference
-            .sync_state
-            .as_ref()
-            .and_then(|state| state.status)
+        && reference.sync_state.as_ref().and_then(|state| state.status)
             != Some(TaskBoardStatus::Done)
 }
 

--- a/src/task_board/external/github/review_projection.rs
+++ b/src/task_board/external/github/review_projection.rs
@@ -43,12 +43,12 @@ pub(crate) fn imported_review_pull_request_references(
     Ok(board
         .list(None)?
         .into_iter()
-        .filter(|item| is_imported_review(item) && is_review_inbox_status(item.status))
+        .filter(is_imported_review)
         .flat_map(|item| {
             item.external_refs
                 .clone()
                 .into_iter()
-                .filter(is_github_pull_request)
+                .filter(is_active_github_review_reference)
                 .filter_map(move |reference| normalized_reference(&item, &reference))
         })
         .collect::<BTreeSet<_>>()
@@ -59,11 +59,11 @@ pub(crate) fn imported_review_pull_request_references(
 pub(crate) fn imported_review_references_from_items(items: &[TaskBoardItem]) -> Vec<(String, u64)> {
     items
         .iter()
-        .filter(|item| is_imported_review(item) && is_review_inbox_status(item.status))
+        .filter(|item| is_imported_review(item))
         .flat_map(|item| {
             item.external_refs
                 .iter()
-                .filter(|reference| is_github_pull_request(reference))
+                .filter(|reference| is_active_github_review_reference(reference))
                 .filter_map(|reference| normalized_reference(item, reference))
         })
         .collect::<BTreeSet<_>>()
@@ -112,15 +112,24 @@ fn projection_patch(
     snapshots: &BTreeMap<String, &GitHubPullRequestSnapshot>,
 ) -> Option<TaskBoardItemPatch> {
     let (reference_index, snapshot) = matching_imported_review(item, snapshots)?;
-    let status = projected_status(snapshot, item.status);
-    if item.status == status {
+    let observed_status = observed_review_status(snapshot)?;
+    let last_synced_status = item.external_refs[reference_index]
+        .sync_state
+        .as_ref()
+        .and_then(|state| state.status);
+    let status = reconciled_review_status(item.status, last_synced_status, observed_status);
+    let mut external_refs = item.external_refs.clone();
+    let sync_state_changed = update_sync_state(
+        &mut external_refs[reference_index],
+        snapshot,
+        observed_status,
+    );
+    if item.status == status && !sync_state_changed {
         return None;
     }
-    let mut external_refs = item.external_refs.clone();
-    update_sync_state(&mut external_refs[reference_index], snapshot, status);
     Some(TaskBoardItemPatch {
-        status: Some(status),
-        external_refs: Some(external_refs),
+        status: (item.status != status).then_some(status),
+        external_refs: sync_state_changed.then_some(external_refs),
         ..TaskBoardItemPatch::default()
     })
 }
@@ -177,43 +186,55 @@ fn is_imported_review(item: &TaskBoardItem) -> bool {
         && item.external_refs.iter().any(is_github_pull_request)
 }
 
-fn projected_status(
-    snapshot: &GitHubPullRequestSnapshot,
-    current: TaskBoardStatus,
-) -> TaskBoardStatus {
+fn observed_review_status(snapshot: &GitHubPullRequestSnapshot) -> Option<TaskBoardStatus> {
     if snapshot.is_open == Some(false) || snapshot.viewer_review_requested == Some(false) {
-        return if is_review_inbox_status(current) {
-            TaskBoardStatus::Done
-        } else {
-            current
-        };
+        return Some(TaskBoardStatus::Done);
     }
-    if snapshot.viewer_review_requested == Some(true) && current == TaskBoardStatus::Done {
-        return TaskBoardStatus::Todo;
+    if snapshot.viewer_review_requested == Some(true) {
+        return Some(TaskBoardStatus::Todo);
     }
-    current
+    None
 }
 
-fn is_review_inbox_status(status: TaskBoardStatus) -> bool {
-    matches!(
-        status,
-        TaskBoardStatus::Todo
-            | TaskBoardStatus::HumanRequired
-            | TaskBoardStatus::AgenticReview
-            | TaskBoardStatus::NeedsYou
-            | TaskBoardStatus::PlanReview
-    )
+pub(crate) fn reconciled_review_status(
+    current: TaskBoardStatus,
+    last_synced: Option<TaskBoardStatus>,
+    observed: TaskBoardStatus,
+) -> TaskBoardStatus {
+    last_synced.map_or(current, |last_synced| {
+        if current == last_synced {
+            observed
+        } else {
+            current
+        }
+    })
+}
+
+fn is_active_github_review_reference(reference: &ExternalRef) -> bool {
+    is_github_pull_request(reference)
+        && reference
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status)
+            != Some(TaskBoardStatus::Done)
 }
 
 fn update_sync_state(
     reference: &mut ExternalRef,
     snapshot: &GitHubPullRequestSnapshot,
     status: TaskBoardStatus,
-) {
+) -> bool {
+    if reference.sync_state.as_ref().is_some_and(|state| {
+        state.status == Some(status)
+            && state.updated_at.as_deref() == Some(snapshot.updated_at.as_str())
+    }) {
+        return false;
+    }
     let state = reference.sync_state.get_or_insert_default();
     state.status = Some(status);
     state.updated_at = Some(snapshot.updated_at.clone());
     state.synced_at = Some(utc_now());
+    true
 }
 
 #[cfg(test)]

--- a/src/task_board/external/github/review_projection.rs
+++ b/src/task_board/external/github/review_projection.rs
@@ -203,13 +203,14 @@ pub(crate) fn reconciled_review_status(
 ) -> TaskBoardStatus {
     let current = current.canonical_persisted_status();
     let observed = observed.canonical_persisted_status();
-    last_synced.map_or(current, |last_synced| {
-        if current == last_synced.canonical_persisted_status() {
-            observed
-        } else {
-            current
-        }
-    })
+    let last_synced = last_synced
+        .unwrap_or(TaskBoardStatus::Todo)
+        .canonical_persisted_status();
+    if current == last_synced {
+        observed
+    } else {
+        current
+    }
 }
 
 fn is_active_github_review_reference(reference: &ExternalRef) -> bool {

--- a/src/task_board/external/github/review_projection/tests.rs
+++ b/src/task_board/external/github/review_projection/tests.rs
@@ -3,6 +3,50 @@ use tempfile::tempdir;
 use super::*;
 use crate::task_board::types::{ExternalRefSyncState, PlanningState, TaskBoardItem};
 
+fn review_sync_state(status: TaskBoardStatus, updated_at: &str) -> ExternalRefSyncState {
+    ExternalRefSyncState {
+        status: Some(status),
+        updated_at: Some(updated_at.to_owned()),
+        ..ExternalRefSyncState::default()
+    }
+}
+
+#[test]
+fn review_status_reconciliation_uses_the_last_sync_as_shared_truth() {
+    assert_eq!(
+        reconciled_review_status(
+            TaskBoardStatus::InProgress,
+            Some(TaskBoardStatus::Todo),
+            TaskBoardStatus::Todo,
+        ),
+        TaskBoardStatus::InProgress
+    );
+    assert_eq!(
+        reconciled_review_status(
+            TaskBoardStatus::Todo,
+            Some(TaskBoardStatus::Todo),
+            TaskBoardStatus::Done,
+        ),
+        TaskBoardStatus::Done
+    );
+    assert_eq!(
+        reconciled_review_status(
+            TaskBoardStatus::InProgress,
+            Some(TaskBoardStatus::Todo),
+            TaskBoardStatus::Done,
+        ),
+        TaskBoardStatus::InProgress
+    );
+    assert_eq!(
+        reconciled_review_status(
+            TaskBoardStatus::Done,
+            Some(TaskBoardStatus::Done),
+            TaskBoardStatus::Todo,
+        ),
+        TaskBoardStatus::Todo
+    );
+}
+
 #[test]
 fn shared_review_snapshot_completes_imported_review_request() {
     let temp = tempdir().expect("tempdir");
@@ -25,7 +69,10 @@ fn shared_review_snapshot_completes_imported_review_request() {
         provider: ExternalRefProvider::GitHub,
         external_id: "example/repo#42".into(),
         url: Some("https://github.com/example/repo/pull/42".into()),
-        sync_state: Some(ExternalRefSyncState::default()),
+        sync_state: Some(review_sync_state(
+            TaskBoardStatus::Todo,
+            "2026-07-11T10:00:00Z",
+        )),
     }];
     board.create("Old title", "Body", item).expect("create");
 
@@ -115,7 +162,10 @@ fn active_review_request_preserves_local_workflow_progress() {
         provider: ExternalRefProvider::GitHub,
         external_id: "example/repo#42".into(),
         url: Some("https://github.com/example/repo/pull/42".into()),
-        sync_state: None,
+        sync_state: Some(review_sync_state(
+            TaskBoardStatus::Todo,
+            "2026-07-11T10:00:00Z",
+        )),
     }];
     board.create("Review title", "Body", item).expect("create");
 
@@ -131,7 +181,7 @@ fn active_review_request_preserves_local_workflow_progress() {
     )
     .expect("reconcile");
 
-    assert!(!changed);
+    assert!(changed);
     assert_eq!(
         board
             .get("github-example-repo-42")
@@ -201,7 +251,10 @@ fn completed_remote_review_does_not_interrupt_active_execution() {
         provider: ExternalRefProvider::GitHub,
         external_id: "example/repo#42".into(),
         url: Some("https://github.com/example/repo/pull/42".into()),
-        sync_state: None,
+        sync_state: Some(review_sync_state(
+            TaskBoardStatus::Todo,
+            "2026-07-11T10:00:00Z",
+        )),
     }];
     board.create("Review title", "Body", item).expect("create");
 
@@ -217,13 +270,23 @@ fn completed_remote_review_does_not_interrupt_active_execution() {
     )
     .expect("reconcile");
 
-    assert!(!changed);
+    assert!(changed);
     assert_eq!(
         board
             .get("github-example-repo-42")
             .expect("review item")
             .status,
         TaskBoardStatus::InProgress
+    );
+    assert_eq!(
+        board
+            .get("github-example-repo-42")
+            .expect("review item")
+            .external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::Done)
     );
 }
 
@@ -244,7 +307,10 @@ fn candidate_projection_reloads_refs_edited_after_listing() {
         provider: ExternalRefProvider::GitHub,
         external_id: "example/repo#42".into(),
         url: Some("https://github.com/example/repo/pull/42".into()),
-        sync_state: None,
+        sync_state: Some(review_sync_state(
+            TaskBoardStatus::Todo,
+            "2026-07-11T10:00:00Z",
+        )),
     }];
     board.create("Review title", "Body", item).expect("create");
     let candidate_id = board.list(None).expect("list")[0].id.clone();
@@ -320,13 +386,16 @@ fn active_imported_reviews_are_discovered_for_exact_resolution() {
         "Body".into(),
         "2026-07-11T10:00:00Z".into(),
     );
-    active.status = TaskBoardStatus::Todo;
+    active.status = TaskBoardStatus::InProgress;
     active.imported_from_provider = Some(ExternalRefProvider::GitHub);
     active.external_refs = vec![ExternalRef {
         provider: ExternalRefProvider::GitHub,
         external_id: "Example/Repo#42".into(),
         url: Some("https://github.com/Example/Repo/pull/42".into()),
-        sync_state: None,
+        sync_state: Some(review_sync_state(
+            TaskBoardStatus::Todo,
+            "2026-07-11T10:00:00Z",
+        )),
     }];
     board
         .create("Active review", "Body", active)
@@ -344,7 +413,10 @@ fn active_imported_reviews_are_discovered_for_exact_resolution() {
         provider: ExternalRefProvider::GitHub,
         external_id: "example/repo#43".into(),
         url: Some("https://github.com/example/repo/pull/43".into()),
-        sync_state: None,
+        sync_state: Some(review_sync_state(
+            TaskBoardStatus::Done,
+            "2026-07-11T10:00:00Z",
+        )),
     }];
     board
         .create("Completed review", "Body", completed)

--- a/src/task_board/external/github/review_projection/tests.rs
+++ b/src/task_board/external/github/review_projection/tests.rs
@@ -45,6 +45,14 @@ fn review_status_reconciliation_uses_the_last_sync_as_shared_truth() {
         ),
         TaskBoardStatus::Todo
     );
+    assert_eq!(
+        reconciled_review_status(TaskBoardStatus::Todo, None, TaskBoardStatus::Done),
+        TaskBoardStatus::Done
+    );
+    assert_eq!(
+        reconciled_review_status(TaskBoardStatus::InProgress, None, TaskBoardStatus::Done),
+        TaskBoardStatus::InProgress
+    );
 }
 
 #[test]
@@ -63,7 +71,7 @@ fn review_status_reconciliation_canonicalizes_legacy_shared_truth() {
 }
 
 #[test]
-fn shared_review_snapshot_completes_imported_review_request() {
+fn shared_review_snapshot_completes_legacy_import_without_sync_status() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let mut item = TaskBoardItem::new(
@@ -84,10 +92,7 @@ fn shared_review_snapshot_completes_imported_review_request() {
         provider: ExternalRefProvider::GitHub,
         external_id: "example/repo#42".into(),
         url: Some("https://github.com/example/repo/pull/42".into()),
-        sync_state: Some(review_sync_state(
-            TaskBoardStatus::Todo,
-            "2026-07-11T10:00:00Z",
-        )),
+        sync_state: None,
     }];
     board.create("Old title", "Body", item).expect("create");
 

--- a/src/task_board/external/github/review_projection/tests.rs
+++ b/src/task_board/external/github/review_projection/tests.rs
@@ -48,6 +48,21 @@ fn review_status_reconciliation_uses_the_last_sync_as_shared_truth() {
 }
 
 #[test]
+fn review_status_reconciliation_canonicalizes_legacy_shared_truth() {
+    for (current, last_synced) in [
+        (TaskBoardStatus::Todo, TaskBoardStatus::New),
+        (TaskBoardStatus::AgenticReview, TaskBoardStatus::PlanReview),
+        (TaskBoardStatus::HumanRequired, TaskBoardStatus::NeedsYou),
+        (TaskBoardStatus::Failed, TaskBoardStatus::Blocked),
+    ] {
+        assert_eq!(
+            reconciled_review_status(current, Some(last_synced), TaskBoardStatus::Done),
+            TaskBoardStatus::Done
+        );
+    }
+}
+
+#[test]
 fn shared_review_snapshot_completes_imported_review_request() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));

--- a/src/task_board/external/sync/reconcile.rs
+++ b/src/task_board/external/sync/reconcile.rs
@@ -7,8 +7,9 @@ use crate::task_board::types::{
     ExternalRef, ExternalRefProvider, ExternalRefSyncState, TaskBoardItem, TaskBoardStatus,
 };
 
+use super::super::github::reconciled_review_status;
 use super::merge::{
-    changed_fields, external_ref_matches, pull_conflict_fields, sync_state_from_task,
+    changed_fields, external_ref_matches, matching_ref, pull_conflict_fields, sync_state_from_task,
 };
 use super::{
     ExternalSyncAction, ExternalSyncDirection, ExternalSyncOperation, ExternalSyncOptions,
@@ -119,21 +120,18 @@ fn reconciliation_patch(item: &TaskBoardItem, task: &ExternalTask) -> TaskBoardI
 }
 
 fn reconciled_status(item: &TaskBoardItem, task: &ExternalTask) -> TaskBoardStatus {
-    if is_active_github_review_request(item, task)
-        && !matches!(
-            item.status,
-            TaskBoardStatus::Done | TaskBoardStatus::HumanRequired | TaskBoardStatus::NeedsYou
-        )
-    {
-        return item.status;
+    if !is_github_review_request(item, task) {
+        return task.status;
     }
-    task.status
+    let last_synced_status = matching_ref(item, &task.reference, task.project_id.as_deref())
+        .and_then(|reference| reference.sync_state.as_ref())
+        .and_then(|state| state.status);
+    reconciled_review_status(item.status, last_synced_status, task.status)
 }
 
-fn is_active_github_review_request(item: &TaskBoardItem, task: &ExternalTask) -> bool {
+fn is_github_review_request(item: &TaskBoardItem, task: &ExternalTask) -> bool {
     item.imported_from_provider == Some(ExternalRefProvider::GitHub)
         && task.reference.provider == ExternalProvider::GitHub
-        && task.status == TaskBoardStatus::Todo
         && task
             .reference
             .url

--- a/src/task_board/external/sync/stale_reviews.rs
+++ b/src/task_board/external/sync/stale_reviews.rs
@@ -6,6 +6,7 @@ use crate::task_board::store::TaskBoardItemPatch;
 use crate::task_board::types::{ExternalRefProvider, TaskBoardItem, TaskBoardStatus};
 use crate::workspace::utc_now;
 
+use super::super::github::reconciled_review_status;
 use super::merge::{external_ref_matches, matching_ref};
 use super::{ExternalSyncAction, ExternalSyncOperation, ExternalSyncOptions, TaskBoardSyncStore};
 
@@ -49,16 +50,7 @@ pub(super) async fn reconcile_stale_github_review_requests(
 }
 
 fn allows_stale_review_reconcile(options: ExternalSyncOptions) -> bool {
-    options.status.is_none_or(|status| {
-        matches!(
-            status,
-            TaskBoardStatus::Todo
-                | TaskBoardStatus::HumanRequired
-                | TaskBoardStatus::AgenticReview
-                | TaskBoardStatus::NeedsYou
-                | TaskBoardStatus::PlanReview
-        )
-    })
+    options.status.is_none()
 }
 
 fn stale_review_request_operation(
@@ -84,8 +76,16 @@ fn stale_review_request_patch(
     item: &TaskBoardItem,
     reference: &ExternalTaskRef,
 ) -> TaskBoardItemPatch {
+    let last_synced_status = matching_ref(item, reference, item.project_id.as_deref())
+        .and_then(|reference| reference.sync_state.as_ref())
+        .and_then(|state| state.status);
+    let status = reconciled_review_status(
+        item.status,
+        last_synced_status,
+        TaskBoardStatus::Done,
+    );
     let mut patch = TaskBoardItemPatch {
-        status: Some(TaskBoardStatus::Done),
+        status: (item.status != status).then_some(status),
         ..TaskBoardItemPatch::default()
     };
     patch.external_refs = Some(
@@ -122,18 +122,14 @@ fn is_stale_github_review_request(
     tasks: &[ExternalTask],
 ) -> bool {
     item.imported_from_provider == Some(ExternalRefProvider::GitHub)
-        && matches!(
-            item.status,
-            TaskBoardStatus::Todo
-                | TaskBoardStatus::HumanRequired
-                | TaskBoardStatus::AgenticReview
-                | TaskBoardStatus::NeedsYou
-                | TaskBoardStatus::PlanReview
-        )
         && reference
             .url
             .as_deref()
             .is_some_and(|url| url.contains("/pull/"))
+        && matching_ref(item, reference, item.project_id.as_deref())
+            .and_then(|reference| reference.sync_state.as_ref())
+            .and_then(|state| state.status)
+            != Some(TaskBoardStatus::Done)
         && !tasks
             .iter()
             .any(|task| matching_ref(item, &task.reference, task.project_id.as_deref()).is_some())

--- a/src/task_board/external/sync/stale_reviews.rs
+++ b/src/task_board/external/sync/stale_reviews.rs
@@ -50,7 +50,9 @@ pub(super) async fn reconcile_stale_github_review_requests(
 }
 
 fn allows_stale_review_reconcile(options: ExternalSyncOptions) -> bool {
-    options.status.is_none()
+    options
+        .status
+        .is_none_or(|status| status == TaskBoardStatus::Todo)
 }
 
 fn stale_review_request_operation(
@@ -79,11 +81,7 @@ fn stale_review_request_patch(
     let last_synced_status = matching_ref(item, reference, item.project_id.as_deref())
         .and_then(|reference| reference.sync_state.as_ref())
         .and_then(|state| state.status);
-    let status = reconciled_review_status(
-        item.status,
-        last_synced_status,
-        TaskBoardStatus::Done,
-    );
+    let status = reconciled_review_status(item.status, last_synced_status, TaskBoardStatus::Done);
     let mut patch = TaskBoardItemPatch {
         status: (item.status != status).then_some(status),
         ..TaskBoardItemPatch::default()

--- a/src/task_board/external/tests/support.rs
+++ b/src/task_board/external/tests/support.rs
@@ -152,7 +152,7 @@ fn github_review_request_ref(external_id: &str) -> ExternalRef {
     reference.sync_state = Some(ExternalRefSyncState {
         title: Some("Review requested".to_owned()),
         body: Some("Please review the pull request.".to_owned()),
-        status: Some(TaskBoardStatus::HumanRequired),
+        status: Some(TaskBoardStatus::Todo),
         project_id: Some("owner/repo".to_owned()),
         updated_at: Some("2026-05-14T03:00:00Z".to_owned()),
         synced_at: Some("2026-05-14T03:00:00Z".to_owned()),

--- a/src/task_board/external/tests/sync.rs
+++ b/src/task_board/external/tests/sync.rs
@@ -257,7 +257,7 @@ async fn sync_external_tasks_dry_run_reports_reconciliation_without_writing() {
 }
 
 #[tokio::test]
-async fn sync_external_tasks_resolves_stale_github_review_requests() {
+async fn stale_review_sync_records_remote_completion_without_overriding_local_status() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let item = super::support::github_review_request_item(
@@ -299,7 +299,7 @@ async fn sync_external_tasks_resolves_stale_github_review_requests() {
     let updated = board
         .get("github-owner-repo-71")
         .expect("load resolved review request");
-    assert_eq!(updated.status, TaskBoardStatus::Done);
+    assert_eq!(updated.status, TaskBoardStatus::AgenticReview);
     assert_eq!(
         updated.external_refs[0]
             .sync_state
@@ -307,6 +307,21 @@ async fn sync_external_tasks_resolves_stale_github_review_requests() {
             .and_then(|state| state.status),
         Some(TaskBoardStatus::Done)
     );
+
+    let repeated = sync_external_tasks(
+        &board,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::GitHub),
+            direction: ExternalSyncDirection::Pull,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            status: None,
+        },
+        &clients,
+    )
+    .await
+    .expect("repeat sync external tasks");
+    assert!(repeated.is_empty(), "recorded remote truth must not churn");
 }
 
 #[tokio::test]

--- a/src/task_board/external/tests/sync.rs
+++ b/src/task_board/external/tests/sync.rs
@@ -257,8 +257,7 @@ async fn sync_external_tasks_dry_run_reports_reconciliation_without_writing() {
 }
 
 #[tokio::test]
-async fn todo_filtered_stale_review_sync_records_remote_completion_without_overriding_local_status()
-{
+async fn todo_filtered_stale_review_sync_preserves_local_status() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let item = super::support::github_review_request_item(

--- a/src/task_board/external/tests/sync.rs
+++ b/src/task_board/external/tests/sync.rs
@@ -257,7 +257,8 @@ async fn sync_external_tasks_dry_run_reports_reconciliation_without_writing() {
 }
 
 #[tokio::test]
-async fn stale_review_sync_records_remote_completion_without_overriding_local_status() {
+async fn todo_filtered_stale_review_sync_records_remote_completion_without_overriding_local_status()
+{
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let item = super::support::github_review_request_item(
@@ -269,11 +270,9 @@ async fn stale_review_sync_records_remote_completion_without_overriding_local_st
         .create("Review requested", "Please review the pull request.", item)
         .expect("create review request task");
 
-    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
-        ExternalProvider::GitHub,
-        Vec::new(),
-    )
-    .with_authoritative_review_inbox())];
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(
+        FakeSyncClient::new(ExternalProvider::GitHub, Vec::new()).with_authoritative_review_inbox(),
+    )];
 
     let operations = sync_external_tasks(
         &board,
@@ -282,7 +281,7 @@ async fn stale_review_sync_records_remote_completion_without_overriding_local_st
             direction: ExternalSyncDirection::Pull,
             conflict_policy: ExternalSyncConflictPolicy::Report,
             dry_run: false,
-            status: None,
+            status: Some(TaskBoardStatus::Todo),
         },
         &clients,
     )
@@ -315,7 +314,7 @@ async fn stale_review_sync_records_remote_completion_without_overriding_local_st
             direction: ExternalSyncDirection::Pull,
             conflict_policy: ExternalSyncConflictPolicy::Report,
             dry_run: false,
-            status: None,
+            status: Some(TaskBoardStatus::Todo),
         },
         &clients,
     )
@@ -337,11 +336,9 @@ async fn sync_external_tasks_dry_run_reports_stale_todo_github_review_requests_w
         .create("Review requested", "Please review the pull request.", item)
         .expect("create review request task");
 
-    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
-        ExternalProvider::GitHub,
-        Vec::new(),
-    )
-    .with_authoritative_review_inbox())];
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(
+        FakeSyncClient::new(ExternalProvider::GitHub, Vec::new()).with_authoritative_review_inbox(),
+    )];
 
     let operations = sync_external_tasks(
         &board,
@@ -383,11 +380,9 @@ async fn sync_external_tasks_resolves_stale_todo_github_review_requests() {
         .create("Review requested", "Please review the pull request.", item)
         .expect("create todo review request task");
 
-    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
-        ExternalProvider::GitHub,
-        Vec::new(),
-    )
-    .with_authoritative_review_inbox())];
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(
+        FakeSyncClient::new(ExternalProvider::GitHub, Vec::new()).with_authoritative_review_inbox(),
+    )];
 
     let operations = sync_external_tasks(
         &board,


### PR DESCRIPTION
## Motivation
Review synchronization could overwrite a user-selected Task Board lane with its projected inbox status, causing cards to move back after a manual change.

## Implementation
- reconcile local and external review status from their last shared sync state
- preserve local workflow choices while recording external completion and re-request transitions
- align shared review imports with the Todo inbox contract and cover every lane, lifecycle transitions, and idempotent refreshes
