### PR TITLE
feat(monitor): preserve Cloud fallback for remote pairing

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobilePairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobilePairing.swift
@@ -206,6 +206,14 @@ public struct MobilePairedStationCredential: Codable, Equatable, Identifiable, S
     !snapshotKeyID.isEmpty
       && !symmetricKeyRawRepresentation.isEmpty
   }
+
+  public var referencedDeviceIdentityIDs: Set<String> {
+    var identityIDs = Set([deviceIdentityID])
+    if let remoteIdentityID = remoteDaemonAccess?.deviceIdentityID {
+      identityIDs.insert(remoteIdentityID)
+    }
+    return identityIDs
+  }
 }
 
 public protocol MobilePairingTransport: Sendable {

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonModels.swift
@@ -61,6 +61,7 @@ public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStri
   public var serverSPKISHA256: MobileRemoteDaemonSPKIPin
   public var pairedAt: Date
   public var reviewsQuery: MobileRemoteDaemonReviewsQuery?
+  public var deviceIdentityID: String?
 
   public init(
     endpoint: URL,
@@ -73,7 +74,8 @@ public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStri
     tokenHint: String,
     serverSPKISHA256: MobileRemoteDaemonSPKIPin,
     pairedAt: Date,
-    reviewsQuery: MobileRemoteDaemonReviewsQuery? = nil
+    reviewsQuery: MobileRemoteDaemonReviewsQuery? = nil,
+    deviceIdentityID: String? = nil
   ) {
     self.endpoint = endpoint
     self.clientID = clientID
@@ -86,12 +88,14 @@ public struct MobileRemoteDaemonAccess: Codable, Equatable, Sendable, CustomStri
     self.serverSPKISHA256 = serverSPKISHA256
     self.pairedAt = pairedAt
     self.reviewsQuery = reviewsQuery
+    self.deviceIdentityID = deviceIdentityID
   }
 
   public var description: String {
     "MobileRemoteDaemonAccess(endpoint: \(endpoint.absoluteString), clientID: \(clientID), "
       + "platform: \(platform), role: \(role.rawValue), scopes: \(scopes), "
       + "tokenHint: \(tokenHint), reviewsQuery: \(reviewsQuery == nil ? "none" : "configured"), "
+      + "deviceIdentityID: \(deviceIdentityID ?? "legacy"), "
       + "bearerToken: <redacted>)"
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing+Fallback.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing+Fallback.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+func updatedRemotePairingCredential(
+  _ credential: MobilePairedStationCredential,
+  access: MobileRemoteDaemonAccess,
+  now: Date
+) -> MobilePairedStationCredential {
+  var credential = credential
+  credential.remoteDaemonAccess = access
+  credential.lastUsedAt = now
+  return credential
+}
+
+func newRemotePairingCredential(
+  invitation: MobileRemoteDaemonPairingInvitation,
+  identity: MobileDeviceIdentity,
+  access: MobileRemoteDaemonAccess,
+  existingCredentials: [MobilePairedStationCredential],
+  now: Date
+) -> MobilePairedStationCredential {
+  let stationID = MobileRemoteDaemonStationID.make(endpoint: invitation.endpoint)
+  let existing = existingCredentials.first { $0.stationID == stationID }
+  return MobilePairedStationCredential(
+    stationID: stationID,
+    stationName: invitation.endpoint.host ?? invitation.endpoint.absoluteString,
+    endpoint: invitation.endpoint,
+    stationPublicKeyFingerprint: invitation.serverSPKISHA256.value,
+    deviceIdentityID: identity.id,
+    snapshotKeyID: "",
+    commandKeyID: "",
+    symmetricKeyRawRepresentation: Data(),
+    pairedAt: access.pairedAt,
+    lastUsedAt: now,
+    defaultStation: existing?.defaultStation ?? existingCredentials.isEmpty,
+    remoteDaemonAccess: access
+  )
+}
+
+func remotePairingBaseCredential(
+  invitation: MobileRemoteDaemonPairingInvitation,
+  identity: MobileDeviceIdentity,
+  cloudFallbackStationID: String?,
+  existingCredentials: [MobilePairedStationCredential]
+) throws -> MobilePairedStationCredential? {
+  if let cloudFallbackStationID {
+    guard
+      let selected = existingCredentials.first(where: {
+        $0.stationID == cloudFallbackStationID
+      }),
+      isCompatibleCloudFallback(
+        selected,
+        invitation: invitation,
+        identity: identity
+      )
+    else {
+      throw MobileRemoteDaemonPairingError.invalidCloudFallbackStation
+    }
+    return selected
+  }
+
+  if let existingRemote = existingCredentials.first(where: {
+    $0.remoteDaemonAccess?.endpoint == invitation.endpoint
+  }), existingRemote.hasCloudMirrorAccess || remoteIdentityID(existingRemote) == identity.id {
+    return existingRemote
+  }
+
+  let cloudFallbacks = existingCredentials.filter { credential in
+    isCompatibleCloudFallback(
+      credential,
+      invitation: invitation,
+      identity: identity
+    )
+  }
+  guard cloudFallbacks.count == 1 else {
+    return nil
+  }
+  return cloudFallbacks[0]
+}
+
+private func isCompatibleCloudFallback(
+  _ credential: MobilePairedStationCredential,
+  invitation: MobileRemoteDaemonPairingInvitation,
+  identity: MobileDeviceIdentity
+) -> Bool {
+  credential.hasCloudMirrorAccess
+    && (credential.remoteDaemonAccess == nil
+      || credential.remoteDaemonAccess?.endpoint == invitation.endpoint)
+    && (credential.deviceIdentityID == identity.id
+      || identity.id == MobileRemoteDaemonPairingDevice.watchOS.identityID)
+}
+
+private func remoteIdentityID(_ credential: MobilePairedStationCredential) -> String {
+  credential.remoteDaemonAccess?.deviceIdentityID ?? credential.deviceIdentityID
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
@@ -47,6 +47,7 @@ public enum MobileRemoteDaemonPairingError: Error, Equatable, Sendable {
   case invalidResponse
   case serverStatus(Int)
   case claimMismatch
+  case invalidCloudFallbackStation
 }
 
 public struct MobileRemoteDaemonPairingDevice: Equatable, Sendable {
@@ -62,8 +63,12 @@ public struct MobileRemoteDaemonPairingDevice: Equatable, Sendable {
   }
 
   public func owns(_ credential: MobilePairedStationCredential) -> Bool {
-    credential.deviceIdentityID == identityID
-      && credential.remoteDaemonAccess?.platform.caseInsensitiveCompare(platform) == .orderedSame
+    guard let access = credential.remoteDaemonAccess else {
+      return false
+    }
+    let remoteIdentityID = access.deviceIdentityID ?? credential.deviceIdentityID
+    return remoteIdentityID == identityID
+      && access.platform.caseInsensitiveCompare(platform) == .orderedSame
   }
 }
 
@@ -156,10 +161,18 @@ public actor MobileRemoteDaemonPairingCoordinator<Transport: MobileRemoteDaemonP
   public func pair(
     invitationURL: URL,
     deviceName: String,
+    cloudFallbackStationID: String? = nil,
     now: Date = .now
   ) async throws -> MobilePairedStationCredential {
     let invitation = try MobileRemoteDaemonPairingInvitation.decode(invitationURL, now: now)
     let identity = try await loadOrCreateIdentity(deviceName: deviceName, now: now)
+    let existing = try await credentialStore.loadAll()
+    let baseCredential = try remotePairingBaseCredential(
+      invitation: invitation,
+      identity: identity,
+      cloudFallbackStationID: cloudFallbackStationID,
+      existingCredentials: existing
+    )
     let clientID = try makeClientID(identity: identity)
     let claim = try await transport.claim(
       invitation: invitation,
@@ -178,49 +191,79 @@ public actor MobileRemoteDaemonPairingCoordinator<Transport: MobileRemoteDaemonP
       tokenHint: claim.tokenHint,
       serverSPKISHA256: invitation.serverSPKISHA256,
       pairedAt: claim.pairedAt,
-      reviewsQuery: claim.reviewsQuery
+      reviewsQuery: claim.reviewsQuery,
+      deviceIdentityID: identity.id
     )
-    let stationID = MobileRemoteDaemonStationID.make(endpoint: invitation.endpoint)
-    let existing = try await credentialStore.loadAll()
-    let existingCredential = existing.first { $0.stationID == stationID }
-    let credential = MobilePairedStationCredential(
-      stationID: stationID,
-      stationName: invitation.endpoint.host ?? invitation.endpoint.absoluteString,
-      endpoint: invitation.endpoint,
-      stationPublicKeyFingerprint: invitation.serverSPKISHA256.value,
-      deviceIdentityID: identity.id,
-      snapshotKeyID: "",
-      commandKeyID: "",
-      symmetricKeyRawRepresentation: Data(),
-      pairedAt: claim.pairedAt,
-      lastUsedAt: now,
-      defaultStation: existingCredential?.defaultStation ?? existing.isEmpty,
-      remoteDaemonAccess: access
+    let credential =
+      if let baseCredential {
+        updatedRemotePairingCredential(
+          baseCredential,
+          access: access,
+          now: now
+        )
+      } else {
+        newRemotePairingCredential(
+          invitation: invitation,
+          identity: identity,
+          access: access,
+          existingCredentials: existing,
+          now: now
+        )
+      }
+    let replacedCredentials = replacedCredentials(
+      from: existing,
+      with: credential,
+      remoteEndpoint: invitation.endpoint
     )
     try await credentialStore.save(credential)
-    try await removeReplacedIdentityIfUnused(
-      existingCredential: existingCredential,
+    for replaced in replacedCredentials where replaced.stationID != credential.stationID {
+      try await credentialStore.delete(stationID: replaced.stationID)
+    }
+    try await removeReplacedIdentitiesIfUnused(
+      replacedCredentials: replacedCredentials,
       existingCredentials: existing,
       replacement: credential
     )
     return credential
   }
 
-  private func removeReplacedIdentityIfUnused(
-    existingCredential: MobilePairedStationCredential?,
+  private func replacedCredentials(
+    from existingCredentials: [MobilePairedStationCredential],
+    with replacement: MobilePairedStationCredential,
+    remoteEndpoint: URL
+  ) -> [MobilePairedStationCredential] {
+    existingCredentials.filter { existing in
+      if existing.stationID == replacement.stationID {
+        return true
+      }
+      return replacement.hasCloudMirrorAccess
+        && !existing.hasCloudMirrorAccess
+        && existing.remoteDaemonAccess?.endpoint == remoteEndpoint
+        && device.owns(existing)
+    }
+  }
+
+  private func removeReplacedIdentitiesIfUnused(
+    replacedCredentials: [MobilePairedStationCredential],
     existingCredentials: [MobilePairedStationCredential],
     replacement: MobilePairedStationCredential
   ) async throws {
-    guard let existingCredential,
-      existingCredential.deviceIdentityID != replacement.deviceIdentityID,
-      !existingCredentials.contains(where: {
-        $0.stationID != replacement.stationID
-          && $0.deviceIdentityID == existingCredential.deviceIdentityID
-      })
-    else {
+    guard !replacedCredentials.isEmpty else {
       return
     }
-    try await identityStore.delete(id: existingCredential.deviceIdentityID)
+    let replacedStationIDs = Set(replacedCredentials.map(\.stationID))
+    let retainedIdentityIDs = Set(
+      existingCredentials
+        .filter { !replacedStationIDs.contains($0.stationID) }
+        .flatMap(\.referencedDeviceIdentityIDs)
+    ).union(replacement.referencedDeviceIdentityIDs)
+    let replacedIdentityIDs = Set(
+      replacedCredentials.flatMap(\.referencedDeviceIdentityIDs)
+    )
+    for identityID in replacedIdentityIDs
+    where !retainedIdentityIDs.contains(identityID) {
+      try await identityStore.delete(id: identityID)
+    }
   }
 
   private func loadOrCreateIdentity(

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
@@ -215,6 +215,7 @@ extension MirrorStore {
     }
     do {
       let pairingLink = try MobilePairingLink.decode(invitationURL, now: now)
+      let cloudFallbackStationID = cloudFallbackStationID(for: pairingLink)
       let wasDemoModeEnabled = demoModeEnabled
       demoModeEnabled = false
       if wasDemoModeEnabled {
@@ -225,6 +226,7 @@ extension MirrorStore {
       let credential = try await pairer.pair(
         invitationURL: invitationURL,
         deviceName: deviceName,
+        cloudFallbackStationID: cloudFallbackStationID,
         now: now
       )
       try await rebuildSyncClients(preferredStationID: credential.stationID)
@@ -237,6 +239,26 @@ extension MirrorStore {
     }
   }
 
+  private func cloudFallbackStationID(for pairingLink: MobilePairingLink) -> String? {
+    guard case .remote(let invitation) = pairingLink else {
+      return nil
+    }
+    let compatibleCredentials = pairedCredentials.filter { credential in
+      credential.hasCloudMirrorAccess
+        && (credential.remoteDaemonAccess == nil
+          || credential.remoteDaemonAccess?.endpoint == invitation.endpoint)
+    }
+    if let selected = compatibleCredentials.first(where: {
+      $0.stationID == selectedStationID
+    }) {
+      return selected.stationID
+    }
+    guard compatibleCredentials.count == 1 else {
+      return nil
+    }
+    return compatibleCredentials[0].stationID
+  }
+
   public func unpair(stationID: String) async {
     guard let identityStore, let credentialStore else {
       syncStatus = .stale("Pairing storage is unavailable.")
@@ -246,12 +268,14 @@ extension MirrorStore {
       let removedCredential = try await credentialStore.load(stationID: stationID)
       try await credentialStore.delete(stationID: stationID)
       let remainingCredentials = try await credentialStore.loadAll()
-      if let removedCredential,
-        !remainingCredentials.contains(where: {
-          $0.deviceIdentityID == removedCredential.deviceIdentityID
-        })
-      {
-        try await identityStore.delete(id: removedCredential.deviceIdentityID)
+      let retainedIdentityIDs = Set(
+        remainingCredentials.flatMap(\.referencedDeviceIdentityIDs)
+      )
+      if let removedCredential {
+        for identityID in removedCredential.referencedDeviceIdentityIDs
+        where !retainedIdentityIDs.contains(identityID) {
+          try await identityStore.delete(id: identityID)
+        }
       }
       syncClientsByStationID.removeValue(forKey: stationID)
       snapshot.commands.removeAll { $0.stationID == stationID }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+WatchRemotePairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+WatchRemotePairing.swift
@@ -39,18 +39,52 @@ extension MirrorStore {
     if let pairingMutationGate {
       do {
         try await pairingMutationGate.perform { @MainActor [self] in
-          await unpair(stationID: stationID)
+          await removeDirectWatchCredential(credential)
         }
       } catch {
         syncStatus = mobileMonitorSyncStatus(for: error)
         return
       }
     } else {
-      await unpair(stationID: stationID)
+      await removeDirectWatchCredential(credential)
     }
-    guard !pairedCredentials.contains(where: { $0.stationID == stationID }) else {
+    guard
+      !pairedCredentials.contains(where: {
+        $0.stationID == stationID && MobileRemoteDaemonPairingDevice.watchOS.owns($0)
+      })
+    else {
       return
     }
     requestFreshPairingMaterial?()
+  }
+
+  private func removeDirectWatchCredential(
+    _ credential: MobilePairedStationCredential
+  ) async {
+    guard credential.hasCloudMirrorAccess else {
+      await unpair(stationID: credential.stationID)
+      return
+    }
+    guard let identityStore, let credentialStore else {
+      syncStatus = .stale("Pairing storage is unavailable.")
+      return
+    }
+    do {
+      let remoteIdentityID = credential.remoteDaemonAccess?.deviceIdentityID
+      var fallback = credential
+      fallback.remoteDaemonAccess = nil
+      try await credentialStore.save(fallback)
+      let remainingCredentials = try await credentialStore.loadAll()
+      let retainedIdentityIDs = Set(
+        remainingCredentials.flatMap(\.referencedDeviceIdentityIDs)
+      )
+      if let remoteIdentityID, !retainedIdentityIDs.contains(remoteIdentityID) {
+        try await identityStore.delete(id: remoteIdentityID)
+      }
+      try await rebuildSyncClients(preferredStationID: fallback.stationID)
+      syncStatus = .paired(fallback.stationName)
+    } catch {
+      syncStatus = mobileMonitorSyncStatus(for: error)
+    }
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStoreCollaborators.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStoreCollaborators.swift
@@ -8,6 +8,7 @@ public protocol MobileMonitorCredentialPairer: Sendable {
   func pair(
     invitationURL: URL,
     deviceName: String,
+    cloudFallbackStationID: String?,
     now: Date
   ) async throws -> MobilePairedStationCredential
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/LiveMobileMonitorCredentialPairer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/LiveMobileMonitorCredentialPairer.swift
@@ -28,6 +28,7 @@ actor LiveMobileMonitorCredentialPairer: MobileMonitorCredentialPairer {
   func pair(
     invitationURL: URL,
     deviceName: String,
+    cloudFallbackStationID: String?,
     now: Date
   ) async throws -> MobilePairedStationCredential {
     switch try MobilePairingLink.decode(invitationURL, now: now) {
@@ -41,6 +42,7 @@ actor LiveMobileMonitorCredentialPairer: MobileMonitorCredentialPairer {
       return try await remoteCoordinator.pair(
         invitationURL: invitationURL,
         deviceName: deviceName,
+        cloudFallbackStationID: cloudFallbackStationID,
         now: now
       )
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/LiveWatchRemoteDaemonCredentialPairer.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/LiveWatchRemoteDaemonCredentialPairer.swift
@@ -24,12 +24,14 @@ actor LiveWatchRemoteDaemonCredentialPairer: MobileMonitorCredentialPairer {
   func pair(
     invitationURL: URL,
     deviceName: String,
+    cloudFallbackStationID: String?,
     now: Date
   ) async throws -> MobilePairedStationCredential {
     try await mutationGate.perform { [coordinator] in
       try await coordinator.pair(
         invitationURL: invitationURL,
         deviceName: deviceName,
+        cloudFallbackStationID: cloudFallbackStationID,
         now: now
       )
     }

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonFallbackPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonFallbackPairingTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import HarnessMonitorCrypto
+import XCTest
+
+final class MobileRemoteDaemonFallbackPairingTests: XCTestCase {
+  func testCoordinatorPreservesSingleCloudMirrorStationAsFallback() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.iOS.identityID,
+      now: now.addingTimeInterval(-600)
+    )
+    let cloudCredential = makePairedStationCredential(
+      stationID: "station-studio",
+      deviceIdentityID: identity.id,
+      now: now.addingTimeInterval(-300)
+    )
+    let identityStore = InMemoryMobileDeviceIdentityStore(identities: [identity])
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [cloudCredential]
+    )
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      transport: RecordingRemotePairingTransport(
+        claim: MobileRemoteDaemonPairingClaim(
+          clientID: "ios-identity-fingerprint",
+          displayName: "Bart's iPhone",
+          platform: "ios",
+          role: .operator,
+          scopes: ["read", "write"],
+          token: "server-issued-token",
+          tokenHint: "abcd1234",
+          pairedAt: now
+        )
+      ),
+      device: .iOS
+    )
+
+    let credential = try await coordinator.pair(
+      invitationURL: remoteInvitationURL(now: now),
+      deviceName: "Bart's iPhone",
+      now: now
+    )
+
+    XCTAssertEqual(credential.stationID, cloudCredential.stationID)
+    XCTAssertEqual(credential.endpoint, cloudCredential.endpoint)
+    XCTAssertEqual(credential.snapshotKeyID, cloudCredential.snapshotKeyID)
+    XCTAssertEqual(credential.commandKeyID, cloudCredential.commandKeyID)
+    XCTAssertEqual(
+      credential.symmetricKeyRawRepresentation,
+      cloudCredential.symmetricKeyRawRepresentation
+    )
+    XCTAssertTrue(credential.hasCloudMirrorAccess)
+    XCTAssertEqual(credential.remoteDaemonAccess?.bearerToken, "server-issued-token")
+    let storedCredentials = try await credentialStore.loadAll()
+    XCTAssertEqual(storedCredentials, [credential])
+  }
+
+  func testCoordinatorUsesSelectedCloudFallbackAmongMultipleStations() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.iOS.identityID,
+      now: now.addingTimeInterval(-600)
+    )
+    let studio = makePairedStationCredential(
+      stationID: "station-studio",
+      deviceIdentityID: identity.id,
+      now: now.addingTimeInterval(-300)
+    )
+    let laptop = makePairedStationCredential(
+      stationID: "station-laptop",
+      deviceIdentityID: identity.id,
+      now: now.addingTimeInterval(-200)
+    )
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [studio, laptop]
+    )
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: InMemoryMobileDeviceIdentityStore(identities: [identity]),
+      credentialStore: credentialStore,
+      transport: RecordingRemotePairingTransport(
+        claim: MobileRemoteDaemonPairingClaim(
+          clientID: "ios-identity-fingerprint",
+          displayName: "Bart's iPhone",
+          platform: "ios",
+          role: .operator,
+          scopes: ["read", "write"],
+          token: "server-issued-token",
+          tokenHint: "abcd1234",
+          pairedAt: now
+        )
+      ),
+      device: .iOS
+    )
+
+    let credential = try await coordinator.pair(
+      invitationURL: remoteInvitationURL(now: now),
+      deviceName: "Bart's iPhone",
+      cloudFallbackStationID: laptop.stationID,
+      now: now
+    )
+
+    XCTAssertEqual(credential.stationID, laptop.stationID)
+    XCTAssertEqual(credential.snapshotKeyID, laptop.snapshotKeyID)
+    XCTAssertEqual(credential.remoteDaemonAccess?.bearerToken, "server-issued-token")
+    let storedCredentials = try await credentialStore.loadAll()
+    XCTAssertEqual(storedCredentials.count, 2)
+    XCTAssertEqual(
+      storedCredentials.first { $0.stationID == laptop.stationID },
+      credential
+    )
+    XCTAssertEqual(
+      storedCredentials.first { $0.stationID == studio.stationID },
+      studio
+    )
+  }
+
+  func testCoordinatorRejectsMissingCloudFallbackBeforeClaim() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.iOS.identityID,
+      now: now.addingTimeInterval(-600)
+    )
+    let studio = makePairedStationCredential(
+      stationID: "station-studio",
+      deviceIdentityID: identity.id,
+      now: now.addingTimeInterval(-300)
+    )
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [studio]
+    )
+    let transport = RecordingRemotePairingTransport(
+      claim: MobileRemoteDaemonPairingClaim(
+        clientID: "ios-identity-fingerprint",
+        displayName: "Bart's iPhone",
+        platform: "ios",
+        role: .operator,
+        scopes: ["read", "write"],
+        token: "server-issued-token",
+        tokenHint: "abcd1234",
+        pairedAt: now
+      )
+    )
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: InMemoryMobileDeviceIdentityStore(identities: [identity]),
+      credentialStore: credentialStore,
+      transport: transport,
+      device: .iOS
+    )
+
+    do {
+      _ = try await coordinator.pair(
+        invitationURL: remoteInvitationURL(now: now),
+        deviceName: "Bart's iPhone",
+        cloudFallbackStationID: "station-missing",
+        now: now
+      )
+      XCTFail("expected missing Cloud fallback to fail")
+    } catch {
+      XCTAssertEqual(
+        error as? MobileRemoteDaemonPairingError,
+        .invalidCloudFallbackStation
+      )
+    }
+
+    let capturedRequest = await transport.lastRequest()
+    XCTAssertNil(capturedRequest)
+    let storedCredentials = try await credentialStore.loadAll()
+    XCTAssertEqual(storedCredentials, [studio])
+  }
+
+  func testSelectedCloudFallbackRemovesStandaloneRemoteDuplicate() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let identity = makePairingIdentity(
+      id: MobileRemoteDaemonPairingDevice.iOS.identityID,
+      now: now.addingTimeInterval(-600)
+    )
+    let cloudCredential = makePairedStationCredential(
+      stationID: "station-studio",
+      deviceIdentityID: identity.id,
+      now: now.addingTimeInterval(-300)
+    )
+    let standaloneRemote = MobilePairedStationCredential(
+      stationID: "remote-daemon-example-com",
+      stationName: "daemon.example.com",
+      endpoint: URL(string: "https://daemon.example.com")!,
+      stationPublicKeyFingerprint: testSPKIPin,
+      deviceIdentityID: identity.id,
+      snapshotKeyID: "",
+      commandKeyID: "",
+      symmetricKeyRawRepresentation: Data(),
+      pairedAt: now.addingTimeInterval(-200),
+      remoteDaemonAccess: try remoteAccess(deviceIdentityID: identity.id)
+    )
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [cloudCredential, standaloneRemote]
+    )
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: InMemoryMobileDeviceIdentityStore(identities: [identity]),
+      credentialStore: credentialStore,
+      transport: RecordingRemotePairingTransport(
+        claim: MobileRemoteDaemonPairingClaim(
+          clientID: "ios-identity-fingerprint",
+          displayName: "Bart's iPhone",
+          platform: "ios",
+          role: .operator,
+          scopes: ["read", "write"],
+          token: "server-issued-token",
+          tokenHint: "abcd1234",
+          pairedAt: now
+        )
+      ),
+      device: .iOS
+    )
+
+    let credential = try await coordinator.pair(
+      invitationURL: remoteInvitationURL(now: now),
+      deviceName: "Bart's iPhone",
+      cloudFallbackStationID: cloudCredential.stationID,
+      now: now
+    )
+
+    XCTAssertEqual(credential.stationID, cloudCredential.stationID)
+    let storedCredentials = try await credentialStore.loadAll()
+    XCTAssertEqual(storedCredentials, [credential])
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingTests.swift
@@ -166,6 +166,7 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
     let decoded = try JSONDecoder().decode(MobileRemoteDaemonAccess.self, from: legacyPayload)
 
     XCTAssertNil(decoded.reviewsQuery)
+    XCTAssertNil(decoded.deviceIdentityID)
   }
 
   func testAdminRoleCanReadBeforeScopeExpansion() throws {
@@ -266,7 +267,7 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
       symmetricKeyRawRepresentation: Data(),
       pairedAt: now,
       defaultStation: true,
-      remoteDaemonAccess: try remoteAccess()
+      remoteDaemonAccess: try remoteAccess(deviceIdentityID: identity.id)
     )
     let transfer = MobileWatchPairingTransfer(
       identities: [identity],
@@ -277,11 +278,12 @@ final class MobileRemoteDaemonPairingTests: XCTestCase {
     let decoded = try MobileWatchPairingTransfer.decode(try transfer.encodedData())
 
     XCTAssertEqual(decoded.credentials.first?.remoteDaemonAccess, credential.remoteDaemonAccess)
+    XCTAssertEqual(decoded.credentials.first?.remoteDaemonAccess?.deviceIdentityID, identity.id)
     XCTAssertEqual(decoded, transfer)
   }
 }
 
-private actor RecordingRemotePairingTransport: MobileRemoteDaemonPairingTransport {
+actor RecordingRemotePairingTransport: MobileRemoteDaemonPairingTransport {
   struct Request: Sendable {
     var clientID: String
     var displayName: String
@@ -310,9 +312,9 @@ private actor RecordingRemotePairingTransport: MobileRemoteDaemonPairingTranspor
   }
 }
 
-private let testSPKIPin = "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
+let testSPKIPin = "sha256/CQ8Rnn313xPUG+5zny4xTooD6AxAsZr/anC/ea4bTIY="
 
-private func remoteInvitationURL(
+func remoteInvitationURL(
   now: Date,
   endpoint: String = "https://daemon.example.com",
   ttl: TimeInterval = 600
@@ -335,7 +337,7 @@ private func remoteInvitationURL(
   return try XCTUnwrap(URL(string: "harness://remote-pair?payload=\(encoded)"))
 }
 
-private func remoteAccess() throws -> MobileRemoteDaemonAccess {
+func remoteAccess(deviceIdentityID: String? = nil) throws -> MobileRemoteDaemonAccess {
   MobileRemoteDaemonAccess(
     endpoint: URL(string: "https://daemon.example.com")!,
     clientID: "ios-identity-fingerprint",
@@ -347,7 +349,8 @@ private func remoteAccess() throws -> MobileRemoteDaemonAccess {
     tokenHint: "abcd1234",
     serverSPKISHA256: try MobileRemoteDaemonSPKIPin(validating: testSPKIPin),
     pairedAt: Date(timeIntervalSince1970: 1_752_124_405),
-    reviewsQuery: remoteReviewsQuery()
+    reviewsQuery: remoteReviewsQuery(),
+    deviceIdentityID: deviceIdentityID
   )
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonWatchPairingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonWatchPairingTests.swift
@@ -85,6 +85,54 @@ final class MobileRemoteDaemonWatchPairingTests: XCTestCase {
     let storedPhoneIdentity = try await identityStore.load(id: phoneIdentity.id)
     XCTAssertEqual(storedPhoneIdentity, phoneIdentity)
   }
+
+  func testWatchPairingPreservesCloudFallbackWithIndependentRemoteOwnership() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let phoneIdentity = MobileDeviceIdentity(
+      id: "default-mobile-device",
+      displayName: "Bart's iPhone",
+      signingPrivateKeyRawRepresentation: Data(repeating: 1, count: 32),
+      agreementPrivateKeyRawRepresentation: Data(repeating: 2, count: 32),
+      createdAt: now.addingTimeInterval(-60)
+    )
+    var cloudFallback = try transferredPhoneCredential(identity: phoneIdentity, now: now)
+    cloudFallback.snapshotKeyID = "snapshot-key"
+    cloudFallback.commandKeyID = "command-key"
+    cloudFallback.symmetricKeyRawRepresentation = Data(repeating: 3, count: 32)
+    let identityStore = InMemoryMobileDeviceIdentityStore(identities: [phoneIdentity])
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [cloudFallback]
+    )
+    let coordinator = MobileRemoteDaemonPairingCoordinator(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      transport: RecordingWatchRemotePairingTransport(pairedAt: now),
+      device: .watchOS
+    )
+
+    let credential = try await coordinator.pair(
+      invitationURL: try watchRemoteInvitationURL(now: now),
+      deviceName: "Bart's Apple Watch",
+      now: now
+    )
+
+    XCTAssertEqual(credential.stationID, cloudFallback.stationID)
+    XCTAssertEqual(credential.deviceIdentityID, phoneIdentity.id)
+    XCTAssertEqual(credential.snapshotKeyID, cloudFallback.snapshotKeyID)
+    XCTAssertEqual(credential.commandKeyID, cloudFallback.commandKeyID)
+    XCTAssertEqual(
+      credential.symmetricKeyRawRepresentation,
+      cloudFallback.symmetricKeyRawRepresentation
+    )
+    XCTAssertTrue(credential.hasCloudMirrorAccess)
+    XCTAssertTrue(MobileRemoteDaemonPairingDevice.watchOS.owns(credential))
+    let storedWatchIdentity = try await identityStore.load(
+      id: MobileRemoteDaemonPairingDevice.watchOS.identityID
+    )
+    let storedPhoneIdentity = try await identityStore.load(id: phoneIdentity.id)
+    XCTAssertNotNil(storedWatchIdentity)
+    XCTAssertNotNil(storedPhoneIdentity)
+  }
 }
 
 private actor RecordingWatchRemotePairingTransport: MobileRemoteDaemonPairingTransport {

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingPayloadTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingPayloadTests.swift
@@ -99,12 +99,64 @@ final class WatchRemoteDaemonPairingPayloadTests: XCTestCase {
     XCTAssertFalse(paired)
     XCTAssertEqual(store.pairedCredentials, [credential])
   }
+
+  func testWatchForwardsSelectedCloudFallbackAmongMultipleStations() async throws {
+    let now = Date(timeIntervalSince1970: 1_752_124_400)
+    let phoneIdentity = MobileDeviceIdentity(
+      id: "phone-identity",
+      displayName: "Bart's iPhone",
+      createdAt: now.addingTimeInterval(-600)
+    )
+    let studio = watchCloudCredential(
+      stationID: "station-studio",
+      identityID: phoneIdentity.id,
+      defaultStation: true,
+      now: now.addingTimeInterval(-300)
+    )
+    let laptop = watchCloudCredential(
+      stationID: "station-laptop",
+      identityID: phoneIdentity.id,
+      defaultStation: false,
+      now: now.addingTimeInterval(-200)
+    )
+    let identityStore = InMemoryMobileDeviceIdentityStore(identities: [phoneIdentity])
+    let credentialStore = InMemoryMobilePairedStationCredentialStore(
+      credentials: [studio, laptop]
+    )
+    let pairer = RecordingWatchCredentialPairer(
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      credential: try watchRemoteCredential(now: now)
+    )
+    let store = MirrorStore(
+      demoModeEnabled: false,
+      profile: .watch,
+      identityStore: identityStore,
+      credentialStore: credentialStore,
+      syncClientFactory: WatchPairingSyncClientFactory(),
+      pairer: pairer,
+      sharedSnapshotStore: nil
+    )
+    await store.loadStoredPairings()
+    store.selectedStationID = laptop.stationID
+
+    let paired = await store.pairDirectWatchDaemon(
+      payload: try watchRemoteInvitationURL(now: now).absoluteString,
+      deviceName: "Bart's Apple Watch",
+      now: now
+    )
+
+    XCTAssertTrue(paired)
+    let capturedRequest = await pairer.lastRequest()
+    XCTAssertEqual(capturedRequest?.cloudFallbackStationID, laptop.stationID)
+  }
 }
 
 private struct FailingWatchCredentialPairer: MobileMonitorCredentialPairer {
   func pair(
     invitationURL: URL,
     deviceName: String,
+    cloudFallbackStationID: String?,
     now: Date
   ) async throws -> MobilePairedStationCredential {
     throw WatchPairingTestError.claimFailed
@@ -119,6 +171,7 @@ private actor RecordingWatchCredentialPairer: MobileMonitorCredentialPairer {
   struct Request: Sendable {
     var invitationURL: URL
     var deviceName: String
+    var cloudFallbackStationID: String?
     var now: Date
   }
 
@@ -140,9 +193,15 @@ private actor RecordingWatchCredentialPairer: MobileMonitorCredentialPairer {
   func pair(
     invitationURL: URL,
     deviceName: String,
+    cloudFallbackStationID: String?,
     now: Date
   ) async throws -> MobilePairedStationCredential {
-    request = Request(invitationURL: invitationURL, deviceName: deviceName, now: now)
+    request = Request(
+      invitationURL: invitationURL,
+      deviceName: deviceName,
+      cloudFallbackStationID: cloudFallbackStationID,
+      now: now
+    )
     try await identityStore.save(
       MobileDeviceIdentity(
         id: credential.deviceIdentityID,
@@ -228,6 +287,26 @@ private func watchRemoteCredential(now: Date) throws -> MobilePairedStationCrede
       serverSPKISHA256: pin,
       pairedAt: now
     )
+  )
+}
+
+private func watchCloudCredential(
+  stationID: String,
+  identityID: String,
+  defaultStation: Bool,
+  now: Date
+) -> MobilePairedStationCredential {
+  MobilePairedStationCredential(
+    stationID: stationID,
+    stationName: stationID,
+    endpoint: URL(string: "https://\(stationID).local/pair")!,
+    stationPublicKeyFingerprint: "00:11:22:33:44:55:66:77",
+    deviceIdentityID: identityID,
+    snapshotKeyID: "snapshot-key",
+    commandKeyID: "command-key",
+    symmetricKeyRawRepresentation: Data(repeating: 3, count: 32),
+    pairedAt: now,
+    defaultStation: defaultStation
   )
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HarnessMonitorCore
 @testable import HarnessMonitorCrypto
 import HarnessMonitorMirrorStore
 import XCTest
@@ -71,11 +72,38 @@ final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
     XCTAssertEqual(storedCredential, fixture.credential)
     XCTAssertEqual(fixture.transferRequests.value, 0)
   }
+
+  func testRemovingDirectWatchPairingRetainsCloudFallback() async throws {
+    let fixture = try WatchRemotePairingStoreFixture(device: .watchOS, cloudFallback: true)
+    let fallbackIdentity = try XCTUnwrap(fixture.fallbackIdentity)
+    await fixture.store.loadStoredPairings()
+    fixture.store.requestFreshPairingMaterial = { fixture.transferRequests.increment() }
+
+    await fixture.store.removeDirectWatchPairing(stationID: fixture.credential.stationID)
+
+    let storedCredential = try await fixture.credentialStore.load(
+      stationID: fixture.credential.stationID
+    )
+    let storedWatchIdentity = try await fixture.identityStore.load(id: fixture.identity.id)
+    let storedFallbackIdentity = try await fixture.identityStore.load(id: fallbackIdentity.id)
+    XCTAssertEqual(storedCredential?.snapshotKeyID, fixture.credential.snapshotKeyID)
+    XCTAssertEqual(storedCredential?.commandKeyID, fixture.credential.commandKeyID)
+    XCTAssertEqual(
+      storedCredential?.symmetricKeyRawRepresentation,
+      fixture.credential.symmetricKeyRawRepresentation
+    )
+    XCTAssertTrue(storedCredential?.hasCloudMirrorAccess == true)
+    XCTAssertNil(storedCredential?.remoteDaemonAccess)
+    XCTAssertNil(storedWatchIdentity)
+    XCTAssertEqual(storedFallbackIdentity, fallbackIdentity)
+    XCTAssertEqual(fixture.transferRequests.value, 1)
+  }
 }
 
 @MainActor
 private struct WatchRemotePairingStoreFixture {
   let identity: MobileDeviceIdentity
+  let fallbackIdentity: MobileDeviceIdentity?
   let credential: MobilePairedStationCredential
   let identityStore: InMemoryMobileDeviceIdentityStore
   let credentialStore: InMemoryMobilePairedStationCredentialStore
@@ -84,7 +112,8 @@ private struct WatchRemotePairingStoreFixture {
 
   init(
     device: MobileRemoteDaemonPairingDevice,
-    mutationGate: MobilePairingMutationGate = MobilePairingMutationGate()
+    mutationGate: MobilePairingMutationGate = MobilePairingMutationGate(),
+    cloudFallback: Bool = false
   ) throws {
     let now = Date(timeIntervalSince1970: 1_752_124_400)
     let endpoint = URL(string: "https://daemon.example.com")!
@@ -98,15 +127,24 @@ private struct WatchRemotePairingStoreFixture {
       agreementPrivateKeyRawRepresentation: Data(repeating: 2, count: 32),
       createdAt: now
     )
+    fallbackIdentity = cloudFallback
+      ? MobileDeviceIdentity(
+        id: MobileRemoteDaemonPairingDevice.iOS.identityID,
+        displayName: "ios",
+        signingPrivateKeyRawRepresentation: Data(repeating: 4, count: 32),
+        agreementPrivateKeyRawRepresentation: Data(repeating: 5, count: 32),
+        createdAt: now.addingTimeInterval(-60)
+      )
+      : nil
     credential = MobilePairedStationCredential(
       stationID: "remote-daemon-example-com",
       stationName: "daemon.example.com",
       endpoint: endpoint,
       stationPublicKeyFingerprint: pin.value,
-      deviceIdentityID: device.identityID,
-      snapshotKeyID: "",
-      commandKeyID: "",
-      symmetricKeyRawRepresentation: Data(),
+      deviceIdentityID: fallbackIdentity?.id ?? device.identityID,
+      snapshotKeyID: cloudFallback ? "snapshot-key" : "",
+      commandKeyID: cloudFallback ? "command-key" : "",
+      symmetricKeyRawRepresentation: cloudFallback ? Data(repeating: 3, count: 32) : Data(),
       pairedAt: now,
       defaultStation: true,
       remoteDaemonAccess: MobileRemoteDaemonAccess(
@@ -119,19 +157,54 @@ private struct WatchRemotePairingStoreFixture {
         bearerToken: "server-token",
         tokenHint: "token123",
         serverSPKISHA256: pin,
-        pairedAt: now
+        pairedAt: now,
+        deviceIdentityID: device.identityID
       )
     )
-    identityStore = InMemoryMobileDeviceIdentityStore(identities: [identity])
+    identityStore = InMemoryMobileDeviceIdentityStore(
+      identities: [identity] + [fallbackIdentity].compactMap { $0 }
+    )
     credentialStore = InMemoryMobilePairedStationCredentialStore(credentials: [credential])
     store = MirrorStore(
       demoModeEnabled: false,
       profile: .watch,
       identityStore: identityStore,
       credentialStore: credentialStore,
+      syncClientFactory: WatchRemovalSyncClientFactory(),
       pairingMutationGate: mutationGate,
       sharedSnapshotStore: nil
     )
+  }
+}
+
+private struct WatchRemovalSyncClientFactory: MobileMonitorSyncClientFactory {
+  func makeSyncClient(
+    credential: MobilePairedStationCredential,
+    identity: MobileDeviceIdentity
+  ) -> any MobileMonitorSyncClient {
+    WatchRemovalSyncClient()
+  }
+}
+
+private struct WatchRemovalSyncClient: MobileMonitorSyncClient {
+  func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot? {
+    nil
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonSyncError.commandsUnavailable
   }
 }
 


### PR DESCRIPTION
## Motivation
Direct remote pairing replaced an existing CloudMirror station credential, so iPhone and watch lost CloudKit fallback when direct access failed. Removing direct watch access also deleted the full station credential.

## Implementation
- Keep remote bearer access and device ownership alongside existing CloudMirror keys, including selected-station routing and stale standalone-profile cleanup.
- Remove only direct watch access while retaining Cloud fallback and cleaning unreferenced identities.
- Add TDD coverage for fallback selection, pre-claim validation, serialized watch transfer, store rebuilding, and iOS/watchOS builds.
