### PR TITLE
feat(remote): secure viewer task reads

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/ReviewsFilesWireTypes.generated.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/ReviewsFilesWireTypes.generated.swift
@@ -600,9 +600,24 @@ public struct ReviewsFilesViewedResponseWire: Codable, Equatable, Sendable {
 
 public enum FilesLargeDiffStrategyWire: String, Codable, Equatable, Sendable, CaseIterable, Identifiable {
   case autoLocalClone = "auto_local_clone"
-  case forceGitHubRest = "force_git_hub_rest"
+  case forceGitHubRest = "force_github_rest"
 
   public var id: String { rawValue }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    switch rawValue {
+    case "auto_local_clone": self = .autoLocalClone
+    case "force_github_rest", "force_git_hub_rest": self = .forceGitHubRest
+    default: throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot initialize FilesLargeDiffStrategyWire from invalid String value \(rawValue)")
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
 }
 
 public struct LocalCloneListEntryWire: Codable, Equatable, Sendable {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/TaskBoardItemWireTypes.generated.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/TaskBoardItemWireTypes.generated.swift
@@ -183,10 +183,25 @@ public struct ExternalRefWire: Codable, Equatable, Sendable {
 }
 
 public enum ExternalRefProviderWire: String, Codable, Equatable, Sendable, CaseIterable, Identifiable {
-  case gitHub = "git_hub"
+  case gitHub = "github"
   case todoist = "todoist"
 
   public var id: String { rawValue }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    switch rawValue {
+    case "github", "git_hub": self = .gitHub
+    case "todoist": self = .todoist
+    default: throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot initialize ExternalRefProviderWire from invalid String value \(rawValue)")
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
 }
 
 public struct ExternalRefSyncStateWire: Codable, Equatable, Sendable {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardModels.swift
@@ -118,8 +118,27 @@ extension TaskBoardAgentMode {
 }
 
 public enum TaskBoardExternalRefProvider: String, Codable, Sendable {
-  case gitHub = "git_hub"
+  case gitHub = "github"
   case todoist
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    switch rawValue {
+    case "github", "git_hub": self = .gitHub
+    case "todoist": self = .todoist
+    default:
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Unknown task-board external reference provider: \(rawValue)"
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
 }
 
 public struct TaskBoardExternalRef: Codable, Equatable, Sendable {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardSummaryModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardSummaryModels.swift
@@ -6,8 +6,27 @@ public struct TaskBoardStatusCount: Codable, Equatable, Sendable {
 }
 
 public enum TaskBoardExternalProvider: String, Codable, Sendable {
-  case gitHub = "git_hub"
+  case gitHub = "github"
   case todoist
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    switch rawValue {
+    case "github", "git_hub": self = .gitHub
+    case "todoist": self = .todoist
+    default:
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Unknown task-board external provider: \(rawValue)"
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
 }
 
 public enum TaskBoardExternalSyncAction: String, Codable, CaseIterable, Sendable {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/ReviewFile.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/ReviewFile.swift
@@ -95,7 +95,26 @@ public enum ReviewFileViewedOutcome: String, Codable, Equatable, Sendable, CaseI
 /// Settings choice for substantial-PR strategy. Mirrors the daemon enum.
 public enum FilesLargeDiffStrategy: String, Codable, Equatable, Sendable, CaseIterable {
   case autoLocalClone = "auto_local_clone"
-  case forceGitHubRest = "force_git_hub_rest"
+  case forceGitHubRest = "force_github_rest"
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    switch rawValue {
+    case "auto_local_clone": self = .autoLocalClone
+    case "force_github_rest", "force_git_hub_rest": self = .forceGitHubRest
+    default:
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Unknown large-diff strategy: \(rawValue)"
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
 }
 
 /// Per-file metadata returned by the daemon's `files_list` endpoint.

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/Previews/PreviewTaskBoardOperationsPanel.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/Previews/PreviewTaskBoardOperationsPanel.swift
@@ -100,7 +100,7 @@ private enum TaskBoardOperationsPreviewFixtures {
         "total": 1,
         "providers": [
           {
-            "provider": "git_hub",
+            "provider": "github",
             "configured": true,
             "linked": 1,
             "pushable": 1,
@@ -110,7 +110,7 @@ private enum TaskBoardOperationsPreviewFixtures {
         ],
         "operations": [
           {
-            "provider": "git_hub",
+            "provider": "github",
             "action": "push",
             "boardItemId": "preview-board-only",
             "externalId": null,

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/ReviewFileModelTests+Patch.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/ReviewFileModelTests+Patch.swift
@@ -148,7 +148,10 @@ final class ReviewFileModelPatchTests: XCTestCase {
       FilesLargeDiffStrategy.self, from: Data(json.utf8))
     XCTAssertEqual(parsed, .autoLocalClone)
     let encoded = try JSONEncoder().encode(FilesLargeDiffStrategy.forceGitHubRest)
-    XCTAssertEqual(String(bytes: encoded, encoding: .utf8), "\"force_git_hub_rest\"")
+    XCTAssertEqual(String(bytes: encoded, encoding: .utf8), "\"force_github_rest\"")
+    let legacy = try JSONDecoder().decode(
+      FilesLargeDiffStrategy.self, from: Data("\"force_git_hub_rest\"".utf8))
+    XCTAssertEqual(legacy, .forceGitHubRest)
   }
 
   func testServedByValueRoundTripsSnakeCase() throws {

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/ReviewsFilesWireTypesDecodingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/ReviewsFilesWireTypesDecodingTests.swift
@@ -94,8 +94,11 @@ struct ReviewsFilesWireTypesDecodingTests {
 
   @Test("decodes the large-diff strategy and a local clone list entry")
   func decodesLargeDiffStrategyAndClonesEntry() throws {
-    // FilesLargeDiffStrategy is snake_case; serde splits the GitHub word so
-    // ForceGitHubRest serializes as force_git_hub_rest.
+    // The public wire name treats GitHub as one word.
+    #expect(
+      try decoder.decode(FilesLargeDiffStrategyWire.self, from: Data("\"force_github_rest\"".utf8))
+        == .forceGitHubRest
+    )
     #expect(
       try decoder.decode(FilesLargeDiffStrategyWire.self, from: Data("\"force_git_hub_rest\"".utf8))
         == .forceGitHubRest

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientFixtures.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientFixtures.swift
@@ -113,7 +113,7 @@ let sampleTaskBoardSyncSummaryJSON: [String: JSONValue] = [
   "total": .number(1),
   "providers": .array([
     .object([
-      "provider": .string("git_hub"),
+      "provider": .string("github"),
       "configured": .bool(true),
       "linked": .number(1),
       "pushable": .number(0),
@@ -123,7 +123,7 @@ let sampleTaskBoardSyncSummaryJSON: [String: JSONValue] = [
   ]),
   "operations": .array([
     .object([
-      "provider": .string("git_hub"),
+      "provider": .string("github"),
       "action": .string("push"),
       "board_item_id": .string("board-1"),
       "external_id": .string("123"),

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientHTTPContractTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientHTTPContractTests.swift
@@ -257,7 +257,7 @@ extension TaskBoardAPIClientTests {
     #expect(records[3].body?["clear_session_id"] as? Bool == true)
     #expect(records[3].body?["clear_work_item_id"] as? Bool == true)
     #expect(records[5].body?["status"] as? String == "todo")
-    #expect(records[5].body?["provider"] as? String == "git_hub")
+    #expect(records[5].body?["provider"] as? String == "github")
     #expect(records[5].body?["direction"] as? String == "push")
     #expect(records[5].body?["dry_run"] as? Bool == false)
     #expect(records[6].body?["status"] as? String == "todo")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientTests.swift
@@ -5,6 +5,29 @@ import Testing
 
 @Suite("Task-board daemon API client", .serialized)
 struct TaskBoardAPIClientTests {
+  @Test("GitHub providers encode canonically and accept legacy values")
+  func gitHubProviderWireNames() throws {
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+
+    #expect(
+      String(bytes: try encoder.encode(TaskBoardExternalProvider.gitHub), encoding: .utf8)
+        == #""github""#
+    )
+    #expect(
+      String(bytes: try encoder.encode(TaskBoardExternalRefProvider.gitHub), encoding: .utf8)
+        == #""github""#
+    )
+    #expect(
+      try decoder.decode(TaskBoardExternalProvider.self, from: Data(#""git_hub""#.utf8))
+        == .gitHub
+    )
+    #expect(
+      try decoder.decode(TaskBoardExternalRefProvider.self, from: Data(#""git_hub""#.utf8))
+        == .gitHub
+    )
+  }
+
   @Test("Git runtime config decodes daemon default payload")
   func gitRuntimeConfigDecodesDaemonDefaultPayload() throws {
     let data = Data(#"{"global":{"signing":{"mode":"none"}}}"#.utf8)
@@ -112,7 +135,7 @@ struct TaskBoardAPIClientTests {
         "agent_mode": "interactive",
         "external_refs": [
           {
-            "provider": "git_hub",
+            "provider": "github",
             "external_id": "123",
             "url": "https://example.invalid/issues/123"
           }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientTextFixtures.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientTextFixtures.swift
@@ -126,7 +126,7 @@ let sampleTaskBoardSyncSummaryText =
     "total": 1,
     "providers": [
       {
-        "provider": "git_hub",
+        "provider": "github",
         "configured": true,
         "linked": 1,
         "pushable": 0,
@@ -136,7 +136,7 @@ let sampleTaskBoardSyncSummaryText =
     ],
     "operations": [
       {
-        "provider": "git_hub",
+        "provider": "github",
         "action": "push",
         "board_item_id": "board-1",
         "external_id": "123",

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientWebSocketContractTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientWebSocketContractTests.swift
@@ -235,7 +235,7 @@ extension TaskBoardAPIClientTests {
     #expect(objectValue(calls[3].params, key: "clear_planning") == .bool(true))
     #expect(objectValue(calls[3].params, key: "clear_workflow") == .bool(true))
     #expect(objectValue(calls[5].params, key: "status") == .string("todo"))
-    #expect(objectValue(calls[5].params, key: "provider") == .string("git_hub"))
+    #expect(objectValue(calls[5].params, key: "provider") == .string("github"))
     #expect(objectValue(calls[5].params, key: "direction") == .string("push"))
     #expect(objectValue(calls[5].params, key: "dry_run") == .bool(false))
     #expect(objectValue(calls[6].params, key: "status") == .string("todo"))

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardItemWireDecodingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardItemWireDecodingTests.swift
@@ -109,6 +109,15 @@ struct TaskBoardItemWireDecodingTests {
     #expect(items.first?.id == "task-1")
     #expect(items.first?.workflow?.status == .running)
   }
+
+  @Test("accepts the legacy GitHub provider spelling")
+  func decodesLegacyGitHubProvider() throws {
+    let provider = try decoder.decode(
+      ExternalRefProviderWire.self,
+      from: Data(#""git_hub""#.utf8)
+    )
+    #expect(provider == .gitHub)
+  }
 }
 
 private let fullItemPayloadFixture = """
@@ -125,13 +134,13 @@ private let fullItemPayloadFixture = """
     "agent_mode": "interactive",
     "external_refs": [
       {
-        "provider": "git_hub",
+        "provider": "github",
         "external_id": "123",
         "url": "https://example.com/123",
         "sync_state": { "title": "Synced", "status": "todo", "synced_at": "2026-06-17T10:00:00Z" }
       }
     ],
-    "imported_from_provider": "git_hub",
+    "imported_from_provider": "github",
     "planning": { "summary": "plan", "approved_by": "lead", "approved_at": "2026-06-17T09:00:00Z" },
     "workflow": {
       "execution_id": "exec-1",

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSyncSummaryWireDecodingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSyncSummaryWireDecodingTests.swift
@@ -17,11 +17,11 @@ struct TaskBoardSyncSummaryWireDecodingTests {
       {
         "total": 5,
         "providers": [
-          {"provider": "git_hub", "configured": true, "linked": 3, "pushable": 1,
+          {"provider": "github", "configured": true, "linked": 3, "pushable": 1,
            "blocked": 0, "token_env": ["GH_TOKEN"]}
         ],
         "operations": [
-          {"provider": "git_hub", "action": "conflict", "board_item_id": "b1",
+          {"provider": "github", "action": "conflict", "board_item_id": "b1",
            "external_id": "e1", "url": "https://example.com/1", "dry_run": true, "applied": false,
            "changed_fields": ["title"], "unsupported_fields": ["labels"]}
         ]

--- a/examples/policy-codegen.rs
+++ b/examples/policy-codegen.rs
@@ -26,7 +26,14 @@ use syn::{
 /// raw value.
 struct SwiftStringEnum {
     name: String,
-    cases: Vec<(String, String)>,
+    cases: Vec<SwiftStringEnumCase>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SwiftStringEnumCase {
+    name: String,
+    raw_value: String,
+    aliases: Vec<String>,
 }
 
 /// A generated Swift struct field with its wire `CodingKey`, the decoder
@@ -85,11 +92,39 @@ fn emit_string_enum(out: &mut String, spec: &SwiftStringEnum) {
         spec.name
     )
     .unwrap();
-    for (case, raw) in &spec.cases {
-        writeln!(out, "  case {case} = \"{raw}\"").unwrap();
+    for case in &spec.cases {
+        writeln!(out, "  case {} = \"{}\"", case.name, case.raw_value).unwrap();
     }
     out.push_str("\n  public var id: String { rawValue }\n");
+    if spec.cases.iter().any(|case| !case.aliases.is_empty()) {
+        emit_string_enum_codable(out, spec);
+    }
     out.push_str("}\n");
+}
+
+fn emit_string_enum_codable(out: &mut String, spec: &SwiftStringEnum) {
+    out.push_str("\n  public init(from decoder: Decoder) throws {\n");
+    out.push_str("    let container = try decoder.singleValueContainer()\n");
+    out.push_str("    let rawValue = try container.decode(String.self)\n");
+    out.push_str("    switch rawValue {\n");
+    for case in &spec.cases {
+        write!(out, "    case \"{}\"", case.raw_value).unwrap();
+        for alias in &case.aliases {
+            write!(out, ", \"{alias}\"").unwrap();
+        }
+        writeln!(out, ": self = .{}", case.name).unwrap();
+    }
+    writeln!(
+        out,
+        "    default: throw DecodingError.dataCorruptedError(in: container, debugDescription: \"Cannot initialize {} from invalid String value \\(rawValue)\")",
+        spec.name
+    )
+    .unwrap();
+    out.push_str("    }\n  }\n\n");
+    out.push_str("  public func encode(to encoder: Encoder) throws {\n");
+    out.push_str("    var container = encoder.singleValueContainer()\n");
+    out.push_str("    try container.encode(rawValue)\n");
+    out.push_str("  }\n");
 }
 
 /// Wire enums the app keeps forward-compatible: an unrecognized daemon value
@@ -139,10 +174,10 @@ fn emit_open_enum(out: &mut String, spec: &SwiftStringEnum) {
     // Emitting both a `case unknown` and the `case unknown(String)` catch-all
     // is an invalid redeclaration, so drop the known case and let the catch-all
     // own it - matching the hand-written open enums.
-    let cases: Vec<&(String, String)> = spec
+    let cases: Vec<&SwiftStringEnumCase> = spec
         .cases
         .iter()
-        .filter(|(case, _)| case != "unknown")
+        .filter(|case| case.name != "unknown")
         .collect();
     writeln!(
         out,
@@ -150,24 +185,28 @@ fn emit_open_enum(out: &mut String, spec: &SwiftStringEnum) {
         spec.name
     )
     .unwrap();
-    for (case, _) in &cases {
-        writeln!(out, "  case {case}").unwrap();
+    for case in &cases {
+        writeln!(out, "  case {}", case.name).unwrap();
     }
     out.push_str("  case unknown(String)\n\n");
     let known = cases
         .iter()
-        .map(|(case, _)| format!(".{case}"))
+        .map(|case| format!(".{}", case.name))
         .collect::<Vec<_>>()
         .join(", ");
     writeln!(out, "  public static let allCases: [Self] = [{known}]\n").unwrap();
     out.push_str("  public var rawValue: String {\n    switch self {\n");
-    for (case, raw) in &cases {
-        writeln!(out, "    case .{case}: \"{raw}\"").unwrap();
+    for case in &cases {
+        writeln!(out, "    case .{}: \"{}\"", case.name, case.raw_value).unwrap();
     }
     out.push_str("    case .unknown(let raw): raw\n    }\n  }\n\n");
     out.push_str("  public init(rawValue: String) {\n    switch rawValue {\n");
-    for (case, raw) in &cases {
-        writeln!(out, "    case \"{raw}\": self = .{case}").unwrap();
+    for case in &cases {
+        write!(out, "    case \"{}\"", case.raw_value).unwrap();
+        for alias in &case.aliases {
+            write!(out, ", \"{alias}\"").unwrap();
+        }
+        writeln!(out, ": self = .{}", case.name).unwrap();
     }
     out.push_str("    default: self = .unknown(rawValue)\n    }\n  }\n\n");
     out.push_str("  public var id: String { rawValue }\n");
@@ -1554,6 +1593,11 @@ struct SerdeField {
     skip_serializing_if: Option<String>,
 }
 
+struct SerdeVariant {
+    rename: Option<String>,
+    aliases: Vec<String>,
+}
+
 /// The identifiers inside every `#[derive(...)]` on an item.
 fn derive_idents(attrs: &[Attribute]) -> Vec<String> {
     let mut idents = Vec::new();
@@ -1669,6 +1713,33 @@ fn serde_field(attrs: &[Attribute]) -> SerdeField {
         flatten,
         skip_serializing_if,
     }
+}
+
+/// Read the canonical wire name and decode-only aliases from an enum variant.
+fn serde_variant(attrs: &[Attribute]) -> SerdeVariant {
+    let mut rename = None;
+    let mut aliases = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let _ = attr.parse_nested_meta(|meta| {
+            let is_rename = meta.path.is_ident("rename");
+            let is_alias = meta.path.is_ident("alias");
+            if let Ok(value) = meta.value() {
+                let lit: Lit = value.parse()?;
+                if let Lit::Str(text) = lit {
+                    if is_rename {
+                        rename = Some(text.value());
+                    } else if is_alias {
+                        aliases.push(text.value());
+                    }
+                }
+            }
+            Ok(())
+        });
+    }
+    SerdeVariant { rename, aliases }
 }
 
 /// Parse the defaults sources, mapping each zero-argument default function to the
@@ -2057,10 +2128,14 @@ fn build_string_enum(item: &ItemEnum) -> SwiftStringEnum {
                 variant.ident
             );
             let name = variant.ident.to_string();
-            (
-                escape_keyword(pascal_to_camel(&name)),
-                variant_wire_value(&name, rename_all.as_deref()),
-            )
+            let serde = serde_variant(&variant.attrs);
+            SwiftStringEnumCase {
+                name: escape_keyword(pascal_to_camel(&name)),
+                raw_value: serde
+                    .rename
+                    .unwrap_or_else(|| variant_wire_value(&name, rename_all.as_deref())),
+                aliases: serde.aliases,
+            }
         })
         .collect();
     SwiftStringEnum {
@@ -3173,14 +3248,22 @@ fn main() {
 mod tests {
     use super::*;
 
+    fn string_enum_case(name: &str, raw_value: &str) -> SwiftStringEnumCase {
+        SwiftStringEnumCase {
+            name: name.to_string(),
+            raw_value: raw_value.to_string(),
+            aliases: Vec::new(),
+        }
+    }
+
     #[test]
     fn emits_string_backed_enum_with_snake_case_raw_values() {
         let spec = SwiftStringEnum {
             name: "PolicyGraphMode".to_string(),
             cases: vec![
-                ("draft".to_string(), "draft".to_string()),
-                ("dryRun".to_string(), "dry_run".to_string()),
-                ("enforced".to_string(), "enforced".to_string()),
+                string_enum_case("draft", "draft"),
+                string_enum_case("dryRun", "dry_run"),
+                string_enum_case("enforced", "enforced"),
             ],
         };
 
@@ -3195,9 +3278,9 @@ mod tests {
         let spec = SwiftStringEnum {
             name: "TaskBoardGitSigningMode".to_string(),
             cases: vec![
-                ("none".to_string(), "none".to_string()),
-                ("ssh".to_string(), "ssh".to_string()),
-                ("gpg".to_string(), "gpg".to_string()),
+                string_enum_case("none", "none"),
+                string_enum_case("ssh", "ssh"),
+                string_enum_case("gpg", "gpg"),
             ],
         };
 
@@ -3240,9 +3323,9 @@ mod tests {
         let spec = SwiftStringEnum {
             name: "ReviewMergeableState".to_string(),
             cases: vec![
-                ("mergeable".to_string(), "mergeable".to_string()),
-                ("conflicting".to_string(), "conflicting".to_string()),
-                ("unknown".to_string(), "unknown".to_string()),
+                string_enum_case("mergeable", "mergeable"),
+                string_enum_case("conflicting", "conflicting"),
+                string_enum_case("unknown", "unknown"),
             ],
         };
 
@@ -3367,10 +3450,36 @@ pub struct Drop { pub other: String }
         assert_eq!(
             spec.cases,
             vec![
-                ("speechToText".to_string(), "speechToText".to_string()),
-                ("raw".to_string(), "raw".to_string()),
+                string_enum_case("speechToText", "speechToText"),
+                string_enum_case("raw", "raw"),
             ]
         );
+    }
+
+    #[test]
+    fn variant_rename_is_canonical_and_alias_is_decode_only() {
+        let item: ItemEnum = syn::parse_str(
+            "#[serde(rename_all = \"snake_case\")] enum Provider { #[serde(rename = \"github\", alias = \"git_hub\")] GitHub, Todoist }",
+        )
+        .expect("enum parses");
+        let spec = build_string_enum(&item);
+        assert_eq!(
+            spec.cases,
+            vec![
+                SwiftStringEnumCase {
+                    name: "gitHub".to_string(),
+                    raw_value: "github".to_string(),
+                    aliases: vec!["git_hub".to_string()],
+                },
+                string_enum_case("todoist", "todoist"),
+            ]
+        );
+
+        let mut out = String::new();
+        emit_string_enum(&mut out, &spec);
+        assert!(out.contains("case gitHub = \"github\""));
+        assert!(out.contains("case \"github\", \"git_hub\": self = .gitHub"));
+        assert!(out.contains("try container.encode(rawValue)"));
     }
 
     #[test]

--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -103,7 +103,7 @@ pub(crate) fn require_auth(
     }
 }
 
-pub(crate) fn websocket_remote_client(
+pub(crate) fn authenticated_remote_client(
     headers: &HeaderMap,
     state: &DaemonHttpState,
 ) -> Result<Option<RemoteStoredClient>, Box<Response>> {

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -67,7 +67,7 @@ mod tests;
 mod voice;
 
 pub use auth::DaemonHttpAuthMode;
-pub(crate) use auth::websocket_remote_client;
+pub(crate) use auth::authenticated_remote_client;
 pub(crate) use managed_agents::{
     acp_inspect_response, acp_transcript_response, ensure_acp_agent, ensure_acp_enabled,
     ensure_codex_agent, ensure_terminal_agent_async, managed_agent_list_response_async,

--- a/src/daemon/http/task_board/items.rs
+++ b/src/daemon/http/task_board/items.rs
@@ -14,10 +14,13 @@ use crate::daemon::protocol::{
     TaskBoardPlanRevokeRequest, TaskBoardPlanSubmitRequest, TaskBoardSyncRequest,
     TaskBoardUpdateItemRequest, http_paths,
 };
+use crate::daemon::remote_task_board::{
+    is_remote_viewer, project_task_board_item, project_task_board_list,
+};
 use crate::task_board::TaskBoardStatus;
 
 use super::super::DaemonHttpState;
-use super::super::auth::{authorize_control_request, require_auth};
+use super::super::auth::{authenticated_remote_client, authorize_control_request, require_auth};
 use super::super::response::{extract_request_id, timed_json};
 use super::super::task_board_route_executor;
 
@@ -83,19 +86,22 @@ pub(super) async fn get_task_board_items(
     headers: HeaderMap,
     State(state): State<DaemonHttpState>,
 ) -> Response {
-    let (start, request_id) = match authenticated_request(&headers, &state) {
+    let (start, request_id, viewer) = match authenticated_task_board_read(&headers, &state) {
         Ok(parts) => parts,
         Err(response) => return *response,
     };
     let request = TaskBoardListItemsRequest {
         status: query.status,
     };
+    let result = task_board_route_executor::list_items(&state, &request)
+        .await
+        .map(|response| project_task_board_list(response, viewer));
     timed_json(
         "GET",
         http_paths::TASK_BOARD_ITEMS,
         &request_id,
         start,
-        task_board_route_executor::list_items(&state, &request).await,
+        result,
     )
 }
 
@@ -104,16 +110,20 @@ pub(super) async fn get_task_board_item(
     headers: HeaderMap,
     State(state): State<DaemonHttpState>,
 ) -> Response {
-    let (start, request_id) = match authenticated_request(&headers, &state) {
+    let (start, request_id, viewer) = match authenticated_task_board_read(&headers, &state) {
         Ok(parts) => parts,
         Err(response) => return *response,
     };
+    let result =
+        task_board_route_executor::get_item(&state, &TaskBoardGetItemRequest { id: item_id })
+            .await
+            .map(|item| project_task_board_item(item, viewer));
     timed_json(
         "GET",
         http_paths::TASK_BOARD_ITEM,
         &request_id,
         start,
-        task_board_route_executor::get_item(&state, &TaskBoardGetItemRequest { id: item_id }).await,
+        result,
     )
 }
 
@@ -427,6 +437,16 @@ pub(in super::super) fn authenticated_request(
     let request_id = extract_request_id(headers);
     require_auth(headers, state)?;
     Ok((start, request_id))
+}
+
+fn authenticated_task_board_read(
+    headers: &HeaderMap,
+    state: &DaemonHttpState,
+) -> Result<(Instant, String, bool), Box<Response>> {
+    let start = Instant::now();
+    let request_id = extract_request_id(headers);
+    let client = authenticated_remote_client(headers, state)?;
+    Ok((start, request_id, is_remote_viewer(client.as_ref())))
 }
 
 pub(in super::super) fn authorized_control_request_parts<T: ControlPlaneActorRequest>(

--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -47,6 +47,7 @@ mod remote_authz_audit;
 mod remote_limits;
 mod remote_limits_support;
 mod remote_pairing;
+mod remote_viewer_task_board;
 mod reviews_policy_writes;
 mod session_archive_tests;
 mod shutdown;

--- a/src/daemon/http/tests/remote_viewer_task_board.rs
+++ b/src/daemon/http/tests/remote_viewer_task_board.rs
@@ -129,7 +129,7 @@ async fn seed_sensitive_item(state: &crate::daemon::http::DaemonHttpState) {
     let item: TaskBoardItem = serde_json::from_value(json!({
         "schema_version": 1,
         "id": ITEM_ID,
-        "title": "Deploy api_key=title-secret",
+        "title": "Deploy api_key=title-secret token=viewer-title-secret",
         "body": format!(
             "Authorization: Bearer abcdefghijklmnop {}",
             "private details ".repeat(20)
@@ -201,6 +201,7 @@ fn assert_viewer_projection(item: &Value) {
     let serialized = serde_json::to_string(item).expect("serialize viewer item");
     for secret in [
         "title-secret",
+        "viewer-title-secret",
         "abcdefghijklmnop",
         "github_pat_abcdefghijklmnopqrstuvwxyz123456",
         "user:password",

--- a/src/daemon/http/tests/remote_viewer_task_board.rs
+++ b/src/daemon/http/tests/remote_viewer_task_board.rs
@@ -1,0 +1,311 @@
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use axum::http::{HeaderValue, header::AUTHORIZATION};
+use futures_util::{SinkExt, StreamExt};
+use reqwest::StatusCode;
+use serde_json::{Value, json};
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+use crate::daemon::http::DaemonHttpAuthMode;
+use crate::daemon::protocol::{http_paths, ws_methods};
+use crate::daemon::remote::RemoteRole;
+use crate::daemon::remote_auth::REMOTE_CLIENT_ID_HEADER;
+use crate::daemon::remote_identity::RemoteClientRegistration;
+use crate::task_board::TaskBoardItem;
+
+use super::test_http_state_with_db;
+
+const VIEWER_ID: &str = "viewer-task-board";
+const OPERATOR_ID: &str = "operator-task-board";
+const ITEM_ID: &str = "remote-sensitive-item";
+
+#[test]
+fn remote_task_board_reads_minimize_viewer_payloads_for_http_and_websocket() {
+    let sandbox = tempdir().expect("tempdir");
+    harness_testkit::with_isolated_harness_env(sandbox.path(), || {
+        tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(run_remote_viewer_projection_flow());
+    });
+}
+
+async fn run_remote_viewer_projection_flow() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    state.remote_domain = Some("daemon.example.com".to_string());
+    register_remote_client(&state, VIEWER_ID, RemoteRole::Viewer);
+    register_remote_client(&state, OPERATOR_ID, RemoteRole::Operator);
+    seed_sensitive_item(&state).await;
+
+    let (base_url, server) = serve_http(state).await;
+    let client = reqwest::Client::new();
+
+    let viewer_list =
+        get_http_json(&client, &base_url, http_paths::TASK_BOARD_ITEMS, VIEWER_ID).await;
+    assert_viewer_projection(&viewer_list["items"][0]);
+    let viewer_item = get_http_json(
+        &client,
+        &base_url,
+        &format!("{}/{}", http_paths::TASK_BOARD_ITEMS, ITEM_ID),
+        VIEWER_ID,
+    )
+    .await;
+    assert_viewer_projection(&viewer_item);
+
+    let operator_list = get_http_json(
+        &client,
+        &base_url,
+        http_paths::TASK_BOARD_ITEMS,
+        OPERATOR_ID,
+    )
+    .await;
+    assert_full_item(&operator_list["items"][0]);
+
+    let mut viewer_socket = connect_remote_ws(&base_url, VIEWER_ID).await;
+    let viewer_ws_list = ws_rpc(
+        &mut viewer_socket,
+        "viewer-list",
+        ws_methods::TASK_BOARD_LIST,
+        json!({}),
+    )
+    .await;
+    assert_viewer_projection(&viewer_ws_list["result"]["items"][0]);
+    let viewer_ws_item = ws_rpc(
+        &mut viewer_socket,
+        "viewer-get",
+        ws_methods::TASK_BOARD_GET,
+        json!({ "id": ITEM_ID }),
+    )
+    .await;
+    assert_viewer_projection(&viewer_ws_item["result"]);
+
+    let mut operator_socket = connect_remote_ws(&base_url, OPERATOR_ID).await;
+    let operator_ws_list = ws_rpc(
+        &mut operator_socket,
+        "operator-list",
+        ws_methods::TASK_BOARD_LIST,
+        json!({}),
+    )
+    .await;
+    assert_full_item(&operator_ws_list["result"]["items"][0]);
+
+    server.abort();
+    let _ = server.await;
+}
+
+fn register_remote_client(
+    state: &crate::daemon::http::DaemonHttpState,
+    client_id: &str,
+    role: RemoteRole,
+) {
+    let registration = RemoteClientRegistration::new_for_tests(
+        client_id,
+        "Task board client",
+        "test",
+        role,
+        crate::daemon::remote::scopes_for_role(role),
+        &remote_token(client_id),
+        "2026-07-13T00:00:00Z",
+    )
+    .expect("remote registration");
+    state
+        .db
+        .get()
+        .expect("db slot")
+        .lock()
+        .expect("db lock")
+        .register_remote_client(&registration)
+        .expect("register remote client");
+}
+
+async fn seed_sensitive_item(state: &crate::daemon::http::DaemonHttpState) {
+    let item: TaskBoardItem = serde_json::from_value(json!({
+        "schema_version": 1,
+        "id": ITEM_ID,
+        "title": "Deploy api_key=title-secret",
+        "body": format!(
+            "Authorization: Bearer abcdefghijklmnop {}",
+            "private details ".repeat(20)
+        ),
+        "status": "todo",
+        "priority": "high",
+        "tags": ["github_pat_abcdefghijklmnopqrstuvwxyz123456"],
+        "project_id": "https://user:password@example.com/repo",
+        "target_project_types": ["github"],
+        "agent_mode": "headless",
+        "external_refs": [{
+            "provider": "github",
+            "external_id": "owner/repo#123",
+            "url": "https://github.com/owner/repo/issues/123"
+        }],
+        "planning": { "summary": "operator planning detail" },
+        "workflow": {
+            "status": "running",
+            "branch": "c/private-branch",
+            "worktree": "/Users/private/worktree",
+            "last_error": "token=workflow-secret",
+            "policy_trace_ids": ["trace-private"]
+        },
+        "session_id": "session-safe-id",
+        "work_item_id": "work-safe-id",
+        "usage": { "input_tokens": 100, "output_tokens": 50, "cost_usd": 1.25 },
+        "created_at": "2026-07-13T00:00:00Z",
+        "updated_at": "2026-07-13T00:01:00Z"
+    }))
+    .expect("sensitive task item");
+    state
+        .async_db
+        .get()
+        .expect("async db")
+        .create_task_board_item(item)
+        .await
+        .expect("seed task item");
+}
+
+fn assert_viewer_projection(item: &Value) {
+    let keys = item
+        .as_object()
+        .expect("viewer item object")
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        keys,
+        BTreeSet::from([
+            "agent_mode",
+            "body",
+            "created_at",
+            "id",
+            "priority",
+            "project_id",
+            "schema_version",
+            "session_id",
+            "status",
+            "tags",
+            "title",
+            "updated_at",
+            "work_item_id",
+        ])
+    );
+    assert_eq!(item["id"], ITEM_ID);
+    assert_eq!(item["session_id"], "session-safe-id");
+    assert_eq!(item["work_item_id"], "work-safe-id");
+    assert!(item["body"].as_str().expect("body").chars().count() <= 180);
+    let serialized = serde_json::to_string(item).expect("serialize viewer item");
+    for secret in [
+        "title-secret",
+        "abcdefghijklmnop",
+        "github_pat_abcdefghijklmnopqrstuvwxyz123456",
+        "user:password",
+        "workflow-secret",
+        "/Users/private/worktree",
+        "operator planning detail",
+    ] {
+        assert!(!serialized.contains(secret), "viewer item exposed {secret}");
+    }
+    assert!(serialized.contains("[redacted]"));
+}
+
+fn assert_full_item(item: &Value) {
+    assert_eq!(item["workflow"]["worktree"], "/Users/private/worktree");
+    assert_eq!(item["workflow"]["last_error"], "token=workflow-secret");
+    assert_eq!(item["planning"]["summary"], "operator planning detail");
+    assert_eq!(item["external_refs"][0]["external_id"], "owner/repo#123");
+    assert_eq!(item["usage"]["cost_usd"].as_f64(), Some(1.25));
+}
+
+async fn get_http_json(
+    client: &reqwest::Client,
+    base_url: &str,
+    path: &str,
+    client_id: &str,
+) -> Value {
+    let response = client
+        .get(format!("{base_url}{path}"))
+        .header(REMOTE_CLIENT_ID_HEADER, client_id)
+        .bearer_auth(remote_token(client_id))
+        .send()
+        .await
+        .expect("send task-board request");
+    let status = response.status();
+    let body = response.json::<Value>().await.expect("task-board json");
+    assert_eq!(status, StatusCode::OK, "task-board response: {body}");
+    body
+}
+
+async fn connect_remote_ws(
+    base_url: &str,
+    client_id: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    let mut request = format!(
+        "{}{}",
+        base_url.replacen("http://", "ws://", 1),
+        http_paths::WS
+    )
+    .into_client_request()
+    .expect("websocket request");
+    request.headers_mut().insert(
+        REMOTE_CLIENT_ID_HEADER,
+        HeaderValue::from_str(client_id).expect("client id header"),
+    );
+    request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {}", remote_token(client_id)))
+            .expect("authorization header"),
+    );
+    connect_async(request).await.expect("connect websocket").0
+}
+
+async fn ws_rpc<S>(socket: &mut S, id: &str, method: &str, params: Value) -> Value
+where
+    S: SinkExt<Message>
+        + StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>>
+        + Unpin,
+    <S as futures_util::Sink<Message>>::Error: std::fmt::Debug,
+{
+    timeout(Duration::from_secs(5), async {
+        socket
+            .send(Message::Text(
+                json!({ "id": id, "method": method, "params": params })
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .expect("send websocket request");
+        while let Some(frame) = socket.next().await {
+            let Message::Text(text) = frame.expect("read websocket frame") else {
+                continue;
+            };
+            let value = serde_json::from_str::<Value>(&text).expect("websocket json");
+            if value["id"].as_str() == Some(id) {
+                return value;
+            }
+        }
+        panic!("missing websocket response for {id}");
+    })
+    .await
+    .expect("websocket response timeout")
+}
+
+fn remote_token(client_id: &str) -> String {
+    format!("remote-token-secret-{client_id}")
+}
+
+async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {
+    let app = super::super::daemon_http_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let address = listener.local_addr().expect("listener address");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve router");
+    });
+    (format!("http://{address}"), server)
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -52,6 +52,7 @@ pub mod remote_identity;
 pub mod remote_pairing;
 pub(crate) mod remote_redaction;
 pub(crate) mod remote_request_audit;
+pub(crate) mod remote_task_board;
 pub mod remote_tls;
 pub mod service;
 pub mod snapshot;

--- a/src/daemon/remote_redaction.rs
+++ b/src/daemon/remote_redaction.rs
@@ -9,7 +9,7 @@ static KNOWN_SECRET_RULES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(
     vec![
         (
             Regex::new(
-                r#"(?i)(\b(?:aws_secret_access_key|aws_access_key_id|github_token|gh_token|gitlab_token|openai_api_key|anthropic_api_key|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key|token|secret|password|passwd|pwd)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;]+)"#,
+                r#"(?i)(["']?\b(?:aws_secret_access_key|aws_access_key_id|github_token|gh_token|gitlab_token|openai_api_key|anthropic_api_key|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key|token|secret|password|passwd|pwd)\b["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;]+)"#,
             )
             .expect("known secret key regex"),
             "$1[redacted]",
@@ -138,6 +138,18 @@ mod tests {
             assert!(!redacted.contains(secret), "secret remained: {secret}");
         }
         assert_eq!(redacted.matches("[redacted]").count(), 6);
+    }
+
+    #[test]
+    fn known_secret_redaction_matches_quoted_json_keys() {
+        let value = r#"{"api_key":"json-alpha","token":"json-delta","name":"safe"} {'password': 'json-charlie'}"#;
+
+        let redacted = redact_known_secrets(value);
+
+        for secret in ["json-alpha", "json-delta", "json-charlie"] {
+            assert!(!redacted.contains(secret), "secret remained: {secret}");
+        }
+        assert!(redacted.contains(r#""name":"safe""#));
     }
 
     #[test]

--- a/src/daemon/remote_redaction.rs
+++ b/src/daemon/remote_redaction.rs
@@ -8,7 +8,7 @@ static KNOWN_SECRET_RULES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(
     vec![
         (
             Regex::new(
-                r#"(?i)(\b(?:aws_secret_access_key|aws_access_key_id|github_token|gh_token|gitlab_token|openai_api_key|anthropic_api_key|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key|secret|password|passwd|pwd)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;]+)"#,
+                r#"(?i)(\b(?:aws_secret_access_key|aws_access_key_id|github_token|gh_token|gitlab_token|openai_api_key|anthropic_api_key|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key|token|secret|password|passwd|pwd)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;]+)"#,
             )
             .expect("known secret key regex"),
             "$1[redacted]",
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn known_secret_redaction_matches_remote_client_policy() {
         let value = concat!(
-            "api_key=alpha Bearer abcdefghijklmnop ",
+            "api_key=alpha token=delta Bearer abcdefghijklmnop ",
             "https://user:password@example.com ",
             "github_pat_abcdefghijklmnopqrstuvwxyz123456 ",
             "AKIAABCDEFGHIJKLMNOP"
@@ -115,6 +115,7 @@ mod tests {
 
         for secret in [
             "alpha",
+            "delta",
             "abcdefghijklmnop",
             "user:password",
             "github_pat_",
@@ -122,6 +123,6 @@ mod tests {
         ] {
             assert!(!redacted.contains(secret), "secret remained: {secret}");
         }
-        assert_eq!(redacted.matches("[redacted]").count(), 5);
+        assert_eq!(redacted.matches("[redacted]").count(), 6);
     }
 }

--- a/src/daemon/remote_redaction.rs
+++ b/src/daemon/remote_redaction.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -59,11 +60,22 @@ static KNOWN_SECRET_RULES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(
 
 #[must_use]
 pub(crate) fn redact_known_secrets(value: &str) -> String {
-    KNOWN_SECRET_RULES
-        .iter()
-        .fold(value.to_string(), |redacted, (expression, replacement)| {
-            expression.replace_all(&redacted, *replacement).into_owned()
-        })
+    apply_redaction_rules(value.to_string(), &KNOWN_SECRET_RULES)
+}
+
+fn apply_redaction_rules(mut redacted: String, rules: &[(Regex, &'static str)]) -> String {
+    for (expression, replacement) in rules {
+        let replaced = {
+            match expression.replace_all(&redacted, *replacement) {
+                Cow::Borrowed(_) => None,
+                Cow::Owned(replaced) => Some(replaced),
+            }
+        };
+        if let Some(replaced) = replaced {
+            redacted = replaced;
+        }
+    }
+    redacted
 }
 
 pub(crate) fn redact_secret_detail(detail: &str) -> String {
@@ -101,7 +113,9 @@ fn is_secret_value_terminator(value_char: char) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::redact_known_secrets;
+    use regex::Regex;
+
+    use super::{apply_redaction_rules, redact_known_secrets};
 
     #[test]
     fn known_secret_redaction_matches_remote_client_policy() {
@@ -124,5 +138,18 @@ mod tests {
             assert!(!redacted.contains(secret), "secret remained: {secret}");
         }
         assert_eq!(redacted.matches("[redacted]").count(), 6);
+    }
+
+    #[test]
+    fn no_match_rule_preserves_the_owned_buffer() {
+        let mut value = String::with_capacity(64);
+        value.push_str("ordinary viewer title");
+        let original_buffer = value.as_ptr();
+        let rules = [(Regex::new(r"secret=").expect("test regex"), "[redacted]")];
+
+        let redacted = apply_redaction_rules(value, &rules);
+
+        assert_eq!(redacted.as_ptr(), original_buffer);
+        assert_eq!(redacted, "ordinary viewer title");
     }
 }

--- a/src/daemon/remote_redaction.rs
+++ b/src/daemon/remote_redaction.rs
@@ -1,3 +1,71 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+const REDACTED: &str = "[redacted]";
+
+static KNOWN_SECRET_RULES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    vec![
+        (
+            Regex::new(
+                r#"(?i)(\b(?:aws_secret_access_key|aws_access_key_id|github_token|gh_token|gitlab_token|openai_api_key|anthropic_api_key|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key|secret|password|passwd|pwd)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;]+)"#,
+            )
+            .expect("known secret key regex"),
+            "$1[redacted]",
+        ),
+        (
+            Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+                .expect("bearer token regex"),
+            "Bearer [redacted]",
+        ),
+        (
+            Regex::new(r"(?i)(https?://)[^\s/@]+:[^\s/@]+@")
+                .expect("URL credentials regex"),
+            "$1[redacted]@",
+        ),
+        (
+            Regex::new(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b").expect("GitHub PAT regex"),
+            REDACTED,
+        ),
+        (
+            Regex::new(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b").expect("GitHub token regex"),
+            REDACTED,
+        ),
+        (
+            Regex::new(r"\bglpat-[A-Za-z0-9_-]{20,}\b").expect("GitLab token regex"),
+            REDACTED,
+        ),
+        (
+            Regex::new(r"\bsk-[A-Za-z0-9]{20,}\b").expect("API token regex"),
+            REDACTED,
+        ),
+        (
+            Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b").expect("Slack token regex"),
+            REDACTED,
+        ),
+        (
+            Regex::new(r"\bAKIA[0-9A-Z]{16}\b").expect("AWS access key regex"),
+            REDACTED,
+        ),
+        (
+            Regex::new(
+                r"(?is)-----BEGIN [^-]*(?:PRIVATE KEY|SECRET|TOKEN).*?-----END [^-]*-----",
+            )
+            .expect("PEM secret regex"),
+            REDACTED,
+        ),
+    ]
+});
+
+#[must_use]
+pub(crate) fn redact_known_secrets(value: &str) -> String {
+    KNOWN_SECRET_RULES
+        .iter()
+        .fold(value.to_string(), |redacted, (expression, replacement)| {
+            expression.replace_all(&redacted, *replacement).into_owned()
+        })
+}
+
 pub(crate) fn redact_secret_detail(detail: &str) -> String {
     let mut redacted = String::with_capacity(detail.len());
     let mut offset = 0;
@@ -29,4 +97,31 @@ pub(crate) fn redact_secret_detail(detail: &str) -> String {
 fn is_secret_value_terminator(value_char: char) -> bool {
     value_char.is_whitespace()
         || matches!(value_char, '&' | ';' | ',' | ')' | ']' | '}' | '"' | '\'')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_known_secrets;
+
+    #[test]
+    fn known_secret_redaction_matches_remote_client_policy() {
+        let value = concat!(
+            "api_key=alpha Bearer abcdefghijklmnop ",
+            "https://user:password@example.com ",
+            "github_pat_abcdefghijklmnopqrstuvwxyz123456 ",
+            "AKIAABCDEFGHIJKLMNOP"
+        );
+        let redacted = redact_known_secrets(value);
+
+        for secret in [
+            "alpha",
+            "abcdefghijklmnop",
+            "user:password",
+            "github_pat_",
+            "AKIA",
+        ] {
+            assert!(!redacted.contains(secret), "secret remained: {secret}");
+        }
+        assert_eq!(redacted.matches("[redacted]").count(), 5);
+    }
 }

--- a/src/daemon/remote_task_board.rs
+++ b/src/daemon/remote_task_board.rs
@@ -1,0 +1,142 @@
+use serde::Serialize;
+
+use crate::daemon::protocol::TaskBoardListItemsResponse;
+use crate::daemon::remote::RemoteRole;
+use crate::daemon::remote_identity::RemoteStoredClient;
+use crate::task_board::{AgentMode, TaskBoardItem, TaskBoardPriority, TaskBoardStatus};
+
+use super::remote_redaction::redact_known_secrets;
+
+const BODY_PREVIEW_CHAR_LIMIT: usize = 180;
+const BODY_PREVIEW_PREFIX_LIMIT: usize = BODY_PREVIEW_CHAR_LIMIT - 3;
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub(crate) enum TaskBoardReadItemResponse {
+    Full(Box<TaskBoardItem>),
+    Viewer(Box<RemoteViewerTaskBoardItem>),
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub(crate) enum TaskBoardReadListResponse {
+    Full(TaskBoardListItemsResponse),
+    Viewer(RemoteViewerTaskBoardListResponse),
+}
+
+#[derive(Serialize)]
+pub(crate) struct RemoteViewerTaskBoardListResponse {
+    items: Vec<RemoteViewerTaskBoardItem>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct RemoteViewerTaskBoardItem {
+    schema_version: u32,
+    id: String,
+    title: String,
+    body: String,
+    status: TaskBoardStatus,
+    priority: TaskBoardPriority,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    project_id: Option<String>,
+    agent_mode: AgentMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    work_item_id: Option<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+#[must_use]
+pub(crate) fn is_remote_viewer(client: Option<&RemoteStoredClient>) -> bool {
+    client.is_some_and(|client| client.role == RemoteRole::Viewer)
+}
+
+#[must_use]
+pub(crate) fn project_task_board_list(
+    response: TaskBoardListItemsResponse,
+    viewer: bool,
+) -> TaskBoardReadListResponse {
+    if viewer {
+        TaskBoardReadListResponse::Viewer(RemoteViewerTaskBoardListResponse {
+            items: response
+                .items
+                .into_iter()
+                .map(RemoteViewerTaskBoardItem::from)
+                .collect(),
+        })
+    } else {
+        TaskBoardReadListResponse::Full(response)
+    }
+}
+
+#[must_use]
+pub(crate) fn project_task_board_item(
+    item: TaskBoardItem,
+    viewer: bool,
+) -> TaskBoardReadItemResponse {
+    if viewer {
+        TaskBoardReadItemResponse::Viewer(Box::new(item.into()))
+    } else {
+        TaskBoardReadItemResponse::Full(Box::new(item))
+    }
+}
+
+impl From<TaskBoardItem> for RemoteViewerTaskBoardItem {
+    fn from(item: TaskBoardItem) -> Self {
+        Self {
+            schema_version: item.schema_version,
+            id: item.id,
+            title: redact_known_secrets(&item.title),
+            body: body_preview(&item.body),
+            status: item.status,
+            priority: item.priority,
+            tags: item
+                .tags
+                .into_iter()
+                .map(|tag| redact_known_secrets(&tag))
+                .collect(),
+            project_id: item
+                .project_id
+                .map(|project_id| redact_known_secrets(&project_id)),
+            agent_mode: item.agent_mode,
+            session_id: item.session_id,
+            work_item_id: item.work_item_id,
+            created_at: item.created_at,
+            updated_at: item.updated_at,
+        }
+    }
+}
+
+fn body_preview(body: &str) -> String {
+    let redacted = redact_known_secrets(body.trim());
+    if redacted.chars().count() <= BODY_PREVIEW_CHAR_LIMIT {
+        return redacted;
+    }
+    format!(
+        "{}...",
+        redacted
+            .chars()
+            .take(BODY_PREVIEW_PREFIX_LIMIT)
+            .collect::<String>()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::body_preview;
+
+    #[test]
+    fn viewer_body_preview_redacts_then_truncates_by_character() {
+        let body = format!("Bearer abcdefghijklmnop {}", "\u{017c}".repeat(200));
+        let preview = body_preview(&body);
+
+        assert_eq!(preview.chars().count(), 180);
+        assert!(preview.starts_with("Bearer [redacted]"));
+        assert!(preview.ends_with("..."));
+        assert!(!preview.contains("abcdefghijklmnop"));
+    }
+}

--- a/src/daemon/remote_task_board.rs
+++ b/src/daemon/remote_task_board.rs
@@ -113,16 +113,20 @@ impl From<TaskBoardItem> for RemoteViewerTaskBoardItem {
 
 fn body_preview(body: &str) -> String {
     let redacted = redact_known_secrets(body.trim());
-    if redacted.chars().count() <= BODY_PREVIEW_CHAR_LIMIT {
-        return redacted;
+    let mut chars = redacted.chars();
+    let prefix = chars
+        .by_ref()
+        .take(BODY_PREVIEW_CHAR_LIMIT)
+        .collect::<String>();
+    if chars.next().is_none() {
+        return prefix;
     }
-    format!(
-        "{}...",
-        redacted
-            .chars()
-            .take(BODY_PREVIEW_PREFIX_LIMIT)
-            .collect::<String>()
-    )
+    let mut preview = prefix
+        .chars()
+        .take(BODY_PREVIEW_PREFIX_LIMIT)
+        .collect::<String>();
+    preview.push_str("...");
+    preview
 }
 
 #[cfg(test)]
@@ -138,5 +142,15 @@ mod tests {
         assert!(preview.starts_with("Bearer [redacted]"));
         assert!(preview.ends_with("..."));
         assert!(!preview.contains("abcdefghijklmnop"));
+    }
+
+    #[test]
+    fn viewer_body_preview_keeps_180_characters_and_truncates_181() {
+        let exact = "x".repeat(180);
+        assert_eq!(body_preview(&exact), exact);
+        assert_eq!(
+            body_preview(&"x".repeat(181)),
+            format!("{}...", "x".repeat(177))
+        );
     }
 }

--- a/src/daemon/websocket/connection.rs
+++ b/src/daemon/websocket/connection.rs
@@ -107,7 +107,7 @@ pub(crate) async fn ws_upgrade_handler(
     metadata.record_on_span(&connection_span);
     let baggage = apply_parent_context_from_headers(&connection_span, &headers);
     record_trace_id_on_span(&connection_span);
-    let remote_client = match http::websocket_remote_client(&headers, &state) {
+    let remote_client = match http::authenticated_remote_client(&headers, &state) {
         Ok(client) => client,
         Err(response) => {
             record_rejected_connection(&connection_span, &client_label);

--- a/src/daemon/websocket/dispatch/routing.rs
+++ b/src/daemon/websocket/dispatch/routing.rs
@@ -47,7 +47,7 @@ pub(super) async fn dispatch_known_method(
     if let Some(response) = dispatch_reviews_method(request, state).await {
         return Some(response);
     }
-    if let Some(response) = dispatch_task_board_method(request, state).await {
+    if let Some(response) = dispatch_task_board_method(request, state, connection).await {
         return Some(response);
     }
     if let Some(response) = dispatch_core_method(request, state, connection).await {

--- a/src/daemon/websocket/task_board.rs
+++ b/src/daemon/websocket/task_board.rs
@@ -1,21 +1,25 @@
+use std::sync::{Arc, Mutex};
+
 use crate::daemon::audit_events::{AuditEventDraft, record_audit_result};
 use crate::daemon::http::{DaemonHttpState, task_board_route_executor};
 use crate::daemon::protocol::{
     ControlPlaneActorRequest, TaskBoardAuditRequest, TaskBoardCatalogRequest,
     TaskBoardCreateItemRequest, TaskBoardDeleteItemRequest, TaskBoardDispatchRequest,
-    TaskBoardEvaluateRequest, TaskBoardGetItemRequest, TaskBoardGitSigningVerifyRequest,
-    TaskBoardHostSetProjectTypesRequest, TaskBoardListItemsRequest, TaskBoardPlanApproveRequest,
-    TaskBoardPlanBeginRequest, TaskBoardPlanRevokeRequest, TaskBoardPlanSubmitRequest,
-    TaskBoardSyncRequest, TaskBoardUpdateItemRequest, WsRequest, WsResponse, ws_methods,
+    TaskBoardEvaluateRequest, TaskBoardGitSigningVerifyRequest,
+    TaskBoardHostSetProjectTypesRequest, TaskBoardPlanApproveRequest, TaskBoardPlanBeginRequest,
+    TaskBoardPlanRevokeRequest, TaskBoardPlanSubmitRequest, TaskBoardSyncRequest,
+    TaskBoardUpdateItemRequest, WsRequest, WsResponse, ws_methods,
 };
 use crate::errors::CliError;
 use serde::de::DeserializeOwned;
 
+use super::connection::ConnectionState;
 use super::frames::error_response;
 use super::mutations::dispatch_query_result;
 
 mod orchestrator;
 mod policy;
+mod read;
 mod secret_handoff;
 
 #[expect(
@@ -25,14 +29,19 @@ mod secret_handoff;
 pub(crate) async fn dispatch_task_board_method(
     request: &WsRequest,
     state: &DaemonHttpState,
+    connection: &Arc<Mutex<ConnectionState>>,
 ) -> Option<WsResponse> {
     match request.method.as_str() {
         ws_methods::TASK_BOARD_CREATE => Some(dispatch_task_board_create(request, state).await),
         ws_methods::TASK_BOARD_CAPABILITIES => {
-            Some(dispatch_task_board_capabilities(request, state).await)
+            Some(read::dispatch_task_board_capabilities(request, state).await)
         }
-        ws_methods::TASK_BOARD_LIST => Some(dispatch_task_board_list(request, state).await),
-        ws_methods::TASK_BOARD_GET => Some(dispatch_task_board_get(request, state).await),
+        ws_methods::TASK_BOARD_LIST => {
+            Some(read::dispatch_task_board_list(request, state, connection).await)
+        }
+        ws_methods::TASK_BOARD_GET => {
+            Some(read::dispatch_task_board_get(request, state, connection).await)
+        }
         ws_methods::TASK_BOARD_UPDATE => Some(dispatch_task_board_update(request, state).await),
         ws_methods::TASK_BOARD_DELETE => Some(dispatch_task_board_delete(request, state).await),
         ws_methods::TASK_BOARD_PLAN_BEGIN => {
@@ -116,16 +125,6 @@ pub(crate) async fn dispatch_task_board_method(
     }
 }
 
-async fn dispatch_task_board_capabilities(
-    request: &WsRequest,
-    state: &DaemonHttpState,
-) -> WsResponse {
-    dispatch_query_result(
-        &request.id,
-        task_board_route_executor::capabilities(state).await,
-    )
-}
-
 async fn dispatch_task_board_create(request: &WsRequest, state: &DaemonHttpState) -> WsResponse {
     let Ok(body) = parse_params::<TaskBoardCreateItemRequest>(request) else {
         return invalid_params(request);
@@ -145,26 +144,6 @@ async fn dispatch_task_board_create(request: &WsRequest, state: &DaemonHttpState
     )
     .await;
     dispatch_query_result(&request.id, result)
-}
-
-async fn dispatch_task_board_list(request: &WsRequest, state: &DaemonHttpState) -> WsResponse {
-    let Ok(body) = parse_params_or_default::<TaskBoardListItemsRequest>(request) else {
-        return invalid_params(request);
-    };
-    dispatch_query_result(
-        &request.id,
-        task_board_route_executor::list_items(state, &body).await,
-    )
-}
-
-async fn dispatch_task_board_get(request: &WsRequest, state: &DaemonHttpState) -> WsResponse {
-    let Ok(body) = parse_params::<TaskBoardGetItemRequest>(request) else {
-        return invalid_params(request);
-    };
-    dispatch_query_result(
-        &request.id,
-        task_board_route_executor::get_item(state, &body).await,
-    )
 }
 
 async fn dispatch_task_board_update(request: &WsRequest, state: &DaemonHttpState) -> WsResponse {

--- a/src/daemon/websocket/task_board/read.rs
+++ b/src/daemon/websocket/task_board/read.rs
@@ -1,0 +1,58 @@
+use std::sync::{Arc, Mutex};
+
+use crate::daemon::http::{DaemonHttpState, task_board_route_executor};
+use crate::daemon::protocol::{
+    TaskBoardGetItemRequest, TaskBoardListItemsRequest, WsRequest, WsResponse,
+};
+use crate::daemon::remote_task_board::{
+    is_remote_viewer, project_task_board_item, project_task_board_list,
+};
+
+use super::super::connection::ConnectionState;
+use super::super::mutations::dispatch_query_result;
+use super::{invalid_params, parse_params, parse_params_or_default};
+
+pub(super) async fn dispatch_task_board_capabilities(
+    request: &WsRequest,
+    state: &DaemonHttpState,
+) -> WsResponse {
+    dispatch_query_result(
+        &request.id,
+        task_board_route_executor::capabilities(state).await,
+    )
+}
+
+pub(super) async fn dispatch_task_board_list(
+    request: &WsRequest,
+    state: &DaemonHttpState,
+    connection: &Arc<Mutex<ConnectionState>>,
+) -> WsResponse {
+    let Ok(body) = parse_params_or_default::<TaskBoardListItemsRequest>(request) else {
+        return invalid_params(request);
+    };
+    let viewer = connection_is_remote_viewer(connection);
+    let result = task_board_route_executor::list_items(state, &body)
+        .await
+        .map(|response| project_task_board_list(response, viewer));
+    dispatch_query_result(&request.id, result)
+}
+
+pub(super) async fn dispatch_task_board_get(
+    request: &WsRequest,
+    state: &DaemonHttpState,
+    connection: &Arc<Mutex<ConnectionState>>,
+) -> WsResponse {
+    let Ok(body) = parse_params::<TaskBoardGetItemRequest>(request) else {
+        return invalid_params(request);
+    };
+    let viewer = connection_is_remote_viewer(connection);
+    let result = task_board_route_executor::get_item(state, &body)
+        .await
+        .map(|item| project_task_board_item(item, viewer));
+    dispatch_query_result(&request.id, result)
+}
+
+fn connection_is_remote_viewer(connection: &Arc<Mutex<ConnectionState>>) -> bool {
+    let connection = connection.lock().expect("connection lock");
+    is_remote_viewer(connection.remote_client())
+}

--- a/src/daemon/websocket/task_board/read.rs
+++ b/src/daemon/websocket/task_board/read.rs
@@ -53,6 +53,27 @@ pub(super) async fn dispatch_task_board_get(
 }
 
 fn connection_is_remote_viewer(connection: &Arc<Mutex<ConnectionState>>) -> bool {
-    let connection = connection.lock().expect("connection lock");
+    let Ok(connection) = connection.lock() else {
+        return true;
+    };
     is_remote_viewer(connection.remote_client())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use super::*;
+
+    #[test]
+    fn poisoned_connection_lock_keeps_viewer_projection_enabled() {
+        let connection = Arc::new(Mutex::new(ConnectionState::new()));
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = connection.lock().expect("connection lock");
+            panic!("poison connection lock");
+        }));
+
+        assert!(panic.is_err());
+        assert!(connection_is_remote_viewer(&connection));
+    }
 }

--- a/src/daemon/websocket/task_board/tests.rs
+++ b/src/daemon/websocket/task_board/tests.rs
@@ -45,6 +45,7 @@ use super::*;
 #[tokio::test]
 async fn ws_task_board_method_parity_against_constants() {
     let state = test_http_state_with_db();
+    let connection = Arc::new(Mutex::new(ConnectionState::new()));
     for method in TASK_BOARD_WS_METHOD_CATALOG {
         let request = WsRequest {
             id: format!("ws-parity-{method}"),
@@ -52,7 +53,7 @@ async fn ws_task_board_method_parity_against_constants() {
             params: json!({}),
             trace_context: None,
         };
-        let response = dispatch_task_board_method(&request, &state).await;
+        let response = dispatch_task_board_method(&request, &state, &connection).await;
         assert!(
             response.is_some(),
             "ws method {method} has no handler arm in dispatch_task_board_method",
@@ -63,12 +64,13 @@ async fn ws_task_board_method_parity_against_constants() {
 #[tokio::test]
 async fn ws_unknown_task_board_method_returns_none() {
     let state = test_http_state_with_db();
+    let connection = Arc::new(Mutex::new(ConnectionState::new()));
     let request = WsRequest {
         id: "ws-parity-unknown".into(),
         method: "task_board.unknown_method".into(),
         params: json!({}),
         trace_context: None,
     };
-    let response = dispatch_task_board_method(&request, &state).await;
+    let response = dispatch_task_board_method(&request, &state, &connection).await;
     assert!(response.is_none());
 }

--- a/src/reviews/files/service.rs
+++ b/src/reviews/files/service.rs
@@ -23,6 +23,7 @@ pub enum FilesLargeDiffStrategy {
     #[default]
     AutoLocalClone,
     /// Always use GitHub REST regardless of size (no local clones).
+    #[serde(rename = "force_github_rest", alias = "force_git_hub_rest")]
     ForceGitHubRest,
 }
 
@@ -224,6 +225,20 @@ mod tests {
         assert_eq!(config.strategy, FilesLargeDiffStrategy::AutoLocalClone);
         assert_eq!(config.local_clone_threshold_lines, 500);
         assert!(!config.local_clone_disabled_by_environment);
+    }
+
+    #[test]
+    fn github_strategy_uses_canonical_wire_name_and_accepts_legacy_value() {
+        assert_eq!(
+            serde_json::to_string(&FilesLargeDiffStrategy::ForceGitHubRest)
+                .expect("serialize strategy"),
+            r#""force_github_rest""#
+        );
+        assert_eq!(
+            serde_json::from_str::<FilesLargeDiffStrategy>(r#""force_git_hub_rest""#)
+                .expect("decode legacy strategy"),
+            FilesLargeDiffStrategy::ForceGitHubRest
+        );
     }
 
     #[test]

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -41,6 +41,8 @@ pub const GITHUB_REPOSITORY_ENV: &str = "GITHUB_REPOSITORY";
 #[value(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum ExternalProvider {
+    #[value(name = "github", alias = "git_hub")]
+    #[serde(rename = "github", alias = "git_hub")]
     GitHub,
     Todoist,
 }

--- a/src/task_board/external/tests.rs
+++ b/src/task_board/external/tests.rs
@@ -3,3 +3,4 @@ mod delete;
 mod github;
 mod support;
 mod sync;
+mod wire;

--- a/src/task_board/external/tests/wire.rs
+++ b/src/task_board/external/tests/wire.rs
@@ -1,0 +1,24 @@
+use crate::task_board::{ExternalProvider, ExternalRefProvider};
+
+#[test]
+fn github_providers_use_canonical_wire_name_and_accept_legacy_values() {
+    assert_eq!(
+        serde_json::to_string(&ExternalProvider::GitHub).expect("serialize external provider"),
+        r#""github""#
+    );
+    assert_eq!(
+        serde_json::to_string(&ExternalRefProvider::GitHub)
+            .expect("serialize external reference provider"),
+        r#""github""#
+    );
+    assert_eq!(
+        serde_json::from_str::<ExternalProvider>(r#""git_hub""#)
+            .expect("decode legacy external provider"),
+        ExternalProvider::GitHub
+    );
+    assert_eq!(
+        serde_json::from_str::<ExternalRefProvider>(r#""git_hub""#)
+            .expect("decode legacy external reference provider"),
+        ExternalRefProvider::GitHub
+    );
+}

--- a/src/task_board/types.rs
+++ b/src/task_board/types.rs
@@ -218,6 +218,8 @@ pub struct ExternalRef {
 #[value(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum ExternalRefProvider {
+    #[value(name = "github", alias = "git_hub")]
+    #[serde(rename = "github", alias = "git_hub")]
     GitHub,
     Todoist,
 }


### PR DESCRIPTION
## Motivation

Remote viewers currently receive full task-board records, including workflow internals, planning data, external references, usage, and secrets embedded in display fields. GitHub provider enums also serialize acronym casing as `git_hub`, which disagrees with the public `github` contract.

## Implementation

- Project viewer task-board list and get responses to a redacted summary on HTTP and WebSocket while preserving full operator and admin responses.
- Add shared secret redaction and 180-character body previews.
- Make `github` and `force_github_rest` canonical wire values while accepting legacy spellings on decode.
- Teach Swift codegen about variant renames and aliases, regenerate wire types, and cover Rust and Monitor contracts.