### PR TITLE
fix(remote): enforce independent pairing limits

### DIFF
--- a/src/daemon/http/tests/remote_pairing.rs
+++ b/src/daemon/http/tests/remote_pairing.rs
@@ -191,7 +191,7 @@ async fn remote_pair_claim_rejects_replay_and_audits_without_leaking_code() {
 }
 
 #[tokio::test]
-async fn remote_pair_claim_rate_limits_repeated_bad_code_attempts() {
+async fn remote_pair_claim_rate_limits_one_ip_across_rotating_bad_codes() {
     let mut state = remote_pairing_state();
     state.remote_pairing_limiter = Arc::new(Mutex::new(RemotePairingRateLimiter::new_for_tests(2)));
     let db = state.db.get().expect("db slot").clone();
@@ -199,16 +199,15 @@ async fn remote_pair_claim_rate_limits_repeated_bad_code_attempts() {
     let client = reqwest::Client::new();
     let url = format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM);
 
-    for expected_status in [
-        StatusCode::BAD_REQUEST,
-        StatusCode::BAD_REQUEST,
-        StatusCode::TOO_MANY_REQUESTS,
+    for (code, expected_status) in [
+        ("not-a-real-code-1", StatusCode::BAD_REQUEST),
+        ("not-a-real-code-2", StatusCode::BAD_REQUEST),
+        ("not-a-real-code-3", StatusCode::TOO_MANY_REQUESTS),
     ] {
         let response = client
             .post(&url)
-            .header("x-forwarded-for", "203.0.113.91")
             .json(&serde_json::json!({
-                "code": "not-a-real-code",
+                "code": code,
                 "domain": "daemon.example.com",
                 "client_id": "ios-rate-limit",
                 "display_name": "iPhone",

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -1,4 +1,3 @@
-use std::collections::{BTreeMap, VecDeque};
 use std::error::Error;
 use std::fmt;
 
@@ -15,13 +14,14 @@ use crate::reviews::ReviewsQueryRequest;
 
 mod reviews;
 pub(crate) use reviews::normalize_remote_reviews_query;
+mod rate_limit;
+pub use rate_limit::RemotePairingRateLimiter;
 
 #[cfg(test)]
 #[path = "remote_pairing_tests.rs"]
 mod tests;
 
 const PAIRING_RANDOM_BYTES: usize = 32;
-const DEFAULT_RATE_LIMITER_MAX_ENTRIES: usize = 4096;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemotePairingError {
@@ -336,104 +336,6 @@ pub struct RemotePairingClaimedClient {
     pub client: RemoteStoredClient,
     pub bearer_token: RemoteBearerToken,
     pub reviews_query: Option<ReviewsQueryRequest>,
-}
-
-#[derive(Debug, Clone)]
-pub struct RemotePairingRateLimiter {
-    max_attempts: u32,
-    max_entries: usize,
-    attempts: BTreeMap<RemotePairingAttemptKey, u32>,
-    attempt_order: VecDeque<RemotePairingAttemptKey>,
-}
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct RemotePairingAttemptKey {
-    remote_addr: String,
-    code_fingerprint: String,
-}
-
-impl fmt::Debug for RemotePairingAttemptKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RemotePairingAttemptKey")
-            .field("remote_addr", &self.remote_addr)
-            .field("code_fingerprint", &"<redacted>")
-            .finish()
-    }
-}
-
-impl RemotePairingAttemptKey {
-    fn new(remote_addr: &str, code_fingerprint: &str) -> Self {
-        Self {
-            remote_addr: remote_addr.to_string(),
-            code_fingerprint: code_fingerprint.to_string(),
-        }
-    }
-}
-
-impl RemotePairingRateLimiter {
-    #[must_use]
-    pub fn new(max_attempts: u32) -> Self {
-        Self::new_bounded(max_attempts, DEFAULT_RATE_LIMITER_MAX_ENTRIES)
-    }
-
-    fn new_bounded(max_attempts: u32, max_entries: usize) -> Self {
-        Self {
-            max_attempts: max_attempts.max(1),
-            max_entries: max_entries.max(1),
-            attempts: BTreeMap::new(),
-            attempt_order: VecDeque::new(),
-        }
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn new_for_tests(max_attempts: u32) -> Self {
-        Self::new(max_attempts)
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn new_bounded_for_tests(max_attempts: u32, max_entries: usize) -> Self {
-        Self::new_bounded(max_attempts, max_entries)
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn tracked_attempts_for_tests(&self) -> usize {
-        self.attempts.len()
-    }
-
-    /// Record one failed/suspicious pairing attempt for an address/code tuple.
-    ///
-    /// # Errors
-    /// Returns [`RemotePairingError::RateLimited`] after the configured limit.
-    pub fn record_attempt(
-        &mut self,
-        remote_addr: &str,
-        code_fingerprint: &str,
-    ) -> Result<(), RemotePairingError> {
-        let key = RemotePairingAttemptKey::new(remote_addr, code_fingerprint);
-        if !self.attempts.contains_key(&key) {
-            self.evict_until_room();
-            self.attempt_order.push_back(key.clone());
-        }
-        let count = self.attempts.entry(key).or_insert(0);
-        if *count >= self.max_attempts {
-            return Err(RemotePairingError::RateLimited);
-        }
-        *count += 1;
-        Ok(())
-    }
-
-    fn evict_until_room(&mut self) {
-        while self.attempts.len() >= self.max_entries {
-            let Some(oldest) = self.attempt_order.pop_front() else {
-                self.attempts.clear();
-                return;
-            };
-            self.attempts.remove(&oldest);
-        }
-    }
 }
 
 /// Validate that the public claim domain matches the daemon endpoint domain.

--- a/src/daemon/remote_pairing/rate_limit.rs
+++ b/src/daemon/remote_pairing/rate_limit.rs
@@ -1,0 +1,129 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::fmt;
+
+use super::RemotePairingError;
+
+const DEFAULT_MAX_ENTRIES: usize = 4096;
+
+#[derive(Clone)]
+pub struct RemotePairingRateLimiter {
+    max_attempts: u32,
+    max_entries: usize,
+    ip_attempts: BTreeMap<String, u32>,
+    ip_order: VecDeque<String>,
+    code_attempts: BTreeMap<String, u32>,
+    code_order: VecDeque<String>,
+}
+
+impl fmt::Debug for RemotePairingRateLimiter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RemotePairingRateLimiter")
+            .field("max_attempts", &self.max_attempts)
+            .field("max_entries", &self.max_entries)
+            .field("tracked_ip_addresses", &self.ip_attempts.len())
+            .field("tracked_code_fingerprints", &self.code_attempts.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl RemotePairingRateLimiter {
+    #[must_use]
+    pub fn new(max_attempts: u32) -> Self {
+        Self::new_bounded(max_attempts, DEFAULT_MAX_ENTRIES)
+    }
+
+    fn new_bounded(max_attempts: u32, max_entries: usize) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            max_entries: max_entries.max(1),
+            ip_attempts: BTreeMap::new(),
+            ip_order: VecDeque::new(),
+            code_attempts: BTreeMap::new(),
+            code_order: VecDeque::new(),
+        }
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn new_for_tests(max_attempts: u32) -> Self {
+        Self::new(max_attempts)
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn new_bounded_for_tests(max_attempts: u32, max_entries: usize) -> Self {
+        Self::new_bounded(max_attempts, max_entries)
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn tracked_attempts_for_tests(&self) -> (usize, usize) {
+        (self.ip_attempts.len(), self.code_attempts.len())
+    }
+
+    /// Record one pairing attempt against independent address and code budgets.
+    ///
+    /// # Errors
+    /// Returns [`RemotePairingError::RateLimited`] when either budget has
+    /// reached the configured limit.
+    pub fn record_attempt(
+        &mut self,
+        remote_addr: &str,
+        code_fingerprint: &str,
+    ) -> Result<(), RemotePairingError> {
+        if limit_reached(&self.ip_attempts, remote_addr, self.max_attempts)
+            || limit_reached(&self.code_attempts, code_fingerprint, self.max_attempts)
+        {
+            return Err(RemotePairingError::RateLimited);
+        }
+
+        record_bounded_attempt(
+            &mut self.ip_attempts,
+            &mut self.ip_order,
+            remote_addr,
+            self.max_entries,
+        );
+        record_bounded_attempt(
+            &mut self.code_attempts,
+            &mut self.code_order,
+            code_fingerprint,
+            self.max_entries,
+        );
+        Ok(())
+    }
+}
+
+fn limit_reached(attempts: &BTreeMap<String, u32>, key: &str, max_attempts: u32) -> bool {
+    attempts
+        .get(key)
+        .is_some_and(|count| *count >= max_attempts)
+}
+
+fn record_bounded_attempt(
+    attempts: &mut BTreeMap<String, u32>,
+    order: &mut VecDeque<String>,
+    key: &str,
+    max_entries: usize,
+) {
+    if !attempts.contains_key(key) {
+        evict_until_room(attempts, order, max_entries);
+        order.push_back(key.to_string());
+    }
+    let count = attempts.entry(key.to_string()).or_insert(0);
+    *count = count.saturating_add(1);
+}
+
+fn evict_until_room(
+    attempts: &mut BTreeMap<String, u32>,
+    order: &mut VecDeque<String>,
+    max_entries: usize,
+) {
+    while attempts.len() >= max_entries {
+        let Some(oldest) = order.pop_front() else {
+            attempts.clear();
+            return;
+        };
+        attempts.remove(&oldest);
+    }
+}

--- a/src/daemon/remote_pairing/rate_limit.rs
+++ b/src/daemon/remote_pairing/rate_limit.rs
@@ -106,12 +106,15 @@ fn record_bounded_attempt(
     key: &str,
     max_entries: usize,
 ) {
-    if !attempts.contains_key(key) {
-        evict_until_room(attempts, order, max_entries);
-        order.push_back(key.to_string());
+    if let Some(count) = attempts.get_mut(key) {
+        *count = count.saturating_add(1);
+        return;
     }
-    let count = attempts.entry(key.to_string()).or_insert(0);
-    *count = count.saturating_add(1);
+
+    evict_until_room(attempts, order, max_entries);
+    let key = key.to_string();
+    order.push_back(key.clone());
+    attempts.insert(key, 1);
 }
 
 fn evict_until_room(

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    RemotePairingAttemptKey, RemotePairingClaimRequest, RemotePairingCode, RemotePairingCodeHash,
-    RemotePairingRateLimiter, RemotePairingRecord, validate_pairing_domain,
+    RemotePairingClaimRequest, RemotePairingCode, RemotePairingCodeHash, RemotePairingRateLimiter,
+    RemotePairingRecord, validate_pairing_domain,
 };
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 use crate::reviews::ReviewsQueryRequest;
@@ -175,17 +175,27 @@ fn remote_pairing_claim_request_rejects_blank_audit_event_id() {
 }
 
 #[test]
-fn remote_pairing_rate_limits_ip_and_code_attempts() {
+fn remote_pairing_rate_limiter_enforces_independent_ip_budget() {
     let mut limiter = RemotePairingRateLimiter::new_for_tests(2);
 
     assert!(limiter.record_attempt("203.0.113.10", "code-1").is_ok());
-    assert!(limiter.record_attempt("203.0.113.10", "code-1").is_ok());
-    assert!(limiter.record_attempt("203.0.113.10", "code-1").is_err());
-    assert!(limiter.record_attempt("203.0.113.11", "code-1").is_ok());
+    assert!(limiter.record_attempt("203.0.113.10", "code-2").is_ok());
+    assert!(limiter.record_attempt("203.0.113.10", "code-3").is_err());
+    assert!(limiter.record_attempt("203.0.113.11", "code-3").is_ok());
 }
 
 #[test]
-fn remote_pairing_rate_limiter_uses_tuple_keys_without_delimiter_collisions() {
+fn remote_pairing_rate_limiter_enforces_independent_code_budget() {
+    let mut limiter = RemotePairingRateLimiter::new_for_tests(2);
+
+    assert!(limiter.record_attempt("203.0.113.10", "code-1").is_ok());
+    assert!(limiter.record_attempt("203.0.113.11", "code-1").is_ok());
+    assert!(limiter.record_attempt("203.0.113.12", "code-1").is_err());
+    assert!(limiter.record_attempt("203.0.113.12", "code-2").is_ok());
+}
+
+#[test]
+fn remote_pairing_rate_limiter_keys_do_not_have_delimiter_collisions() {
     let mut limiter = RemotePairingRateLimiter::new_for_tests(1);
 
     assert!(limiter.record_attempt("addr\0part", "code").is_ok());
@@ -197,26 +207,28 @@ fn remote_pairing_rate_limiter_uses_tuple_keys_without_delimiter_collisions() {
 }
 
 #[test]
-fn remote_pairing_attempt_key_debug_redacts_code_fingerprint() {
-    let key = RemotePairingAttemptKey::new("203.0.113.10", "raw-secret-code");
-    let debug = format!("{key:?}");
+fn remote_pairing_rate_limiter_debug_redacts_code_fingerprints() {
+    let mut limiter = RemotePairingRateLimiter::new_for_tests(2);
+    limiter
+        .record_attempt("203.0.113.10", "raw-secret-code")
+        .expect("record attempt");
+    let debug = format!("{limiter:?}");
 
-    assert!(debug.contains("203.0.113.10"));
     assert!(!debug.contains("raw-secret-code"));
-    assert!(debug.contains("<redacted>"));
+    assert!(debug.contains("tracked_code_fingerprints"));
 }
 
 #[test]
 fn remote_pairing_rate_limiter_bounds_tracked_attempts() {
     let mut limiter = RemotePairingRateLimiter::new_bounded_for_tests(1, 2);
 
-    assert!(limiter.record_attempt("203.0.113.1", "code").is_ok());
-    assert!(limiter.record_attempt("203.0.113.2", "code").is_ok());
-    assert!(limiter.record_attempt("203.0.113.3", "code").is_ok());
+    assert!(limiter.record_attempt("203.0.113.1", "code-1").is_ok());
+    assert!(limiter.record_attempt("203.0.113.2", "code-2").is_ok());
+    assert!(limiter.record_attempt("203.0.113.3", "code-3").is_ok());
 
-    assert_eq!(limiter.tracked_attempts_for_tests(), 2);
+    assert_eq!(limiter.tracked_attempts_for_tests(), (2, 2));
     assert!(
-        limiter.record_attempt("203.0.113.1", "code").is_ok(),
+        limiter.record_attempt("203.0.113.1", "code-1").is_ok(),
         "oldest entries are evicted when the limiter reaches its bound"
     );
 }

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -195,13 +195,13 @@ fn remote_pairing_rate_limiter_enforces_independent_code_budget() {
 }
 
 #[test]
-fn remote_pairing_rate_limiter_keys_do_not_have_delimiter_collisions() {
+fn remote_pairing_rate_limiter_treats_delimiters_as_key_content() {
     let mut limiter = RemotePairingRateLimiter::new_for_tests(1);
 
     assert!(limiter.record_attempt("addr\0part", "code").is_ok());
     assert!(
         limiter.record_attempt("addr", "part\0code").is_ok(),
-        "distinct address/code tuples must not collide"
+        "distinct addresses and code fingerprints must remain independent"
     );
     assert!(limiter.record_attempt("addr\0part", "code").is_err());
 }


### PR DESCRIPTION
## Motivation

Pairing attempts were keyed by an IP/code tuple. Rotating codes bypassed the IP budget, and rotating IPs bypassed the code budget.

## Implementation

- Track bounded IP and code attempt budgets independently.
- Reject an attempt before mutation when either budget is exhausted.
- Keep code fingerprints out of debug output.
- Add red-to-green unit and HTTP coverage; `mise run harness:check` passes.