### PR TITLE
fix(remote): avoid authorization audit starvation

### DIFF
--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -59,6 +59,7 @@ mod rebuild;
 mod remote_acme;
 mod remote_acme_cas;
 mod remote_identity;
+mod remote_identity_async;
 mod remote_pairing;
 mod review_writes;
 mod runtime;

--- a/src/daemon/db/remote_identity.rs
+++ b/src/daemon/db/remote_identity.rs
@@ -34,13 +34,13 @@ SELECT client_id, display_name, platform, role, scopes_json, token_hash, token_h
 FROM remote_clients
 ORDER BY created_at ASC, client_id ASC";
 
-const INSERT_REMOTE_AUDIT_EVENT_SQL: &str = "
+pub(super) const INSERT_REMOTE_AUDIT_EVENT_SQL: &str = "
 INSERT INTO remote_audit_events (
     event_id, recorded_at, request_id, client_id, route_or_method, scope,
     scope_decision, outcome, remote_addr, error_detail, metadata_json
 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, '{}')";
 
-const MARK_REMOTE_AUDIT_EVENT_FAILED_SQL: &str = "
+pub(super) const MARK_REMOTE_AUDIT_EVENT_FAILED_SQL: &str = "
 UPDATE remote_audit_events
 SET outcome = 'failure', error_detail = ?2
 WHERE event_id = ?1 AND scope_decision = 'allowed'";

--- a/src/daemon/db/remote_identity_async.rs
+++ b/src/daemon/db/remote_identity_async.rs
@@ -1,0 +1,62 @@
+use sqlx::query;
+
+use super::remote_identity::{INSERT_REMOTE_AUDIT_EVENT_SQL, MARK_REMOTE_AUDIT_EVENT_FAILED_SQL};
+use super::{AsyncDaemonDb, CliError, db_error};
+use crate::daemon::remote_identity::{RemoteAuditEvent, redact_remote_error_detail};
+
+impl AsyncDaemonDb {
+    /// Persist a remote authorization audit without blocking a Tokio worker.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL failure.
+    pub(crate) async fn record_remote_audit_event(
+        &self,
+        event: &RemoteAuditEvent,
+    ) -> Result<(), CliError> {
+        query(INSERT_REMOTE_AUDIT_EVENT_SQL)
+            .bind(&event.event_id)
+            .bind(&event.recorded_at)
+            .bind(event.request_id.as_deref())
+            .bind(event.client_id.as_deref())
+            .bind(&event.route_or_method)
+            .bind(event.scope.as_str())
+            .bind(event.scope_decision.as_str())
+            .bind(event.outcome.as_str())
+            .bind(event.remote_addr.as_deref())
+            .bind(event.error_detail())
+            .execute(self.pool())
+            .await
+            .map_err(|error| {
+                db_error(format!(
+                    "insert remote audit event {}: {error}",
+                    event.event_id
+                ))
+            })?;
+        Ok(())
+    }
+
+    /// Mark a persisted allowed request as failed without blocking a Tokio worker.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the row is missing, denied, or cannot be updated.
+    pub(crate) async fn mark_remote_audit_event_failed(
+        &self,
+        event_id: &str,
+        error_detail: &str,
+    ) -> Result<(), CliError> {
+        let error_detail = redact_remote_error_detail(error_detail);
+        let changed = query(MARK_REMOTE_AUDIT_EVENT_FAILED_SQL)
+            .bind(event_id)
+            .bind(error_detail)
+            .execute(self.pool())
+            .await
+            .map_err(|error| db_error(format!("mark remote audit {event_id} failed: {error}")))?
+            .rows_affected();
+        if changed == 1 {
+            return Ok(());
+        }
+        Err(db_error(format!(
+            "mark remote audit {event_id} failed: allowed event not found"
+        )))
+    }
+}

--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -51,7 +51,7 @@ impl RemoteHttpLimitAudit {
         }))
     }
 
-    pub(super) fn record_rejection(
+    pub(super) async fn record_rejection(
         &self,
         state: &DaemonHttpState,
         error_detail: &str,
@@ -63,18 +63,8 @@ impl RemoteHttpLimitAudit {
             self.route,
             error_detail,
         )
+        .await
     }
-}
-
-pub(super) fn audit_remote_http_limit_rejection(
-    request: &Request<Body>,
-    state: &DaemonHttpState,
-    error_detail: &str,
-) -> Result<(), Box<Response>> {
-    let Some((context, route)) = remote_http_limit_audit_target(request, state)? else {
-        return Ok(());
-    };
-    record_remote_http_limit_rejection(&context, request.headers(), state, route, error_detail)
 }
 
 pub(super) fn authorize_control_request<T: ControlPlaneActorRequest>(
@@ -154,54 +144,70 @@ pub(crate) async fn authorize_remote_http_request(
     let Some(route) = http_route_contract(request.method(), route_path) else {
         return remote_auth_error_response(RemoteAuthError::MissingScopeContract);
     };
-    let client = match authenticate_and_audit_remote_http_request(&request, &state, route) {
-        Ok(client) => client,
-        Err(response) => return *response,
+    let audit = match RemoteHttpAuditContext::from_request(&request, route) {
+        Ok(audit) => audit,
+        Err(error) => return remote_auth_error_response(error),
     };
+    let verification = verify_remote_client(request.headers(), &state);
+    let client =
+        match authenticate_and_audit_remote_http_request(&audit, verification, &state, route).await
+        {
+            Ok(client) => client,
+            Err(response) => return *response,
+        };
     let actor = client.control_plane_actor_id();
     REMOTE_HTTP_CLIENT
         .scope(client, with_control_plane_actor(actor, next.run(request)))
         .await
 }
 
-fn authenticate_and_audit_remote_http_request(
-    request: &Request<Body>,
+async fn authenticate_and_audit_remote_http_request(
+    audit: &RemoteHttpAuditContext,
+    verification: Result<RemoteStoredClient, Box<Response>>,
     state: &DaemonHttpState,
     route: &HttpApiRouteContract,
 ) -> Result<RemoteStoredClient, Box<Response>> {
-    let audit = RemoteHttpAuditContext::from_request(request, route)
-        .map_err(|error| Box::new(remote_auth_error_response(error)))?;
-    let client = verify_remote_client(request.headers(), state)
-        .map_err(|response| Box::new(audit_verification_failure(&audit, state, *response)))?;
-    authorize_and_audit_remote_http_client(&audit, state, route, client)
+    let client = match verification {
+        Ok(client) => client,
+        Err(response) => {
+            return Err(Box::new(
+                audit_verification_failure(audit, state, *response).await,
+            ));
+        }
+    };
+    authorize_and_audit_remote_http_client(audit, state, route, client).await
 }
 
-fn audit_verification_failure(
+async fn audit_verification_failure(
     audit: &RemoteHttpAuditContext,
     state: &DaemonHttpState,
     response: Response,
 ) -> Response {
     let error_detail = auth_audit::authentication_error_detail(response.status());
-    match audit.record_denied(state, None, error_detail) {
+    match audit.record_denied(state, None, error_detail).await {
         Ok(()) => response,
         Err(error) => auth_audit::unavailable_response(&error),
     }
 }
 
-fn authorize_and_audit_remote_http_client(
+async fn authorize_and_audit_remote_http_client(
     audit: &RemoteHttpAuditContext,
     state: &DaemonHttpState,
     route: &HttpApiRouteContract,
     client: RemoteStoredClient,
 ) -> Result<RemoteStoredClient, Box<Response>> {
     if let Err(error) = authorize_remote_http_route(&client, route) {
-        return match audit.record_denied(state, Some(&client.client_id), &error.to_string()) {
+        return match audit
+            .record_denied(state, Some(&client.client_id), &error.to_string())
+            .await
+        {
             Ok(()) => Err(Box::new(remote_auth_error_response(error))),
             Err(audit_error) => Err(Box::new(auth_audit::unavailable_response(&audit_error))),
         };
     }
     audit
         .record_allowed(state, &client.client_id)
+        .await
         .map_err(|error| Box::new(auth_audit::unavailable_response(&error)))?;
     Ok(client)
 }
@@ -264,24 +270,30 @@ fn remote_http_limit_audit_target(
     Ok(Some((context, route)))
 }
 
-fn record_remote_http_limit_rejection(
+async fn record_remote_http_limit_rejection(
     audit: &RemoteHttpAuditContext,
     headers: &HeaderMap,
     state: &DaemonHttpState,
     route: &HttpApiRouteContract,
     error_detail: &str,
 ) -> Result<(), Box<Response>> {
-    match audit.amend_recorded_failure(state, error_detail) {
+    match audit.amend_recorded_failure(state, error_detail).await {
         Ok(true) => return Ok(()),
         Ok(false) => {}
         Err(error) => return Err(Box::new(auth_audit::unavailable_response(&error))),
     }
     let result = match verify_remote_client(headers, state) {
         Ok(client) if authorize_remote_http_route(&client, route).is_ok() => {
-            audit.record_allowed_failure(state, &client.client_id, error_detail)
+            audit
+                .record_allowed_failure(state, &client.client_id, error_detail)
+                .await
         }
-        Ok(client) => audit.record_denied(state, Some(&client.client_id), error_detail),
-        Err(_) => audit.record_denied(state, None, error_detail),
+        Ok(client) => {
+            audit
+                .record_denied(state, Some(&client.client_id), error_detail)
+                .await
+        }
+        Err(_) => audit.record_denied(state, None, error_detail).await,
     };
     result.map_err(|error| Box::new(auth_audit::unavailable_response(&error)))
 }

--- a/src/daemon/http/auth_audit.rs
+++ b/src/daemon/http/auth_audit.rs
@@ -61,7 +61,7 @@ impl RemoteHttpAuditContext {
         })
     }
 
-    pub(super) fn record_allowed(
+    pub(super) async fn record_allowed(
         &self,
         state: &DaemonHttpState,
         client_id: &str,
@@ -73,11 +73,12 @@ impl RemoteHttpAuditContext {
             self.scope,
             self.remote_addr.as_deref(),
         )
-        .record(state.db.get());
+        .record(state.async_db.get())
+        .await;
         self.finish_record(result)
     }
 
-    pub(super) fn record_allowed_failure(
+    pub(super) async fn record_allowed_failure(
         &self,
         state: &DaemonHttpState,
         client_id: &str,
@@ -91,11 +92,12 @@ impl RemoteHttpAuditContext {
             self.remote_addr.as_deref(),
             error_detail,
         )
-        .record(state.db.get());
+        .record(state.async_db.get())
+        .await;
         self.finish_record(result)
     }
 
-    pub(super) fn record_denied(
+    pub(super) async fn record_denied(
         &self,
         state: &DaemonHttpState,
         client_id: Option<&str>,
@@ -109,11 +111,12 @@ impl RemoteHttpAuditContext {
             self.remote_addr.as_deref(),
             error_detail,
         )
-        .record(state.db.get());
+        .record(state.async_db.get())
+        .await;
         self.finish_record(result)
     }
 
-    pub(super) fn amend_recorded_failure(
+    pub(super) async fn amend_recorded_failure(
         &self,
         state: &DaemonHttpState,
         error_detail: &str,
@@ -125,7 +128,9 @@ impl RemoteHttpAuditContext {
         else {
             return Ok(false);
         };
-        receipt.mark_failed(state.db.get(), error_detail)?;
+        receipt
+            .mark_failed(state.async_db.get(), error_detail)
+            .await?;
         Ok(true)
     }
 

--- a/src/daemon/http/remote_limits.rs
+++ b/src/daemon/http/remote_limits.rs
@@ -12,7 +12,7 @@ use http_body_util::{BodyExt as _, Limited};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
 use tokio::time::timeout;
 
-use super::auth::{self, RemoteHttpLimitAudit};
+use super::auth::RemoteHttpLimitAudit;
 use super::auth_audit::RemoteHttpAuditMarker;
 use super::{DaemonHttpAuthMode, DaemonHttpState};
 use crate::daemon::remote_tls::{
@@ -158,13 +158,55 @@ pub(super) async fn admit_remote_http_request(
     request
         .extensions_mut()
         .insert(RemoteHttpAuditMarker::default());
+    let (config, _permit) = match remote_http_admission(&state, &request) {
+        Ok(admission) => admission,
+        Err(rejection) => {
+            let response = audited_http_limit_response(
+                &state,
+                RemoteHttpLimitAudit::from_request(&request, &state),
+                rejection.status,
+                rejection.message,
+            )
+            .await;
+            return rejection.with_response_headers(response);
+        }
+    };
+    run_remote_http_request_with_timeout(&state, request, next, config).await
+}
+
+async fn run_remote_http_request_with_timeout(
+    state: &DaemonHttpState,
+    request: Request<Body>,
+    next: Next,
+    config: RemoteRequestLimitConfig,
+) -> Response {
+    let timeout_audit = match RemoteHttpLimitAudit::from_request(&request, state) {
+        Ok(audit) => audit,
+        Err(response) => return *response,
+    };
+    match timeout(config.request_timeout, next.run(request)).await {
+        Ok(response) => response,
+        Err(_) => {
+            audited_http_limit_response_from_snapshot(
+                state,
+                timeout_audit.as_ref(),
+                StatusCode::GATEWAY_TIMEOUT,
+                "remote request exceeded the configured timeout",
+            )
+            .await
+        }
+    }
+}
+
+fn remote_http_admission(
+    state: &DaemonHttpState,
+    request: &Request<Body>,
+) -> Result<(RemoteRequestLimitConfig, OwnedSemaphorePermit), RemoteHttpLimitRejection> {
     let Some(limits) = state.remote_request_limits.as_ref() else {
-        return audited_http_limit_response(
-            &state,
-            &request,
+        return Err(RemoteHttpLimitRejection::new(
             StatusCode::SERVICE_UNAVAILABLE,
             "remote request limits are unavailable",
-        );
+        ));
     };
     let config = limits.config();
     let uri_bytes = request
@@ -172,12 +214,10 @@ pub(super) async fn admit_remote_http_request(
         .path_and_query()
         .map_or(0, |value| value.as_str().len());
     if uri_bytes > config.max_http_uri_bytes {
-        return audited_http_limit_response(
-            &state,
-            &request,
+        return Err(RemoteHttpLimitRejection::new(
             StatusCode::URI_TOO_LONG,
             "remote request URI exceeds the configured limit",
-        );
+        ));
     }
     let header_bytes = request
         .headers()
@@ -188,34 +228,49 @@ pub(super) async fn admit_remote_http_request(
                 .saturating_add(value.as_bytes().len())
         });
     if header_bytes > config.max_http_header_bytes {
-        return audited_http_limit_response(
-            &state,
-            &request,
+        return Err(RemoteHttpLimitRejection::new(
             StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             "remote request headers exceed the configured limit",
-        );
+        ));
     }
-    let Ok(_permit) = limits.try_http_permit() else {
-        let response = audited_http_limit_response(
-            &state,
-            &request,
+    let permit = limits.try_http_permit().map_err(|_| {
+        RemoteHttpLimitRejection::with_retry_after(
             StatusCode::TOO_MANY_REQUESTS,
             "remote request concurrency limit reached",
-        );
-        return with_retry_after(response);
-    };
-    let timeout_audit = match RemoteHttpLimitAudit::from_request(&request, &state) {
-        Ok(audit) => audit,
-        Err(response) => return *response,
-    };
-    match timeout(config.request_timeout, next.run(request)).await {
-        Ok(response) => response,
-        Err(_) => audited_http_limit_response_from_snapshot(
-            &state,
-            timeout_audit.as_ref(),
-            StatusCode::GATEWAY_TIMEOUT,
-            "remote request exceeded the configured timeout",
-        ),
+        )
+    })?;
+    Ok((config, permit))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RemoteHttpLimitRejection {
+    status: StatusCode,
+    message: &'static str,
+    retry_after: bool,
+}
+
+impl RemoteHttpLimitRejection {
+    const fn new(status: StatusCode, message: &'static str) -> Self {
+        Self {
+            status,
+            message,
+            retry_after: false,
+        }
+    }
+
+    const fn with_retry_after(status: StatusCode, message: &'static str) -> Self {
+        Self {
+            status,
+            message,
+            retry_after: true,
+        }
+    }
+
+    fn with_response_headers(self, response: Response) -> Response {
+        if self.retry_after {
+            return with_retry_after(response);
+        }
+        response
     }
 }
 
@@ -234,21 +289,24 @@ pub(super) async fn limit_remote_http_body(
     if content_length_exceeds(&request, max_bytes) {
         return audited_http_limit_response(
             &state,
-            &request,
+            RemoteHttpLimitAudit::from_request(&request, &state),
             StatusCode::PAYLOAD_TOO_LARGE,
             "remote request body exceeds the configured limit",
-        );
+        )
+        .await;
     }
     let (parts, body) = request.into_parts();
     let collected = Limited::new(body, max_bytes).collect().await;
     let Ok(collected) = collected else {
         let rejected = Request::from_parts(parts, Body::empty());
+        let audit = RemoteHttpLimitAudit::from_request(&rejected, &state);
         return audited_http_limit_response(
             &state,
-            &rejected,
+            audit,
             StatusCode::PAYLOAD_TOO_LARGE,
             "remote request body exceeds the configured limit",
-        );
+        )
+        .await;
     };
     next.run(Request::from_parts(parts, Body::from(collected.to_bytes())))
         .await
@@ -308,25 +366,30 @@ fn with_retry_after(mut response: Response) -> Response {
     response
 }
 
-fn audited_http_limit_response(
+async fn audited_http_limit_response(
     state: &DaemonHttpState,
-    request: &Request<Body>,
+    audit: Result<Option<RemoteHttpLimitAudit>, Box<Response>>,
     status: StatusCode,
     message: &str,
 ) -> Response {
-    match auth::audit_remote_http_limit_rejection(request, state, message) {
-        Ok(()) => limit_response(status, message),
-        Err(response) => *response,
-    }
+    let audit = match audit {
+        Ok(audit) => audit,
+        Err(response) => return *response,
+    };
+    audited_http_limit_response_from_snapshot(state, audit.as_ref(), status, message).await
 }
 
-fn audited_http_limit_response_from_snapshot(
+async fn audited_http_limit_response_from_snapshot(
     state: &DaemonHttpState,
     audit: Option<&RemoteHttpLimitAudit>,
     status: StatusCode,
     message: &str,
 ) -> Response {
-    match audit.map_or(Ok(()), |audit| audit.record_rejection(state, message)) {
+    let result = match audit {
+        Some(audit) => audit.record_rejection(state, message).await,
+        None => Ok(()),
+    };
+    match result {
         Ok(()) => limit_response(status, message),
         Err(response) => *response,
     }

--- a/src/daemon/http/remote_limits.rs
+++ b/src/daemon/http/remote_limits.rs
@@ -158,7 +158,7 @@ pub(super) async fn admit_remote_http_request(
     request
         .extensions_mut()
         .insert(RemoteHttpAuditMarker::default());
-    let (config, _permit) = match remote_http_admission(&state, &request) {
+    let (config, permit) = match remote_http_admission(&state, &request) {
         Ok(admission) => admission,
         Err(rejection) => {
             let response = audited_http_limit_response(
@@ -171,7 +171,9 @@ pub(super) async fn admit_remote_http_request(
             return rejection.with_response_headers(response);
         }
     };
-    run_remote_http_request_with_timeout(&state, request, next, config).await
+    let response = run_remote_http_request_with_timeout(&state, request, next, config).await;
+    drop(permit);
+    response
 }
 
 async fn run_remote_http_request_with_timeout(

--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -44,6 +44,7 @@ mod policy_io_route_parity;
 mod remote_actor;
 mod remote_authz;
 mod remote_authz_audit;
+mod remote_authz_audit_contention;
 mod remote_limits;
 mod remote_limits_support;
 mod remote_pairing;

--- a/src/daemon/http/tests/remote_authz_audit_contention.rs
+++ b/src/daemon/http/tests/remote_authz_audit_contention.rs
@@ -182,8 +182,12 @@ impl ContendingWriter {
     fn release_after(self, delay: Duration) -> ScheduledWriterRelease {
         let task = tokio::spawn(async move {
             sleep(delay).await;
-            self.release.send(()).expect("release contending writer");
-            self.thread.join().expect("join contending SQLite writer");
+            tokio::task::spawn_blocking(move || {
+                self.release.send(()).expect("release contending writer");
+                self.thread.join().expect("join contending SQLite writer");
+            })
+            .await
+            .expect("join contending writer release task");
         });
         ScheduledWriterRelease(task)
     }

--- a/src/daemon/http/tests/remote_authz_audit_contention.rs
+++ b/src/daemon/http/tests/remote_authz_audit_contention.rs
@@ -1,0 +1,198 @@
+use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use axum::http::StatusCode;
+use futures_util::{SinkExt as _, StreamExt as _};
+use rusqlite::TransactionBehavior;
+use serde_json::json;
+use tokio::time::{sleep, timeout};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::daemon::protocol::{http_paths, ws_methods};
+use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_identity::{RemoteAuditOutcome, RemoteAuditScopeDecision};
+
+use super::remote_limits_support::{
+    audit_for_request, remote_state_with_viewer, remote_ws_request, send_remote_health,
+    serve_remote, stop_server,
+};
+
+const AUDIT_CONTENTION_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[tokio::test(flavor = "current_thread")]
+async fn remote_http_authorization_audit_yields_to_contending_writer() {
+    let state = remote_state_with_viewer();
+    let audit_state = state.clone();
+    let db_path = state.db_path.clone().expect("remote database path");
+    let (base_url, server) = serve_remote(state).await;
+    let writer = ContendingWriter::begin(&db_path);
+    let release = writer.release_after(Duration::from_millis(25));
+
+    let response = timeout(
+        AUDIT_CONTENTION_TIMEOUT,
+        send_remote_health(reqwest::Client::new(), base_url, "audit-http-contention"),
+    )
+    .await
+    .expect("HTTP audit contention timed out")
+    .expect("send HTTP request during audit contention");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    release.finish().await;
+    let audit = audit_for_request(&audit_state, "audit-http-contention");
+    assert_successful_read_audit(&audit, &format!("GET {}", http_paths::HEALTH));
+    stop_server(server).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn waiting_remote_audit_does_not_block_concurrent_authentication() {
+    let state = remote_state_with_viewer();
+    let db_path = state.db_path.clone().expect("remote database path");
+    let (base_url, server) = serve_remote(state).await;
+    let writer = ContendingWriter::begin(&db_path);
+    let first_request = tokio::spawn(send_remote_health(
+        reqwest::Client::new(),
+        base_url.clone(),
+        "audit-http-contention-first",
+    ));
+    sleep(Duration::from_millis(100)).await;
+    let release = writer.release_after(Duration::from_millis(25));
+
+    let second_response = timeout(
+        AUDIT_CONTENTION_TIMEOUT,
+        send_remote_health(
+            reqwest::Client::new(),
+            base_url,
+            "audit-http-contention-second",
+        ),
+    )
+    .await;
+    let first_response = timeout(AUDIT_CONTENTION_TIMEOUT, first_request).await;
+
+    release.finish().await;
+    stop_server(server).await;
+    let first_response = first_response
+        .expect("first contending request timed out")
+        .expect("join first contending request")
+        .expect("send first contending request");
+    let second_response = second_response
+        .expect("concurrent authentication timed out")
+        .expect("send concurrent authenticated request");
+    assert_eq!(first_response.status(), StatusCode::OK);
+    assert_eq!(second_response.status(), StatusCode::OK);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn remote_websocket_authorization_audit_yields_to_contending_writer() {
+    let state = remote_state_with_viewer();
+    let audit_state = state.clone();
+    let db_path = state.db_path.clone().expect("remote database path");
+    let (base_url, server) = serve_remote(state).await;
+    let request = remote_ws_request(&base_url, "viewer", "audit-ws-contention-handshake");
+    let (mut socket, _) = connect_async(request).await.expect("connect WebSocket");
+    let writer = ContendingWriter::begin(&db_path);
+    let release = writer.release_after(Duration::from_millis(25));
+
+    let response = websocket_rpc(&mut socket, "audit-ws-contention").await;
+    assert_eq!(response["error"], serde_json::Value::Null);
+
+    release.finish().await;
+    let audit = audit_for_request(&audit_state, "audit-ws-contention");
+    assert_successful_read_audit(&audit, ws_methods::PING);
+    let _ = socket.close(None).await;
+    stop_server(server).await;
+}
+
+fn assert_successful_read_audit(
+    audit: &crate::daemon::remote_identity::RemoteStoredAuditEvent,
+    target: &str,
+) {
+    assert_eq!(audit.client_id.as_deref(), Some("viewer"));
+    assert_eq!(audit.route_or_method, target);
+    assert_eq!(audit.scope, RemoteAccessScope::Read);
+    assert_eq!(audit.scope_decision, RemoteAuditScopeDecision::Allowed);
+    assert_eq!(audit.outcome, RemoteAuditOutcome::Success);
+    assert_eq!(audit.error_detail, None);
+}
+
+async fn websocket_rpc(
+    socket: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    request_id: &str,
+) -> serde_json::Value {
+    timeout(AUDIT_CONTENTION_TIMEOUT, async {
+        socket
+            .send(Message::Text(
+                json!({"id": request_id, "method": ws_methods::PING, "params": {}})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .expect("send WebSocket request during audit contention");
+        while let Some(frame) = socket.next().await {
+            let Message::Text(text) = frame.expect("read WebSocket frame") else {
+                continue;
+            };
+            let response = serde_json::from_str::<serde_json::Value>(&text)
+                .expect("deserialize WebSocket response");
+            if response["id"].as_str() == Some(request_id) {
+                return response;
+            }
+        }
+        panic!("missing WebSocket response for {request_id}");
+    })
+    .await
+    .expect("WebSocket audit contention timed out")
+}
+
+struct ContendingWriter {
+    release: mpsc::Sender<()>,
+    thread: thread::JoinHandle<()>,
+}
+
+impl ContendingWriter {
+    fn begin(db_path: &Path) -> Self {
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let db_path = db_path.to_owned();
+        let thread = thread::spawn(move || {
+            let mut connection =
+                rusqlite::Connection::open(db_path).expect("open contending SQLite writer");
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .expect("begin contending SQLite write transaction");
+            ready_tx.send(()).expect("signal contending writer ready");
+            release_rx
+                .recv()
+                .expect("receive contending writer release");
+            transaction
+                .commit()
+                .expect("commit contending SQLite writer");
+        });
+        ready_rx.recv().expect("wait for contending SQLite writer");
+        Self {
+            release: release_tx,
+            thread,
+        }
+    }
+
+    fn release_after(self, delay: Duration) -> ScheduledWriterRelease {
+        let task = tokio::spawn(async move {
+            sleep(delay).await;
+            self.release.send(()).expect("release contending writer");
+            self.thread.join().expect("join contending SQLite writer");
+        });
+        ScheduledWriterRelease(task)
+    }
+}
+
+struct ScheduledWriterRelease(tokio::task::JoinHandle<()>);
+
+impl ScheduledWriterRelease {
+    async fn finish(self) {
+        self.0.await.expect("finish contending writer release");
+    }
+}

--- a/src/daemon/remote_request_audit.rs
+++ b/src/daemon/remote_request_audit.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use uuid::Uuid;
 
-use super::db::DaemonDb;
+use super::db::AsyncDaemonDb;
 use super::remote::RemoteAccessScope;
 use super::remote_identity::{RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision};
 use crate::errors::{CliError, CliErrorKind};
@@ -30,25 +30,17 @@ pub(crate) struct RemoteAuthorizationAuditReceipt {
 }
 
 impl RemoteAuthorizationAuditReceipt {
-    pub(crate) fn mark_failed(
+    pub(crate) async fn mark_failed(
         &self,
-        db: Option<&Arc<Mutex<DaemonDb>>>,
+        db: Option<&Arc<AsyncDaemonDb>>,
         error_detail: &str,
     ) -> Result<(), CliError> {
         if self.decision == RemoteAuditScopeDecision::Denied {
             return Ok(());
         }
-        let db = db.ok_or_else(|| {
-            CliError::from(CliErrorKind::workflow_io(
-                "remote authorization audit store is unavailable",
-            ))
-        })?;
-        let db = db.lock().map_err(|error| {
-            CliError::from(CliErrorKind::workflow_io(format!(
-                "remote authorization audit store lock: {error}"
-            )))
-        })?;
+        let db = db.ok_or_else(remote_audit_store_unavailable)?;
         db.mark_remote_audit_event_failed(&self.event_id, error_detail)
+            .await
     }
 }
 
@@ -116,23 +108,14 @@ impl<'a> RemoteAuthorizationAudit<'a> {
     ///
     /// # Errors
     /// Returns [`CliError`] when the audit store is unavailable or rejects the event.
-    pub(crate) fn record(
+    pub(crate) async fn record(
         self,
-        db: Option<&Arc<Mutex<DaemonDb>>>,
+        db: Option<&Arc<AsyncDaemonDb>>,
     ) -> Result<RemoteAuthorizationAuditReceipt, CliError> {
-        let db = db.ok_or_else(|| {
-            CliError::from(CliErrorKind::workflow_io(
-                "remote authorization audit store is unavailable",
-            ))
-        })?;
-        let db = db.lock().map_err(|error| {
-            CliError::from(CliErrorKind::workflow_io(format!(
-                "remote authorization audit store lock: {error}"
-            )))
-        })?;
+        let db = db.ok_or_else(remote_audit_store_unavailable)?;
         let request_id = bounded_request_id(self.request_id);
         let event_id = format!("remote-auth-{}", Uuid::new_v4());
-        db.record_remote_audit_event(&RemoteAuditEvent::new(
+        let event = RemoteAuditEvent::new(
             event_id.clone(),
             utc_now(),
             Some(request_id.as_ref()),
@@ -143,12 +126,19 @@ impl<'a> RemoteAuthorizationAudit<'a> {
             self.outcome,
             self.remote_addr,
             self.error_detail,
-        ))?;
+        );
+        db.record_remote_audit_event(&event).await?;
         Ok(RemoteAuthorizationAuditReceipt {
             event_id,
             decision: self.decision,
         })
     }
+}
+
+fn remote_audit_store_unavailable() -> CliError {
+    CliError::from(CliErrorKind::workflow_io(
+        "remote authorization audit store is unavailable",
+    ))
 }
 
 fn bounded_request_id(request_id: &str) -> Cow<'_, str> {
@@ -168,6 +158,14 @@ fn bounded_request_id(request_id: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    use rusqlite::TransactionBehavior;
+    use tempfile::tempdir;
+
+    use super::super::db::DaemonDb;
 
     #[test]
     fn remote_authorization_audit_bounds_unicode_request_ids_on_a_character_boundary() {
@@ -178,5 +176,58 @@ mod tests {
         assert!(bounded.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
         assert!(bounded.ends_with(REMOTE_AUDIT_TRUNCATION_MARKER));
         assert!(bounded.is_char_boundary(bounded.len()));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn remote_authorization_audit_yields_while_sqlite_writer_finishes() {
+        let temp = tempdir().expect("create audit contention tempdir");
+        let db_path = temp.path().join("harness.db");
+        drop(DaemonDb::open(&db_path).expect("initialize daemon database"));
+        let db = Arc::new(
+            AsyncDaemonDb::connect(&db_path)
+                .await
+                .expect("open async daemon database"),
+        );
+        let (writer_ready_tx, writer_ready_rx) = mpsc::channel();
+        let (release_writer_tx, release_writer_rx) = mpsc::channel();
+        let writer_path = db_path.clone();
+        let writer = thread::spawn(move || {
+            let mut connection =
+                rusqlite::Connection::open(writer_path).expect("open contending SQLite writer");
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .expect("hold SQLite write transaction");
+            writer_ready_tx.send(()).expect("signal writer ready");
+            release_writer_rx.recv().expect("receive writer release");
+            transaction.commit().expect("commit contending writer");
+        });
+        writer_ready_rx.recv().expect("wait for SQLite writer");
+
+        let release = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            release_writer_tx.send(()).expect("release SQLite writer");
+        });
+        let receipt = RemoteAuthorizationAudit::allowed(
+            "audit-contention-request",
+            "remote-client",
+            "reviews.files_list",
+            RemoteAccessScope::Read,
+            Some("203.0.113.10"),
+        )
+        .record(Some(&db))
+        .await
+        .expect("persist remote audit after contending writer releases");
+
+        release.await.expect("join writer release task");
+        writer.join().expect("join contending SQLite writer");
+        let events = DaemonDb::open(&db_path)
+            .expect("open daemon database for audit verification")
+            .load_remote_audit_events(10)
+            .expect("load remote audits");
+        assert!(
+            events
+                .iter()
+                .any(|event| event.event_id == receipt.event_id)
+        );
     }
 }

--- a/src/daemon/websocket/connection.rs
+++ b/src/daemon/websocket/connection.rs
@@ -269,7 +269,9 @@ fn spawn_inbound_task(
                                 Arc::clone(&connection),
                                 priority_tx.clone(),
                                 &mut dispatch_tasks,
-                            ) {
+                            )
+                            .await
+                            {
                                 IncomingMessageAction::ContinueLoop => {}
                                 IncomingMessageAction::CloseConnection => break,
                                 IncomingMessageAction::RespondBatch(frames) => {
@@ -424,7 +426,7 @@ pub(crate) fn incoming_message_counts_as_activity(message: &Message) -> bool {
     )
 }
 
-pub(crate) fn handle_incoming_message(
+pub(crate) async fn handle_incoming_message(
     message: Message,
     state: DaemonHttpState,
     connection: Arc<Mutex<ConnectionState>>,
@@ -435,13 +437,16 @@ pub(crate) fn handle_incoming_message(
         Message::Text(text) => {
             while dispatch_tasks.try_join_next().is_some() {}
             if let Some(rejection) = remote_dispatch_rejection(&state, dispatch_tasks.len()) {
-                return IncomingMessageAction::RespondBatch(handle_overloaded_message(
-                    &text,
-                    &state,
-                    &connection,
-                    rejection.status,
-                    rejection.message,
-                ));
+                return IncomingMessageAction::RespondBatch(
+                    handle_overloaded_message(
+                        &text,
+                        &state,
+                        &connection,
+                        rejection.status,
+                        rejection.message,
+                    )
+                    .await,
+                );
             }
             spawn_text_dispatch(
                 text.to_string(),

--- a/src/daemon/websocket/connection/tests.rs
+++ b/src/daemon/websocket/connection/tests.rs
@@ -234,7 +234,8 @@ async fn incoming_ping_frames_reply_with_matching_pong() {
         connection,
         priority_tx,
         &mut dispatch_tasks,
-    );
+    )
+    .await;
 
     match action {
         IncomingMessageAction::RespondBatch(frames) => {
@@ -296,7 +297,8 @@ async fn remote_websocket_caps_in_flight_dispatch_tasks() {
         connection,
         priority_tx,
         &mut dispatch_tasks,
-    );
+    )
+    .await;
 
     assert_eq!(dispatch_tasks.len(), 1, "overload must not spawn work");
     let IncomingMessageAction::RespondBatch(frames) = action else {

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -54,7 +54,7 @@ pub(crate) async fn handle_message(
     })
 }
 
-pub(crate) fn handle_overloaded_message(
+pub(crate) async fn handle_overloaded_message(
     text: &str,
     state: &DaemonHttpState,
     connection: &Arc<Mutex<ConnectionState>>,
@@ -76,7 +76,9 @@ pub(crate) fn handle_overloaded_message(
         state,
         connection,
         RemoteWsAllowedAudit::Failure(message),
-    ) {
+    )
+    .await
+    {
         return serialize_response_frames(&response).unwrap_or_else(|_| {
             serialize_error_response_frames(
                 Some(&request.id),
@@ -183,7 +185,7 @@ async fn dispatch_inner(
     connection: &Arc<Mutex<ConnectionState>>,
 ) -> WsResponse {
     if let Err(response) =
-        authorize_remote_ws_request(request, state, connection, RemoteWsAllowedAudit::Success)
+        authorize_remote_ws_request(request, state, connection, RemoteWsAllowedAudit::Success).await
     {
         return *response;
     }
@@ -225,7 +227,7 @@ enum RemoteWsAllowedAudit<'a> {
     Failure(&'a str),
 }
 
-fn authorize_remote_ws_request(
+async fn authorize_remote_ws_request(
     request: &WsRequest,
     state: &DaemonHttpState,
     connection: &Arc<Mutex<ConnectionState>>,
@@ -246,7 +248,8 @@ fn authorize_remote_ws_request(
             required_scope,
             remote_addr.as_deref(),
             error,
-        )?;
+        )
+        .await?;
         return Err(Box::new(remote_ws_auth_error_response(&request.id, error)));
     };
     let client = match refresh_remote_connection_client(state, connection) {
@@ -260,7 +263,8 @@ fn authorize_remote_ws_request(
                 required_scope,
                 remote_addr.as_deref(),
                 error,
-            )?;
+            )
+            .await?;
             return Err(Box::new(remote_ws_auth_error_response(&request.id, error)));
         }
         Err(error) => return Err(remote_ws_auth_store_error_response(request, &error)),
@@ -287,7 +291,8 @@ fn authorize_remote_ws_request(
                 }
             };
             audit
-                .record(state.db.get())
+                .record(state.async_db.get())
+                .await
                 .map(|_| ())
                 .map_err(|error| remote_ws_audit_error_response(request, &error))
         }
@@ -299,7 +304,8 @@ fn authorize_remote_ws_request(
                 required_scope,
                 remote_addr.as_deref(),
                 error,
-            )?;
+            )
+            .await?;
             Err(Box::new(remote_ws_auth_error_response(&request.id, error)))
         }
     }
@@ -334,7 +340,7 @@ pub(crate) fn remote_viewer_projection_required(connection: &Arc<Mutex<Connectio
     is_remote_viewer(connection.remote_client())
 }
 
-fn record_remote_ws_denial(
+async fn record_remote_ws_denial(
     request: &WsRequest,
     state: &DaemonHttpState,
     client_id: Option<&str>,
@@ -350,7 +356,8 @@ fn record_remote_ws_denial(
         remote_addr,
         &error.to_string(),
     )
-    .record(state.db.get())
+    .record(state.async_db.get())
+    .await
     .map(|_| ())
     .map_err(|audit_error| remote_ws_audit_error_response(request, &audit_error))
 }

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -27,11 +27,14 @@ fn ws_request_deserialization() {
 async fn remote_ws_dispatch_allows_viewer_read_method() {
     let mut state = super::super::test_support::test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
-    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
-        "viewer",
-        RemoteRole::Viewer,
-        &[RemoteAccessScope::Read],
-    ))));
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(
+        registered_remote_client(
+            &state,
+            "viewer",
+            RemoteRole::Viewer,
+            &[RemoteAccessScope::Read],
+        ),
+    )));
     let request = ws_request("req-read", ws_methods::PING);
 
     let response = dispatch(&request, &state, &connection).await;
@@ -44,11 +47,14 @@ async fn remote_ws_dispatch_allows_viewer_read_method() {
 async fn remote_ws_dispatch_denies_viewer_write_method() {
     let mut state = super::super::test_support::test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
-    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(remote_client(
-        "viewer",
-        RemoteRole::Viewer,
-        &[RemoteAccessScope::Read],
-    ))));
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(
+        registered_remote_client(
+            &state,
+            "viewer",
+            RemoteRole::Viewer,
+            &[RemoteAccessScope::Read],
+        ),
+    )));
     let request = ws_request("req-write", ws_methods::SESSION_START);
 
     let response = dispatch(&request, &state, &connection).await;
@@ -234,4 +240,30 @@ fn remote_client(
         revoked_at: None,
         rotated_at: None,
     }
+}
+
+fn registered_remote_client(
+    state: &DaemonHttpState,
+    client_id: &str,
+    role: RemoteRole,
+    scopes: &[RemoteAccessScope],
+) -> RemoteStoredClient {
+    let registration = RemoteClientRegistration::new_for_tests(
+        client_id,
+        "MacBook Pro",
+        "macos",
+        role,
+        scopes,
+        "remote-token-secret",
+        "2026-06-21T18:30:00Z",
+    )
+    .expect("remote client registration");
+    state
+        .db
+        .get()
+        .expect("db slot")
+        .lock()
+        .expect("db lock")
+        .register_remote_client(&registration)
+        .expect("register remote client")
 }


### PR DESCRIPTION
## Motivation
Remote authorization audit writes can wait on SQLite while holding up Tokio workers. Under real Reviews traffic this cascaded into 5, 10, and 15 second WebSocket failures with `REMOTE_AUDIT` errors.

## Implementation
- Persist request authorization audits through the canonical async SQLx pool.
- Await fail-closed audit writes across HTTP, request limits, and WebSocket dispatch.
- Add real single-thread SQLite contention proofs for HTTP, WebSocket, and concurrent authentication.
- Persist valid WebSocket test clients before per-message revocation refresh.
