### PR TITLE
fix(task-board): audit provider synchronization

### DIFF
--- a/src/daemon/audit_events.rs
+++ b/src/daemon/audit_events.rs
@@ -48,6 +48,14 @@ pub(crate) async fn record_audit_result<T>(
         return;
     };
 
+    record_audit_result_in_db(async_db, draft, result).await;
+}
+
+pub(crate) async fn record_audit_result_in_db<T>(
+    async_db: &AsyncDaemonDb,
+    draft: AuditEventDraft,
+    result: &Result<T, CliError>,
+) {
     let event = audit_event_from_result(draft, result);
     persist_audit_event(async_db, &event).await;
 }
@@ -85,7 +93,7 @@ pub(crate) async fn record_audit_event(
     clippy::cognitive_complexity,
     reason = "audit persistence branches separately for db and legacy-event fallback"
 )]
-async fn persist_audit_event(async_db: &Arc<AsyncDaemonDb>, event: &HarnessMonitorAuditEvent) {
+async fn persist_audit_event(async_db: &AsyncDaemonDb, event: &HarnessMonitorAuditEvent) {
     match async_db.upsert_audit_event(event).await {
         Ok(()) => broadcast_audit_event(event),
         Err(error) => {

--- a/src/daemon/db/async_pool.rs
+++ b/src/daemon/db/async_pool.rs
@@ -161,6 +161,11 @@ impl AsyncDaemonDb {
         &self.pool
     }
 
+    #[must_use]
+    pub(crate) fn storage_path(&self) -> &Path {
+        &self.path
+    }
+
     /// Read the canonical schema version through `SQLx`.
     ///
     /// # Errors

--- a/src/daemon/http/tests/task_board_crud.rs
+++ b/src/daemon/http/tests/task_board_crud.rs
@@ -77,6 +77,7 @@ async fn run_flow() {
             .as_str()
             .is_some_and(|message| message.contains("external sync token missing"))
     );
+    assert_task_board_sync_audit(&client, &base_url).await;
     let audit = get_json(
         &client,
         &base_url,
@@ -203,6 +204,30 @@ async fn run_flow() {
 
     server.abort();
     let _ = server.await;
+}
+
+async fn assert_task_board_sync_audit(client: &reqwest::Client, base_url: &str) {
+    let sync_audit = get_json(
+        client,
+        base_url,
+        &format!("{}?action_keys=task_board.sync", http_paths::AUDIT_EVENTS),
+    )
+    .await;
+    let sync_events = sync_audit["events"].as_array().expect("sync audit events");
+    assert_eq!(sync_events.len(), 2);
+    assert!(sync_events.iter().any(|event| {
+        event["outcome"].as_str() == Some("success")
+            && event["payload_json"]["direction"].as_str() == Some("push")
+    }));
+    assert!(sync_events.iter().any(|event| {
+        event["outcome"].as_str() == Some("failure")
+            && event["payload_json"]["provider"].as_str() == Some("todoist")
+    }));
+    assert!(sync_events.iter().all(|event| {
+        event["source"].as_str() == Some("taskBoard")
+            && event["category"].as_str() == Some("taskBoardMutation")
+            && event["action_key"].as_str() == Some("task_board.sync")
+    }));
 }
 
 async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {

--- a/src/daemon/service/reviews/github_projection.rs
+++ b/src/daemon/service/reviews/github_projection.rs
@@ -14,6 +14,10 @@ use crate::task_board::{
     imported_review_references_from_items, reconcile_review_item_from_snapshots,
 };
 
+use super::super::task_board_db::{
+    ReviewsProjectionAuditSummary, record_reviews_projection_result,
+};
+
 pub(super) enum MissingReviewResolution {
     ExactActiveImports(ReviewsQueryRequest),
     ProvidedSnapshotsOnly,
@@ -37,8 +41,33 @@ pub(super) async fn reconcile_task_board(
     backport_patterns: &[String],
     expected_revision: u64,
 ) -> Result<bool, CliError> {
+    let result = reconcile_task_board_inner(
+        database,
+        items,
+        authoritative_viewer_keys,
+        missing_review_resolution,
+        backport_detection_enabled,
+        backport_patterns,
+        expected_revision,
+    )
+    .await;
+    if let Some(database) = database {
+        record_reviews_projection_result(database, &result).await;
+    }
+    result.map(|summary| summary.is_stable())
+}
+
+async fn reconcile_task_board_inner(
+    database: Option<&AsyncDaemonDb>,
+    items: &[ReviewItem],
+    authoritative_viewer_keys: &HashSet<String>,
+    missing_review_resolution: MissingReviewResolution,
+    backport_detection_enabled: bool,
+    backport_patterns: &[String],
+    expected_revision: u64,
+) -> Result<ReviewsProjectionAuditSummary, CliError> {
     let Some(database) = database else {
-        return Ok(true);
+        return Ok(ReviewsProjectionAuditSummary::new(true, &[], 0));
     };
     let mut observed_items = items.to_vec();
     let mut observed_authoritative_viewer_keys = authoritative_viewer_keys.clone();
@@ -60,9 +89,9 @@ pub(super) async fn reconcile_task_board(
         observed_items.extend(resolved_items);
     }
     let Some(_revision_guard) = stable_data_revision_guard(expected_revision).await else {
-        return Ok(false);
+        return Ok(ReviewsProjectionAuditSummary::new(false, &[], 0));
     };
-    let configured_keys =
+    let (configured_keys, operations) =
         super::super::task_board_db::reconcile_shared_review_items_db(database, &observed_items)
             .await?;
     let mut snapshots = observed_items
@@ -70,8 +99,12 @@ pub(super) async fn reconcile_task_board(
         .map(|item| snapshot_from_review(item, &observed_authoritative_viewer_keys))
         .collect::<Vec<_>>();
     mark_ineligible_snapshots(&mut snapshots, &configured_keys);
-    reconcile_snapshots(database, snapshots).await?;
-    Ok(GitHubProtectedClient::data_revision() == expected_revision)
+    let snapshot_update_count = reconcile_snapshots(database, snapshots).await?;
+    Ok(ReviewsProjectionAuditSummary::new(
+        GitHubProtectedClient::data_revision() == expected_revision,
+        &operations,
+        snapshot_update_count,
+    ))
 }
 
 async fn resolve_missing_review_items(
@@ -164,18 +197,18 @@ fn snapshot_key(repository: &str, number: u64) -> String {
 async fn reconcile_snapshots(
     database: &AsyncDaemonDb,
     snapshots: Vec<GitHubPullRequestSnapshot>,
-) -> Result<bool, CliError> {
+) -> Result<usize, CliError> {
     let items = database.list_task_board_items(None).await?;
-    let mut changed = false;
+    let mut update_count = 0;
     for item in items {
         let mutation = database
             .update_task_board_item(&item.id, |current| {
                 Ok(reconcile_review_item_from_snapshots(current, &snapshots))
             })
             .await?;
-        changed |= mutation.is_some();
+        update_count += usize::from(mutation.is_some());
     }
-    Ok(changed)
+    Ok(update_count)
 }
 
 fn snapshot_from_review(

--- a/src/daemon/service/reviews/refresh.rs
+++ b/src/daemon/service/reviews/refresh.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
+use std::slice;
 
 use crate::errors::CliError;
 use crate::github_api::{
@@ -8,10 +9,15 @@ use crate::reviews::{
     ReviewItem, ReviewRepositoryLabel, ReviewTarget, ReviewsGitHubClient, ReviewsRefreshRequest,
     ReviewsRefreshResponse,
 };
-use crate::task_board::reconcile_review_item_from_snapshots;
+use crate::task_board::{
+    TaskBoardItem, imported_review_references_from_items, reconcile_review_item_from_snapshots,
+};
 use crate::workspace::utc_now;
 
 use super::super::db::AsyncDaemonDb;
+use super::super::task_board_db::{
+    ReviewsProjectionAuditSummary, record_targeted_reviews_projection_result,
+};
 use super::cache_internal::{patch_cached_items, patch_cached_repository_labels};
 use super::token::token_bound_targets;
 use super::{
@@ -81,24 +87,73 @@ pub(super) async fn reconcile_targeted_missing_task_board_reviews(
     missing_pull_request_ids: &[String],
     expected_revision: u64,
 ) -> Result<bool, CliError> {
+    let result = reconcile_targeted_missing_task_board_reviews_inner(
+        database,
+        request,
+        missing_pull_request_ids,
+        expected_revision,
+    )
+    .await;
+    if let Some(database) = database {
+        record_targeted_reviews_projection_result(database, &result).await;
+    }
+    result.map(|summary| summary.is_stable())
+}
+
+async fn reconcile_targeted_missing_task_board_reviews_inner(
+    database: Option<&AsyncDaemonDb>,
+    request: &ReviewsRefreshRequest,
+    missing_pull_request_ids: &[String],
+    expected_revision: u64,
+) -> Result<ReviewsProjectionAuditSummary, CliError> {
     let Some(database) = database else {
-        return Ok(true);
+        return Ok(ReviewsProjectionAuditSummary::new(true, &[], 0));
     };
     let snapshots = missing_review_snapshots(&request.targets, missing_pull_request_ids);
     if snapshots.is_empty() {
-        return Ok(true);
+        return Ok(ReviewsProjectionAuditSummary::new(true, &[], 0));
     }
     let Some(_revision_guard) = stable_data_revision_guard(expected_revision).await else {
-        return Ok(false);
+        return Ok(ReviewsProjectionAuditSummary::new(false, &[], 0));
     };
+    let missing_references = snapshots
+        .iter()
+        .map(|snapshot| {
+            (
+                snapshot.repository.trim().to_ascii_lowercase(),
+                snapshot.number,
+            )
+        })
+        .collect::<HashSet<_>>();
+    let mut update_count = 0;
     for item in database.list_task_board_items(None).await? {
-        database
+        if !has_targeted_active_review(&item, &missing_references) {
+            continue;
+        }
+        let mutation = database
             .update_task_board_item(&item.id, |current| {
+                if !has_targeted_active_review(current, &missing_references) {
+                    return Ok(false);
+                }
                 Ok(reconcile_review_item_from_snapshots(current, &snapshots))
             })
             .await?;
+        update_count += usize::from(mutation.is_some());
     }
-    Ok(GitHubProtectedClient::data_revision() == expected_revision)
+    Ok(ReviewsProjectionAuditSummary::new(
+        GitHubProtectedClient::data_revision() == expected_revision,
+        &[],
+        update_count,
+    ))
+}
+
+fn has_targeted_active_review(
+    item: &TaskBoardItem,
+    missing_references: &HashSet<(String, u64)>,
+) -> bool {
+    imported_review_references_from_items(slice::from_ref(item))
+        .into_iter()
+        .any(|reference| missing_references.contains(&reference))
 }
 
 fn missing_review_snapshots(

--- a/src/daemon/service/reviews_tests/projection.rs
+++ b/src/daemon/service/reviews_tests/projection.rs
@@ -412,6 +412,40 @@ async fn targeted_missing_refresh_completes_only_matching_imported_review() {
             .and_then(|state| state.status),
         Some(TaskBoardStatus::HumanRequired)
     );
+
+    let revision_after_first = db.task_board_revision().await.expect("first revision");
+    assert!(
+        reconcile_targeted_missing_task_board_reviews(
+            Some(&db),
+            &request,
+            &["pr_missing".into()],
+            crate::github_api::GitHubProtectedClient::data_revision(),
+        )
+        .await
+        .expect("repeat missing review reconciliation")
+    );
+    assert_eq!(
+        db.task_board_revision().await.expect("second revision"),
+        revision_after_first,
+        "an unchanged missing review must not be rewritten"
+    );
+    let events = db
+        .load_audit_events(&crate::daemon::protocol::HarnessMonitorAuditEventsRequest {
+            action_keys: vec!["task_board.sync".into()],
+            ..Default::default()
+        })
+        .await
+        .expect("load sync audit events")
+        .events;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].outcome, "success");
+    assert_eq!(
+        events[0]
+            .payload_json
+            .as_ref()
+            .and_then(|payload| payload["snapshot_update_count"].as_u64()),
+        Some(1)
+    );
 }
 
 async fn create_imported_review(db: &AsyncDaemonDb, item_id: &str, repository: &str, number: u64) {

--- a/src/daemon/service/task_board_db.rs
+++ b/src/daemon/service/task_board_db.rs
@@ -28,9 +28,14 @@ use crate::workspace::utc_now;
 #[cfg(test)]
 mod external_ref_tests;
 mod reviews_sync;
+mod sync_audit;
 
 pub(crate) use reviews_sync::reconcile_shared_review_items_db;
 use reviews_sync::shared_review_request_client;
+pub(crate) use sync_audit::{
+    ReviewsProjectionAuditSummary, record_reviews_projection_result,
+    record_targeted_reviews_projection_result,
+};
 
 #[async_trait]
 impl TaskBoardSyncStore for AsyncDaemonDb {
@@ -237,6 +242,40 @@ pub(crate) async fn task_board_host_set_project_types_db(
 }
 
 pub(crate) async fn sync_task_board_db(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardSyncRequest,
+) -> Result<TaskBoardSyncResponse, CliError> {
+    sync_task_board_db_with_trigger(
+        db,
+        request,
+        sync_audit::TaskBoardSyncAuditTrigger::Requested,
+    )
+    .await
+}
+
+pub(crate) async fn sync_task_board_for_orchestrator_db(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardSyncRequest,
+) -> Result<TaskBoardSyncResponse, CliError> {
+    sync_task_board_db_with_trigger(
+        db,
+        request,
+        sync_audit::TaskBoardSyncAuditTrigger::Orchestrator,
+    )
+    .await
+}
+
+async fn sync_task_board_db_with_trigger(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardSyncRequest,
+    trigger: sync_audit::TaskBoardSyncAuditTrigger,
+) -> Result<TaskBoardSyncResponse, CliError> {
+    let result = sync_task_board_db_inner(db, request).await;
+    sync_audit::record_request_result(db, request, trigger, &result).await;
+    result
+}
+
+async fn sync_task_board_db_inner(
     db: &AsyncDaemonDb,
     request: &TaskBoardSyncRequest,
 ) -> Result<TaskBoardSyncResponse, CliError> {

--- a/src/daemon/service/task_board_db/reviews_sync.rs
+++ b/src/daemon/service/task_board_db/reviews_sync.rs
@@ -10,8 +10,9 @@ use crate::errors::{CliError, CliErrorKind};
 use crate::github_api::stable_data_revision_guard;
 use crate::reviews::{ReviewItem, ReviewPullRequestState, ReviewsQueryRequest};
 use crate::task_board::{
-    ExternalProvider, ExternalSyncClient, ExternalSyncDirection, ExternalSyncOptions, ExternalTask,
-    ExternalTaskRef, TaskBoardItem, TaskBoardStatus, sync_external_tasks,
+    ExternalProvider, ExternalSyncClient, ExternalSyncDirection, ExternalSyncOperation,
+    ExternalSyncOptions, ExternalTask, ExternalTaskRef, TaskBoardItem, TaskBoardStatus,
+    sync_external_tasks,
 };
 
 pub(super) struct SharedReviewRequestClient {
@@ -104,7 +105,7 @@ pub(super) async fn shared_review_request_client(
 pub(crate) async fn reconcile_shared_review_items_db(
     db: &AsyncDaemonDb,
     items: &[ReviewItem],
-) -> Result<HashSet<String>, CliError> {
+) -> Result<(HashSet<String>, Vec<ExternalSyncOperation>), CliError> {
     let settings = db.task_board_orchestrator_settings().await?;
     let configured_keys = items
         .iter()
@@ -123,10 +124,10 @@ pub(crate) async fn reconcile_shared_review_items_db(
         items,
         false,
     ) else {
-        return Ok(configured_keys);
+        return Ok((configured_keys, Vec::new()));
     };
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
-    sync_external_tasks(
+    let operations = sync_external_tasks(
         db,
         ExternalSyncOptions {
             provider: Some(ExternalProvider::GitHub),
@@ -137,7 +138,7 @@ pub(crate) async fn reconcile_shared_review_items_db(
         &clients,
     )
     .await?;
-    Ok(configured_keys)
+    Ok((configured_keys, operations))
 }
 
 fn shared_review_request_client_from_settings(

--- a/src/daemon/service/task_board_db/sync_audit.rs
+++ b/src/daemon/service/task_board_db/sync_audit.rs
@@ -122,6 +122,9 @@ impl BackgroundAuditState {
         now: Instant,
     ) -> AuditDecision {
         let trigger_failures = self.failures.entry(scope).or_default();
+        trigger_failures.retain(|_, last_recorded_at| {
+            now.saturating_duration_since(*last_recorded_at) < BACKGROUND_FAILURE_REPEAT_INTERVAL
+        });
         let should_record = trigger_failures
             .get(&fingerprint)
             .is_none_or(|last_recorded_at| {
@@ -386,6 +389,7 @@ mod tests {
             ),
             AuditDecision::Record { recovered: false }
         );
+        assert_eq!(state.failures[&(0, trigger)].len(), 1);
     }
 
     #[test]

--- a/src/daemon/service/task_board_db/sync_audit.rs
+++ b/src/daemon/service/task_board_db/sync_audit.rs
@@ -1,0 +1,502 @@
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::{Mutex, OnceLock, PoisonError};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+use crate::daemon::audit_events::{AuditEventDraft, record_audit_result_in_db};
+use crate::daemon::db::AsyncDaemonDb;
+use crate::daemon::protocol::{TaskBoardSyncRequest, TaskBoardSyncResponse};
+use crate::errors::CliError;
+use crate::task_board::{
+    ExternalProvider, ExternalSyncAction, ExternalSyncConflictPolicy, ExternalSyncDirection,
+    ExternalSyncOperation,
+};
+
+const BACKGROUND_FAILURE_REPEAT_INTERVAL: Duration = Duration::from_mins(15);
+
+static BACKGROUND_AUDIT_STATE: OnceLock<Mutex<BackgroundAuditState>> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum TaskBoardSyncAuditTrigger {
+    Requested,
+    Orchestrator,
+    ReviewsProjection,
+    ReviewsTargetedRefresh,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReviewsProjectionAuditSummary {
+    stable: bool,
+    operation_count: usize,
+    applied_operation_count: usize,
+    conflict_count: usize,
+    snapshot_update_count: usize,
+}
+
+impl ReviewsProjectionAuditSummary {
+    pub(crate) fn new(
+        stable: bool,
+        operations: &[ExternalSyncOperation],
+        snapshot_update_count: usize,
+    ) -> Self {
+        Self {
+            stable,
+            operation_count: operations.len(),
+            applied_operation_count: applied_operation_count(operations),
+            conflict_count: conflict_count(operations),
+            snapshot_update_count,
+        }
+    }
+
+    pub(crate) const fn is_stable(&self) -> bool {
+        self.stable
+    }
+
+    const fn has_applied_change(&self) -> bool {
+        self.applied_operation_count > 0 || self.snapshot_update_count > 0
+    }
+}
+
+impl TaskBoardSyncAuditTrigger {
+    const fn payload_value(self) -> &'static str {
+        match self {
+            Self::Requested => "requested",
+            Self::Orchestrator => "orchestrator",
+            Self::ReviewsProjection => "reviews_projection",
+            Self::ReviewsTargetedRefresh => "reviews_targeted_refresh",
+        }
+    }
+
+    const fn actor(self) -> &'static str {
+        match self {
+            Self::Requested => "Harness daemon",
+            Self::Orchestrator => "Task Board orchestrator",
+            Self::ReviewsProjection => "Reviews sync",
+            Self::ReviewsTargetedRefresh => "Reviews refresh",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuditDecision {
+    Suppress,
+    Record { recovered: bool },
+}
+
+#[derive(Debug, Default)]
+struct BackgroundAuditState {
+    failures: HashMap<(u64, TaskBoardSyncAuditTrigger), HashMap<u64, Instant>>,
+}
+
+impl BackgroundAuditState {
+    fn decide(
+        &mut self,
+        database_fingerprint: u64,
+        trigger: TaskBoardSyncAuditTrigger,
+        failure_fingerprint: Option<u64>,
+        has_applied_change: bool,
+        now: Instant,
+    ) -> AuditDecision {
+        if trigger == TaskBoardSyncAuditTrigger::Requested {
+            return AuditDecision::Record { recovered: false };
+        }
+        let scope = (database_fingerprint, trigger);
+        if let Some(fingerprint) = failure_fingerprint {
+            return self.decide_failure(scope, fingerprint, now);
+        }
+
+        let recovered = self.failures.remove(&scope).is_some();
+        if recovered || has_applied_change {
+            AuditDecision::Record { recovered }
+        } else {
+            AuditDecision::Suppress
+        }
+    }
+
+    fn decide_failure(
+        &mut self,
+        scope: (u64, TaskBoardSyncAuditTrigger),
+        fingerprint: u64,
+        now: Instant,
+    ) -> AuditDecision {
+        let trigger_failures = self.failures.entry(scope).or_default();
+        let should_record = trigger_failures
+            .get(&fingerprint)
+            .is_none_or(|last_recorded_at| {
+                now.saturating_duration_since(*last_recorded_at)
+                    >= BACKGROUND_FAILURE_REPEAT_INTERVAL
+            });
+        if !should_record {
+            return AuditDecision::Suppress;
+        }
+
+        trigger_failures.insert(fingerprint, now);
+        AuditDecision::Record { recovered: false }
+    }
+}
+
+pub(super) async fn record_request_result(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardSyncRequest,
+    trigger: TaskBoardSyncAuditTrigger,
+    result: &Result<TaskBoardSyncResponse, CliError>,
+) {
+    let operations = result
+        .as_ref()
+        .ok()
+        .map(|summary| summary.operations.as_slice());
+    let decision = audit_decision(
+        db,
+        trigger,
+        result.as_ref().err(),
+        operations
+            .unwrap_or_default()
+            .iter()
+            .any(|operation| operation.applied),
+    );
+    let AuditDecision::Record { recovered } = decision else {
+        return;
+    };
+    let mut payload = json!({
+        "trigger": trigger.payload_value(),
+        "status": request.status,
+        "provider": request.provider,
+        "direction": request.direction,
+        "conflict_policy": request.conflict_policy,
+        "dry_run": request.dry_run,
+    });
+    add_recovery(&mut payload, recovered);
+    if let Ok(summary) = result {
+        add_summary_counts(&mut payload, summary.total, &summary.operations);
+    }
+    record(db, trigger, payload, result).await;
+}
+
+pub(crate) async fn record_reviews_projection_result(
+    db: &AsyncDaemonDb,
+    result: &Result<ReviewsProjectionAuditSummary, CliError>,
+) {
+    record_reviews_result(db, TaskBoardSyncAuditTrigger::ReviewsProjection, result).await;
+}
+
+pub(crate) async fn record_targeted_reviews_projection_result(
+    db: &AsyncDaemonDb,
+    result: &Result<ReviewsProjectionAuditSummary, CliError>,
+) {
+    record_reviews_result(
+        db,
+        TaskBoardSyncAuditTrigger::ReviewsTargetedRefresh,
+        result,
+    )
+    .await;
+}
+
+async fn record_reviews_result(
+    db: &AsyncDaemonDb,
+    trigger: TaskBoardSyncAuditTrigger,
+    result: &Result<ReviewsProjectionAuditSummary, CliError>,
+) {
+    let has_applied_change = result
+        .as_ref()
+        .is_ok_and(ReviewsProjectionAuditSummary::has_applied_change);
+    let decision = match result {
+        Ok(summary) if !summary.is_stable() => unstable_projection_decision(has_applied_change),
+        _ => audit_decision(db, trigger, result.as_ref().err(), has_applied_change),
+    };
+    let AuditDecision::Record { recovered } = decision else {
+        return;
+    };
+    let mut payload = json!({
+        "trigger": trigger.payload_value(),
+        "provider": ExternalProvider::GitHub,
+        "direction": ExternalSyncDirection::Pull,
+        "conflict_policy": ExternalSyncConflictPolicy::Report,
+        "dry_run": false,
+    });
+    add_recovery(&mut payload, recovered);
+    if let Ok(summary) = result {
+        payload["stable"] = json!(summary.stable);
+        payload["operation_count"] = json!(summary.operation_count);
+        payload["applied_operation_count"] = json!(summary.applied_operation_count);
+        payload["conflict_count"] = json!(summary.conflict_count);
+        payload["snapshot_update_count"] = json!(summary.snapshot_update_count);
+    }
+    record(db, trigger, payload, result).await;
+}
+
+async fn record<T>(
+    db: &AsyncDaemonDb,
+    trigger: TaskBoardSyncAuditTrigger,
+    payload_json: Value,
+    result: &Result<T, CliError>,
+) {
+    record_audit_result_in_db(
+        db,
+        AuditEventDraft {
+            source: "taskBoard",
+            category: "taskBoardMutation",
+            kind: "task_board.sync",
+            action_key: "task_board.sync",
+            title: "Sync task-board providers".to_owned(),
+            subject: None,
+            actor: Some(trigger.actor().to_owned()),
+            payload_json: Some(payload_json),
+            related_urls: Vec::new(),
+        },
+        result,
+    )
+    .await;
+}
+
+fn audit_decision(
+    db: &AsyncDaemonDb,
+    trigger: TaskBoardSyncAuditTrigger,
+    error: Option<&CliError>,
+    has_applied_change: bool,
+) -> AuditDecision {
+    let failure_fingerprint = error.map(error_fingerprint);
+    let database_fingerprint = fingerprint(db.storage_path());
+    let state = BACKGROUND_AUDIT_STATE.get_or_init(|| Mutex::new(BackgroundAuditState::default()));
+    state.lock().unwrap_or_else(PoisonError::into_inner).decide(
+        database_fingerprint,
+        trigger,
+        failure_fingerprint,
+        has_applied_change,
+        Instant::now(),
+    )
+}
+
+fn error_fingerprint(error: &CliError) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    error.code().hash(&mut hasher);
+    error.message().hash(&mut hasher);
+    hasher.finish()
+}
+
+fn fingerprint<T: Hash + ?Sized>(value: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+const fn unstable_projection_decision(has_applied_change: bool) -> AuditDecision {
+    if has_applied_change {
+        AuditDecision::Record { recovered: false }
+    } else {
+        AuditDecision::Suppress
+    }
+}
+
+fn add_recovery(payload: &mut Value, recovered: bool) {
+    if recovered {
+        payload["recovered"] = json!(true);
+    }
+}
+
+fn add_summary_counts(
+    payload: &mut Value,
+    total_items: usize,
+    operations: &[ExternalSyncOperation],
+) {
+    payload["total_items"] = json!(total_items);
+    add_operation_counts(payload, operations);
+}
+
+fn add_operation_counts(payload: &mut Value, operations: &[ExternalSyncOperation]) {
+    payload["operation_count"] = json!(operations.len());
+    payload["applied_operation_count"] = json!(applied_operation_count(operations));
+    payload["conflict_count"] = json!(conflict_count(operations));
+}
+
+fn applied_operation_count(operations: &[ExternalSyncOperation]) -> usize {
+    operations
+        .iter()
+        .filter(|operation| operation.applied)
+        .count()
+}
+
+fn conflict_count(operations: &[ExternalSyncOperation]) -> usize {
+    operations
+        .iter()
+        .filter(|operation| operation.action == ExternalSyncAction::Conflict)
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::CliErrorKind;
+
+    #[test]
+    fn requested_sync_always_records_and_background_requires_a_change() {
+        let now = Instant::now();
+        let mut state = BackgroundAuditState::default();
+
+        assert_eq!(
+            state.decide(0, TaskBoardSyncAuditTrigger::Requested, None, false, now),
+            AuditDecision::Record { recovered: false }
+        );
+        assert_eq!(
+            state.decide(0, TaskBoardSyncAuditTrigger::Orchestrator, None, false, now),
+            AuditDecision::Suppress
+        );
+        assert_eq!(
+            state.decide(
+                0,
+                TaskBoardSyncAuditTrigger::ReviewsProjection,
+                None,
+                true,
+                now
+            ),
+            AuditDecision::Record { recovered: false }
+        );
+    }
+
+    #[test]
+    fn background_failure_records_first_changed_and_periodic_occurrences() {
+        let now = Instant::now();
+        let trigger = TaskBoardSyncAuditTrigger::Orchestrator;
+        let mut state = BackgroundAuditState::default();
+
+        assert_eq!(
+            state.decide(0, trigger, Some(1), false, now),
+            AuditDecision::Record { recovered: false }
+        );
+        assert_eq!(
+            state.decide(0, trigger, Some(1), false, now + Duration::from_secs(1)),
+            AuditDecision::Suppress
+        );
+        assert_eq!(
+            state.decide(0, trigger, Some(2), false, now + Duration::from_secs(2)),
+            AuditDecision::Record { recovered: false }
+        );
+        assert_eq!(
+            state.decide(0, trigger, Some(1), false, now + Duration::from_secs(3)),
+            AuditDecision::Suppress
+        );
+        assert_eq!(
+            state.decide(
+                0,
+                trigger,
+                Some(2),
+                false,
+                now + Duration::from_secs(2) + BACKGROUND_FAILURE_REPEAT_INTERVAL
+            ),
+            AuditDecision::Record { recovered: false }
+        );
+    }
+
+    #[test]
+    fn failure_fingerprint_distinguishes_messages_with_the_same_error_code() {
+        let provider_error: CliError =
+            CliErrorKind::workflow_io("provider authentication failed").into();
+        let database_error: CliError =
+            CliErrorKind::workflow_io("task database unavailable").into();
+
+        assert_eq!(provider_error.code(), database_error.code());
+        assert_ne!(
+            error_fingerprint(&provider_error),
+            error_fingerprint(&database_error)
+        );
+    }
+
+    #[test]
+    fn background_recovery_records_once_even_without_an_applied_change() {
+        let now = Instant::now();
+        let trigger = TaskBoardSyncAuditTrigger::ReviewsProjection;
+        let mut state = BackgroundAuditState::default();
+
+        assert_eq!(
+            state.decide(0, trigger, Some(1), false, now),
+            AuditDecision::Record { recovered: false }
+        );
+        assert_eq!(
+            state.decide(0, trigger, None, false, now + Duration::from_secs(1)),
+            AuditDecision::Record { recovered: true }
+        );
+        assert_eq!(
+            state.decide(0, trigger, None, false, now + Duration::from_secs(2)),
+            AuditDecision::Suppress
+        );
+
+        let mut payload = json!({});
+        add_recovery(&mut payload, true);
+        assert_eq!(payload["recovered"], true);
+    }
+
+    #[test]
+    fn background_health_is_isolated_per_database() {
+        let now = Instant::now();
+        let trigger = TaskBoardSyncAuditTrigger::ReviewsProjection;
+        let mut state = BackgroundAuditState::default();
+
+        assert_eq!(
+            state.decide(1, trigger, Some(1), false, now),
+            AuditDecision::Record { recovered: false }
+        );
+        assert_eq!(
+            state.decide(2, trigger, None, false, now),
+            AuditDecision::Suppress
+        );
+        assert_eq!(
+            state.decide(1, trigger, None, false, now),
+            AuditDecision::Record { recovered: true }
+        );
+    }
+
+    #[test]
+    fn unstable_projection_does_not_clear_failure_or_report_recovery() {
+        let now = Instant::now();
+        let trigger = TaskBoardSyncAuditTrigger::ReviewsProjection;
+        let mut state = BackgroundAuditState::default();
+
+        assert_eq!(
+            state.decide(0, trigger, Some(1), false, now),
+            AuditDecision::Record { recovered: false }
+        );
+        assert_eq!(unstable_projection_decision(false), AuditDecision::Suppress);
+        assert_eq!(
+            unstable_projection_decision(true),
+            AuditDecision::Record { recovered: false }
+        );
+        assert_eq!(
+            state.decide(0, trigger, None, false, now + Duration::from_secs(1)),
+            AuditDecision::Record { recovered: true }
+        );
+    }
+
+    #[test]
+    fn aggregate_payload_contains_counts_without_raw_operations() {
+        let mut payload = json!({ "trigger": "requested" });
+        add_summary_counts(
+            &mut payload,
+            7,
+            &[
+                operation(true, ExternalSyncAction::Pull),
+                operation(false, ExternalSyncAction::Conflict),
+            ],
+        );
+
+        assert_eq!(payload["total_items"], 7);
+        assert_eq!(payload["operation_count"], 2);
+        assert_eq!(payload["applied_operation_count"], 1);
+        assert_eq!(payload["conflict_count"], 1);
+        assert!(payload.get("operations").is_none());
+    }
+
+    fn operation(applied: bool, action: ExternalSyncAction) -> ExternalSyncOperation {
+        ExternalSyncOperation {
+            provider: ExternalProvider::GitHub,
+            action,
+            board_item_id: Some("task-1".to_owned()),
+            external_id: Some("external-1".to_owned()),
+            url: Some("https://example.test/items/1".to_owned()),
+            dry_run: false,
+            applied,
+            changed_fields: Vec::new(),
+            unsupported_fields: Vec::new(),
+        }
+    }
+}

--- a/src/daemon/service/task_board_orchestrator_db.rs
+++ b/src/daemon/service/task_board_orchestrator_db.rs
@@ -25,7 +25,7 @@ use crate::workspace::utc_now;
 
 use super::task_board::dispatch_task_board_async;
 use super::task_board_db::{
-    active_external_sync_config_db, sync_task_board_db, task_board_host_local_db,
+    active_external_sync_config_db, sync_task_board_for_orchestrator_db, task_board_host_local_db,
 };
 use super::task_board_evaluation::evaluate_task_board_async;
 use super::task_board_github::run_task_board_github_automation_async;
@@ -163,7 +163,7 @@ async fn sync_github_tasks(
     {
         return Ok(());
     }
-    prepared.sync = sync_task_board_db(
+    prepared.sync = sync_task_board_for_orchestrator_db(
         db,
         &TaskBoardSyncRequest {
             status: prepared.input.status,

--- a/src/daemon/websocket/task_board.rs
+++ b/src/daemon/websocket/task_board.rs
@@ -286,23 +286,10 @@ async fn dispatch_task_board_sync(request: &WsRequest, state: &DaemonHttpState) 
     let Ok(body) = parse_params_or_default::<TaskBoardSyncRequest>(request) else {
         return invalid_params(request);
     };
-    let result = task_board_route_executor::sync(state, &body).await;
-    record_task_board_audit_result(
-        state,
-        "task_board.sync",
-        "Sync task-board providers",
-        None,
-        serde_json::json!({
-            "status": body.status,
-            "provider": body.provider,
-            "direction": body.direction,
-            "conflict_policy": body.conflict_policy,
-            "dry_run": body.dry_run,
-        }),
-        &result,
+    dispatch_query_result(
+        &request.id,
+        task_board_route_executor::sync(state, &body).await,
     )
-    .await;
-    dispatch_query_result(&request.id, result)
 }
 
 async fn dispatch_task_board_dispatch(request: &WsRequest, state: &DaemonHttpState) -> WsResponse {

--- a/src/daemon/websocket/task_board/tests.rs
+++ b/src/daemon/websocket/task_board/tests.rs
@@ -37,7 +37,9 @@ const TASK_BOARD_WS_METHOD_CATALOG: &[&str] = &[
     ws_methods::POLICY_PIPELINE_AUDIT,
 ];
 
+use harness_testkit::with_isolated_harness_env;
 use serde_json::json;
+use tempfile::tempdir;
 
 use super::super::test_support::test_http_state_with_db;
 use super::*;
@@ -73,4 +75,49 @@ async fn ws_unknown_task_board_method_returns_none() {
     };
     let response = dispatch_task_board_method(&request, &state, &connection).await;
     assert!(response.is_none());
+}
+
+#[test]
+fn ws_task_board_sync_persists_exactly_one_audit_event() {
+    let sandbox = tempdir().expect("tempdir");
+    with_isolated_harness_env(sandbox.path(), || {
+        tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(async {
+                let state = test_http_state_with_db();
+                let connection = Arc::new(Mutex::new(ConnectionState::new()));
+                let response = dispatch_task_board_method(
+                    &WsRequest {
+                        id: "ws-sync-audit".into(),
+                        method: ws_methods::TASK_BOARD_SYNC.into(),
+                        params: json!({ "direction": "push", "dry_run": true }),
+                        trace_context: None,
+                    },
+                    &state,
+                    &connection,
+                )
+                .await;
+                assert!(response.is_some());
+
+                let events = state
+                    .async_db
+                    .get()
+                    .expect("async db")
+                    .load_audit_events(&crate::daemon::protocol::HarnessMonitorAuditEventsRequest {
+                        action_keys: vec!["task_board.sync".into()],
+                        ..Default::default()
+                    })
+                    .await
+                    .expect("load audit events")
+                    .events;
+                assert_eq!(events.len(), 1);
+                assert_eq!(events[0].outcome, "success");
+                assert_eq!(
+                    events[0].payload_json.as_ref().and_then(|payload| {
+                        payload.get("trigger").and_then(serde_json::Value::as_str)
+                    }),
+                    Some("requested")
+                );
+            });
+    });
 }


### PR DESCRIPTION
## Motivation
Task Board provider synchronization ran through HTTP and background paths without durable audit records, leaving the Audit view incomplete and obscuring automatic changes and failures.

## Implementation
- move synchronization auditing to shared daemon boundaries for requested, orchestrated, and Reviews-driven reconciliation
- persist bounded success, failure, and recovery aggregates while throttling repeated background failures and no-op polls
- cover HTTP, WebSocket, projection, retry, and audit payload behavior
