### PR TITLE
fix(remote): persist client activity

### DIFF
--- a/src/daemon/db/async_bootstrap.rs
+++ b/src/daemon/db/async_bootstrap.rs
@@ -122,6 +122,7 @@ const fn migration_floor_version(migration_version: i64) -> u64 {
         22 => 28,
         23 => 29,
         24 => 30,
+        25 => 31,
         _ => u64::MAX,
     }
 }

--- a/src/daemon/db/migrations/0025_daemon_v31_remote_client_activity.sql
+++ b/src/daemon/db/migrations/0025_daemon_v31_remote_client_activity.sql
@@ -1,0 +1,12 @@
+CREATE TRIGGER IF NOT EXISTS remote_audit_events_touch_client_activity
+AFTER INSERT ON remote_audit_events
+WHEN NEW.request_id IS NOT NULL AND NEW.client_id IS NOT NULL
+BEGIN
+    UPDATE remote_clients
+    SET last_seen_at = NEW.recorded_at
+    WHERE client_id = NEW.client_id
+      AND revoked_at IS NULL
+      AND (last_seen_at IS NULL OR last_seen_at < NEW.recorded_at);
+END;
+
+UPDATE schema_meta SET value = '31' WHERE key = 'version';

--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -88,6 +88,7 @@ mod schema_v27;
 mod schema_v28;
 mod schema_v29;
 mod schema_v30;
+mod schema_v31;
 #[allow(dead_code)]
 mod task_board;
 pub(crate) use task_board::{
@@ -287,7 +288,7 @@ impl fmt::Debug for DaemonDb {
     }
 }
 
-pub(crate) const SCHEMA_VERSION: &str = "30";
+pub(crate) const SCHEMA_VERSION: &str = "31";
 
 /// Summary of what was imported from file-based storage.
 #[derive(Debug, Default)]

--- a/src/daemon/db/schema.rs
+++ b/src/daemon/db/schema.rs
@@ -190,6 +190,9 @@ impl DaemonDb {
         if version_number <= 29 {
             self.migrate_v29_to_v30()?;
         }
+        if version_number <= 30 {
+            self.migrate_v30_to_v31()?;
+        }
         Ok(())
     }
 
@@ -301,6 +304,10 @@ impl DaemonDb {
 
     fn migrate_v29_to_v30(&self) -> Result<(), CliError> {
         super::schema_v30::run(&self.conn)
+    }
+
+    fn migrate_v30_to_v31(&self) -> Result<(), CliError> {
+        super::schema_v31::run(&self.conn)
     }
 }
 

--- a/src/daemon/db/schema_repairs.rs
+++ b/src/daemon/db/schema_repairs.rs
@@ -30,6 +30,7 @@ const CURRENT_SCHEMA_POLICY_COLUMNS: &[(&str, &str)] = &[
 
 const DEPRECATED_SCHEMA_POLICY_COLUMNS: &[(&str, &str)] =
     &[("policy_workspace", "enforcement_snapshot_json")];
+const CURRENT_SCHEMA_TRIGGERS: &[&str] = &["remote_audit_events_touch_client_activity"];
 
 const CURRENT_SCHEMA_REMOTE_ACME_COLUMNS: &[(&str, &str)] = &[
     ("remote_acme_state", "domain"),
@@ -93,6 +94,11 @@ pub(super) fn current_schema_shape_needs_repair(
             return Ok(true);
         }
     }
+    for trigger in CURRENT_SCHEMA_TRIGGERS {
+        if !trigger_exists(conn, trigger)? {
+            return Ok(true);
+        }
+    }
     Ok(false)
 }
 
@@ -118,6 +124,7 @@ pub(super) fn repair_current_schema_shape(db: &DaemonDb) -> Result<(), CliError>
     super::schema_v28::run(&db.conn)?;
     super::schema_v29::run(&db.conn)?;
     super::schema_v30::run(&db.conn)?;
+    super::schema_v31::run(&db.conn)?;
     db.conn
         .execute(
             "UPDATE schema_meta SET value = ?1 WHERE key = 'version'",
@@ -252,6 +259,16 @@ fn table_exists(conn: &super::Connection, table_name: &str) -> Result<bool, CliE
     )
     .map(|count| count > 0)
     .map_err(|error| db_error(format!("check {table_name} table existence: {error}")))
+}
+
+fn trigger_exists(conn: &super::Connection, trigger_name: &str) -> Result<bool, CliError> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name = ?1",
+        [trigger_name],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|count| count > 0)
+    .map_err(|error| db_error(format!("check {trigger_name} trigger existence: {error}")))
 }
 
 fn column_exists(

--- a/src/daemon/db/schema_v31.rs
+++ b/src/daemon/db/schema_v31.rs
@@ -1,0 +1,11 @@
+use rusqlite::Connection;
+
+use super::{CliError, db_error};
+
+const REMOTE_CLIENT_ACTIVITY_DDL: &str =
+    include_str!("migrations/0025_daemon_v31_remote_client_activity.sql");
+
+pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
+    conn.execute_batch(REMOTE_CLIENT_ACTIVITY_DDL)
+        .map_err(|error| db_error(format!("apply remote client activity schema v31: {error}")))
+}

--- a/src/daemon/db/tests/async_pool.rs
+++ b/src/daemon/db/tests/async_pool.rs
@@ -27,7 +27,7 @@ async fn connect_reads_current_schema_version() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=24).collect::<Vec<i64>>()
+        (1..=25).collect::<Vec<i64>>()
     );
 }
 
@@ -52,7 +52,7 @@ async fn connect_bootstraps_empty_database_with_sqlx_migrations() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=24).collect::<Vec<i64>>()
+        (1..=25).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -144,7 +144,7 @@ async fn connect_migrates_legacy_schema_before_opening_pool() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=24).collect::<Vec<i64>>()
+        (1..=25).collect::<Vec<i64>>()
     );
 }
 
@@ -188,7 +188,7 @@ async fn connect_preserves_existing_db_when_baseline_checksum_drifted() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=24).collect::<Vec<i64>>()
+        (1..=25).collect::<Vec<i64>>()
     );
 }
 
@@ -247,7 +247,7 @@ async fn connect_accepts_v22_db_with_recorded_policy_snapshot_migration() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=24).collect::<Vec<i64>>()
+        (1..=25).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -280,7 +280,7 @@ async fn connect_seeds_v18_sqlx_ledger_when_sync_schema_already_applied() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=24).collect::<Vec<i64>>()
+        (1..=25).collect::<Vec<i64>>()
     );
 }
 
@@ -370,7 +370,7 @@ async fn connect_repairs_v8_active_sessions_without_leader_before_opening_pool()
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=24).collect::<Vec<i64>>()
+        (1..=25).collect::<Vec<i64>>()
     );
     drop(async_db);
 

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -19,6 +19,7 @@ mod projects;
 mod reconcile;
 mod remote_acme;
 mod remote_acme_providers;
+mod remote_client_activity;
 mod remote_identity;
 mod remote_pairing;
 mod remote_pairing_reviews;

--- a/src/daemon/db/tests/remote_client_activity.rs
+++ b/src/daemon/db/tests/remote_client_activity.rs
@@ -1,0 +1,244 @@
+use sqlx::query_scalar;
+
+use super::*;
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::{
+    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteClientRegistration,
+};
+
+const ACTIVITY_TRIGGER: &str = "remote_audit_events_touch_client_activity";
+
+#[test]
+fn remote_client_activity_advances_monotonically_for_authenticated_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    register_activity_client(&db, "active-client", "active-token");
+
+    db.record_remote_audit_event(&activity_event(
+        "activity-denied",
+        "2026-07-13T12:45:00Z",
+        Some("active-client"),
+        RemoteAuditScopeDecision::Denied,
+    ))
+    .expect("record denied authenticated activity");
+    assert_eq!(
+        remote_client_last_seen_at(&db, "active-client").as_deref(),
+        Some("2026-07-13T12:45:00Z")
+    );
+
+    db.record_remote_audit_event(&activity_event(
+        "activity-older",
+        "2026-07-13T12:44:00Z",
+        Some("active-client"),
+        RemoteAuditScopeDecision::Allowed,
+    ))
+    .expect("record older activity");
+    assert_eq!(
+        remote_client_last_seen_at(&db, "active-client").as_deref(),
+        Some("2026-07-13T12:45:00Z"),
+        "out-of-order audit persistence must not move activity backwards"
+    );
+
+    db.record_remote_audit_event(&activity_event(
+        "activity-newer",
+        "2026-07-13T12:46:00Z",
+        Some("active-client"),
+        RemoteAuditScopeDecision::Allowed,
+    ))
+    .expect("record newer activity");
+    assert_eq!(
+        remote_client_last_seen_at(&db, "active-client").as_deref(),
+        Some("2026-07-13T12:46:00Z")
+    );
+}
+
+#[test]
+fn remote_client_activity_ignores_anonymous_and_revoked_audits() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    register_activity_client(&db, "inactive-client", "inactive-token");
+
+    db.record_remote_audit_event(&activity_event(
+        "activity-anonymous",
+        "2026-07-13T12:45:00Z",
+        None,
+        RemoteAuditScopeDecision::Denied,
+    ))
+    .expect("record anonymous audit");
+    assert_eq!(remote_client_last_seen_at(&db, "inactive-client"), None);
+
+    db.record_remote_audit_event(&RemoteAuditEvent::new(
+        "activity-management",
+        "2026-07-13T12:45:30Z",
+        None,
+        Some("inactive-client"),
+        "remote.clients.rotate",
+        RemoteAccessScope::Admin,
+        RemoteAuditScopeDecision::Allowed,
+        RemoteAuditOutcome::Success,
+        None,
+        None,
+    ))
+    .expect("record client management audit");
+    assert_eq!(
+        remote_client_last_seen_at(&db, "inactive-client"),
+        None,
+        "management of a target client is not activity by that client"
+    );
+
+    db.revoke_remote_client("inactive-client", "2026-07-13T12:46:00Z")
+        .expect("revoke client");
+    db.record_remote_audit_event(&activity_event(
+        "activity-revoked",
+        "2026-07-13T12:47:00Z",
+        Some("inactive-client"),
+        RemoteAuditScopeDecision::Denied,
+    ))
+    .expect("record revoked client audit");
+    assert_eq!(
+        remote_client_last_seen_at(&db, "inactive-client"),
+        None,
+        "revoked credentials must not appear active"
+    );
+}
+
+#[test]
+fn remote_client_activity_migrates_v30_databases() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("harness.db");
+    {
+        let db = DaemonDb::open(&path).expect("open current db");
+        register_activity_client(&db, "migrated-client", "migrated-token");
+    }
+    let conn = Connection::open(&path).expect("open sqlite");
+    conn.execute_batch(&format!(
+        "DROP TRIGGER IF EXISTS {ACTIVITY_TRIGGER};
+         UPDATE schema_meta SET value = '30' WHERE key = 'version';"
+    ))
+    .expect("downgrade to v30");
+    drop(conn);
+
+    let db = DaemonDb::open(&path).expect("migrate v30 database");
+    assert_eq!(db.schema_version().expect("schema version"), "31");
+    assert_eq!(activity_trigger_count(&db), 1);
+    db.record_remote_audit_event(&activity_event(
+        "activity-after-migration",
+        "2026-07-13T12:48:00Z",
+        Some("migrated-client"),
+        RemoteAuditScopeDecision::Allowed,
+    ))
+    .expect("record activity after migration");
+    assert_eq!(
+        remote_client_last_seen_at(&db, "migrated-client").as_deref(),
+        Some("2026-07-13T12:48:00Z")
+    );
+}
+
+#[test]
+fn remote_client_activity_repairs_a_missing_current_trigger() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("harness.db");
+    {
+        let db = DaemonDb::open(&path).expect("open current db");
+        register_activity_client(&db, "repaired-client", "repaired-token");
+    }
+    let conn = Connection::open(&path).expect("open sqlite");
+    conn.execute_batch(&format!("DROP TRIGGER IF EXISTS {ACTIVITY_TRIGGER};"))
+        .expect("drop activity trigger");
+    drop(conn);
+
+    let db = DaemonDb::open(&path).expect("repair current database");
+    assert_eq!(activity_trigger_count(&db), 1);
+    db.record_remote_audit_event(&activity_event(
+        "activity-after-repair",
+        "2026-07-13T12:49:00Z",
+        Some("repaired-client"),
+        RemoteAuditScopeDecision::Allowed,
+    ))
+    .expect("record activity after repair");
+    assert_eq!(
+        remote_client_last_seen_at(&db, "repaired-client").as_deref(),
+        Some("2026-07-13T12:49:00Z")
+    );
+}
+
+#[tokio::test]
+async fn remote_client_activity_updates_through_async_audit_persistence() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("harness.db");
+    {
+        let db = DaemonDb::open(&path).expect("open sync db");
+        register_activity_client(&db, "async-client", "async-token");
+    }
+    let db = AsyncDaemonDb::connect(&path).await.expect("open async db");
+
+    db.record_remote_audit_event(&activity_event(
+        "activity-async",
+        "2026-07-13T12:50:00Z",
+        Some("async-client"),
+        RemoteAuditScopeDecision::Allowed,
+    ))
+    .await
+    .expect("record async activity");
+    let last_seen_at = query_scalar::<_, Option<String>>(
+        "SELECT last_seen_at FROM remote_clients WHERE client_id = ?1",
+    )
+    .bind("async-client")
+    .fetch_one(db.pool())
+    .await
+    .expect("load async activity");
+    assert_eq!(last_seen_at.as_deref(), Some("2026-07-13T12:50:00Z"));
+}
+
+fn register_activity_client(db: &DaemonDb, client_id: &str, token: &str) {
+    let registration = RemoteClientRegistration::new_for_tests(
+        client_id,
+        "Activity Client",
+        "macos",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        token,
+        "2026-07-13T12:40:00Z",
+    )
+    .expect("client registration");
+    db.register_remote_client(&registration)
+        .expect("register activity client");
+}
+
+fn activity_event(
+    event_id: &str,
+    recorded_at: &str,
+    client_id: Option<&str>,
+    decision: RemoteAuditScopeDecision,
+) -> RemoteAuditEvent {
+    RemoteAuditEvent::new(
+        event_id,
+        recorded_at,
+        Some(event_id),
+        client_id,
+        "GET /v1/health",
+        RemoteAccessScope::Read,
+        decision,
+        RemoteAuditOutcome::Success,
+        Some("203.0.113.10"),
+        None,
+    )
+}
+
+fn remote_client_last_seen_at(db: &DaemonDb, client_id: &str) -> Option<String> {
+    db.conn
+        .query_row(
+            "SELECT last_seen_at FROM remote_clients WHERE client_id = ?1",
+            [client_id],
+            |row| row.get(0),
+        )
+        .expect("load client activity")
+}
+
+fn activity_trigger_count(db: &DaemonDb) -> i64 {
+    db.conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name = ?1",
+            [ACTIVITY_TRIGGER],
+            |row| row.get(0),
+        )
+        .expect("count activity trigger")
+}


### PR DESCRIPTION
## Motivation

Remote client records expose `last_seen_at`, but authenticated HTTPS and WSS activity never updates it. Operators cannot distinguish active credentials from abandoned ones.

## Implementation

- add a forward-only schema v31 trigger that advances active client activity in the same transaction as mandatory request audit persistence
- ignore anonymous, revoked, out-of-order, and client-management audit events
- cover rusqlite, SQLx, v30 migration, and missing-trigger repair paths with TDD proofs