### PR TITLE
feat(task-board): move operations into inspector

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitor/App/HarnessMonitorAppCommands.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitor/App/HarnessMonitorAppCommands.swift
@@ -17,8 +17,8 @@ struct HarnessMonitorAppCommands: Commands {
   private var searchFocusAction
   @FocusedValue(\.harnessSessionSidebarSelection)
   private var sidebarSelectionFocus
-  @FocusedValue(\.harnessTaskBoardSelection)
-  private var taskBoardSelectionFocus
+  @FocusedValue(\.harnessTaskBoardCommandFocus)
+  private var taskBoardCommandFocus
   @FocusedValue(\.dashboardAuditCopyCommand)
   private var dashboardAuditCopyFocus
   @FocusedValue(\.harnessPolicyCanvasCommandFocus)
@@ -75,6 +75,10 @@ struct HarnessMonitorAppCommands: Commands {
 
   private var searchCommandTitle: LocalizedStringKey {
     searchFocusAction?.menuLabel.localizedTitle ?? "Find"
+  }
+
+  private var taskBoardSelectionFocus: TaskBoardSelectionFocus? {
+    taskBoardCommandFocus?.selection
   }
 
   private var deleteSelectionCommandTitle: String {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Support/HarnessMonitorAccessibilityIDs.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Support/HarnessMonitorAccessibilityIDs.swift
@@ -141,6 +141,9 @@ public enum HarnessMonitorAccessibility {
 
   public static let dashboardNewSessionButton = "harness.dashboard.new-session"
   public static let dashboardOpenFolderButton = "harness.dashboard.open-folder"
+  public static let taskBoardOperationsInspector = "harness.task-board.operations.inspector"
+  public static let taskBoardOperationsInspectorToolbarButton =
+    "harness.task-board.operations.inspector.toolbar"
   public static let sessionsBoardRoot = "harness.board.root"
   public static let sessionsBoardScrollView = "harness.board.scroll"
   public static let openRecentRoot = "harness.open.recent"

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Support/HarnessMonitorAccessibilityIDs.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Support/HarnessMonitorAccessibilityIDs.swift
@@ -142,7 +142,7 @@ public enum HarnessMonitorAccessibility {
   public static let dashboardNewSessionButton = "harness.dashboard.new-session"
   public static let dashboardOpenFolderButton = "harness.dashboard.open-folder"
   public static let taskBoardOperationsInspector = "harness.task-board.operations.inspector"
-  public static let taskBoardOperationsInspectorToolbarButton =
+  public static let taskBoardOperationsInspectorButton =
     "harness.task-board.operations.inspector.toolbar"
   public static let sessionsBoardRoot = "harness.board.root"
   public static let sessionsBoardScrollView = "harness.board.scroll"

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardRouteContent.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardRouteContent.swift
@@ -202,7 +202,7 @@ struct DashboardTaskBoardRouteView: View {
       TaskBoardOperationsInspector(
         store: store,
         taskBoardItems: dashboardUI.taskBoardItems,
-        isVisible: operationsInspectorVisible
+        isVisible: operationsInspectorVisible && isRouteVisible
       )
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -213,7 +213,7 @@ struct DashboardTaskBoardRouteView: View {
     .task(id: taskBoardInboxSessionIDs) {
       await refreshVisibleTaskBoardInboxSnapshot()
     }
-    .task {
+    .onAppear {
       operationsInspectorDispatcher.toggleInspector = toggleOperationsInspector
     }
     .onReceive(

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardRouteContent.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardRouteContent.swift
@@ -43,7 +43,8 @@ struct DashboardRouteContent: View, Equatable {
       DashboardTaskBoardRouteView(
         store: store,
         dashboardUI: dashboardUI,
-        sessionCatalog: sessionCatalog
+        sessionCatalog: sessionCatalog,
+        isRouteVisible: isTaskBoardVisible
       )
       .layoutValue(key: DashboardRetainedRouteKey.self, value: .taskBoard)
       .opacity(isTaskBoardVisible ? 1 : 0)
@@ -164,11 +165,16 @@ struct DashboardTaskBoardRouteView: View {
   let store: HarnessMonitorStore
   let dashboardUI: HarnessMonitorStore.ContentDashboardSlice
   let sessionCatalog: HarnessMonitorStore.SessionCatalogSlice
+  let isRouteVisible: Bool
+  @AppStorage(TaskBoardOperationsInspectorVisibility.storageKey)
+  private var operationsInspectorVisible = TaskBoardOperationsInspectorVisibility.defaultValue
   @State private var taskBoardInboxSnapshot = TaskBoardInboxSnapshot(
     generatedAt: nil,
     isFromCache: true
   )
   @State private var perfScrollPosition = ScrollPosition()
+  @State private var operationsInspectorDispatcher =
+    TaskBoardOperationsInspectorFocusDispatcher()
   private let perfScrollHookEnabled = HarnessMonitorPerfDashboardScrollBus.isActive()
 
   private var visibleTaskBoardSessions: [SessionSummary] {
@@ -180,14 +186,24 @@ struct DashboardTaskBoardRouteView: View {
     visibleTaskBoardSessions.map(\.sessionId)
   }
 
+  private var operationsInspectorFocus: TaskBoardOperationsInspectorFocus? {
+    guard isRouteVisible else { return nil }
+    return TaskBoardOperationsInspectorFocus(
+      isVisible: operationsInspectorVisible,
+      canToggle: true,
+      dispatcher: operationsInspectorDispatcher
+    )
+  }
+
   var body: some View {
     let _ = HarnessMonitorPerfTrace.countBodyEval("DashboardTaskBoardRouteView")
-    Group {
-      if perfScrollHookEnabled {
-        dashboardScrollingContent(scrollPosition: $perfScrollPosition)
-      } else {
-        dashboardExpandedContent
-      }
+    HStack(spacing: 0) {
+      taskBoardMainContent
+      TaskBoardOperationsInspector(
+        store: store,
+        taskBoardItems: dashboardUI.taskBoardItems,
+        isVisible: operationsInspectorVisible
+      )
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .onAppear {
@@ -196,6 +212,9 @@ struct DashboardTaskBoardRouteView: View {
     }
     .task(id: taskBoardInboxSessionIDs) {
       await refreshVisibleTaskBoardInboxSnapshot()
+    }
+    .task {
+      operationsInspectorDispatcher.toggleInspector = toggleOperationsInspector
     }
     .onReceive(
       NotificationCenter.default.publisher(
@@ -221,6 +240,14 @@ struct DashboardTaskBoardRouteView: View {
     }
   }
 
+  @ViewBuilder private var taskBoardMainContent: some View {
+    if perfScrollHookEnabled {
+      dashboardScrollingContent(scrollPosition: $perfScrollPosition)
+    } else {
+      dashboardExpandedContent
+    }
+  }
+
   private var taskBoardOverviewContent: some View {
     TaskBoardOverviewHost(
       scope: .dashboard,
@@ -230,7 +257,10 @@ struct DashboardTaskBoardRouteView: View {
       decisions: store.supervisorOpenDecisions,
       orchestratorStatus: dashboardUI.taskBoardOrchestratorStatus,
       evaluationSummary: dashboardUI.taskBoardEvaluationSummary,
-      isActionInFlight: dashboardUI.isBusy
+      isActionInFlight: dashboardUI.isBusy,
+      showsOperationsPanel: false,
+      isCommandFocusActive: isRouteVisible,
+      operationsInspectorFocus: operationsInspectorFocus
     )
   }
 
@@ -277,5 +307,10 @@ struct DashboardTaskBoardRouteView: View {
     )
     guard !Task.isCancelled else { return }
     taskBoardInboxSnapshot = snapshot
+  }
+
+  @MainActor
+  private func toggleOperationsInspector() {
+    operationsInspectorVisible.toggle()
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardWindowToolbar.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardWindowToolbar.swift
@@ -79,6 +79,7 @@ private struct TaskBoardOperationsInspectorToolbarButton: View {
 
   var body: some View {
     Button {
+      guard isToggleEnabled else { return }
       operationsInspectorFocus?.dispatcher.performToggleInspector()
     } label: {
       Image(systemName: "sidebar.trailing")
@@ -96,7 +97,9 @@ private struct TaskBoardOperationsInspectorToolbarButton: View {
       label: "Task Board Operations",
       value: operationsInspectorFocus?.isVisible == true ? "Shown" : "Hidden",
       hint: buttonTitle,
+      enabled: isToggleEnabled,
       pressAction: {
+        guard isToggleEnabled else { return }
         operationsInspectorFocus?.dispatcher.performToggleInspector()
       }
     )

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardWindowToolbar.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardWindowToolbar.swift
@@ -6,6 +6,7 @@ struct DashboardWindowToolbar: ToolbarContent {
   let store: HarnessMonitorStore
   let navigation: WindowNavigationState
   let showsQuickActions: Bool
+  let showsTaskBoardOperationsInspectorToggle: Bool
   let showsPolicyInspectorToggle: Bool
   let sleepPreventionPresentation: SleepPreventionToolbarPresentation
 
@@ -39,7 +40,13 @@ struct DashboardWindowToolbar: ToolbarContent {
 
     GlobalPolicyEnforcementToolbarGroup(store: store)
 
-    if showsPolicyInspectorToggle {
+    if showsTaskBoardOperationsInspectorToggle {
+      ToolbarSpacer(.fixed, placement: .primaryAction)
+        .sharedBackgroundVisibility(.hidden)
+      ToolbarItem(placement: .primaryAction) {
+        TaskBoardOperationsInspectorToolbarButton()
+      }
+    } else if showsPolicyInspectorToggle {
       // Sits to the right of the kill switch as its own platter: the hidden
       // spacer breaks the shared glass background so the inspector toggle reads
       // as a separate group, not part of the enforcement control.
@@ -49,6 +56,50 @@ struct DashboardWindowToolbar: ToolbarContent {
         PolicyCanvasInspectorToolbarButton()
       }
     }
+  }
+}
+
+private struct TaskBoardOperationsInspectorToolbarButton: View {
+  @FocusedValue(\.harnessTaskBoardCommandFocus)
+  private var taskBoardCommandFocus
+
+  private var operationsInspectorFocus: TaskBoardOperationsInspectorFocus? {
+    taskBoardCommandFocus?.operationsInspector
+  }
+
+  private var buttonTitle: String {
+    operationsInspectorFocus?.isVisible == true
+      ? "Hide Task Board Operations"
+      : "Show Task Board Operations"
+  }
+
+  private var isToggleEnabled: Bool {
+    operationsInspectorFocus?.canToggle == true
+  }
+
+  var body: some View {
+    Button {
+      operationsInspectorFocus?.dispatcher.performToggleInspector()
+    } label: {
+      Image(systemName: "sidebar.trailing")
+        .frame(width: 14, height: 14)
+    }
+    .disabled(!isToggleEnabled)
+    .help(buttonTitle)
+    .accessibilityLabel("Task Board Operations")
+    .accessibilityValue(operationsInspectorFocus?.isVisible == true ? "Shown" : "Hidden")
+    .accessibilityIdentifier(
+      HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton
+    )
+    .harnessMCPButton(
+      HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton,
+      label: "Task Board Operations",
+      value: operationsInspectorFocus?.isVisible == true ? "Shown" : "Hidden",
+      hint: buttonTitle,
+      pressAction: {
+        operationsInspectorFocus?.dispatcher.performToggleInspector()
+      }
+    )
   }
 }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardWindowToolbar.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardWindowToolbar.swift
@@ -89,10 +89,10 @@ private struct TaskBoardOperationsInspectorToolbarButton: View {
     .accessibilityLabel("Task Board Operations")
     .accessibilityValue(operationsInspectorFocus?.isVisible == true ? "Shown" : "Hidden")
     .accessibilityIdentifier(
-      HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton
+      HarnessMonitorAccessibility.taskBoardOperationsInspectorButton
     )
     .harnessMCPButton(
-      HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton,
+      HarnessMonitorAccessibility.taskBoardOperationsInspectorButton,
       label: "Task Board Operations",
       value: operationsInspectorFocus?.isVisible == true ? "Shown" : "Hidden",
       hint: buttonTitle,

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardWindowView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Dashboard/DashboardWindowView.swift
@@ -188,6 +188,7 @@ public struct DashboardWindowView: View {
             store: store,
             navigation: windowNavigationState,
             showsQuickActions: route == .taskBoard,
+            showsTaskBoardOperationsInspectorToggle: route == .taskBoard,
             showsPolicyInspectorToggle: route == .policyCanvas,
             sleepPreventionPresentation: SleepPreventionToolbarPresentation(
               isEnabled: store.contentUI.toolbar.sleepPreventionEnabled

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsDispatchCard.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsDispatchCard.swift
@@ -5,15 +5,16 @@ import SwiftUI
 /// Dispatch operations card. Owns its own filter/project-dir/actor @State
 /// and hosts the dispatch confirmation dialog. Receives the unfiltered
 /// `taskBoardItems` plus the parent's resolved `localHostProjectTypes`.
-/// Host-aware filtering runs in a presentation worker so the operations
-/// card can update controls without scanning the whole board on the
-/// main actor.
+/// Board visibility, ordering, and host-aware filtering run in a presentation
+/// worker so the operations card can update controls without scanning the
+/// whole board on the main actor.
 struct TaskBoardOperationsDispatchCard: View, TaskBoardOperationsHost {
   let store: HarnessMonitorStore
   let metrics: TaskBoardOverviewMetrics
   let dashboard: HarnessMonitorStore.ContentDashboardSlice
   let taskBoardItems: [TaskBoardItem]
   let localHostProjectTypes: [String]
+  let isActive: Bool
 
   @Environment(\.fontScale)
   private var fontScale
@@ -26,6 +27,7 @@ struct TaskBoardOperationsDispatchCard: View, TaskBoardOperationsHost {
   @State private var pendingConfirmation: TaskBoardDispatchConfirmationPresentation?
   @State private var presentationWorker = TaskBoardOperationsDispatchPresentationWorker()
   @State private var cachedPresentation = TaskBoardOperationsDispatchPresentation.empty
+  @State private var presentedInput: TaskBoardOperationsDispatchPresentationInput?
   @State private var presentationGeneration: UInt64 = 0
 
   var captionFont: Font {
@@ -40,6 +42,15 @@ struct TaskBoardOperationsDispatchCard: View, TaskBoardOperationsHost {
       taskBoardItems: taskBoardItems,
       localHostProjectTypes: localHostProjectTypes
     )
+  }
+
+  private var activePresentationInput: TaskBoardOperationsDispatchPresentationInput? {
+    isActive ? presentationInput : nil
+  }
+
+  private var isPresentationCurrent: Bool {
+    guard isActive else { return false }
+    return presentedInput == presentationInput
   }
 
   var body: some View {
@@ -153,7 +164,8 @@ struct TaskBoardOperationsDispatchCard: View, TaskBoardOperationsHost {
               help: dryRun
                 ? "Preview how task-board items will dispatch"
                 : "Dispatch the selected board scope into live session work"
-            )
+            ),
+            isDisabled: !isPresentationCurrent
           ) {
             if request.dryRun {
               Task { @MainActor in
@@ -219,8 +231,9 @@ struct TaskBoardOperationsDispatchCard: View, TaskBoardOperationsHost {
         }
       }
     }
-    .task(id: presentationInput) {
-      await rebuildPresentation(input: presentationInput)
+    .task(id: activePresentationInput) {
+      guard let activePresentationInput else { return }
+      await rebuildPresentation(input: activePresentationInput)
     }
     .confirmationDialog(
       pendingConfirmation?.title ?? "Dispatch items?",
@@ -259,6 +272,7 @@ struct TaskBoardOperationsDispatchCard: View, TaskBoardOperationsHost {
     if cachedPresentation != presentation {
       cachedPresentation = presentation
     }
+    presentedInput = input
   }
 
   private var formattedLocalHostProjectTypes: String {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsDispatchPresentationWorker.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsDispatchPresentationWorker.swift
@@ -54,8 +54,9 @@ actor TaskBoardOperationsDispatchPresentationWorker {
     }
 
     cachedInput = input
+    let visibleItems = TaskBoardVisibleItems.sorted(input.taskBoardItems)
     let dispatchableItems = TaskBoardHostMachine.dispatchableItems(
-      input.taskBoardItems,
+      visibleItems,
       machineProjectTypes: input.localHostProjectTypes
     )
     cachedOutput = TaskBoardOperationsDispatchPresentation(
@@ -63,7 +64,7 @@ actor TaskBoardOperationsDispatchPresentationWorker {
       dispatchableItemsByID: Dictionary(
         uniqueKeysWithValues: dispatchableItems.map { ($0.id, $0) }
       ),
-      didFilterOut: !input.taskBoardItems.isEmpty && dispatchableItems.isEmpty
+      didFilterOut: !visibleItems.isEmpty && dispatchableItems.isEmpty
     )
     return cachedOutput
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsInspector.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsInspector.swift
@@ -1,0 +1,78 @@
+import HarnessMonitorKit
+import SwiftUI
+
+enum TaskBoardOperationsInspectorVisibility {
+  static let storageKey = "taskBoard.operationsInspectorVisible"
+  static let defaultValue = false
+}
+
+@MainActor
+public final class TaskBoardOperationsInspectorFocusDispatcher {
+  public var toggleInspector: (() -> Void)?
+
+  public init() {}
+
+  public func performToggleInspector() {
+    toggleInspector?()
+  }
+}
+
+public struct TaskBoardOperationsInspectorFocus: Equatable {
+  public let isVisible: Bool
+  public let canToggle: Bool
+  public let dispatcher: TaskBoardOperationsInspectorFocusDispatcher
+
+  public init(
+    isVisible: Bool,
+    canToggle: Bool,
+    dispatcher: TaskBoardOperationsInspectorFocusDispatcher
+  ) {
+    self.isVisible = isVisible
+    self.canToggle = canToggle
+    self.dispatcher = dispatcher
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.isVisible == rhs.isVisible
+      && lhs.canToggle == rhs.canToggle
+      && lhs.dispatcher === rhs.dispatcher
+  }
+}
+
+struct TaskBoardOperationsInspector: View {
+  private static let width: CGFloat = 380
+
+  let store: HarnessMonitorStore
+  let taskBoardItems: [TaskBoardItem]
+  let isVisible: Bool
+
+  var body: some View {
+    HStack(spacing: 0) {
+      Rectangle()
+        .fill(HarnessMonitorTheme.controlBorder.opacity(0.7))
+        .frame(width: 1)
+        .frame(maxHeight: .infinity)
+
+      ScrollView(.vertical) {
+        TaskBoardOperationsPanel(
+          store: store,
+          taskBoardItems: isVisible ? taskBoardItems : [],
+          isActive: isVisible
+        )
+        .padding(HarnessMonitorTheme.spacingLG)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+      }
+      .scrollBounceBehavior(.basedOnSize)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      .background(.background)
+    }
+    .frame(width: Self.width)
+    .frame(width: isVisible ? Self.width : 0, alignment: .leading)
+    .clipped()
+    .opacity(isVisible ? 1 : 0)
+    .allowsHitTesting(isVisible)
+    .accessibilityHidden(!isVisible)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier(HarnessMonitorAccessibility.taskBoardOperationsInspector)
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsInspector.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsInspector.swift
@@ -66,6 +66,8 @@ struct TaskBoardOperationsInspector: View {
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
       .background(.background)
     }
+    // Preserve the inspector subtree's 380-point layout while the outer frame
+    // collapses only its clipped container, keeping form state and geometry stable.
     .frame(width: Self.width)
     .frame(width: isVisible ? Self.width : 0, alignment: .leading)
     .clipped()

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsPanel.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsPanel.swift
@@ -86,6 +86,8 @@ struct TaskBoardOperationsPanel: View {
     do {
       let snapshot = try await store.taskBoardHostSnapshot()
       localHostProjectTypes = snapshot.local.projectTypes
+    } catch is CancellationError {
+      return
     } catch {
       // Fail open: leave project types empty so dispatch shows every item.
       localHostProjectTypes = []

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsPanel.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsPanel.swift
@@ -2,8 +2,8 @@ import HarnessMonitorKit
 import SwiftUI
 
 /// Thin orchestrator: composes the Sync / Dispatch / Inventory cards in a
-/// 3-column layout and resolves the local host's `project_types` once for
-/// Dispatch's host-aware filter. Each card is its own `View` struct with
+/// responsive 3-column/stacked layout and resolves the local host's
+/// `project_types` once for Dispatch's host-aware filter. Each card is its own `View` struct with
 /// isolated `@State` so a change inside one card no longer invalidates
 /// the other two during scroll - the structural lever that the live Time
 /// Profiler trace 2026-05-16 surfaced as the cold-launch + scroll hot
@@ -11,6 +11,17 @@ import SwiftUI
 struct TaskBoardOperationsPanel: View {
   let store: HarnessMonitorStore
   let taskBoardItems: [TaskBoardItem]
+  let isActive: Bool
+
+  init(
+    store: HarnessMonitorStore,
+    taskBoardItems: [TaskBoardItem],
+    isActive: Bool = true
+  ) {
+    self.store = store
+    self.taskBoardItems = taskBoardItems
+    self.isActive = isActive
+  }
 
   @Environment(\.fontScale)
   var fontScale
@@ -48,7 +59,8 @@ struct TaskBoardOperationsPanel: View {
           metrics: metrics,
           dashboard: dashboard,
           taskBoardItems: taskBoardItems,
-          localHostProjectTypes: localHostProjectTypes
+          localHostProjectTypes: localHostProjectTypes,
+          isActive: isActive
         ),
         inventoryCard: TaskBoardOperationsPanelInventoryCard(
           store: store,
@@ -61,7 +73,10 @@ struct TaskBoardOperationsPanel: View {
       .environment(\.taskBoardOperationsRowLabelFont, rowLabelFont)
       .environment(\.taskBoardOperationsRowLabelWidth, rowLabelWidth)
     }
-    .task { await loadLocalHostProjectTypes() }
+    .task(id: isActive) {
+      guard isActive else { return }
+      await loadLocalHostProjectTypes()
+    }
     .accessibilityElement(children: .contain)
     .accessibilityIdentifier("harness.task-board.operations")
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewHost.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewHost.swift
@@ -16,6 +16,9 @@ struct TaskBoardOverviewHost: View {
   let orchestratorStatus: TaskBoardOrchestratorStatus?
   let evaluationSummary: TaskBoardEvaluationSummary?
   let isActionInFlight: Bool
+  let showsOperationsPanel: Bool
+  let isCommandFocusActive: Bool
+  let operationsInspectorFocus: TaskBoardOperationsInspectorFocus?
 
   init(
     scope: Scope,
@@ -25,7 +28,10 @@ struct TaskBoardOverviewHost: View {
     decisions: [Decision],
     orchestratorStatus: TaskBoardOrchestratorStatus?,
     evaluationSummary: TaskBoardEvaluationSummary?,
-    isActionInFlight: Bool
+    isActionInFlight: Bool,
+    showsOperationsPanel: Bool = true,
+    isCommandFocusActive: Bool = true,
+    operationsInspectorFocus: TaskBoardOperationsInspectorFocus? = nil
   ) {
     self.scope = scope
     self.store = store
@@ -35,6 +41,9 @@ struct TaskBoardOverviewHost: View {
     self.orchestratorStatus = orchestratorStatus
     self.evaluationSummary = evaluationSummary
     self.isActionInFlight = isActionInFlight
+    self.showsOperationsPanel = showsOperationsPanel
+    self.isCommandFocusActive = isCommandFocusActive
+    self.operationsInspectorFocus = operationsInspectorFocus
   }
 
   var body: some View {
@@ -47,6 +56,9 @@ struct TaskBoardOverviewHost: View {
       taskBoardSessionID: scope.sessionID,
       contentHorizontalPadding: scope.taskBoardContentHorizontalPadding,
       fillsAvailableHeight: scope.fillsAvailableHeight,
+      showsOperationsPanel: showsOperationsPanel,
+      isCommandFocusActive: isCommandFocusActive,
+      operationsInspectorFocus: operationsInspectorFocus,
       decisions: decisions,
       isActionInFlight: isActionInFlight,
       onOpenItem: openInboxItem,

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
@@ -123,7 +123,7 @@ actor TaskBoardOverviewPresentationWorker {
       } else {
         input.taskBoardItems
       }
-    let taskBoardItems = sortedTaskBoardItems(scopedTaskBoardItems)
+    let taskBoardItems = TaskBoardVisibleItems.sorted(scopedTaskBoardItems)
     let apiItemsByLane = Dictionary(grouping: taskBoardItems) { item in
       TaskBoardInboxLane(status: item.status) ?? .todo
     }
@@ -211,20 +211,6 @@ actor TaskBoardOverviewPresentationWorker {
     }
   }
 
-  private static func sortedTaskBoardItems(_ items: [TaskBoardItem]) -> [TaskBoardItem] {
-    items
-      .filter { TaskBoardInboxLane(status: $0.status) != nil && $0.deletedAt == nil }
-      .sorted { left, right in
-        if left.priority != right.priority {
-          return priorityRank(left.priority) > priorityRank(right.priority)
-        }
-        if left.updatedAt != right.updatedAt {
-          return left.updatedAt > right.updatedAt
-        }
-        return left.id < right.id
-      }
-  }
-
   private static func sortedOpenDecisionIDs(_ decisions: [DecisionPresentationItem]) -> [String] {
     decisions
       .filter { $0.statusRaw == "open" }
@@ -240,19 +226,6 @@ actor TaskBoardOverviewPresentationWorker {
         return left.id < right.id
       }
       .map(\.id)
-  }
-
-  private static func priorityRank(_ priority: TaskBoardPriority) -> Int {
-    switch priority {
-    case .critical:
-      3
-    case .high:
-      2
-    case .medium:
-      1
-    case .low:
-      0
-    }
   }
 
   private static func severityRank(_ severity: String) -> Int {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+SelectionFocus.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+SelectionFocus.swift
@@ -1,6 +1,14 @@
 import HarnessMonitorKit
 
 extension TaskBoardOverviewView {
+  var taskBoardCommandFocus: TaskBoardCommandFocus? {
+    guard isCommandFocusActive else { return nil }
+    return TaskBoardCommandFocus(
+      selection: taskBoardSelectionFocus,
+      operationsInspector: operationsInspectorFocus
+    )
+  }
+
   var taskBoardSelectionFocus: TaskBoardSelectionFocus {
     TaskBoardSelectionFocus(
       selectionCount: orderedSelectedCardIDs.count,

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift
@@ -10,6 +10,9 @@ public struct TaskBoardOverviewView: View {
   let taskBoardSessionID: String?
   let contentHorizontalPadding: CGFloat
   let fillsAvailableHeight: Bool
+  let showsOperationsPanel: Bool
+  let isCommandFocusActive: Bool
+  let operationsInspectorFocus: TaskBoardOperationsInspectorFocus?
   let decisions: [Decision]
   let decisionsByID: [String: Decision]
   let decisionItems: [DecisionPresentationItem]
@@ -95,6 +98,9 @@ public struct TaskBoardOverviewView: View {
     taskBoardSessionID: String? = nil,
     contentHorizontalPadding: CGFloat = 24,
     fillsAvailableHeight: Bool = false,
+    showsOperationsPanel: Bool = true,
+    isCommandFocusActive: Bool = true,
+    operationsInspectorFocus: TaskBoardOperationsInspectorFocus? = nil,
     decisions: [Decision] = [],
     isActionInFlight: Bool = false,
     onOpenItem: @escaping (TaskBoardInboxItem) -> Void = { _ in },
@@ -126,6 +132,9 @@ public struct TaskBoardOverviewView: View {
     self.taskBoardSessionID = taskBoardSessionID
     self.contentHorizontalPadding = contentHorizontalPadding
     self.fillsAvailableHeight = fillsAvailableHeight
+    self.showsOperationsPanel = showsOperationsPanel
+    self.isCommandFocusActive = isCommandFocusActive
+    self.operationsInspectorFocus = operationsInspectorFocus
     self.decisions = decisions
     self.decisionsByID =
       decisionsByID ?? Dictionary(uniqueKeysWithValues: decisions.map { ($0.id, $0) })
@@ -168,8 +177,8 @@ public struct TaskBoardOverviewView: View {
       \.taskBoardLaneAppearance,
       TaskBoardLaneAppearance(rawValue: laneAppearancePreferencesRawValue)
     )
-    .harnessFocusedSceneValue(\.harnessTaskBoardSelection, taskBoardSelectionFocus)
-    .taskBoardSelectionForwardDeleteShortcut(taskBoardSelectionFocus)
+    .harnessFocusedSceneValue(\.harnessTaskBoardCommandFocus, taskBoardCommandFocus)
+    .taskBoardSelectionForwardDeleteShortcut(taskBoardCommandFocus?.selection)
     .taskBoardCardPreferences(projectLabelResolver: cachedPresentation.projectLabelResolver)
     .environment(relativeTimeClock)
     .sheet(item: taskBoardManagementSheet) { taskBoardManagementSheet in
@@ -230,7 +239,7 @@ extension TaskBoardOverviewView {
       }
     }
     taskBoardDetailRow { headerTitle }
-    if let store {
+    if showsOperationsPanel, let store {
       taskBoardDetailRow {
         TaskBoardOperationsPanel(store: store, taskBoardItems: cachedPresentation.taskBoardItems)
       }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardSelectionFocus.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardSelectionFocus.swift
@@ -40,8 +40,23 @@ public struct TaskBoardSelectionFocus: Equatable {
   }
 }
 
+public struct TaskBoardCommandFocus: Equatable {
+  public let selection: TaskBoardSelectionFocus
+  public let operationsInspector: TaskBoardOperationsInspectorFocus?
+
+  public init(
+    selection: TaskBoardSelectionFocus,
+    operationsInspector: TaskBoardOperationsInspectorFocus?
+  ) {
+    self.selection = selection
+    self.operationsInspector = operationsInspector
+  }
+}
+
 extension FocusedValues {
-  @Entry public var harnessTaskBoardSelection: TaskBoardSelectionFocus?
+  /// Publish one Task Board-focused value so selection and inspector changes
+  /// cannot produce multiple same-frame FocusedValue updates from the route.
+  @Entry public var harnessTaskBoardCommandFocus: TaskBoardCommandFocus?
 }
 
 extension View {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardVisibleItems.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardVisibleItems.swift
@@ -1,0 +1,30 @@
+import HarnessMonitorKit
+
+enum TaskBoardVisibleItems {
+  static func sorted(_ items: [TaskBoardItem]) -> [TaskBoardItem] {
+    items
+      .filter { TaskBoardInboxLane(status: $0.status) != nil && $0.deletedAt == nil }
+      .sorted { left, right in
+        if left.priority != right.priority {
+          return priorityRank(left.priority) > priorityRank(right.priority)
+        }
+        if left.updatedAt != right.updatedAt {
+          return left.updatedAt > right.updatedAt
+        }
+        return left.id < right.id
+      }
+  }
+
+  private static func priorityRank(_ priority: TaskBoardPriority) -> Int {
+    switch priority {
+    case .critical:
+      3
+    case .high:
+      2
+    case .medium:
+      1
+    case .low:
+      0
+    }
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryMoreTests+Extended.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryMoreTests+Extended.swift
@@ -97,6 +97,36 @@ extension HarnessMonitorUITestAccessibilityRegistryMoreTests {
     #expect(!dashboardToolbar.contains("ToolbarItemGroup(placement: .secondaryAction)"))
     #expect(dashboardToolbar.contains(".sharedBackgroundVisibility(.hidden)"))
     #expect(!dashboardToolbar.contains("Divider()"))
+    #expect(
+      dashboardWindow.contains(
+        "showsTaskBoardOperationsInspectorToggle: route == .taskBoard"
+      )
+    )
+    #expect(
+      dashboardToolbar.contains(
+        "GlobalPolicyEnforcementToolbarGroup(store: store)\n\n    if showsTaskBoardOperationsInspectorToggle"
+      )
+    )
+    #expect(
+      dashboardToolbar.contains(
+        """
+        ToolbarItem(placement: .primaryAction) {
+                TaskBoardOperationsInspectorToolbarButton()
+              }
+        """
+      )
+    )
+    #expect(dashboardToolbar.contains("@FocusedValue(\\.harnessTaskBoardCommandFocus)"))
+    #expect(dashboardToolbar.contains("Image(systemName: \"sidebar.trailing\")"))
+    #expect(dashboardToolbar.contains("\"Hide Task Board Operations\""))
+    #expect(dashboardToolbar.contains("\"Show Task Board Operations\""))
+    #expect(dashboardToolbar.contains(".disabled(!isToggleEnabled)"))
+    #expect(
+      dashboardToolbar.contains(
+        "HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton"
+      )
+    )
+    #expect(dashboardToolbar.contains(".harnessMCPButton("))
   }
 
   @Test("Global enforcement button stays out of auxiliary windows")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryMoreTests+Extended.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryMoreTests+Extended.swift
@@ -123,7 +123,7 @@ extension HarnessMonitorUITestAccessibilityRegistryMoreTests {
     #expect(dashboardToolbar.contains(".disabled(!isToggleEnabled)"))
     #expect(
       dashboardToolbar.contains(
-        "HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton"
+        "HarnessMonitorAccessibility.taskBoardOperationsInspectorButton"
       )
     )
     #expect(dashboardToolbar.contains(".harnessMCPButton("))

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryMoreTests+Extended.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryMoreTests+Extended.swift
@@ -121,6 +121,8 @@ extension HarnessMonitorUITestAccessibilityRegistryMoreTests {
     #expect(dashboardToolbar.contains("\"Hide Task Board Operations\""))
     #expect(dashboardToolbar.contains("\"Show Task Board Operations\""))
     #expect(dashboardToolbar.contains(".disabled(!isToggleEnabled)"))
+    #expect(dashboardToolbar.contains("enabled: isToggleEnabled"))
+    #expect(dashboardToolbar.contains("guard isToggleEnabled else { return }"))
     #expect(
       dashboardToolbar.contains(
         "HarnessMonitorAccessibility.taskBoardOperationsInspectorButton"

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryTests+SessionWindow.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryTests+SessionWindow.swift
@@ -19,6 +19,14 @@ extension HarnessMonitorUITestAccessibilityRegistryTests {
     #expect(
       HarnessMonitorAccessibility.dashboardOpenFolderButton == "harness.dashboard.open-folder")
     #expect(
+      HarnessMonitorAccessibility.taskBoardOperationsInspector
+        == "harness.task-board.operations.inspector"
+    )
+    #expect(
+      HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton
+        == "harness.task-board.operations.inspector.toolbar"
+    )
+    #expect(
       HarnessMonitorAccessibility.dashboardWindowRoute("taskBoard")
         == "harness.dashboard.route.taskboard"
     )

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryTests+SessionWindow.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryTests+SessionWindow.swift
@@ -6,6 +6,7 @@ extension HarnessMonitorUITestAccessibilityRegistryTests {
   @Test("Dashboard and session window identifiers match UI-test mirror")
   func dashboardAndSessionWindowIdentifiersMirror() {
     expectDashboardIdentifiersMirrorRegistry()
+    expectTaskBoardIdentifiersMirrorRegistry()
     expectReviewsIdentifiersMirrorRegistry()
     expectSessionWindowIdentifiersMirrorRegistry()
   }
@@ -18,14 +19,6 @@ extension HarnessMonitorUITestAccessibilityRegistryTests {
       HarnessMonitorAccessibility.dashboardNewSessionButton == "harness.dashboard.new-session")
     #expect(
       HarnessMonitorAccessibility.dashboardOpenFolderButton == "harness.dashboard.open-folder")
-    #expect(
-      HarnessMonitorAccessibility.taskBoardOperationsInspector
-        == "harness.task-board.operations.inspector"
-    )
-    #expect(
-      HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton
-        == "harness.task-board.operations.inspector.toolbar"
-    )
     #expect(
       HarnessMonitorAccessibility.dashboardWindowRoute("taskBoard")
         == "harness.dashboard.route.taskboard"
@@ -105,6 +98,17 @@ extension HarnessMonitorUITestAccessibilityRegistryTests {
     #expect(
       HarnessMonitorAccessibility.dashboardAuditRow("toast-success")
         == "harness.dashboard.audit.row.toast-success"
+    )
+  }
+
+  private func expectTaskBoardIdentifiersMirrorRegistry() {
+    #expect(
+      HarnessMonitorAccessibility.taskBoardOperationsInspector
+        == "harness.task-board.operations.inspector"
+    )
+    #expect(
+      HarnessMonitorAccessibility.taskBoardOperationsInspectorButton
+        == "harness.task-board.operations.inspector.toolbar"
     )
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryTests+SessionWindowProduction.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryTests+SessionWindowProduction.swift
@@ -24,6 +24,9 @@ extension HarnessMonitorUITestAccessibilityRegistryTests {
     let debuggingResultCard = try sourceFile(named: "DashboardDebuggingOCRResultCard.swift")
     let debuggingPreview = try sourceFile(named: "DashboardDebuggingOCRPreview.swift")
     let dashboardToolbar = try sourceFile(named: "DashboardWindowToolbar.swift")
+    let taskBoardOperationsInspector = try sourceFile(
+      named: "TaskBoardOperationsInspector.swift"
+    )
 
     #expect(
       dashboardRoot.contains(
@@ -55,6 +58,16 @@ extension HarnessMonitorUITestAccessibilityRegistryTests {
       auditView.contains("HarnessMonitorAccessibility.dashboardAuditScrollView"))
     #expect(dashboardToolbar.contains("HarnessMonitorAccessibility.dashboardNewSessionButton"))
     #expect(dashboardToolbar.contains("HarnessMonitorAccessibility.dashboardOpenFolderButton"))
+    #expect(
+      taskBoardOperationsInspector.contains(
+        "HarnessMonitorAccessibility.taskBoardOperationsInspector"
+      )
+    )
+    #expect(
+      dashboardToolbar.contains(
+        "HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton"
+      )
+    )
     #expect(dashboardRouteContent.contains("DashboardAuditRouteView("))
     #expect(dashboardRouteContent.contains("DashboardReviewsRouteView("))
     #expect(dashboardToolbar.contains("SleepPreventionToolbarButton("))

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryTests+SessionWindowProduction.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestAccessibilityRegistryTests+SessionWindowProduction.swift
@@ -65,7 +65,7 @@ extension HarnessMonitorUITestAccessibilityRegistryTests {
     )
     #expect(
       dashboardToolbar.contains(
-        "HarnessMonitorAccessibility.taskBoardOperationsInspectorToolbarButton"
+        "HarnessMonitorAccessibility.taskBoardOperationsInspectorButton"
       )
     )
     #expect(dashboardRouteContent.contains("DashboardAuditRouteView("))

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests+Operations.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests+Operations.swift
@@ -1,0 +1,77 @@
+import Testing
+
+@testable import HarnessMonitorKit
+@testable import HarnessMonitorUIPreviewable
+
+@MainActor
+extension TaskBoardOverviewBehaviorTests {
+  @Test("Dispatch presentation filters host project types off main")
+  func dispatchPresentationFiltersHostProjectTypes() async {
+    let worker = TaskBoardOperationsDispatchPresentationWorker()
+    let accepted = taskBoardItem(
+      id: "accepted",
+      status: .todo,
+      targetProjectTypes: ["swift"]
+    )
+    let rejected = taskBoardItem(
+      id: "rejected",
+      status: .todo,
+      targetProjectTypes: ["rust"]
+    )
+
+    let presentation = await worker.compute(
+      input: TaskBoardOperationsDispatchPresentationInput(
+        taskBoardItems: [accepted, rejected],
+        localHostProjectTypes: ["swift"]
+      )
+    )
+
+    #expect(presentation.dispatchableItems.map(\.id) == ["accepted"])
+    #expect(presentation.item(id: "accepted")?.id == "accepted")
+    #expect(presentation.item(id: "rejected") == nil)
+    #expect(!presentation.didFilterOut)
+  }
+
+  @Test("Dispatch presentation matches visible board ordering")
+  func dispatchPresentationMatchesVisibleBoardOrdering() async {
+    let worker = TaskBoardOperationsDispatchPresentationWorker()
+    let high = taskBoardItem(id: "high", status: .todo, priority: .critical)
+    let low = taskBoardItem(id: "low", status: .todo, priority: .low)
+    let done = taskBoardItem(id: "done", status: .done)
+    let deleted = taskBoardItem(
+      id: "deleted",
+      status: .todo,
+      deletedAt: "2026-05-14T10:02:00Z"
+    )
+
+    let presentation = await worker.compute(
+      input: TaskBoardOperationsDispatchPresentationInput(
+        taskBoardItems: [done, low, deleted, high],
+        localHostProjectTypes: []
+      )
+    )
+
+    #expect(presentation.dispatchableItems.map(\.id) == ["high", "low"])
+    #expect(!presentation.didFilterOut)
+  }
+
+  @Test("Hidden board items do not report a host mismatch")
+  func hiddenBoardItemsDoNotReportHostMismatch() async {
+    let worker = TaskBoardOperationsDispatchPresentationWorker()
+    let done = taskBoardItem(
+      id: "done",
+      status: .done,
+      targetProjectTypes: ["unavailable"]
+    )
+
+    let presentation = await worker.compute(
+      input: TaskBoardOperationsDispatchPresentationInput(
+        taskBoardItems: [done],
+        localHostProjectTypes: ["local"]
+      )
+    )
+
+    #expect(presentation.dispatchableItems.isEmpty)
+    #expect(!presentation.didFilterOut)
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests+Presentation.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOverviewBehaviorTests+Presentation.swift
@@ -73,33 +73,6 @@ extension TaskBoardOverviewBehaviorTests {
     )
   }
 
-  @Test("Dispatch presentation filters host project types off main")
-  func dispatchPresentationFiltersHostProjectTypes() async {
-    let worker = TaskBoardOperationsDispatchPresentationWorker()
-    let accepted = taskBoardItem(
-      id: "swift",
-      status: .todo,
-      targetProjectTypes: ["swift"]
-    )
-    let rejected = taskBoardItem(
-      id: "rust",
-      status: .todo,
-      targetProjectTypes: ["rust"]
-    )
-
-    let presentation = await worker.compute(
-      input: TaskBoardOperationsDispatchPresentationInput(
-        taskBoardItems: [accepted, rejected],
-        localHostProjectTypes: ["swift"]
-      )
-    )
-
-    #expect(presentation.dispatchableItems.map(\.id) == ["swift"])
-    #expect(presentation.item(id: "swift")?.id == "swift")
-    #expect(presentation.item(id: "rust") == nil)
-    #expect(!presentation.didFilterOut)
-  }
-
   @Test("Inline code formatter strips matched backticks and styles code spans")
   func inlineCodeFormatterStylesMatchedBackticks() {
     let raw = "feat(matches): add `matches` to shared `inbound.Rule` struct"

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardRouteContentSourceTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardRouteContentSourceTests.swift
@@ -251,6 +251,11 @@ struct TaskBoardRouteContentSourceTests {
     )
     #expect(dashboardSource.contains("TaskBoardOperationsInspector("))
     #expect(!dashboardSource.contains("if operationsInspectorVisible {"))
+    #expect(
+      dashboardSource.contains(
+        "isVisible: operationsInspectorVisible && isRouteVisible"
+      )
+    )
     #expect(dashboardSource.contains("taskBoardItems: dashboardUI.taskBoardItems"))
     #expect(dashboardSource.contains("showsOperationsPanel: false"))
     #expect(dashboardSource.contains("isCommandFocusActive: isRouteVisible"))
@@ -260,6 +265,7 @@ struct TaskBoardRouteContentSourceTests {
         "operationsInspectorDispatcher.toggleInspector = toggleOperationsInspector"
       )
     )
+    #expect(dashboardSource.contains(".onAppear {"))
     #expect(dashboardSource.contains("operationsInspectorVisible.toggle()"))
     #expect(overviewHostSource.contains("showsOperationsPanel: Bool = true"))
     #expect(overviewSource.contains("if showsOperationsPanel, let store"))
@@ -274,6 +280,7 @@ struct TaskBoardRouteContentSourceTests {
     #expect(inspectorSource.contains(".accessibilityHidden(!isVisible)"))
     #expect(operationsPanelSource.contains("isActive: Bool = true"))
     #expect(operationsPanelSource.contains(".task(id: isActive)"))
+    #expect(operationsPanelSource.contains("catch is CancellationError"))
     #expect(dispatchCardSource.contains("isActive ? presentationInput : nil"))
     #expect(dispatchCardSource.contains(".task(id: activePresentationInput)"))
     #expect(dispatchCardSource.contains("guard let activePresentationInput else { return }"))

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardRouteContentSourceTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardRouteContentSourceTests.swift
@@ -224,6 +224,65 @@ struct TaskBoardRouteContentSourceTests {
     #expect(dashboardSource.contains(".accessibilityHidden(!isPolicyCanvasVisible)"))
   }
 
+  @Test("Dashboard task board moves operations into a collapsed retained inspector")
+  func dashboardTaskBoardMovesOperationsIntoCollapsedRetainedInspector() throws {
+    let dashboardSource = try previewableSourceFile(
+      domain: "Dashboard",
+      named: "DashboardRouteContent.swift"
+    )
+    let overviewHostSource = try taskBoardSourceFile(named: "TaskBoardOverviewHost.swift")
+    let overviewSource = try taskBoardSourceFile(named: "TaskBoardOverviewView.swift")
+    let inspectorSource = try taskBoardSourceFile(named: "TaskBoardOperationsInspector.swift")
+    let operationsPanelSource = try taskBoardSourceFile(named: "TaskBoardOperationsPanel.swift")
+    let dispatchCardSource = try taskBoardSourceFile(
+      named: "TaskBoardOperationsDispatchCard.swift"
+    )
+
+    #expect(dashboardSource.contains("isRouteVisible: isTaskBoardVisible"))
+    #expect(
+      dashboardSource.contains(
+        "@AppStorage(TaskBoardOperationsInspectorVisibility.storageKey)"
+      )
+    )
+    #expect(
+      dashboardSource.contains(
+        "private var operationsInspectorVisible = TaskBoardOperationsInspectorVisibility.defaultValue"
+      )
+    )
+    #expect(dashboardSource.contains("TaskBoardOperationsInspector("))
+    #expect(!dashboardSource.contains("if operationsInspectorVisible {"))
+    #expect(dashboardSource.contains("taskBoardItems: dashboardUI.taskBoardItems"))
+    #expect(dashboardSource.contains("showsOperationsPanel: false"))
+    #expect(dashboardSource.contains("isCommandFocusActive: isRouteVisible"))
+    #expect(dashboardSource.contains("operationsInspectorFocus: operationsInspectorFocus"))
+    #expect(
+      dashboardSource.contains(
+        "operationsInspectorDispatcher.toggleInspector = toggleOperationsInspector"
+      )
+    )
+    #expect(dashboardSource.contains("operationsInspectorVisible.toggle()"))
+    #expect(overviewHostSource.contains("showsOperationsPanel: Bool = true"))
+    #expect(overviewSource.contains("if showsOperationsPanel, let store"))
+    #expect(inspectorSource.contains("static let defaultValue = false"))
+    #expect(inspectorSource.contains("private static let width: CGFloat = 380"))
+    #expect(inspectorSource.contains("ScrollView(.vertical)"))
+    #expect(inspectorSource.contains("TaskBoardOperationsPanel("))
+    #expect(inspectorSource.contains("taskBoardItems: isVisible ? taskBoardItems : []"))
+    #expect(inspectorSource.contains("isActive: isVisible"))
+    #expect(inspectorSource.contains(".frame(width: isVisible ? Self.width : 0"))
+    #expect(inspectorSource.contains(".allowsHitTesting(isVisible)"))
+    #expect(inspectorSource.contains(".accessibilityHidden(!isVisible)"))
+    #expect(operationsPanelSource.contains("isActive: Bool = true"))
+    #expect(operationsPanelSource.contains(".task(id: isActive)"))
+    #expect(dispatchCardSource.contains("isActive ? presentationInput : nil"))
+    #expect(dispatchCardSource.contains(".task(id: activePresentationInput)"))
+    #expect(dispatchCardSource.contains("guard let activePresentationInput else { return }"))
+    #expect(dispatchCardSource.contains("guard isActive else { return false }"))
+    #expect(dispatchCardSource.contains("return presentedInput == presentationInput"))
+    #expect(dispatchCardSource.contains("isDisabled: !isPresentationCurrent"))
+    #expect(dispatchCardSource.contains("presentedInput = input"))
+  }
+
   @Test("Task board lanes render every card instead of hiding overflow")
   func taskBoardLanesRenderEveryCardInsteadOfHidingOverflow() throws {
     let unifiedSource = try taskBoardSourceFile(named: "TaskBoardLaneUnifiedColumn.swift")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSelectionFocusTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSelectionFocusTests.swift
@@ -57,6 +57,38 @@ struct TaskBoardSelectionFocusTests {
     #expect(dispatcher.deleteRequestGeneration == 1)
   }
 
+  @Test("Inspector toggle forwards through a stable dispatcher")
+  func inspectorToggleForwardsThroughStableDispatcher() {
+    let dispatcher = TaskBoardOperationsInspectorFocusDispatcher()
+    var toggleCount = 0
+    dispatcher.toggleInspector = {
+      toggleCount += 1
+    }
+    let first = TaskBoardOperationsInspectorFocus(
+      isVisible: false,
+      canToggle: true,
+      dispatcher: dispatcher
+    )
+    let second = TaskBoardOperationsInspectorFocus(
+      isVisible: false,
+      canToggle: true,
+      dispatcher: dispatcher
+    )
+
+    first.dispatcher.performToggleInspector()
+
+    #expect(toggleCount == 1)
+    #expect(first == second)
+    #expect(
+      first
+        != TaskBoardOperationsInspectorFocus(
+          isVisible: true,
+          canToggle: true,
+          dispatcher: dispatcher
+        )
+    )
+  }
+
   @Test("Task board command owns Delete whenever its focus is mounted")
   func taskBoardCommandOwnsDeleteWheneverMounted() throws {
     let commandsSource = try sourceFile(
@@ -68,8 +100,13 @@ struct TaskBoardSelectionFocusTests {
     let overviewSource = try sourceFile(
       at: "Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView.swift"
     )
+    let overviewFocusSource = try sourceFile(
+      at:
+        "Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+SelectionFocus.swift"
+    )
 
-    #expect(commandsSource.contains("@FocusedValue(\\.harnessTaskBoardSelection)"))
+    #expect(commandsSource.contains("@FocusedValue(\\.harnessTaskBoardCommandFocus)"))
+    #expect(commandsSource.contains("taskBoardCommandFocus?.selection"))
     #expect(commandsSource.contains("if let taskBoardSelectionFocus"))
     #expect(commandsSource.contains("return taskBoardSelectionFocus.canDelete"))
     #expect(commandsSource.contains("taskBoardSelectionFocus.performDeleteSelection()"))
@@ -81,16 +118,29 @@ struct TaskBoardSelectionFocusTests {
     #expect(!focusSource.contains("deleteSelection: (() -> Void)?"))
     #expect(focusSource.contains(".opacity(0)"))
     #expect(focusSource.contains(".accessibilityHidden(true)"))
+    #expect(focusSource.contains("public struct TaskBoardCommandFocus: Equatable"))
     #expect(
-      overviewSource.contains(
-        ".harnessFocusedSceneValue(\\.harnessTaskBoardSelection, taskBoardSelectionFocus)"
+      focusSource.contains(
+        "public let operationsInspector: TaskBoardOperationsInspectorFocus?"
+      )
+    )
+    #expect(
+      focusSource.contains(
+        "@Entry public var harnessTaskBoardCommandFocus: TaskBoardCommandFocus?"
       )
     )
     #expect(
       overviewSource.contains(
-        ".taskBoardSelectionForwardDeleteShortcut(taskBoardSelectionFocus)"
+        ".harnessFocusedSceneValue(\\.harnessTaskBoardCommandFocus, taskBoardCommandFocus)"
       )
     )
+    #expect(
+      overviewSource.contains(
+        ".taskBoardSelectionForwardDeleteShortcut(taskBoardCommandFocus?.selection)"
+      )
+    )
+    #expect(overviewFocusSource.contains("guard isCommandFocusActive else { return nil }"))
+    #expect(overviewFocusSource.contains("operationsInspector: operationsInspectorFocus"))
     #expect(
       overviewSource.contains(
         ".onChange(of: taskBoardSelectionDispatcher.deleteRequestGeneration)"


### PR DESCRIPTION
## Motivation
Task Board operations consume vertical board space and differ from the inspector-based controls used by Policies.

## Implementation
- move Sync, Dispatch, and Audit & Inventory into a persistent right-side inspector that starts collapsed
- add a far-right toolbar toggle with route-scoped focus and accessibility support
- preserve operation form state, align Dispatch inputs with visible board items, and suspend hidden processing