### PR TITLE
fix(remote): revoke forgotten client credentials

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/API/RemoteDaemonRevocationClient.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/API/RemoteDaemonRevocationClient.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+public protocol RemoteDaemonClientRevoking: Sendable {
+  func revoke(profile: RemoteDaemonProfile, token: String) async throws
+}
+
+public struct HTTPRemoteDaemonRevocationClient: RemoteDaemonClientRevoking, Sendable {
+  public typealias SessionFactory = @Sendable (HarnessMonitorServerTrust) -> URLSession
+
+  private let sessionFactory: SessionFactory
+
+  public init() {
+    self.init(sessionFactory: Self.defaultSession)
+  }
+
+  public init(sessionFactory: @escaping SessionFactory) {
+    self.sessionFactory = sessionFactory
+  }
+
+  public func revoke(profile: RemoteDaemonProfile, token: String) async throws {
+    guard let url = URL(string: "/v1/remote/client/revoke", relativeTo: profile.endpoint) else {
+      throw HarnessMonitorAPIError.invalidEndpoint(profile.endpoint.absoluteString)
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    HarnessMonitorConnection(
+      endpoint: profile.endpoint,
+      token: token,
+      remoteClientID: profile.clientID,
+      serverTrust: .spkiSHA256(profile.serverSPKISHA256),
+      source: .remote(profileID: profile.id)
+    ).applyAuthenticationHeaders(to: &request)
+    let session = sessionFactory(.spkiSHA256(profile.serverSPKISHA256))
+    defer { session.finishTasksAndInvalidate() }
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw HarnessMonitorAPIError.invalidResponse
+    }
+    if response.statusCode == 401 || (200..<300).contains(response.statusCode) {
+      return
+    }
+    throw HarnessMonitorAPIClient.decodeError(statusCode: response.statusCode, data: data)
+  }
+
+  private static func defaultSession(serverTrust: HarnessMonitorServerTrust) -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.timeoutIntervalForRequest = 15
+    configuration.timeoutIntervalForResource = 30
+    return HarnessMonitorURLSessionFactory.make(
+      configuration: configuration,
+      serverTrust: serverTrust
+    )
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/RemoteDaemonProfileCoordinator.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/RemoteDaemonProfileCoordinator.swift
@@ -4,6 +4,7 @@ public actor RemoteDaemonProfileCoordinator {
   private let repository: any RemoteDaemonProfilePersisting
   private let tokenStore: any RemoteDaemonTokenPersisting
   private let claimant: any RemoteDaemonPairingClaiming
+  private let revoker: any RemoteDaemonClientRevoking
   private let profileIDGenerator: @Sendable () -> UUID
   private let clientIDGenerator: @Sendable (UUID) -> String
 
@@ -11,6 +12,7 @@ public actor RemoteDaemonProfileCoordinator {
     repository: any RemoteDaemonProfilePersisting,
     tokenStore: any RemoteDaemonTokenPersisting,
     claimant: any RemoteDaemonPairingClaiming = HTTPRemoteDaemonPairingClient(),
+    revoker: any RemoteDaemonClientRevoking = HTTPRemoteDaemonRevocationClient(),
     profileIDGenerator: @escaping @Sendable () -> UUID = UUID.init,
     clientIDGenerator: @escaping @Sendable (UUID) -> String = {
       "macos-\($0.uuidString.lowercased())"
@@ -19,6 +21,7 @@ public actor RemoteDaemonProfileCoordinator {
     self.repository = repository
     self.tokenStore = tokenStore
     self.claimant = claimant
+    self.revoker = revoker
     self.profileIDGenerator = profileIDGenerator
     self.clientIDGenerator = clientIDGenerator
   }
@@ -59,7 +62,7 @@ public actor RemoteDaemonProfileCoordinator {
   }
 
   @discardableResult
-  public func forgetActiveProfile() throws -> RemoteDaemonProfile? {
+  public func forgetActiveProfile() async throws -> RemoteDaemonProfile? {
     let originalState = try repository.load()
     guard let activeProfileID = originalState.activeProfileID else {
       return nil
@@ -67,7 +70,13 @@ public actor RemoteDaemonProfileCoordinator {
     guard let profile = originalState.profiles.first(where: { $0.id == activeProfileID }) else {
       throw RemoteDaemonProfileError.profileNotFound
     }
-    let token = try? tokenStore.loadToken(profileID: activeProfileID)
+    let token = try tokenForForget(profile)
+    if profile.status == .active {
+      guard let token else {
+        throw RemoteDaemonProfileError.missingToken
+      }
+      try await revoker.revoke(profile: profile, token: token)
+    }
     var forgottenState = originalState
     forgottenState.profiles.removeAll { $0.id == activeProfileID }
     forgottenState.activeProfileID = nil
@@ -84,6 +93,18 @@ public actor RemoteDaemonProfileCoordinator {
       throw error
     }
     return profile
+  }
+
+  private func tokenForForget(_ profile: RemoteDaemonProfile) throws -> String? {
+    if profile.status == .revoked {
+      return try? tokenStore.loadToken(profileID: profile.id)
+    }
+    guard let token = try tokenStore.loadToken(profileID: profile.id),
+      !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      throw RemoteDaemonProfileError.missingToken
+    }
+    return token
   }
 
   private func activate(_ profile: RemoteDaemonProfile, token: String) throws {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRemoteDaemonSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRemoteDaemonSection.swift
@@ -105,7 +105,10 @@ struct SettingsRemoteDaemonSection: View {
       .disabled(actionState.isInFlight)
       Button("Cancel", role: .cancel) {}
     } message: {
-      Text("This removes the bearer token from Keychain and returns to the local daemon mode")
+      Text(
+        "This revokes this client on the server. "
+          + "It removes its bearer token from Keychain and returns to the local daemon mode."
+      )
     }
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests.swift
@@ -127,7 +127,8 @@ struct HarnessMonitorStoreRemoteConnectionTests {
       profileCoordinator: RemoteDaemonProfileCoordinator(
         repository: repository,
         tokenStore: tokenStore,
-        claimant: EchoRemoteDaemonPairingClaimant()
+        claimant: EchoRemoteDaemonPairingClaimant(),
+        revoker: SuccessfulRemoteDaemonRevoker()
       )
     )
     let daemon = RecordingDaemonController()
@@ -188,6 +189,24 @@ struct HarnessMonitorStoreRemoteConnectionTests {
     #expect(await daemon.recordedWarmUpCallCount() == 1)
   }
 
+  @Test("Revocation failure keeps the remote profile and does not reconnect locally")
+  func revocationFailureKeepsRemoteConnection() async throws {
+    let fixture = try RemoteStoreFixture(revoker: FailingRemoteDaemonRevoker())
+    let daemon = RecordingDaemonController()
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+
+    store.forgetRemoteDaemon()
+    try await waitUntil { store.remoteDaemonActionState.errorMessage != nil }
+
+    #expect(store.usesRemoteDaemon)
+    #expect(store.remoteDaemonProfile == fixture.profile)
+    #expect(try fixture.tokenStore.loadToken(profileID: fixture.profile.id) != nil)
+    #expect(await daemon.recordedWarmUpCallCount() == 0)
+  }
+
   private func waitUntil(
     _ condition: @MainActor () -> Bool
   ) async throws {
@@ -206,7 +225,9 @@ private struct RemoteStoreFixture {
   let tokenStore: RecordingRemoteDaemonTokenStore
   let services: RemoteDaemonServices
 
-  init() throws {
+  init(
+    revoker: any RemoteDaemonClientRevoking = SuccessfulRemoteDaemonRevoker()
+  ) throws {
     let profile = try remoteProfileFixture()
     let repository = InMemoryRemoteDaemonProfileStore(
       state: RemoteDaemonProfileState(profiles: [profile], activeProfileID: profile.id)
@@ -224,7 +245,8 @@ private struct RemoteStoreFixture {
       profileCoordinator: RemoteDaemonProfileCoordinator(
         repository: repository,
         tokenStore: tokenStore,
-        claimant: NeverRemoteDaemonPairingClaimant()
+        claimant: NeverRemoteDaemonPairingClaimant(),
+        revoker: revoker
       )
     )
   }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonPairingClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonPairingClientTests.swift
@@ -102,7 +102,8 @@ struct RemoteDaemonPairingClientTests {
     let coordinator = RemoteDaemonProfileCoordinator(
       repository: repository,
       tokenStore: tokenStore,
-      claimant: StubRemoteDaemonPairingClaimant(result: .success(try claimFixture()))
+      claimant: StubRemoteDaemonPairingClaimant(result: .success(try claimFixture())),
+      revoker: SuccessfulRemoteDaemonRevoker()
     )
 
     let forgotten = try await coordinator.forgetActiveProfile()

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonProfileCoordinatorForgetTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonProfileCoordinatorForgetTests.swift
@@ -19,7 +19,8 @@ struct RemoteDaemonProfileCoordinatorForgetTests {
     )
     let coordinator = RemoteDaemonProfileCoordinator(
       repository: repository,
-      tokenStore: tokenStore
+      tokenStore: tokenStore,
+      revoker: SuccessfulRemoteDaemonRevoker()
     )
 
     await #expect(throws: RemoteDaemonForgetTestError.tokenDeletion) {
@@ -42,7 +43,8 @@ struct RemoteDaemonProfileCoordinatorForgetTests {
     try tokenStore.saveToken("server-issued-token", profileID: profile.id)
     let coordinator = RemoteDaemonProfileCoordinator(
       repository: repository,
-      tokenStore: tokenStore
+      tokenStore: tokenStore,
+      revoker: SuccessfulRemoteDaemonRevoker()
     )
 
     await #expect(throws: RemoteDaemonForgetTestError.metadataSave) {
@@ -65,7 +67,8 @@ struct RemoteDaemonProfileCoordinatorForgetTests {
     try tokenStore.saveToken("server-issued-token", profileID: profile.id)
     let coordinator = RemoteDaemonProfileCoordinator(
       repository: repository,
-      tokenStore: tokenStore
+      tokenStore: tokenStore,
+      revoker: SuccessfulRemoteDaemonRevoker()
     )
 
     await #expect(throws: RemoteDaemonForgetTestError.metadataSave) {
@@ -90,7 +93,8 @@ struct RemoteDaemonProfileCoordinatorForgetTests {
     )
     let coordinator = RemoteDaemonProfileCoordinator(
       repository: repository,
-      tokenStore: tokenStore
+      tokenStore: tokenStore,
+      revoker: SuccessfulRemoteDaemonRevoker()
     )
 
     await #expect(throws: RemoteDaemonForgetTestError.tokenDeletion) {
@@ -102,8 +106,8 @@ struct RemoteDaemonProfileCoordinatorForgetTests {
     #expect(try tokenStore.loadToken(profileID: profile.id) == "server-issued-token")
   }
 
-  @Test("Unreadable token does not prevent forgetting the profile")
-  func unreadableTokenCanStillBeForgotten() async throws {
+  @Test("Unreadable active token preserves the profile for server revocation")
+  func unreadableActiveTokenPreservesProfile() async throws {
     let profile = try remoteProfileFixture()
     let repository = InMemoryRemoteDaemonProfileStore(
       state: RemoteDaemonProfileState(profiles: [profile], activeProfileID: profile.id)
@@ -114,15 +118,20 @@ struct RemoteDaemonProfileCoordinatorForgetTests {
     )
     let coordinator = RemoteDaemonProfileCoordinator(
       repository: repository,
-      tokenStore: tokenStore
+      tokenStore: tokenStore,
+      revoker: SuccessfulRemoteDaemonRevoker()
     )
 
-    let forgotten = try await coordinator.forgetActiveProfile()
+    await #expect(throws: RemoteDaemonForgetTestError.tokenRead) {
+      _ = try await coordinator.forgetActiveProfile()
+    }
 
-    #expect(forgotten == profile)
-    #expect(try repository.load() == RemoteDaemonProfileState())
-    #expect(tokenStore.deleteCallCount == 1)
-    #expect(tokenStore.hasToken(profileID: profile.id) == false)
+    #expect(
+      try repository.load()
+        == RemoteDaemonProfileState(profiles: [profile], activeProfileID: profile.id)
+    )
+    #expect(tokenStore.deleteCallCount == 0)
+    #expect(tokenStore.hasToken(profileID: profile.id))
   }
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonProfileCoordinatorRevocationTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonProfileCoordinatorRevocationTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+
+@testable import HarnessMonitorKit
+
+@Suite("Remote daemon profile revocation", .serialized)
+struct RemoteDaemonProfileCoordinatorRevocationTests {
+  @Test("Revokes an active server credential before removing local state")
+  func revokesBeforeForgetting() async throws {
+    let fixture = try RevocationCoordinatorFixture()
+
+    let forgotten = try await fixture.coordinator.forgetActiveProfile()
+
+    #expect(forgotten == fixture.profile)
+    #expect(
+      await fixture.revoker.recordedCalls()
+        == [.init(clientID: fixture.profile.clientID, token: "server-issued-token")]
+    )
+    #expect(try fixture.repository.load() == RemoteDaemonProfileState())
+    #expect(try fixture.tokenStore.loadToken(profileID: fixture.profile.id) == nil)
+  }
+
+  @Test("Revocation failure preserves the retryable profile and token")
+  func revocationFailurePreservesLocalState() async throws {
+    let fixture = try RevocationCoordinatorFixture(revocationFails: true)
+
+    await #expect(throws: RemoteDaemonRevocationTestError.rejected) {
+      _ = try await fixture.coordinator.forgetActiveProfile()
+    }
+
+    #expect(
+      try fixture.repository.load()
+        == RemoteDaemonProfileState(
+          profiles: [fixture.profile],
+          activeProfileID: fixture.profile.id
+        )
+    )
+    #expect(
+      try fixture.tokenStore.loadToken(profileID: fixture.profile.id) == "server-issued-token"
+    )
+  }
+
+  @Test("Already revoked profiles are removed without another server call")
+  func alreadyRevokedProfileSkipsServerCall() async throws {
+    let activeProfile = try remoteProfileFixture()
+    let revokedProfile = activeProfile.markingRevoked(at: .now)
+    let fixture = try RevocationCoordinatorFixture(profile: revokedProfile)
+
+    _ = try await fixture.coordinator.forgetActiveProfile()
+
+    #expect(await fixture.revoker.recordedCalls().isEmpty)
+    #expect(try fixture.repository.load() == RemoteDaemonProfileState())
+    #expect(try fixture.tokenStore.loadToken(profileID: revokedProfile.id) == nil)
+  }
+
+  @Test("Missing active token fails closed without contacting the server")
+  func missingTokenPreservesProfile() async throws {
+    let fixture = try RevocationCoordinatorFixture(storesToken: false)
+
+    await #expect(throws: RemoteDaemonProfileError.missingToken) {
+      _ = try await fixture.coordinator.forgetActiveProfile()
+    }
+
+    #expect(await fixture.revoker.recordedCalls().isEmpty)
+    #expect(try fixture.repository.load().activeProfileID == fixture.profile.id)
+  }
+}
+
+private struct RevocationCoordinatorFixture {
+  let profile: RemoteDaemonProfile
+  let repository: InMemoryRemoteDaemonProfileStore
+  let tokenStore: RecordingRemoteDaemonTokenStore
+  let revoker: RecordingRemoteDaemonRevoker
+  let coordinator: RemoteDaemonProfileCoordinator
+
+  init(
+    profile: RemoteDaemonProfile? = nil,
+    storesToken: Bool = true,
+    revocationFails: Bool = false
+  ) throws {
+    let profile = try profile ?? remoteProfileFixture()
+    let repository = InMemoryRemoteDaemonProfileStore(
+      state: RemoteDaemonProfileState(profiles: [profile], activeProfileID: profile.id)
+    )
+    let tokenStore = RecordingRemoteDaemonTokenStore()
+    if storesToken {
+      try tokenStore.saveToken("server-issued-token", profileID: profile.id)
+    }
+    let revoker = RecordingRemoteDaemonRevoker(revocationFails: revocationFails)
+    self.profile = profile
+    self.repository = repository
+    self.tokenStore = tokenStore
+    self.revoker = revoker
+    self.coordinator = RemoteDaemonProfileCoordinator(
+      repository: repository,
+      tokenStore: tokenStore,
+      revoker: revoker
+    )
+  }
+}
+
+private enum RemoteDaemonRevocationTestError: Error {
+  case rejected
+}
+
+private actor RecordingRemoteDaemonRevoker: RemoteDaemonClientRevoking {
+  struct Call: Equatable {
+    let clientID: String
+    let token: String
+  }
+
+  private let revocationFails: Bool
+  private var calls: [Call] = []
+
+  init(revocationFails: Bool) {
+    self.revocationFails = revocationFails
+  }
+
+  func revoke(profile: RemoteDaemonProfile, token: String) async throws {
+    calls.append(Call(clientID: profile.clientID, token: token))
+    if revocationFails {
+      throw RemoteDaemonRevocationTestError.rejected
+    }
+  }
+
+  func recordedCalls() -> [Call] {
+    calls
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonRevocationClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonRevocationClientTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+
+@testable import HarnessMonitorKit
+
+@Suite("Remote daemon revocation client", .serialized)
+struct RemoteDaemonRevocationClientTests {
+  @Test("Revokes the authenticated client over the pinned remote connection")
+  func revokesAuthenticatedClient() async throws {
+    RemoteRevocationURLProtocol.reset(status: 200)
+    let recorder = RemoteRevocationSessionRecorder()
+    let client = HTTPRemoteDaemonRevocationClient(sessionFactory: recorder.session(for:))
+    let profile = try remoteProfileFixture()
+
+    try await client.revoke(profile: profile, token: "server-issued-token")
+
+    let request = try #require(RemoteRevocationURLProtocol.lastRequest)
+    #expect(request.url?.absoluteString == "https://daemon.example.com/v1/remote/client/revoke")
+    #expect(request.httpMethod == "POST")
+    #expect(request.httpBody == nil)
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer server-issued-token")
+    #expect(
+      request.value(forHTTPHeaderField: "x-harness-remote-client-id")
+        == profile.clientID
+    )
+    #expect(recorder.lastServerTrust == .spkiSHA256(profile.serverSPKISHA256))
+  }
+
+  @Test("Treats unauthorized as an already invalid credential")
+  func acceptsAlreadyInvalidCredential() async throws {
+    RemoteRevocationURLProtocol.reset(status: 401)
+    let recorder = RemoteRevocationSessionRecorder()
+    let client = HTTPRemoteDaemonRevocationClient(sessionFactory: recorder.session(for:))
+
+    try await client.revoke(
+      profile: remoteProfileFixture(),
+      token: "already-revoked-token"
+    )
+  }
+
+  @Test("Surfaces server failures instead of forgetting locally")
+  func surfacesServerFailure() async throws {
+    RemoteRevocationURLProtocol.reset(status: 503)
+    let recorder = RemoteRevocationSessionRecorder()
+    let client = HTTPRemoteDaemonRevocationClient(sessionFactory: recorder.session(for:))
+
+    do {
+      try await client.revoke(profile: remoteProfileFixture(), token: "server-issued-token")
+      Issue.record("Expected revocation failure")
+    } catch let error as HarnessMonitorAPIError {
+      guard case .server(let code, _) = error else {
+        Issue.record("Expected a server error")
+        return
+      }
+      #expect(code == 503)
+    }
+  }
+}
+
+private final class RemoteRevocationSessionRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var recordedServerTrust: HarnessMonitorServerTrust?
+
+  var lastServerTrust: HarnessMonitorServerTrust? {
+    lock.withLock { recordedServerTrust }
+  }
+
+  func session(for serverTrust: HarnessMonitorServerTrust) -> URLSession {
+    lock.withLock { recordedServerTrust = serverTrust }
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [RemoteRevocationURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+}
+
+private final class RemoteRevocationURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var responseStatus = 200
+  nonisolated(unsafe) private static var recordedRequest: URLRequest?
+
+  static var lastRequest: URLRequest? {
+    lock.withLock { recordedRequest }
+  }
+
+  static func reset(status: Int) {
+    lock.withLock {
+      responseStatus = status
+      recordedRequest = nil
+    }
+  }
+
+  override static func canInit(with request: URLRequest) -> Bool { true }
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let status = Self.lock.withLock {
+      Self.recordedRequest = request
+      return Self.responseStatus
+    }
+    guard let requestURL = request.url,
+      let response = HTTPURLResponse(
+        url: requestURL,
+        statusCode: status,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )
+    else {
+      client?.urlProtocol(self, didFailWithError: HarnessMonitorAPIError.invalidResponse)
+      return
+    }
+    let body = Data(
+      "{\"error\":{\"code\":\"REMOTE_CLIENT_REVOKE\",\"message\":\"unavailable\"}}".utf8
+    )
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: body)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonRevocationTestSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RemoteDaemonRevocationTestSupport.swift
@@ -1,0 +1,15 @@
+@testable import HarnessMonitorKit
+
+struct SuccessfulRemoteDaemonRevoker: RemoteDaemonClientRevoking {
+  func revoke(profile: RemoteDaemonProfile, token: String) async throws {}
+}
+
+enum FailingRemoteDaemonRevokerError: Error {
+  case rejected
+}
+
+struct FailingRemoteDaemonRevoker: RemoteDaemonClientRevoking {
+  func revoke(profile: RemoteDaemonProfile, token: String) async throws {
+    throw FailingRemoteDaemonRevokerError.rejected
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
@@ -14,4 +14,13 @@ extension SessionSwiftUISourceTests {
     #expect(dialogSource.contains("guard !actionState.isInFlight else { return }"))
     #expect(dialogSource.contains(".disabled(actionState.isInFlight)"))
   }
+
+  @Test("Remote forget confirmation promises server credential revocation")
+  func remoteForgetConfirmationDescribesServerRevocation() throws {
+    let source = try sourceFile(at: "Views/Settings/SettingsRemoteDaemonSection.swift")
+
+    #expect(source.contains("revokes this client on the server"))
+    #expect(source.contains("removes its bearer token from Keychain"))
+    #expect(source.contains("returns to the local daemon mode"))
+  }
 }

--- a/src/daemon/db/remote_identity_async.rs
+++ b/src/daemon/db/remote_identity_async.rs
@@ -5,6 +5,65 @@ use super::{AsyncDaemonDb, CliError, db_error};
 use crate::daemon::remote_identity::{RemoteAuditEvent, redact_remote_error_detail};
 
 impl AsyncDaemonDb {
+    /// Revoke a remote client and persist its lifecycle audit atomically.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] on SQL failure or an audit/client identity mismatch.
+    pub(crate) async fn revoke_remote_client_with_audit(
+        &self,
+        client_id: &str,
+        revoked_at: &str,
+        audit: &RemoteAuditEvent,
+    ) -> Result<bool, CliError> {
+        if audit.client_id.as_deref() != Some(client_id) {
+            return Err(db_error("remote revoke audit client id mismatch"));
+        }
+        let mut transaction = self.pool().begin().await.map_err(|error| {
+            db_error(format!("begin remote client revoke transaction: {error}"))
+        })?;
+        let changed = query(
+            "UPDATE remote_clients
+             SET revoked_at = ?2
+             WHERE client_id = ?1 AND revoked_at IS NULL",
+        )
+        .bind(client_id)
+        .bind(revoked_at)
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("revoke remote client {client_id}: {error}")))?
+        .rows_affected();
+        if changed != 1 {
+            transaction.rollback().await.map_err(|error| {
+                db_error(format!("rollback unchanged remote client revoke: {error}"))
+            })?;
+            return Ok(false);
+        }
+        query(INSERT_REMOTE_AUDIT_EVENT_SQL)
+            .bind(&audit.event_id)
+            .bind(&audit.recorded_at)
+            .bind(audit.request_id.as_deref())
+            .bind(audit.client_id.as_deref())
+            .bind(&audit.route_or_method)
+            .bind(audit.scope.as_str())
+            .bind(audit.scope_decision.as_str())
+            .bind(audit.outcome.as_str())
+            .bind(audit.remote_addr.as_deref())
+            .bind(audit.error_detail())
+            .execute(transaction.as_mut())
+            .await
+            .map_err(|error| {
+                db_error(format!(
+                    "insert remote revoke audit event {}: {error}",
+                    audit.event_id
+                ))
+            })?;
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit remote client revoke: {error}")))?;
+        Ok(true)
+    }
+
     /// Persist a remote authorization audit without blocking a Tokio worker.
     ///
     /// # Errors

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -21,6 +21,7 @@ mod remote_acme;
 mod remote_acme_providers;
 mod remote_client_activity;
 mod remote_identity;
+mod remote_identity_async;
 mod remote_pairing;
 mod remote_pairing_reviews;
 mod remote_pairing_status;

--- a/src/daemon/db/tests/remote_identity_async.rs
+++ b/src/daemon/db/tests/remote_identity_async.rs
@@ -1,0 +1,93 @@
+use tempfile::tempdir;
+
+use super::{AsyncDaemonDb, DaemonDb};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::{
+    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteClientRegistration,
+};
+
+const CLIENT_ID: &str = "async-revoke-client";
+const TOKEN: &str = "async-revoke-token-secret";
+
+#[tokio::test]
+async fn remote_client_revoke_rolls_back_when_audit_insert_fails() {
+    let temp = tempdir().expect("create remote identity tempdir");
+    let db_path = temp.path().join("harness.db");
+    let db = DaemonDb::open(&db_path).expect("open daemon db");
+    register_client(&db);
+    let duplicate = revoke_audit(CLIENT_ID, "duplicate-revoke-audit");
+    db.record_remote_audit_event(&duplicate)
+        .expect("seed duplicate audit id");
+    drop(db);
+    let async_db = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect("open async daemon db");
+
+    async_db
+        .revoke_remote_client_with_audit(CLIENT_ID, "2026-07-13T18:00:00Z", &duplicate)
+        .await
+        .expect_err("duplicate audit insert should fail the transaction");
+
+    let db = DaemonDb::open(&db_path).expect("reopen daemon db");
+    assert!(
+        db.verify_remote_client_token(CLIENT_ID, TOKEN)
+            .expect("verify client after rollback")
+            .is_some(),
+        "audit failure must roll back client revocation"
+    );
+}
+
+#[tokio::test]
+async fn remote_client_revoke_rejects_mismatched_audit_identity() {
+    let temp = tempdir().expect("create remote identity tempdir");
+    let db_path = temp.path().join("harness.db");
+    let db = DaemonDb::open(&db_path).expect("open daemon db");
+    register_client(&db);
+    drop(db);
+    let async_db = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect("open async daemon db");
+    let audit = revoke_audit("different-client", "mismatched-revoke-audit");
+
+    async_db
+        .revoke_remote_client_with_audit(CLIENT_ID, "2026-07-13T18:01:00Z", &audit)
+        .await
+        .expect_err("mismatched audit identity should fail");
+
+    let db = DaemonDb::open(&db_path).expect("reopen daemon db");
+    assert!(
+        db.verify_remote_client_token(CLIENT_ID, TOKEN)
+            .expect("verify client after mismatch")
+            .is_some()
+    );
+}
+
+fn register_client(db: &DaemonDb) {
+    let registration = RemoteClientRegistration::new_for_tests(
+        CLIENT_ID,
+        "Async revoke client",
+        "macos",
+        RemoteRole::Viewer,
+        &[RemoteAccessScope::Read],
+        TOKEN,
+        "2026-07-13T17:55:00Z",
+    )
+    .expect("remote client registration");
+    db.register_remote_client(&registration)
+        .expect("register remote client");
+}
+
+fn revoke_audit(client_id: &str, event_id: &str) -> RemoteAuditEvent {
+    RemoteAuditEvent::new(
+        event_id,
+        "2026-07-13T18:00:00Z",
+        Some("remote-revoke-request"),
+        Some(client_id),
+        "remote.clients.self_revoke",
+        RemoteAccessScope::Read,
+        RemoteAuditScopeDecision::Allowed,
+        RemoteAuditOutcome::Success,
+        None,
+        None,
+    )
+}

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -45,6 +45,7 @@ mod improver;
 mod managed_agents;
 mod openrouter_models;
 mod recovery_snapshot_cache;
+mod remote_clients;
 mod remote_limits;
 mod remote_pairing;
 mod response;
@@ -402,6 +403,7 @@ fn daemon_http_router(state: DaemonHttpState) -> Router<()> {
         .merge(agents::agent_routes())
         .merge(managed_agents::managed_agent_routes())
         .merge(openrouter_models::openrouter_model_routes())
+        .merge(remote_clients::remote_client_routes())
         .merge(remote_pairing::remote_pairing_routes())
         .merge(signals::signal_routes())
         .merge(voice::voice_routes())

--- a/src/daemon/http/remote_clients.rs
+++ b/src/daemon/http/remote_clients.rs
@@ -1,0 +1,140 @@
+use std::time::Instant;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::daemon::protocol::http_paths;
+use crate::daemon::remote::RemoteAccessScope;
+use crate::daemon::remote_identity::{
+    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision,
+};
+use crate::errors::CliError;
+use crate::workspace::utc_now;
+
+use super::response::{extract_request_id, timed_response};
+use super::{DaemonHttpState, authenticated_remote_client, require_async_db};
+
+pub(super) fn remote_client_routes() -> Router<DaemonHttpState> {
+    Router::new().route(
+        http_paths::REMOTE_CLIENT_SELF_REVOKE,
+        post(post_remote_client_self_revoke),
+    )
+}
+
+#[derive(Debug, Serialize)]
+struct RemoteClientSelfRevokeResponse {
+    client_id: String,
+    revoked_at: String,
+}
+
+async fn post_remote_client_self_revoke(
+    headers: HeaderMap,
+    State(state): State<DaemonHttpState>,
+) -> Response {
+    let start = Instant::now();
+    let request_id = extract_request_id(&headers);
+    let response = match revoke_authenticated_client(&headers, &state, &request_id).await {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => error.into_response(),
+    };
+    timed_response(
+        "POST",
+        http_paths::REMOTE_CLIENT_SELF_REVOKE,
+        &request_id,
+        start,
+        response,
+    )
+}
+
+async fn revoke_authenticated_client(
+    headers: &HeaderMap,
+    state: &DaemonHttpState,
+    request_id: &str,
+) -> Result<RemoteClientSelfRevokeResponse, RemoteClientSelfRevokeError> {
+    let client = authenticated_remote_client(headers, state)
+        .map_err(RemoteClientSelfRevokeError::Authentication)?
+        .ok_or(RemoteClientSelfRevokeError::RemoteModeRequired)?;
+    let revoked_at = utc_now();
+    let event_id = format!("remote-client-self-revoke-{}", Uuid::new_v4());
+    let audit = RemoteAuditEvent::new(
+        event_id,
+        &revoked_at,
+        Some(request_id),
+        Some(&client.client_id),
+        "remote.clients.self_revoke",
+        RemoteAccessScope::Read,
+        RemoteAuditScopeDecision::Allowed,
+        RemoteAuditOutcome::Success,
+        None,
+        None,
+    );
+    let db = require_async_db(state, "self-revoke remote client")
+        .map_err(RemoteClientSelfRevokeError::Store)?;
+    let changed = db
+        .revoke_remote_client_with_audit(&client.client_id, &revoked_at, &audit)
+        .await
+        .map_err(RemoteClientSelfRevokeError::Store)?;
+    if !changed {
+        return Err(RemoteClientSelfRevokeError::NoLongerActive);
+    }
+    Ok(RemoteClientSelfRevokeResponse {
+        client_id: client.client_id,
+        revoked_at,
+    })
+}
+
+enum RemoteClientSelfRevokeError {
+    Authentication(Box<Response>),
+    RemoteModeRequired,
+    NoLongerActive,
+    Store(CliError),
+}
+
+impl IntoResponse for RemoteClientSelfRevokeError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Authentication(response) => *response,
+            Self::RemoteModeRequired => remote_client_revoke_error(
+                StatusCode::BAD_REQUEST,
+                "remote client self-revocation requires remote daemon mode",
+            ),
+            Self::NoLongerActive => remote_client_revoke_error(
+                StatusCode::UNAUTHORIZED,
+                "remote client credential is no longer active",
+            ),
+            Self::Store(error) => {
+                log_revoke_store_error(&error);
+                remote_client_revoke_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "remote client revocation store is unavailable",
+                )
+            }
+        }
+    }
+}
+
+fn remote_client_revoke_error(status: StatusCode, message: &str) -> Response {
+    (
+        status,
+        Json(serde_json::json!({
+            "error": {
+                "code": "REMOTE_CLIENT_REVOKE",
+                "message": message,
+            }
+        })),
+    )
+        .into_response()
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion inflates the score; tokio-rs/tracing#553"
+)]
+fn log_revoke_store_error(error: &CliError) {
+    tracing::error!(error = %error, "remote client self-revocation failed");
+}

--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -45,6 +45,7 @@ mod remote_actor;
 mod remote_authz;
 mod remote_authz_audit;
 mod remote_authz_audit_contention;
+mod remote_clients;
 mod remote_limits;
 mod remote_limits_support;
 mod remote_pairing;

--- a/src/daemon/http/tests/remote_clients.rs
+++ b/src/daemon/http/tests/remote_clients.rs
@@ -1,0 +1,132 @@
+use reqwest::StatusCode;
+use serde_json::Value;
+
+use crate::daemon::protocol::http_paths;
+use crate::daemon::remote::RemoteRole;
+use crate::daemon::remote_auth::REMOTE_CLIENT_ID_HEADER;
+use crate::daemon::remote_identity::{RemoteAuditOutcome, RemoteAuditScopeDecision};
+
+use super::remote_viewer_support::{register_remote_client, serve_http};
+use super::test_http_state_with_db;
+
+const VIEWER_ID: &str = "self-revoking-viewer";
+const OPERATOR_ID: &str = "unrelated-operator";
+
+#[tokio::test]
+async fn remote_client_self_revoke_revokes_only_authenticated_client_and_audits() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = crate::daemon::http::DaemonHttpAuthMode::Remote;
+    register_remote_client(&state, VIEWER_ID, RemoteRole::Viewer);
+    register_remote_client(&state, OPERATOR_ID, RemoteRole::Operator);
+    let assertion_state = state.clone();
+    let (base_url, server) = serve_http(state).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!(
+            "{base_url}{}",
+            http_paths::REMOTE_CLIENT_SELF_REVOKE
+        ))
+        .header("x-request-id", "remote-self-revoke-request")
+        .header(REMOTE_CLIENT_ID_HEADER, VIEWER_ID)
+        .bearer_auth(remote_token(VIEWER_ID))
+        .send()
+        .await
+        .expect("send self-revoke request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.json::<Value>().await.expect("self-revoke json");
+    assert_eq!(body["client_id"], VIEWER_ID);
+    assert!(
+        body["revoked_at"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+
+    let second_response = client
+        .post(format!(
+            "{base_url}{}",
+            http_paths::REMOTE_CLIENT_SELF_REVOKE
+        ))
+        .header(REMOTE_CLIENT_ID_HEADER, VIEWER_ID)
+        .bearer_auth(remote_token(VIEWER_ID))
+        .send()
+        .await
+        .expect("retry revoked credential");
+    assert_eq!(second_response.status(), StatusCode::UNAUTHORIZED);
+
+    let db = assertion_state
+        .db
+        .get()
+        .expect("db slot")
+        .lock()
+        .expect("db lock");
+    assert!(
+        db.verify_remote_client_token(VIEWER_ID, &remote_token(VIEWER_ID))
+            .expect("verify revoked viewer")
+            .is_none()
+    );
+    assert!(
+        db.verify_remote_client_token(OPERATOR_ID, &remote_token(OPERATOR_ID))
+            .expect("verify unrelated operator")
+            .is_some()
+    );
+    let events = db.load_remote_audit_events(20).expect("load audits");
+    let revoke = events
+        .iter()
+        .find(|event| event.route_or_method == "remote.clients.self_revoke")
+        .expect("self-revoke lifecycle audit");
+    assert_eq!(
+        revoke.request_id.as_deref(),
+        Some("remote-self-revoke-request")
+    );
+    assert_eq!(revoke.client_id.as_deref(), Some(VIEWER_ID));
+    assert_eq!(revoke.scope_decision, RemoteAuditScopeDecision::Allowed);
+    assert_eq!(revoke.outcome, RemoteAuditOutcome::Success);
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn remote_client_self_revoke_rejects_local_mode_without_side_effects() {
+    let state = test_http_state_with_db();
+    register_remote_client(&state, VIEWER_ID, RemoteRole::Viewer);
+    let assertion_state = state.clone();
+    let (base_url, server) = serve_http(state).await;
+
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{base_url}{}",
+            http_paths::REMOTE_CLIENT_SELF_REVOKE
+        ))
+        .bearer_auth("token")
+        .send()
+        .await
+        .expect("send local self-revoke request");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response
+        .json::<Value>()
+        .await
+        .expect("local rejection json");
+    assert_eq!(body["error"]["code"], "REMOTE_CLIENT_REVOKE");
+    assert!(
+        assertion_state
+            .db
+            .get()
+            .expect("db slot")
+            .lock()
+            .expect("db lock")
+            .verify_remote_client_token(VIEWER_ID, &remote_token(VIEWER_ID))
+            .expect("verify viewer")
+            .is_some()
+    );
+
+    server.abort();
+    let _ = server.await;
+}
+
+fn remote_token(client_id: &str) -> String {
+    format!("remote-token-secret-{client_id}")
+}

--- a/src/daemon/protocol/api_contract/http_paths.rs
+++ b/src/daemon/protocol/api_contract/http_paths.rs
@@ -15,6 +15,7 @@ pub const WS: &str = "/v1/ws";
 pub const STREAM: &str = "/v1/stream";
 pub const REMOTE_PAIR_CLAIM: &str = "/v1/remote/pair/claim";
 pub const REMOTE_PAIR_STATUS: &str = "/v1/remote/pair/status";
+pub const REMOTE_CLIENT_SELF_REVOKE: &str = "/v1/remote/client/revoke";
 pub const SESSIONS: &str = "/v1/sessions";
 pub const SESSIONS_ADOPT: &str = "/v1/sessions/adopt";
 pub const SESSION_DETAIL: &str = "/v1/sessions/{session_id}";

--- a/src/daemon/protocol/api_contract/routes_remote.rs
+++ b/src/daemon/protocol/api_contract/routes_remote.rs
@@ -17,4 +17,12 @@ pub(crate) const ROUTES: &[HttpApiRouteContract] = &[
         },
         swift_client_exposed: false,
     },
+    HttpApiRouteContract {
+        method: HttpRouteMethod::Post,
+        path: http_paths::REMOTE_CLIENT_SELF_REVOKE,
+        parity: HttpRouteParity::Exempt {
+            reason: "credential lifecycle action bound to the authenticated caller",
+        },
+        swift_client_exposed: true,
+    },
 ];

--- a/src/daemon/protocol/api_contract/tests.rs
+++ b/src/daemon/protocol/api_contract/tests.rs
@@ -20,7 +20,7 @@ fn every_non_exempt_http_route_has_a_ws_mapping() {
 #[test]
 fn explicit_non_rpc_exemptions_are_documented_and_stable() {
     let exemptions = explicit_exemptions();
-    assert_eq!(exemptions.len(), 8, "unexpected exemption count");
+    assert_eq!(exemptions.len(), 9, "unexpected exemption count");
     let exempt_paths: BTreeSet<_> = exemptions.iter().map(|route| route.path).collect();
     assert_eq!(
         exempt_paths,
@@ -28,6 +28,7 @@ fn explicit_non_rpc_exemptions_are_documented_and_stable() {
             http_paths::DAEMON_TELEMETRY,
             http_paths::REMOTE_PAIR_CLAIM,
             http_paths::REMOTE_PAIR_STATUS,
+            http_paths::REMOTE_CLIENT_SELF_REVOKE,
             http_paths::WS,
             http_paths::STREAM,
             http_paths::SESSION_STREAM,
@@ -41,6 +42,22 @@ fn explicit_non_rpc_exemptions_are_documented_and_stable() {
             .exemption_reason()
             .is_some_and(|reason| !reason.is_empty())
     }));
+}
+
+#[test]
+fn remote_client_self_revoke_is_a_read_scoped_swift_exemption() {
+    let route = HTTP_API_CONTRACT
+        .iter()
+        .find(|route| route.path == http_paths::REMOTE_CLIENT_SELF_REVOKE)
+        .expect("remote client self-revoke route should be registered");
+
+    assert_eq!(route.method, HttpRouteMethod::Post);
+    assert!(route.swift_client_exposed);
+    assert!(route.parity.exemption_reason().is_some());
+    assert_eq!(
+        remote_http_scopes(route),
+        Some(&[RemoteAccessScope::Read][..])
+    );
 }
 
 #[test]

--- a/src/daemon/remote.rs
+++ b/src/daemon/remote.rs
@@ -65,7 +65,9 @@ pub fn remote_http_scopes(route: &HttpApiRouteContract) -> Option<&'static [Remo
         http_paths::READY | http_paths::WS | http_paths::STREAM | http_paths::SESSION_STREAM => {
             Some(READ_SCOPES)
         }
-        http_paths::REMOTE_PAIR_CLAIM | http_paths::REMOTE_PAIR_STATUS => Some(READ_SCOPES),
+        http_paths::REMOTE_PAIR_CLAIM
+        | http_paths::REMOTE_PAIR_STATUS
+        | http_paths::REMOTE_CLIENT_SELF_REVOKE => Some(READ_SCOPES),
         http_paths::DAEMON_TELEMETRY | http_paths::MANAGED_AGENT_ATTACH => Some(WRITE_SCOPES),
         _ => route.parity.ws_method().and_then(remote_ws_scopes),
     }


### PR DESCRIPTION
## Motivation
Forgetting a remote daemon removed only the local profile and Keychain token, leaving the server-side client credential active.

## Implementation
- add an authenticated caller-only self-revoke route with atomic audit persistence
- revoke the remote client before Monitor removes local profile state
- fail closed on revocation errors and cover HTTP, persistence, reconnect, and UI contracts