### PR TITLE
fix(remote): scope review URL resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "aff"
-version = "46.0.0"
+version = "46.0.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "46.0.0"
+version = "46.0.1"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "harness-testkit"
-version = "46.0.0"
+version = "46.0.1"
 dependencies = [
  "assert_cmd",
  "harness",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "aff", "testkit"]
 
 [package]
 name = "harness"
-version = "46.0.0"
+version = "46.0.1"
 edition = "2024"
 rust-version = "1.94"
 include = [

--- a/aff/Cargo.toml
+++ b/aff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aff"
-version = "46.0.0"
+version = "46.0.1"
 edition = "2024"
 rust-version = "1.94"
 

--- a/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
+++ b/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>46.0.0</string>
+	<string>46.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>46.0.0</string>
+	<string>46.0.1</string>
 	<key>LSBackgroundOnly</key>
 	<true/>
 </dict>

--- a/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
+++ b/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
@@ -32,7 +32,7 @@ public enum BuildSettings {
         "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS": .string(
             compilationCacheDiagnosticRemarksSetting
         ),
-        "CURRENT_PROJECT_VERSION": "46.0.0", // VERSION_MARKER_CURRENT
+        "CURRENT_PROJECT_VERSION": "46.0.1", // VERSION_MARKER_CURRENT
         "DEVELOPMENT_TEAM": "Q498EB36N4",
         "DEAD_CODE_STRIPPING": "YES",
         "ENABLE_HARDENED_RUNTIME": "YES",
@@ -61,7 +61,7 @@ public enum BuildSettings {
         "HARNESS_MONITOR_BUILD_GIT_COMMIT": "local-dev",
         "HARNESS_MONITOR_BUILD_GIT_DIRTY": "false",
         "HARNESS_MONITOR_BUILD_WORKSPACE_FINGERPRINT": "local-dev",
-        "MARKETING_VERSION": "46.0.0" // VERSION_MARKER_MARKETING
+        "MARKETING_VERSION": "46.0.1" // VERSION_MARKER_MARKETING
     ]
 
     public static let previewOverrides: SettingsDictionary = [

--- a/src/daemon/protocol/api_contract/tests.rs
+++ b/src/daemon/protocol/api_contract/tests.rs
@@ -170,6 +170,23 @@ fn remote_viewer_scope_is_read_only() {
 }
 
 #[test]
+fn reviews_pull_request_resolve_remote_scope_is_read_only() {
+    let route = HTTP_API_CONTRACT
+        .iter()
+        .find(|route| route.path == http_paths::REVIEWS_PULL_REQUEST_RESOLVE)
+        .expect("reviews pull request resolve route should be registered");
+
+    assert_eq!(
+        remote_http_scopes(route),
+        Some(&[RemoteAccessScope::Read][..])
+    );
+    assert_eq!(
+        remote_ws_scopes(ws_methods::REVIEWS_PULL_REQUEST_RESOLVE),
+        Some(&[RemoteAccessScope::Read][..])
+    );
+}
+
+#[test]
 fn reviews_files_patch_remote_scope_is_read_only() {
     let scopes = remote_ws_scopes(ws_methods::REVIEWS_FILES_PATCH)
         .expect("reviews files patch should declare remote scopes");

--- a/src/daemon/remote.rs
+++ b/src/daemon/remote.rs
@@ -252,6 +252,7 @@ const READ_WS_METHODS: &[&str] = &[
     ws_methods::REVIEWS_REPOSITORY_CATALOG,
     ws_methods::REVIEWS_CAPABILITIES,
     ws_methods::REVIEWS_QUERY,
+    ws_methods::REVIEWS_PULL_REQUEST_RESOLVE,
     ws_methods::REVIEWS_ACTION_PREVIEW,
     ws_methods::REVIEWS_POLICY_PREVIEW,
     ws_methods::REVIEWS_POLICY_STATUS,

--- a/src/daemon/transport/tests/remote_doctor.rs
+++ b/src/daemon/transport/tests/remote_doctor.rs
@@ -1,5 +1,6 @@
 use crate::daemon::db::DaemonDb;
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_acme::{RemoteAcmeAccountCredentials, RemoteCertificateBundle};
 use crate::daemon::remote_identity::RemoteClientRegistration;
 
 use super::super::remote_doctor::run_remote_doctor_with;
@@ -47,20 +48,17 @@ fn daemon_remote_doctor_reports_missing_remote_readiness_and_audits() {
 #[test]
 fn daemon_remote_doctor_reports_ready_state_without_secret_material() {
     let db = DaemonDb::open_in_memory().expect("open db");
-    db.connection()
-        .execute(
-            "UPDATE remote_acme_state
-             SET account_id = 'acct-1',
-                 certificate_pem = 'cert-pem',
-                 private_key_pem = 'key-secret',
-                 certificate_fingerprint = 'fp-1',
-                 renewal_status = 'succeeded',
-                 renewal_error = NULL,
-                 updated_at = '2026-06-21T15:10:00Z'
-             WHERE singleton = 1",
-            [],
-        )
-        .expect("seed acme state");
+    let account = RemoteAcmeAccountCredentials::new(
+        "acct-1",
+        r#"{"id":"acct-1","key_pkcs8":"account-key-secret"}"#,
+    )
+    .expect("valid ACME account");
+    db.record_remote_acme_account(&account, "2026-06-21T15:00:00Z")
+        .expect("seed ACME account");
+    let certificate = RemoteCertificateBundle::new_for_tests("cert-pem", "key-secret");
+    let expected_fingerprint = certificate.fingerprint().to_string();
+    db.record_remote_acme_renewal_success(&certificate, "2026-06-21T15:10:00Z")
+        .expect("seed ACME certificate");
     register_client(&db, "client-active", None);
     register_client(&db, "client-revoked", Some("2026-06-21T15:15:00Z"));
 
@@ -76,13 +74,14 @@ fn daemon_remote_doctor_reports_ready_state_without_secret_material() {
     assert!(response.summary.certificate_configured);
     assert_eq!(
         response.summary.certificate_fingerprint.as_deref(),
-        Some("fp-1")
+        Some(expected_fingerprint.as_str())
     );
     assert_eq!(response.summary.active_client_count, 1);
     assert_eq!(response.summary.revoked_client_count, 1);
 
     let json = serde_json::to_string(&response).expect("serialize response");
-    assert!(json.contains("\"certificate_fingerprint\":\"fp-1\""));
+    assert!(json.contains(&expected_fingerprint));
+    assert!(!json.contains("account-key-secret"));
     assert!(!json.contains("key-secret"));
     assert!(!json.contains("cert-pem"));
 }

--- a/src/daemon/transport/tests/remote_doctor.rs
+++ b/src/daemon/transport/tests/remote_doctor.rs
@@ -79,8 +79,13 @@ fn daemon_remote_doctor_reports_ready_state_without_secret_material() {
     assert_eq!(response.summary.active_client_count, 1);
     assert_eq!(response.summary.revoked_client_count, 1);
 
-    let json = serde_json::to_string(&response).expect("serialize response");
-    assert!(json.contains(&expected_fingerprint));
+    let json = serde_json::to_value(&response).expect("serialize response");
+    assert_eq!(
+        json.pointer("/summary/certificate_fingerprint")
+            .and_then(serde_json::Value::as_str),
+        Some(expected_fingerprint.as_str())
+    );
+    let json = json.to_string();
     assert!(!json.contains("account-key-secret"));
     assert!(!json.contains("key-secret"));
     assert!(!json.contains("cert-pem"));

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-testkit"
-version = "46.0.0"
+version = "46.0.1"
 edition = "2024"
 rust-version = "1.94"
 


### PR DESCRIPTION
## Motivation
The Reviews pull request resolver was added after the remote authorization matrix, leaving its HTTP route and WebSocket method without explicit scopes. Remote mode must reject any API contract that exposes an unscoped operation.

## Implementation
- Assign the read scope to review URL resolution over HTTP and WebSocket.
- Add a focused regression and keep both exhaustive scope matrices green.
- Seed the remote doctor test through production ACME persistence APIs and prove secrets stay redacted.
- Bump package and Monitor versions to 46.0.1.
- Verify with the 347-test remote slice, version:check, and harness:check.