### PR TITLE
fix(mobile): keep remote pairing feedback truthful

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "aff"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "harness-testkit"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "assert_cmd",
  "harness",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "aff", "testkit"]
 
 [package]
 name = "harness"
-version = "46.0.1"
+version = "46.0.2"
 edition = "2024"
 rust-version = "1.94"
 include = [

--- a/aff/Cargo.toml
+++ b/aff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aff"
-version = "46.0.1"
+version = "46.0.2"
 edition = "2024"
 rust-version = "1.94"
 

--- a/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
+++ b/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>46.0.1</string>
+	<string>46.0.2</string>
 	<key>CFBundleVersion</key>
-	<string>46.0.1</string>
+	<string>46.0.2</string>
 	<key>LSBackgroundOnly</key>
 	<true/>
 </dict>

--- a/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCrypto/MobileRemoteDaemonPairing.swift
@@ -43,11 +43,51 @@ public protocol MobileRemoteDaemonPairingTransport: Sendable {
   ) async throws -> MobileRemoteDaemonPairingClaim
 }
 
-public enum MobileRemoteDaemonPairingError: Error, Equatable, Sendable {
+public enum MobileRemoteDaemonPairingError: Error, LocalizedError, Equatable, Sendable {
   case invalidResponse
   case serverStatus(Int)
   case claimMismatch
   case invalidCloudFallbackStation
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidResponse:
+      "The remote daemon returned an invalid pairing response. "
+        + "Update or restart the daemon, then create a new pairing link."
+    case .serverStatus(let statusCode):
+      Self.serverStatusDescription(statusCode)
+    case .claimMismatch:
+      "The remote daemon returned credentials for a different client. "
+        + "Do not use them; create a new pairing link and try again."
+    case .invalidCloudFallbackStation:
+      "The selected CloudKit fallback does not match this remote daemon. "
+        + "Remove the stale pairing and try again."
+    }
+  }
+
+  private static func serverStatusDescription(_ statusCode: Int) -> String {
+    switch statusCode {
+    case 403:
+      "The remote daemon rejected this pairing domain (HTTP 403). "
+        + "Create the link on the server you are connecting to."
+    case 409:
+      "This pairing link has already been used (HTTP 409). "
+        + "Create a new pairing link on the remote daemon."
+    case 410:
+      "This pairing link has expired (HTTP 410). "
+        + "Create a new pairing link on the remote daemon."
+    case 429:
+      "Too many pairing attempts were made (HTTP 429). "
+        + "Wait briefly, then create a new pairing link."
+    case 503:
+      "The remote daemon could not access its pairing store (HTTP 503). "
+        + "This device may already be registered; revoke the existing client on the server, "
+        + "then create a new pairing link."
+    default:
+      "The remote daemon rejected pairing (HTTP \(statusCode)). "
+        + "Check the server status, then create a new pairing link."
+    }
+  }
 }
 
 public struct MobileRemoteDaemonPairingDevice: Equatable, Sendable {

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
@@ -209,8 +209,9 @@ extension MirrorStore {
     deviceName: String,
     now: Date = .now
   ) async -> MobilePairedStationCredential? {
+    pairingFailureDescription = nil
     guard let pairer else {
-      syncStatus = .stale("Pairing service is unavailable.")
+      recordPairingFailure("Pairing service is unavailable.")
       return nil
     }
     do {
@@ -234,9 +235,15 @@ extension MirrorStore {
       await refreshAfterPairingBootstrap()
       return credential
     } catch {
-      syncStatus = mobileMonitorSyncStatus(for: error)
+      recordPairingFailure(mobileMirrorReadableErrorDescription(error))
       return nil
     }
+  }
+
+  func recordPairingFailure(_ description: String) {
+    let status = MirrorSyncStatus.pairingFailed(description)
+    pairingFailureDescription = description
+    syncStatus = status
   }
 
   private func cloudFallbackStationID(for pairingLink: MobilePairingLink) -> String? {
@@ -260,6 +267,7 @@ extension MirrorStore {
   }
 
   public func unpair(stationID: String) async {
+    pairingFailureDescription = nil
     guard let identityStore, let credentialStore else {
       syncStatus = .stale("Pairing storage is unavailable.")
       return

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Sync.swift
@@ -222,6 +222,8 @@ extension MirrorStore {
       if wasDemoModeEnabled {
         snapshot = .empty()
         selectedStationID = ""
+        persistSharedSnapshot(snapshot)
+        reconcileLiveActivity(snapshot)
       }
       syncStatus = .pairing(pairingLink.stationName)
       let credential = try await pairer.pair(

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+WatchRemotePairing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+WatchRemotePairing.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HarnessMonitorCore
 import HarnessMonitorCrypto
 
 extension MirrorStore {
@@ -8,6 +9,7 @@ extension MirrorStore {
     deviceName: String,
     now: Date = .now
   ) async -> Bool {
+    pairingFailureDescription = nil
     do {
       let invitationURL = try MobilePairingLink.normalizedURL(from: payload, now: now)
       guard case .remote = try MobilePairingLink.decode(invitationURL, now: now) else {
@@ -24,7 +26,7 @@ extension MirrorStore {
       }
       return MobileRemoteDaemonPairingDevice.watchOS.owns(credential)
     } catch {
-      syncStatus = mobileMonitorSyncStatus(for: error)
+      recordPairingFailure(mobileMirrorReadableErrorDescription(error))
       return false
     }
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
@@ -126,11 +126,10 @@ public final class MirrorStore {
       return syncStatus
     }
     switch syncStatus {
-    case .unpaired, .pairing, .pairingFailed, .syncing, .stale, .localNetworkDenied,
-      .iCloudAccountUnavailable:
+    case .unpaired, .pairing, .pairingFailed, .syncing, .stale:
       return pairingFailureStatus
-    case .demo, .live, .paired, .privacy, .commandQueued, .commandCompleted,
-      .commandCancelled, .commandFailed:
+    case .demo, .live, .localNetworkDenied, .iCloudAccountUnavailable, .paired, .privacy,
+      .commandQueued, .commandCompleted, .commandCancelled, .commandFailed:
       return syncStatus
     }
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
@@ -18,6 +18,7 @@ public final class MirrorStore {
   public var selectedStationID: String
   public var demoModeEnabled: Bool
   public var syncStatus: MirrorSyncStatus
+  var pairingFailureDescription: String?
   public var lastAuthenticationFailed = false
   public var pairedCredentials: [MobilePairedStationCredential] = []
   public var notificationSettings: MobileNotificationSettings
@@ -120,6 +121,14 @@ public final class MirrorStore {
     snapshot.station(id: selectedStationID)
   }
 
+  public var presentedSyncStatus: MirrorSyncStatus {
+    if let pairingFailureDescription {
+      .pairingFailed(pairingFailureDescription)
+    } else {
+      syncStatus
+    }
+  }
+
   public var sessionsForSelectedStation: [MobileSessionSummary] {
     snapshot.sessions
       .filter { selectedStationID.isEmpty || $0.stationID == selectedStationID }
@@ -164,7 +173,14 @@ public final class MirrorStore {
     guard demoModeEnabled != enabled else {
       return
     }
+    pairingFailureDescription = nil
     demoModeEnabled = enabled
+    if !enabled {
+      snapshot = .empty()
+      selectedStationID = ""
+      persistSharedSnapshot(snapshot)
+      reconcileLiveActivity(snapshot)
+    }
     Task {
       await refresh()
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
@@ -122,11 +122,21 @@ public final class MirrorStore {
   }
 
   public var presentedSyncStatus: MirrorSyncStatus {
-    if let pairingFailureDescription {
-      .pairingFailed(pairingFailureDescription)
-    } else {
-      syncStatus
+    guard let pairingFailureStatus else {
+      return syncStatus
     }
+    switch syncStatus {
+    case .unpaired, .pairing, .pairingFailed, .syncing, .stale, .localNetworkDenied,
+      .iCloudAccountUnavailable:
+      return pairingFailureStatus
+    case .demo, .live, .paired, .privacy, .commandQueued, .commandCompleted,
+      .commandCancelled, .commandFailed:
+      return syncStatus
+    }
+  }
+
+  public var pairingFailureStatus: MirrorSyncStatus? {
+    pairingFailureDescription.map(MirrorSyncStatus.pairingFailed)
   }
 
   public var sessionsForSelectedStation: [MobileSessionSummary] {

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore.swift
@@ -188,6 +188,7 @@ public final class MirrorStore {
     if !enabled {
       snapshot = .empty()
       selectedStationID = ""
+      syncStatus = stationIDsForRefresh().isEmpty ? .unpaired : .syncing
       persistSharedSnapshot(snapshot)
       reconcileLiveActivity(snapshot)
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorSyncStatus.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorSyncStatus.swift
@@ -12,6 +12,7 @@ public enum MirrorSyncStatus: Equatable, Sendable {
   case unpaired
   case demo
   case pairing(String)
+  case pairingFailed(String)
   case syncing
   case live(Date)
   case stale(String)
@@ -29,6 +30,7 @@ public enum MirrorSyncStatus: Equatable, Sendable {
     case .unpaired: "link.badge.plus"
     case .demo: "testtube.2"
     case .pairing: "qrcode.viewfinder"
+    case .pairingFailed: "xmark.icloud"
     case .syncing: "arrow.triangle.2.circlepath"
     case .live: "checkmark.icloud"
     case .stale: "exclamationmark.icloud"
@@ -52,11 +54,18 @@ public enum MirrorSyncStatus: Equatable, Sendable {
     return false
   }
 
+  public var isPairingFailure: Bool {
+    if case .pairingFailed = self {
+      return true
+    }
+    return false
+  }
+
   /// Whether the status reflects a sync failure the foreground loop should
   /// back off from. Drives the staleness-gated refresh interval on both apps.
   public var indicatesSyncFailure: Bool {
     switch self {
-    case .stale, .localNetworkDenied, .iCloudAccountUnavailable:
+    case .pairingFailed, .stale, .localNetworkDenied, .iCloudAccountUnavailable:
       true
     case .unpaired, .demo, .pairing, .syncing, .live, .paired, .privacy,
       .commandQueued, .commandCompleted, .commandCancelled, .commandFailed:

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/Localizable.xcstrings
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/Localizable.xcstrings
@@ -1981,6 +1981,17 @@
         }
       }
     },
+    "Pairing failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parowanie nie powiodło się"
+          }
+        }
+      }
+    },
     "Partially approve" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/MirrorSyncStatus+MobileDisplay.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/MirrorSyncStatus+MobileDisplay.swift
@@ -9,6 +9,7 @@ extension MirrorSyncStatus {
     case .unpaired: String(localized: "No paired Mac")
     case .demo: String(localized: "Demo station")
     case .pairing: String(localized: "Pairing")
+    case .pairingFailed: String(localized: "Pairing failed")
     case .syncing: String(localized: "Syncing")
     case .live: String(localized: "Live")
     case .stale: String(localized: "Sync stale")
@@ -31,6 +32,8 @@ extension MirrorSyncStatus {
       String(localized: "App Review demo data is active")
     case .pairing(let stationName):
       String(localized: "Connecting to \(stationName)")
+    case .pairingFailed(let reason):
+      reason
     case .syncing:
       String(localized: "Fetching the latest encrypted mirror")
     case .live(let date):

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileRootView+SettingsView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileRootView+SettingsView.swift
@@ -41,7 +41,8 @@ struct SettingsView: View {
           if let pairingFailureStatus = store.pairingFailureStatus {
             SyncStatusRow(status: pairingFailureStatus)
               .harnessBalancedListSeparator()
-          } else if store.syncStatus.opensAppSettingsForRecovery {
+          }
+          if store.syncStatus.opensAppSettingsForRecovery {
             SyncStatusRow(status: store.syncStatus)
               .harnessBalancedListSeparator()
           }

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileRootView+SettingsView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileRootView+SettingsView.swift
@@ -38,10 +38,11 @@ struct SettingsView: View {
             )
           )
           .harnessBalancedListSeparator()
-          if store.presentedSyncStatus.opensAppSettingsForRecovery
-            || store.presentedSyncStatus.isPairingFailure
-          {
-            SyncStatusRow(status: store.presentedSyncStatus)
+          if let pairingFailureStatus = store.pairingFailureStatus {
+            SyncStatusRow(status: pairingFailureStatus)
+              .harnessBalancedListSeparator()
+          } else if store.syncStatus.opensAppSettingsForRecovery {
+            SyncStatusRow(status: store.syncStatus)
               .harnessBalancedListSeparator()
           }
           ForEach(store.pairedCredentials) { credential in

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileRootView+SettingsView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileRootView+SettingsView.swift
@@ -38,8 +38,10 @@ struct SettingsView: View {
             )
           )
           .harnessBalancedListSeparator()
-          if store.syncStatus.opensAppSettingsForRecovery {
-            SyncStatusRow(status: store.syncStatus)
+          if store.presentedSyncStatus.opensAppSettingsForRecovery
+            || store.presentedSyncStatus.isPairingFailure
+          {
+            SyncStatusRow(status: store.presentedSyncStatus)
               .harnessBalancedListSeparator()
           }
           ForEach(store.pairedCredentials) { credential in

--- a/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileRootView+TodayView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMobile/MobileRootView+TodayView.swift
@@ -15,7 +15,7 @@ struct TodayView: View {
     NavigationStack {
       List {
         Section {
-          SyncStatusRow(status: store.syncStatus)
+          SyncStatusRow(status: store.presentedSyncStatus)
         }
         Section {
           NeedsYouHeader(snapshot: store.snapshot)

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/Localizable.xcstrings
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/Localizable.xcstrings
@@ -802,6 +802,17 @@
         }
       }
     },
+    "Pairing failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parowanie nie powiodło się"
+          }
+        }
+      }
+    },
     "PR" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/MirrorSyncStatus+WatchDisplay.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/MirrorSyncStatus+WatchDisplay.swift
@@ -10,6 +10,7 @@ extension MirrorSyncStatus {
     case .unpaired: String(localized: "Not paired")
     case .demo: String(localized: "Demo station")
     case .pairing: String(localized: "Pairing")
+    case .pairingFailed: String(localized: "Pairing failed")
     case .syncing: String(localized: "Syncing")
     case .live: String(localized: "Live")
     case .stale: String(localized: "Stale")
@@ -32,6 +33,8 @@ extension MirrorSyncStatus {
       String(localized: "App Review demo")
     case .pairing(let stationName):
       String(localized: "Connecting to \(stationName)")
+    case .pairingFailed(let reason):
+      reason
     case .syncing:
       String(localized: "Fetching mirror")
     case .live(let date):

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/RootView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/RootView.swift
@@ -158,7 +158,7 @@ struct RootView: View {
 
   @ViewBuilder private var statusSection: some View {
     Section {
-      WatchStatusRow(status: store.syncStatus)
+      WatchStatusRow(status: store.presentedSyncStatus)
       if let directWatchCredential {
         Button(role: .destructive) {
           pendingDirectPairingRemoval = directWatchCredential

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
@@ -31,7 +31,7 @@ struct WatchRemoteDaemonPairingView: View {
       }
       if didAttemptPairing, !isPairing {
         Section {
-          Text(store.presentedSyncStatus.subtitle)
+          Text((store.pairingFailureStatus ?? store.syncStatus).subtitle)
             .foregroundStyle(.secondary)
         }
       }

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/WatchRemoteDaemonPairingView.swift
@@ -31,7 +31,7 @@ struct WatchRemoteDaemonPairingView: View {
       }
       if didAttemptPairing, !isPairing {
         Section {
-          Text(store.syncStatus.subtitle)
+          Text(store.presentedSyncStatus.subtitle)
             .foregroundStyle(.secondary)
         }
       }

--- a/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingErrorTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCryptoTests/MobileRemoteDaemonPairingErrorTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import HarnessMonitorCrypto
+import XCTest
+
+final class MobileRemoteDaemonPairingErrorTests: XCTestCase {
+  func testStoreUnavailableExplainsHowToRecover() {
+    let description = localizedDescription(for: .serverStatus(503))
+
+    XCTAssertEqual(
+      description,
+      "The remote daemon could not access its pairing store (HTTP 503). "
+        + "This device may already be registered; revoke the existing client on the server, "
+        + "then create a new pairing link."
+    )
+  }
+
+  func testPairingErrorsNeverExposeRawSwiftTypeNames() {
+    let errors: [MobileRemoteDaemonPairingError] = [
+      .invalidResponse,
+      .serverStatus(403),
+      .serverStatus(409),
+      .serverStatus(410),
+      .serverStatus(429),
+      .serverStatus(500),
+      .claimMismatch,
+      .invalidCloudFallbackStation,
+    ]
+
+    for error in errors {
+      let description = localizedDescription(for: error)
+      XCTAssertFalse(description.isEmpty)
+      XCTAssertFalse(description.contains("MobileRemoteDaemonPairingError"))
+      XCTAssertFalse(description.contains("error 0"))
+    }
+  }
+
+  private func localizedDescription(for error: MobileRemoteDaemonPairingError) -> String {
+    (error as NSError).localizedDescription
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStoreDemoTransitionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStoreDemoTransitionTests.swift
@@ -22,6 +22,7 @@ final class MirrorStoreDemoTransitionTests: XCTestCase {
     store.setDemoMode(false)
 
     XCTAssertFalse(store.demoModeEnabled)
+    XCTAssertEqual(store.presentedSyncStatus, .unpaired)
     XCTAssertTrue(store.snapshot.stations.isEmpty)
     XCTAssertEqual(store.selectedStationID, "")
     XCTAssertTrue(try XCTUnwrap(sharedStore.loadLatestSnapshot()).stations.isEmpty)

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStoreDemoTransitionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStoreDemoTransitionTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorMirrorStore
+import XCTest
+
+@MainActor
+final class MirrorStoreDemoTransitionTests: XCTestCase {
+  func testDisablingDemoModeClearsPersistedDemoSnapshot() async throws {
+    let snapshotURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("mirror-store-demo-\(UUID().uuidString).json")
+    defer { try? FileManager.default.removeItem(at: snapshotURL) }
+
+    let sharedStore = MobileSharedSnapshotStore(fileURL: snapshotURL)
+    let store = MirrorStore(
+      demoModeEnabled: true,
+      sharedSnapshotStore: sharedStore
+    )
+    await store.refresh()
+    XCTAssertFalse(store.snapshot.stations.isEmpty)
+    XCTAssertFalse(try XCTUnwrap(sharedStore.loadLatestSnapshot()).stations.isEmpty)
+
+    store.setDemoMode(false)
+
+    XCTAssertFalse(store.demoModeEnabled)
+    XCTAssertTrue(store.snapshot.stations.isEmpty)
+    XCTAssertEqual(store.selectedStationID, "")
+    XCTAssertTrue(try XCTUnwrap(sharedStore.loadLatestSnapshot()).stations.isEmpty)
+
+    await store.refresh()
+    XCTAssertEqual(store.syncStatus, .unpaired)
+    XCTAssertTrue(store.snapshot.stations.isEmpty)
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStorePairingFeedbackTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStorePairingFeedbackTests.swift
@@ -12,20 +12,61 @@ final class MirrorStorePairingFeedbackTests: XCTestCase {
       pairer: PairingStoreUnavailablePairer(),
       sharedSnapshotStore: nil
     )
-    let expectedStatus = MirrorSyncStatus.pairingFailed(
-      "The remote daemon could not access its pairing store (HTTP 503). "
-        + "This device may already be registered; revoke the existing client on the server, "
-        + "then create a new pairing link."
-    )
 
     await store.handleOpenURL(try remoteInvitationURL(now: now), deviceName: "Bart's iPhone")
 
-    XCTAssertEqual(store.syncStatus, expectedStatus)
+    XCTAssertEqual(store.syncStatus, pairingStoreUnavailableStatus)
 
     await store.refresh()
 
     XCTAssertEqual(store.syncStatus, .unpaired)
-    XCTAssertEqual(store.presentedSyncStatus, expectedStatus)
+    XCTAssertEqual(store.presentedSyncStatus, pairingStoreUnavailableStatus)
+  }
+
+  func testLiveRefreshWinsOverPriorPairingFailure() async throws {
+    let now = Date()
+    let store = MirrorStore(
+      syncClient: SuccessfulPairingFeedbackRefreshClient(),
+      pairer: PairingStoreUnavailablePairer(),
+      sharedSnapshotStore: nil
+    )
+
+    await store.handleOpenURL(try remoteInvitationURL(now: now), deviceName: "Test iPhone")
+    await store.refresh()
+
+    guard case .live = store.syncStatus else {
+      return XCTFail("expected a successful refresh, got \(store.syncStatus)")
+    }
+    XCTAssertEqual(store.presentedSyncStatus, store.syncStatus)
+    XCTAssertEqual(store.pairingFailureStatus, pairingStoreUnavailableStatus)
+  }
+}
+
+private let pairingStoreUnavailableStatus = MirrorSyncStatus.pairingFailed(
+  "The remote daemon could not access its pairing store (HTTP 503). "
+    + "This device may already be registered; revoke the existing client on the server, "
+    + "then create a new pairing link."
+)
+
+private struct SuccessfulPairingFeedbackRefreshClient: MobileMonitorSyncClient {
+  func fetchLatestSnapshot(stationID: String, now: Date) async throws -> MobileMirrorSnapshot? {
+    .empty()
+  }
+
+  func queueCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandSubmission {
+    throw MobileRemoteDaemonPairingError.invalidResponse
+  }
+
+  func cancelCommand(
+    _ command: MobileCommandRecord,
+    currentRevision: Int64,
+    now: Date
+  ) async throws -> MobileCommandReceipt {
+    throw MobileRemoteDaemonPairingError.invalidResponse
   }
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStorePairingFeedbackTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStorePairingFeedbackTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import HarnessMonitorCore
+import HarnessMonitorCrypto
+import HarnessMonitorMirrorStore
+import XCTest
+
+@MainActor
+final class MirrorStorePairingFeedbackTests: XCTestCase {
+  func testPairingStoreFailureStaysVisibleWithRecoveryInstructions() async throws {
+    let now = Date()
+    let store = MirrorStore(
+      pairer: PairingStoreUnavailablePairer(),
+      sharedSnapshotStore: nil
+    )
+    let expectedStatus = MirrorSyncStatus.pairingFailed(
+      "The remote daemon could not access its pairing store (HTTP 503). "
+        + "This device may already be registered; revoke the existing client on the server, "
+        + "then create a new pairing link."
+    )
+
+    await store.handleOpenURL(try remoteInvitationURL(now: now), deviceName: "Bart's iPhone")
+
+    XCTAssertEqual(store.syncStatus, expectedStatus)
+
+    await store.refresh()
+
+    XCTAssertEqual(store.syncStatus, .unpaired)
+    XCTAssertEqual(store.presentedSyncStatus, expectedStatus)
+  }
+}
+
+private struct PairingStoreUnavailablePairer: MobileMonitorCredentialPairer {
+  func pair(
+    invitationURL: URL,
+    deviceName: String,
+    cloudFallbackStationID: String?,
+    now: Date
+  ) async throws -> MobilePairedStationCredential {
+    throw MobileRemoteDaemonPairingError.serverStatus(503)
+  }
+}
+
+private struct RemoteInvitationPayload: Encodable {
+  let version = 1
+  let endpoint = "https://daemon.example.com"
+  let code = "pairing-code"
+  let serverSPKISHA256 = "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  let role = "admin"
+  let scopes = ["read", "write", "admin"]
+  let expiresAt: Date
+
+  enum CodingKeys: String, CodingKey {
+    case version
+    case endpoint
+    case code
+    case serverSPKISHA256 = "server_spki_sha256"
+    case role
+    case scopes
+    case expiresAt = "expires_at"
+  }
+}
+
+private func remoteInvitationURL(now: Date) throws -> URL {
+  let encoder = JSONEncoder()
+  encoder.dateEncodingStrategy = .iso8601
+  let payload = try encoder.encode(
+    RemoteInvitationPayload(expiresAt: now.addingTimeInterval(600))
+  )
+  let encoded = payload.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+  var components = URLComponents()
+  components.scheme = "harness"
+  components.host = "remote-pair"
+  components.queryItems = [URLQueryItem(name: "payload", value: encoded)]
+  return try XCTUnwrap(components.url)
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStorePairingFeedbackTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorStorePairingFeedbackTests.swift
@@ -40,6 +40,42 @@ final class MirrorStorePairingFeedbackTests: XCTestCase {
     XCTAssertEqual(store.presentedSyncStatus, store.syncStatus)
     XCTAssertEqual(store.pairingFailureStatus, pairingStoreUnavailableStatus)
   }
+
+  func testActiveSyncRecoveryWinsOverPriorPairingFailure() async throws {
+    let now = Date()
+    let store = MirrorStore(
+      pairer: PairingStoreUnavailablePairer(),
+      sharedSnapshotStore: nil
+    )
+
+    await store.handleOpenURL(try remoteInvitationURL(now: now), deviceName: "Test iPhone")
+    for status in [MirrorSyncStatus.localNetworkDenied, .iCloudAccountUnavailable] {
+      store.syncStatus = status
+      XCTAssertEqual(store.presentedSyncStatus, status)
+    }
+    XCTAssertEqual(store.pairingFailureStatus, pairingStoreUnavailableStatus)
+  }
+
+  func testPairingExitClearsPersistedDemoSnapshotOnFailure() async throws {
+    let now = Date()
+    let snapshotURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("mirror-store-pairing-demo-\(UUID().uuidString).json")
+    defer { try? FileManager.default.removeItem(at: snapshotURL) }
+    let sharedStore = MobileSharedSnapshotStore(fileURL: snapshotURL)
+    let store = MirrorStore(
+      demoModeEnabled: true,
+      pairer: PairingStoreUnavailablePairer(),
+      sharedSnapshotStore: sharedStore
+    )
+    await store.refresh()
+    XCTAssertFalse(try XCTUnwrap(sharedStore.loadLatestSnapshot()).stations.isEmpty)
+
+    await store.handleOpenURL(try remoteInvitationURL(now: now), deviceName: "Test iPhone")
+
+    XCTAssertFalse(store.demoModeEnabled)
+    XCTAssertTrue(store.snapshot.stations.isEmpty)
+    XCTAssertTrue(try XCTUnwrap(sharedStore.loadLatestSnapshot()).stations.isEmpty)
+  }
 }
 
 private let pairingStoreUnavailableStatus = MirrorSyncStatus.pairingFailed(

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorSyncStatusTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MirrorSyncStatusTests.swift
@@ -8,6 +8,7 @@ final class MirrorSyncStatusTests: XCTestCase {
       (.unpaired, "link.badge.plus"),
       (.demo, "testtube.2"),
       (.pairing("Studio"), "qrcode.viewfinder"),
+      (.pairingFailed("reason"), "xmark.icloud"),
       (.syncing, "arrow.triangle.2.circlepath"),
       (.live(.distantPast), "checkmark.icloud"),
       (.stale("expired"), "exclamationmark.icloud"),
@@ -27,7 +28,8 @@ final class MirrorSyncStatusTests: XCTestCase {
 
   func testIndicatesSyncFailureOnlyForSyncFailureCases() {
     let failures: [MirrorSyncStatus] = [
-      .stale("expired"), .localNetworkDenied, .iCloudAccountUnavailable,
+      .pairingFailed("rejected"), .stale("expired"), .localNetworkDenied,
+      .iCloudAccountUnavailable,
     ]
     for status in failures {
       XCTAssertTrue(status.indicatesSyncFailure, "\(status) is a sync failure")
@@ -46,12 +48,18 @@ final class MirrorSyncStatusTests: XCTestCase {
     XCTAssertTrue(MirrorSyncStatus.localNetworkDenied.opensAppSettingsForRecovery)
     let others: [MirrorSyncStatus] = [
       .unpaired, .demo, .pairing("S"), .syncing, .live(.distantPast), .stale("e"),
-      .iCloudAccountUnavailable, .paired("S"), .privacy("p"),
+      .pairingFailed("e"), .iCloudAccountUnavailable, .paired("S"), .privacy("p"),
       .commandQueued(.distantPast), .commandCompleted(.distantPast),
       .commandCancelled(.distantPast), .commandFailed("b"),
     ]
     for status in others {
       XCTAssertFalse(status.opensAppSettingsForRecovery, "\(status) stays in-app")
     }
+  }
+
+  func testIdentifiesOnlyPairingFailureFeedback() {
+    XCTAssertTrue(MirrorSyncStatus.pairingFailed("rejected").isPairingFailure)
+    XCTAssertFalse(MirrorSyncStatus.pairing("Studio").isPairingFailure)
+    XCTAssertFalse(MirrorSyncStatus.stale("offline").isPairingFailure)
   }
 }

--- a/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
+++ b/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
@@ -32,7 +32,7 @@ public enum BuildSettings {
         "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS": .string(
             compilationCacheDiagnosticRemarksSetting
         ),
-        "CURRENT_PROJECT_VERSION": "46.0.1", // VERSION_MARKER_CURRENT
+        "CURRENT_PROJECT_VERSION": "46.0.2", // VERSION_MARKER_CURRENT
         "DEVELOPMENT_TEAM": "Q498EB36N4",
         "DEAD_CODE_STRIPPING": "YES",
         "ENABLE_HARDENED_RUNTIME": "YES",
@@ -61,7 +61,7 @@ public enum BuildSettings {
         "HARNESS_MONITOR_BUILD_GIT_COMMIT": "local-dev",
         "HARNESS_MONITOR_BUILD_GIT_DIRTY": "false",
         "HARNESS_MONITOR_BUILD_WORKSPACE_FINGERPRINT": "local-dev",
-        "MARKETING_VERSION": "46.0.1" // VERSION_MARKER_MARKETING
+        "MARKETING_VERSION": "46.0.2" // VERSION_MARKER_MARKETING
     ]
 
     public static let previewOverrides: SettingsDictionary = [

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-testkit"
-version = "46.0.1"
+version = "46.0.2"
 edition = "2024"
 rust-version = "1.94"
 


### PR DESCRIPTION
## Motivation
Leaving demo mode kept persisted demo records visible, while remote pairing failures could collapse into generic or short-lived sync state. The iOS app could therefore label stale demo content as live or hide the server's recovery instructions after a normal refresh.

## Implementation
- Clear the shared demo snapshot immediately when demo mode turns off.
- Map remote pairing failures to actionable iOS and watchOS messages and keep the latest pairing failure visible across background refreshes.
- Add focused TDD coverage, verify the behavior against the live smyk.la daemon, and bump the patch version to 46.0.2.