### PR TITLE
fix(remote): repair stable client pairing

### DIFF
--- a/src/daemon/db/remote_identity.rs
+++ b/src/daemon/db/remote_identity.rs
@@ -8,7 +8,7 @@
 
 use rusqlite::{params, types::Type};
 
-use super::{CliError, DaemonDb, OptionalExtension, db_error};
+use super::{CliError, Connection, DaemonDb, OptionalExtension, db_error};
 use crate::daemon::remote::RemoteAccessScope;
 use crate::daemon::remote_identity::{
     RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteClientRegistration,
@@ -21,6 +21,23 @@ INSERT INTO remote_clients (
     client_id, display_name, platform, role, scopes_json, token_hash, token_hint,
     created_at, last_seen_at, revoked_at, rotated_at, metadata_json
 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL, '{}')";
+
+const UPSERT_PAIRING_REMOTE_CLIENT_SQL: &str = "
+INSERT INTO remote_clients (
+    client_id, display_name, platform, role, scopes_json, token_hash, token_hint,
+    created_at, last_seen_at, revoked_at, rotated_at, metadata_json
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL, '{}')
+ON CONFLICT(client_id) DO UPDATE SET
+    display_name = excluded.display_name,
+    platform = excluded.platform,
+    role = excluded.role,
+    scopes_json = excluded.scopes_json,
+    token_hash = excluded.token_hash,
+    token_hint = excluded.token_hint,
+    created_at = excluded.created_at,
+    last_seen_at = NULL,
+    revoked_at = NULL,
+    rotated_at = excluded.created_at";
 
 const SELECT_REMOTE_CLIENT_SQL: &str = "
 SELECT client_id, display_name, platform, role, scopes_json, token_hash, token_hint,
@@ -278,6 +295,43 @@ impl DaemonDb {
             .optional()
             .map_err(|error| db_error(format!("load remote client {client_id}: {error}")))
     }
+}
+
+pub(super) fn upsert_remote_client_for_pairing(
+    conn: &Connection,
+    registration: &RemoteClientRegistration,
+) -> Result<RemoteStoredClient, CliError> {
+    let scopes_json = scopes_to_json(&registration.scopes)?;
+    conn.execute(
+        UPSERT_PAIRING_REMOTE_CLIENT_SQL,
+        params![
+            registration.client_id,
+            registration.display_name,
+            registration.platform,
+            registration.role.as_str(),
+            scopes_json,
+            registration.token_hash.as_storage_value(),
+            registration.token_hint,
+            registration.created_at,
+        ],
+    )
+    .map_err(|error| {
+        db_error(format!(
+            "upsert paired remote client {}: {error}",
+            registration.client_id.as_str()
+        ))
+    })?;
+    conn.query_row(
+        SELECT_REMOTE_CLIENT_SQL,
+        [registration.client_id.as_str()],
+        remote_client_from_row,
+    )
+    .map_err(|error| {
+        db_error(format!(
+            "load paired remote client {}: {error}",
+            registration.client_id.as_str()
+        ))
+    })
 }
 
 fn remote_client_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RemoteStoredClient> {

--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -12,11 +12,12 @@ use std::fmt;
 use chrono::{DateTime, Utc};
 use rusqlite::{params, types::Type};
 
+use super::remote_identity::upsert_remote_client_for_pairing;
 use super::{CliError, Connection, DaemonDb, OptionalExtension, db_error};
 use crate::daemon::remote::RemoteAccessScope;
 use crate::daemon::remote_identity::{
     RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteBearerToken,
-    RemoteClientRegistration, RemoteStoredClient, parse_remote_role, parse_remote_scope,
+    RemoteClientRegistration, parse_remote_role, parse_remote_scope,
 };
 use crate::daemon::remote_pairing::{
     RemotePairingClaimRequest, RemotePairingClaimedClient, RemotePairingCodeHash,
@@ -39,12 +40,6 @@ SELECT pairing_id, code_hash, role, scopes_json, created_at, expires_at,
        claimed_at, claimed_client_id, claim_remote_addr, metadata_json
 FROM remote_pairing_codes
 WHERE code_hash = ?1";
-
-const INSERT_PAIRING_REMOTE_CLIENT_SQL: &str = "
-INSERT INTO remote_clients (
-    client_id, display_name, platform, role, scopes_json, token_hash, token_hint,
-    created_at, last_seen_at, revoked_at, rotated_at, metadata_json
-) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL, '{}')";
 
 const INSERT_PAIRING_REMOTE_AUDIT_EVENT_SQL: &str = "
 INSERT INTO remote_audit_events (
@@ -155,7 +150,7 @@ impl DaemonDb {
         Ok(stored)
     }
 
-    /// Claim a valid one-time remote pairing code and create a remote client.
+    /// Claim a valid one-time remote pairing code and create or replace a remote client.
     ///
     /// # Errors
     /// Returns [`CliError`] when the claim is invalid, expired, already used, or
@@ -269,7 +264,7 @@ impl DaemonDb {
             .unchecked_transaction()
             .map_err(|error| db_error(format!("begin remote pairing claim: {error}")))
             .map_err(RemotePairingClaimCodeError::store)?;
-        let client = insert_remote_client_for_pairing(&transaction, registration)
+        let client = upsert_remote_client_for_pairing(&transaction, registration)
             .map_err(RemotePairingClaimCodeError::store)?;
         let changed = transaction
             .execute(
@@ -360,45 +355,6 @@ impl DaemonDb {
             Some(error_detail),
         ))
     }
-}
-
-fn insert_remote_client_for_pairing(
-    conn: &Connection,
-    registration: &RemoteClientRegistration,
-) -> Result<RemoteStoredClient, CliError> {
-    let scopes_json = scopes_to_json(&registration.scopes)?;
-    conn.execute(
-        INSERT_PAIRING_REMOTE_CLIENT_SQL,
-        params![
-            registration.client_id,
-            registration.display_name,
-            registration.platform,
-            registration.role.as_str(),
-            scopes_json,
-            registration.token_hash.as_storage_value(),
-            registration.token_hint,
-            registration.created_at,
-        ],
-    )
-    .map_err(|error| {
-        db_error(format!(
-            "insert remote client {}: {error}",
-            registration.client_id.as_str()
-        ))
-    })?;
-    Ok(RemoteStoredClient {
-        client_id: registration.client_id.clone(),
-        display_name: registration.display_name.clone(),
-        platform: registration.platform.clone(),
-        role: registration.role,
-        scopes: registration.scopes.clone(),
-        token_hash: registration.token_hash.clone(),
-        token_hint: registration.token_hint.clone(),
-        created_at: registration.created_at.clone(),
-        last_seen_at: None,
-        revoked_at: None,
-        rotated_at: None,
-    })
 }
 
 fn record_remote_audit_event_for_pairing(

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -23,6 +23,7 @@ mod remote_client_activity;
 mod remote_identity;
 mod remote_identity_async;
 mod remote_pairing;
+mod remote_pairing_repair;
 mod remote_pairing_reviews;
 mod remote_pairing_status;
 mod runtime;

--- a/src/daemon/db/tests/remote_pairing_repair.rs
+++ b/src/daemon/db/tests/remote_pairing_repair.rs
@@ -1,0 +1,80 @@
+use super::*;
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_identity::RemoteClientRegistration;
+use crate::daemon::remote_pairing::{
+    RemotePairingClaimRequest, RemotePairingCode, RemotePairingRecord,
+};
+
+#[test]
+fn remote_pairing_claim_replaces_existing_stable_client() {
+    let db = DaemonDb::open_in_memory().expect("open db");
+    let old_token = "existing-stable-client-token";
+    let registration = RemoteClientRegistration::new_for_tests(
+        "stable-iphone",
+        "Old iPhone",
+        "watchos",
+        RemoteRole::Viewer,
+        &[],
+        old_token,
+        "2026-07-14T00:00:00Z",
+    )
+    .expect("existing client registration");
+    db.register_remote_client(&registration)
+        .expect("register existing client");
+
+    let code = RemotePairingCode::from_value_for_tests("stable-client-repair-secret");
+    let record = RemotePairingRecord::new_for_tests(
+        "pairing-stable-client",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        code.expose(),
+        "2026-07-14T00:01:00Z",
+        "2026-07-14T00:11:00Z",
+    )
+    .expect("pairing record");
+    db.create_remote_pairing_code(&record, "audit-create-stable-client")
+        .expect("create pairing");
+    let claim = RemotePairingClaimRequest::new_for_tests(
+        "daemon.example.com",
+        "daemon.example.com",
+        "stable-iphone",
+        "Bart's iPhone",
+        "ios",
+        Some("203.0.113.50"),
+        "audit-claim-stable-client",
+    )
+    .expect("claim request");
+
+    let claimed = db
+        .claim_remote_pairing_code(code.expose(), &claim, "2026-07-14T00:02:00Z")
+        .expect("re-pair stable client");
+
+    assert_eq!(claimed.client.client_id, "stable-iphone");
+    assert_eq!(claimed.client.display_name, "Bart's iPhone");
+    assert_eq!(claimed.client.platform, "ios");
+    assert_eq!(claimed.client.role, RemoteRole::Operator);
+    assert_eq!(
+        claimed.client.scopes,
+        vec![RemoteAccessScope::Read, RemoteAccessScope::Write]
+    );
+    assert_eq!(claimed.client.created_at, "2026-07-14T00:02:00Z");
+    assert_eq!(
+        claimed.client.rotated_at.as_deref(),
+        Some("2026-07-14T00:02:00Z")
+    );
+    assert!(claimed.client.last_seen_at.is_none());
+    assert!(claimed.client.revoked_at.is_none());
+    assert!(
+        db.verify_remote_client_token("stable-iphone", old_token)
+            .expect("verify old token")
+            .is_none(),
+        "re-pairing must invalidate the previous credential"
+    );
+    assert!(
+        db.verify_remote_client_token("stable-iphone", claimed.bearer_token.expose())
+            .expect("verify replacement token")
+            .is_some(),
+        "replacement credential must authenticate"
+    );
+    assert_eq!(db.list_remote_clients().expect("list clients").len(), 1);
+}

--- a/src/daemon/http/tests/remote_pairing.rs
+++ b/src/daemon/http/tests/remote_pairing.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::thread;
 
 use axum::http::StatusCode;
 use tokio::net::TcpListener;
@@ -323,25 +324,12 @@ async fn remote_pair_claim_redacts_store_failures() {
         "2026-06-21T18:00:00Z",
         "2099-06-21T18:10:00Z",
     );
-    let duplicate_token = RemoteBearerToken::generate();
-    let registration = RemoteClientRegistration::new(
-        "duplicate-client",
-        "Existing Client",
-        "ios",
-        RemoteRole::Viewer,
-        &[RemoteAccessScope::Read],
-        duplicate_token.expose(),
-        "2026-06-21T18:01:00Z",
-    )
-    .expect("duplicate client registration");
-    state
-        .db
-        .get()
-        .expect("db slot")
-        .lock()
-        .expect("db lock")
-        .register_remote_client(&registration)
-        .expect("register duplicate client");
+    let db_slot = state.db.clone();
+    let _ = thread::spawn(move || {
+        let _guard = db_slot.get().expect("db slot").lock().expect("db lock");
+        panic!("poison remote pairing store with sensitive detail");
+    })
+    .join();
     let (base_url, server) = serve_http(state).await;
 
     let response = reqwest::Client::new()
@@ -349,13 +337,13 @@ async fn remote_pair_claim_redacts_store_failures() {
         .json(&serde_json::json!({
             "code": code.expose(),
             "domain": "daemon.example.com",
-            "client_id": "duplicate-client",
-            "display_name": "Duplicate Client",
+            "client_id": "store-failure-client",
+            "display_name": "Store Failure Client",
             "platform": "ios",
         }))
         .send()
         .await
-        .expect("send duplicate-client claim");
+        .expect("send store-failure claim");
 
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let body = response
@@ -367,8 +355,78 @@ async fn remote_pair_claim_redacts_store_failures() {
         body["error"]["message"],
         "remote pairing store is unavailable"
     );
-    assert!(!body.to_string().contains("duplicate-client"));
-    assert!(!body.to_string().contains("UNIQUE"));
+    assert!(!body.to_string().contains("store-failure-client"));
+    assert!(!body.to_string().contains("sensitive detail"));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn remote_pair_claim_replaces_existing_stable_client() {
+    let state = remote_pairing_state();
+    let code = seed_pairing_code(
+        &state,
+        "pairing-http-stable-client",
+        RemoteRole::Operator,
+        &[RemoteAccessScope::Read, RemoteAccessScope::Write],
+        "http-stable-client-secret",
+        "2026-07-14T00:00:00Z",
+        "2099-07-14T00:10:00Z",
+    );
+    let old_token = RemoteBearerToken::generate();
+    let registration = RemoteClientRegistration::new(
+        "stable-iphone",
+        "Old iPhone",
+        "watchos",
+        RemoteRole::Viewer,
+        &[],
+        old_token.expose(),
+        "2026-07-14T00:00:30Z",
+    )
+    .expect("existing client registration");
+    let db = state.db.get().expect("db slot").clone();
+    db.lock()
+        .expect("db lock")
+        .register_remote_client(&registration)
+        .expect("register existing client");
+    let (base_url, server) = serve_http(state).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM))
+        .json(&serde_json::json!({
+            "code": code.expose(),
+            "domain": "daemon.example.com",
+            "client_id": "stable-iphone",
+            "display_name": "Bart's iPhone",
+            "platform": "ios",
+        }))
+        .send()
+        .await
+        .expect("send stable-client claim");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response
+        .json::<serde_json::Value>()
+        .await
+        .expect("json body");
+    assert_eq!(body["client_id"], "stable-iphone");
+    assert_eq!(body["display_name"], "Bart's iPhone");
+    assert_eq!(body["platform"], "ios");
+    assert_eq!(body["role"], "operator");
+    assert_eq!(body["scopes"], serde_json::json!(["read", "write"]));
+    let replacement_token = body["token"].as_str().expect("replacement token");
+    let db = db.lock().expect("db lock");
+    assert!(
+        db.verify_remote_client_token("stable-iphone", old_token.expose())
+            .expect("verify old token")
+            .is_none()
+    );
+    assert!(
+        db.verify_remote_client_token("stable-iphone", replacement_token)
+            .expect("verify replacement token")
+            .is_some()
+    );
 
     server.abort();
     let _ = server.await;


### PR DESCRIPTION
## Motivation

Apple clients use a stable client identifier when pairing again. The daemon treated that identifier as a duplicate database row, returned 503, and left the client unable to repair its remote credential.

## Implementation

- Replace an existing stable client inside the one-time pairing transaction while preserving normal client-registration uniqueness.
- Revoke the old bearer token, reset the paired profile, and record rotation timing without creating duplicate client rows.
- Add database and HTTP regressions for replacement, old-token rejection, rollback behavior, and redacted storage failures.