### PR TITLE
fix(watch): activate transferred remote pairing

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
@@ -8,7 +8,7 @@ extension MirrorStore {
   /// its own loadStoredPairings/refresh composition and does not call this.
   public func load() async {
     do {
-      try await activateStoredWatchPairingIfNeeded()
+      _ = try await activateStoredWatchPairingIfNeeded()
     } catch {
       syncStatus = mobileMonitorSyncStatus(for: error)
       return
@@ -32,13 +32,24 @@ extension MirrorStore {
     await refresh()
   }
 
-  private func activateStoredWatchPairingIfNeeded() async throws {
-    guard profile == .watch, demoModeEnabled, let credentialStore else {
+  func loadStoredWatchPairingIfAvailable() async {
+    do {
+      guard try await activateStoredWatchPairingIfNeeded() else { return }
+    } catch {
+      syncStatus = mobileMonitorSyncStatus(for: error)
       return
     }
+    await load()
+  }
+
+  private func activateStoredWatchPairingIfNeeded() async throws -> Bool {
+    guard profile == .watch, demoModeEnabled, let credentialStore else {
+      return false
+    }
     let credentials = try await credentialStore.loadAll()
-    guard !credentials.isEmpty else { return }
+    guard !credentials.isEmpty else { return false }
     demoModeEnabled = false
+    return true
   }
 
   /// Resets transient pairing state and reloads after the iPhone pushes new

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
@@ -7,7 +7,12 @@ extension MirrorStore {
   /// cached snapshot to the paired stations, then refresh. The iOS app drives
   /// its own loadStoredPairings/refresh composition and does not call this.
   public func load() async {
-    await activateStoredWatchPairingIfNeeded()
+    do {
+      try await activateStoredWatchPairingIfNeeded()
+    } catch {
+      syncStatus = mobileMonitorSyncStatus(for: error)
+      return
+    }
     guard !demoModeEnabled else {
       await refresh()
       return
@@ -27,13 +32,12 @@ extension MirrorStore {
     await refresh()
   }
 
-  private func activateStoredWatchPairingIfNeeded() async {
-    guard profile == .watch, demoModeEnabled, let credentialStore,
-      let credentials = try? await credentialStore.loadAll(),
-      !credentials.isEmpty
-    else {
+  private func activateStoredWatchPairingIfNeeded() async throws {
+    guard profile == .watch, demoModeEnabled, let credentialStore else {
       return
     }
+    let credentials = try await credentialStore.loadAll()
+    guard !credentials.isEmpty else { return }
     demoModeEnabled = false
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
@@ -59,6 +59,7 @@ extension MirrorStore {
   }
 
   private func leaveDemoModeForStoredWatchPairing() {
+    pairingFailureDescription = nil
     demoModeEnabled = false
     snapshot = .empty()
     selectedStationID = ""

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
@@ -7,8 +7,9 @@ extension MirrorStore {
   /// cached snapshot to the paired stations, then refresh. The iOS app drives
   /// its own loadStoredPairings/refresh composition and does not call this.
   public func load() async {
+    let activatedStoredWatchPairing: Bool
     do {
-      _ = try await activateStoredWatchPairingIfNeeded()
+      activatedStoredWatchPairing = try await activateStoredWatchPairingIfNeeded()
     } catch {
       syncStatus = mobileMonitorSyncStatus(for: error)
       return
@@ -17,12 +18,18 @@ extension MirrorStore {
       await refresh()
       return
     }
-    do {
-      try await rebuildSyncClients()
-    } catch {
-      syncStatus = mobileMonitorSyncStatus(for: error)
-      return
+    if !activatedStoredWatchPairing {
+      do {
+        try await rebuildSyncClients()
+      } catch {
+        syncStatus = mobileMonitorSyncStatus(for: error)
+        return
+      }
     }
+    await finishLoadWithPreparedSyncClients()
+  }
+
+  private func finishLoadWithPreparedSyncClients() async {
     guard !pairedCredentials.isEmpty else {
       applyCachedSnapshotIfAvailable()
       syncStatus = snapshot.stations.isEmpty ? .unpaired : .stale("Waiting for iPhone pairing.")
@@ -39,21 +46,15 @@ extension MirrorStore {
       syncStatus = mobileMonitorSyncStatus(for: error)
       return
     }
-    await load()
+    await finishLoadWithPreparedSyncClients()
   }
 
   private func activateStoredWatchPairingIfNeeded() async throws -> Bool {
-    guard profile == .watch, demoModeEnabled, let identityStore, let credentialStore else {
+    guard profile == .watch, demoModeEnabled, identityStore != nil, credentialStore != nil else {
       return false
     }
-    let credentials = try await credentialStore.loadAll()
-    var hasUsableCredential = false
-    for credential in credentials
-    where try await identityStore.load(id: credential.deviceIdentityID) != nil {
-      hasUsableCredential = true
-      break
-    }
-    guard hasUsableCredential else { return false }
+    try await rebuildSyncClients()
+    guard !pairedCredentials.isEmpty else { return false }
     leaveDemoModeForStoredWatchPairing()
     return true
   }
@@ -62,7 +63,7 @@ extension MirrorStore {
     pairingFailureDescription = nil
     demoModeEnabled = false
     snapshot = .empty()
-    selectedStationID = ""
+    selectedStationID = defaultStationID ?? pairedCredentials.first?.stationID ?? ""
     syncStatus = .syncing
     persistSharedSnapshot(snapshot)
     reconcileLiveActivity(snapshot)

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
@@ -7,6 +7,7 @@ extension MirrorStore {
   /// cached snapshot to the paired stations, then refresh. The iOS app drives
   /// its own loadStoredPairings/refresh composition and does not call this.
   public func load() async {
+    await activateStoredWatchPairingIfNeeded()
     guard !demoModeEnabled else {
       await refresh()
       return
@@ -24,6 +25,16 @@ extension MirrorStore {
     }
     scopeToPairedStations()
     await refresh()
+  }
+
+  private func activateStoredWatchPairingIfNeeded() async {
+    guard profile == .watch, demoModeEnabled, let credentialStore,
+      let credentials = try? await credentialStore.loadAll(),
+      !credentials.isEmpty
+    else {
+      return
+    }
+    demoModeEnabled = false
   }
 
   /// Resets transient pairing state and reloads after the iPhone pushes new

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Bootstrap.swift
@@ -43,13 +43,28 @@ extension MirrorStore {
   }
 
   private func activateStoredWatchPairingIfNeeded() async throws -> Bool {
-    guard profile == .watch, demoModeEnabled, let credentialStore else {
+    guard profile == .watch, demoModeEnabled, let identityStore, let credentialStore else {
       return false
     }
     let credentials = try await credentialStore.loadAll()
-    guard !credentials.isEmpty else { return false }
-    demoModeEnabled = false
+    var hasUsableCredential = false
+    for credential in credentials
+    where try await identityStore.load(id: credential.deviceIdentityID) != nil {
+      hasUsableCredential = true
+      break
+    }
+    guard hasUsableCredential else { return false }
+    leaveDemoModeForStoredWatchPairing()
     return true
+  }
+
+  private func leaveDemoModeForStoredWatchPairing() {
+    demoModeEnabled = false
+    snapshot = .empty()
+    selectedStationID = ""
+    syncStatus = .syncing
+    persistSharedSnapshot(snapshot)
+    reconcileLiveActivity(snapshot)
   }
 
   /// Resets transient pairing state and reloads after the iPhone pushes new

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Internals.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Internals.swift
@@ -168,7 +168,7 @@ extension MirrorStore {
 
   func refreshForegroundState() async {
     if profile == .watch, demoModeEnabled {
-      await load()
+      await loadStoredWatchPairingIfAvailable()
     } else {
       await refresh()
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Internals.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Internals.swift
@@ -174,9 +174,9 @@ extension MirrorStore {
     }
   }
 
-  private var shouldRunForegroundRefresh: Bool {
+  var shouldRunForegroundRefresh: Bool {
     if profile == .watch, demoModeEnabled {
-      return credentialStore != nil
+      return identityStore != nil && credentialStore != nil
     }
     return !demoModeEnabled && !stationIDsForRefresh().isEmpty
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Internals.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStore+Internals.swift
@@ -157,7 +157,7 @@ extension MirrorStore {
       guard !Task.isCancelled, shouldRunForegroundRefresh else {
         continue
       }
-      await refresh()
+      await refreshForegroundState()
       if syncStatus.indicatesSyncFailure {
         backoff.recordFailure()
       } else {
@@ -166,8 +166,19 @@ extension MirrorStore {
     }
   }
 
+  func refreshForegroundState() async {
+    if profile == .watch, demoModeEnabled {
+      await load()
+    } else {
+      await refresh()
+    }
+  }
+
   private var shouldRunForegroundRefresh: Bool {
-    !demoModeEnabled && !stationIDsForRefresh().isEmpty
+    if profile == .watch, demoModeEnabled {
+      return credentialStore != nil
+    }
+    return !demoModeEnabled && !stationIDsForRefresh().isEmpty
   }
 
   func applyPairedStationPlaceholders(

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStoreProfile.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MirrorStoreProfile.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Per-platform constants the shared store stamps onto commands and demo data.
 /// The iOS app uses `.phone`; the watch uses `.watch`.
-public struct MirrorStoreProfile: Sendable {
+public struct MirrorStoreProfile: Equatable, Sendable {
   public var commandIDPrefix: String
   public var demoActorDeviceID: String
   public var pullRequestMergeAuditReason: String

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/HarnessMonitorWatchApp.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/HarnessMonitorWatchApp.swift
@@ -11,6 +11,8 @@ import WidgetKit
 struct HarnessMonitorWatchApp: App {
   @WKApplicationDelegateAdaptor(WatchAppDelegate.self)
   private var delegate
+  @Environment(\.scenePhase)
+  private var scenePhase
   @State private var store: MirrorStore
   private let pairingReceiver: WatchPairingSessionReceiver
 
@@ -79,6 +81,14 @@ struct HarnessMonitorWatchApp: App {
         .onReceive(
           NotificationCenter.default.publisher(for: .watchMirrorRemoteRefreshRequested)
         ) { _ in
+          Task {
+            await store.load()
+          }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+          guard newPhase == .active else {
+            return
+          }
           Task {
             await store.load()
           }

--- a/apps/harness-monitor/Sources/HarnessMonitorWatch/HarnessMonitorWatchApp.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorWatch/HarnessMonitorWatchApp.swift
@@ -14,6 +14,7 @@ struct HarnessMonitorWatchApp: App {
   @Environment(\.scenePhase)
   private var scenePhase
   @State private var store: MirrorStore
+  @State private var wasBackgrounded = false
   private let pairingReceiver: WatchPairingSessionReceiver
 
   init() {
@@ -86,9 +87,14 @@ struct HarnessMonitorWatchApp: App {
           }
         }
         .onChange(of: scenePhase) { _, newPhase in
-          guard newPhase == .active else {
+          if newPhase == .background {
+            wasBackgrounded = true
             return
           }
+          guard newPhase == .active, wasBackgrounded else {
+            return
+          }
+          wasBackgrounded = false
           Task {
             await store.load()
           }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
@@ -151,11 +151,17 @@ struct HarnessMonitorAppBundleMetadataTests {
     )
 
     #expect(appSource.contains("@Environment(\\.scenePhase)"))
+    #expect(appSource.contains("@State private var wasBackgrounded = false"))
     let activationHandlerStart = try #require(
       appSource.range(of: ".onChange(of: scenePhase)")
     )
     let activationHandlerSource = appSource[activationHandlerStart.lowerBound...]
-    #expect(activationHandlerSource.contains("guard newPhase == .active"))
+    #expect(activationHandlerSource.contains("if newPhase == .background"))
+    #expect(activationHandlerSource.contains("wasBackgrounded = true"))
+    #expect(
+      activationHandlerSource.contains("guard newPhase == .active, wasBackgrounded")
+    )
+    #expect(activationHandlerSource.contains("wasBackgrounded = false"))
     #expect(activationHandlerSource.contains("await store.load()"))
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
@@ -151,9 +151,12 @@ struct HarnessMonitorAppBundleMetadataTests {
     )
 
     #expect(appSource.contains("@Environment(\\.scenePhase)"))
-    #expect(appSource.contains(".onChange(of: scenePhase)"))
-    #expect(appSource.contains("guard newPhase == .active"))
-    #expect(appSource.contains("await store.load()"))
+    let activationHandlerStart = try #require(
+      appSource.range(of: ".onChange(of: scenePhase)")
+    )
+    let activationHandlerSource = appSource[activationHandlerStart.lowerBound...]
+    #expect(activationHandlerSource.contains("guard newPhase == .active"))
+    #expect(activationHandlerSource.contains("await store.load()"))
   }
 
   @Test("Mobile widgets can refresh encrypted mirrors")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorUITestHostEntitlementsTests.swift
@@ -141,6 +141,21 @@ struct HarnessMonitorAppBundleMetadataTests {
     #expect(transferReceiverSource.contains("try await mutationGate.perform"))
   }
 
+  @Test("Watch app reloads transferred pairing material on activation")
+  func watchAppReloadsTransferredPairingMaterialOnActivation() throws {
+    let appSource = try String(
+      contentsOf: monitorAppRoot().appendingPathComponent(
+        "Sources/HarnessMonitorWatch/HarnessMonitorWatchApp.swift"
+      ),
+      encoding: .utf8
+    )
+
+    #expect(appSource.contains("@Environment(\\.scenePhase)"))
+    #expect(appSource.contains(".onChange(of: scenePhase)"))
+    #expect(appSource.contains("guard newPhase == .active"))
+    #expect(appSource.contains("await store.load()"))
+  }
+
   @Test("Mobile widgets can refresh encrypted mirrors")
   func mobileWidgetsCanRefreshEncryptedMirrors() throws {
     let root = monitorAppRoot()

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -18,6 +18,7 @@ final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
     XCTAssertEqual(fixture.store.pairedCredentials, [fixture.credential])
     XCTAssertEqual(fixture.store.selectedStationID, fixture.credential.stationID)
     XCTAssertNotEqual(fixture.store.presentedSyncStatus, .demo)
+    XCTAssertTrue(fixture.store.snapshot.taskBoardItems.isEmpty)
   }
 
   func testWatchForegroundRefreshActivatesStoredPairingInsteadOfDemoFixtures() async throws {
@@ -52,6 +53,37 @@ final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
 
     XCTAssertEqual(store.snapshot, snapshot)
     XCTAssertEqual(store.syncStatus, .demo)
+  }
+
+  func testWatchForegroundRefreshKeepsDemoWhenStoredCredentialIdentityIsMissing() async throws {
+    let fixture = try WatchRemotePairingStoreFixture(device: .iOS)
+    let store = MirrorStore(
+      demoModeEnabled: true,
+      profile: .watch,
+      identityStore: InMemoryMobileDeviceIdentityStore(),
+      credentialStore: fixture.credentialStore,
+      syncClientFactory: WatchRemovalSyncClientFactory(),
+      sharedSnapshotStore: nil
+    )
+    let demoSnapshot = store.snapshot
+
+    await store.refreshForegroundState()
+
+    XCTAssertTrue(store.demoModeEnabled)
+    XCTAssertEqual(store.snapshot, demoSnapshot)
+    XCTAssertEqual(store.syncStatus, .demo)
+  }
+
+  func testWatchForegroundRefreshLoopRequiresBothPairingStores() {
+    let store = MirrorStore(
+      demoModeEnabled: true,
+      profile: .watch,
+      credentialStore: InMemoryMobilePairedStationCredentialStore(),
+      syncClientFactory: WatchRemovalSyncClientFactory(),
+      sharedSnapshotStore: nil
+    )
+
+    XCTAssertFalse(store.shouldRunForegroundRefresh)
   }
 
   func testWatchLoadReportsStoredPairingReadFailureInsteadOfDemo() async {

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -1,11 +1,39 @@
 import Foundation
 import HarnessMonitorCore
 @testable import HarnessMonitorCrypto
-import HarnessMonitorMirrorStore
+@testable import HarnessMonitorMirrorStore
 import XCTest
 
 @MainActor
 final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
+  func testWatchLoadActivatesStoredPairingInsteadOfDemoFixtures() async throws {
+    let fixture = try WatchRemotePairingStoreFixture(
+      device: .iOS,
+      demoModeEnabled: true
+    )
+
+    await fixture.store.load()
+
+    XCTAssertFalse(fixture.store.demoModeEnabled)
+    XCTAssertEqual(fixture.store.pairedCredentials, [fixture.credential])
+    XCTAssertEqual(fixture.store.selectedStationID, fixture.credential.stationID)
+    XCTAssertNotEqual(fixture.store.presentedSyncStatus, .demo)
+  }
+
+  func testWatchForegroundRefreshActivatesStoredPairingInsteadOfDemoFixtures() async throws {
+    let fixture = try WatchRemotePairingStoreFixture(
+      device: .iOS,
+      demoModeEnabled: true
+    )
+
+    await fixture.store.refreshForegroundState()
+
+    XCTAssertFalse(fixture.store.demoModeEnabled)
+    XCTAssertEqual(fixture.store.pairedCredentials, [fixture.credential])
+    XCTAssertEqual(fixture.store.selectedStationID, fixture.credential.stationID)
+    XCTAssertNotEqual(fixture.store.presentedSyncStatus, .demo)
+  }
+
   func testRemovingDirectWatchPairingWaitsForPairingMutationGate() async throws {
     let mutationGate = MobilePairingMutationGate()
     let fixture = try WatchRemotePairingStoreFixture(
@@ -113,7 +141,8 @@ private struct WatchRemotePairingStoreFixture {
   init(
     device: MobileRemoteDaemonPairingDevice,
     mutationGate: MobilePairingMutationGate = MobilePairingMutationGate(),
-    cloudFallback: Bool = false
+    cloudFallback: Bool = false,
+    demoModeEnabled: Bool = false
   ) throws {
     let now = Date(timeIntervalSince1970: 1_752_124_400)
     let endpoint = URL(string: "https://daemon.example.com")!
@@ -166,7 +195,7 @@ private struct WatchRemotePairingStoreFixture {
     )
     credentialStore = InMemoryMobilePairedStationCredentialStore(credentials: [credential])
     store = MirrorStore(
-      demoModeEnabled: false,
+      demoModeEnabled: demoModeEnabled,
       profile: .watch,
       identityStore: identityStore,
       credentialStore: credentialStore,

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -34,6 +34,24 @@ final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
     XCTAssertNotEqual(fixture.store.presentedSyncStatus, .demo)
   }
 
+  func testWatchLoadReportsStoredPairingReadFailureInsteadOfDemo() async {
+    let error = MobilePairedStationCredentialStoreError.unexpectedKeychainStatus(-50)
+    let store = MirrorStore(
+      demoModeEnabled: true,
+      profile: .watch,
+      identityStore: InMemoryMobileDeviceIdentityStore(),
+      credentialStore: FailingWatchCredentialStore(error: error),
+      syncClientFactory: WatchRemovalSyncClientFactory(),
+      sharedSnapshotStore: nil
+    )
+
+    await store.load()
+
+    XCTAssertTrue(store.demoModeEnabled)
+    XCTAssertEqual(store.syncStatus, mobileMonitorSyncStatus(for: error))
+    XCTAssertNotEqual(store.presentedSyncStatus, .demo)
+  }
+
   func testRemovingDirectWatchPairingWaitsForPairingMutationGate() async throws {
     let mutationGate = MobilePairingMutationGate()
     let fixture = try WatchRemotePairingStoreFixture(
@@ -234,6 +252,26 @@ private struct WatchRemovalSyncClient: MobileMonitorSyncClient {
     now: Date
   ) async throws -> MobileCommandReceipt {
     throw MobileRemoteDaemonSyncError.commandsUnavailable
+  }
+}
+
+private struct FailingWatchCredentialStore: MobilePairedStationCredentialStore {
+  let error: MobilePairedStationCredentialStoreError
+
+  func save(_ credential: MobilePairedStationCredential) async throws {
+    throw error
+  }
+
+  func load(stationID: String) async throws -> MobilePairedStationCredential? {
+    throw error
+  }
+
+  func loadAll() async throws -> [MobilePairedStationCredential] {
+    throw error
+  }
+
+  func delete(stationID: String) async throws {
+    throw error
   }
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -99,6 +99,25 @@ final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
     XCTAssertNotEqual(fixture.store.presentedSyncStatus, .pairingFailed("Previous pairing failed."))
   }
 
+  func testWatchActivationReadsStoredCredentialsOnce() async throws {
+    let fixture = try WatchRemotePairingStoreFixture(device: .iOS)
+    let credentialStore = CountingWatchCredentialStore(credentials: [fixture.credential])
+    let store = MirrorStore(
+      demoModeEnabled: true,
+      profile: .watch,
+      identityStore: fixture.identityStore,
+      credentialStore: credentialStore,
+      syncClientFactory: WatchRemovalSyncClientFactory(),
+      sharedSnapshotStore: nil
+    )
+
+    await store.refreshForegroundState()
+    let loadAllCallCount = await credentialStore.loadAllCallCount
+
+    XCTAssertFalse(store.demoModeEnabled)
+    XCTAssertEqual(loadAllCallCount, 1)
+  }
+
   func testWatchLoadReportsStoredPairingReadFailureInsteadOfDemo() async {
     let error = MobilePairedStationCredentialStoreError.unexpectedKeychainStatus(-50)
     let store = MirrorStore(
@@ -337,6 +356,32 @@ private struct FailingWatchCredentialStore: MobilePairedStationCredentialStore {
 
   func delete(stationID: String) async throws {
     throw error
+  }
+}
+
+private actor CountingWatchCredentialStore: MobilePairedStationCredentialStore {
+  private let backing: InMemoryMobilePairedStationCredentialStore
+  private(set) var loadAllCallCount = 0
+
+  init(credentials: [MobilePairedStationCredential]) {
+    backing = InMemoryMobilePairedStationCredentialStore(credentials: credentials)
+  }
+
+  func save(_ credential: MobilePairedStationCredential) async throws {
+    try await backing.save(credential)
+  }
+
+  func load(stationID: String) async throws -> MobilePairedStationCredential? {
+    try await backing.load(stationID: stationID)
+  }
+
+  func loadAll() async throws -> [MobilePairedStationCredential] {
+    loadAllCallCount += 1
+    return try await backing.loadAll()
+  }
+
+  func delete(stationID: String) async throws {
+    try await backing.delete(stationID: stationID)
   }
 }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -34,6 +34,26 @@ final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
     XCTAssertNotEqual(fixture.store.presentedSyncStatus, .demo)
   }
 
+  func testWatchForegroundRefreshWithoutStoredPairingKeepsCurrentDemoSnapshot() async {
+    let snapshot = MobileMirrorSnapshot.empty(
+      now: Date(timeIntervalSince1970: 1_752_124_400)
+    )
+    let store = MirrorStore(
+      snapshot: snapshot,
+      demoModeEnabled: true,
+      profile: .watch,
+      identityStore: InMemoryMobileDeviceIdentityStore(),
+      credentialStore: InMemoryMobilePairedStationCredentialStore(),
+      syncClientFactory: WatchRemovalSyncClientFactory(),
+      sharedSnapshotStore: nil
+    )
+
+    await store.refreshForegroundState()
+
+    XCTAssertEqual(store.snapshot, snapshot)
+    XCTAssertEqual(store.syncStatus, .demo)
+  }
+
   func testWatchLoadReportsStoredPairingReadFailureInsteadOfDemo() async {
     let error = MobilePairedStationCredentialStoreError.unexpectedKeychainStatus(-50)
     let store = MirrorStore(

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/WatchRemoteDaemonPairingStoreTests.swift
@@ -86,6 +86,19 @@ final class WatchRemoteDaemonPairingStoreTests: XCTestCase {
     XCTAssertFalse(store.shouldRunForegroundRefresh)
   }
 
+  func testWatchActivationClearsPriorPairingFailure() async throws {
+    let fixture = try WatchRemotePairingStoreFixture(
+      device: .iOS,
+      demoModeEnabled: true
+    )
+    fixture.store.pairingFailureDescription = "Previous pairing failed."
+
+    await fixture.store.refreshForegroundState()
+
+    XCTAssertNil(fixture.store.pairingFailureDescription)
+    XCTAssertNotEqual(fixture.store.presentedSyncStatus, .pairingFailed("Previous pairing failed."))
+  }
+
   func testWatchLoadReportsStoredPairingReadFailureInsteadOfDemo() async {
     let error = MobilePairedStationCredentialStoreError.unexpectedKeychainStatus(-50)
     let store = MirrorStore(


### PR DESCRIPTION
## Motivation
An Apple Watch already open in demo mode can receive and persist an iPhone-transferred remote-daemon credential without activating it, leaving the watch on demo data until the app is relaunched.

## Implementation
- Activate persisted watch credentials before demo-mode bootstrap.
- Recheck watch pairing storage from the foreground refresh cadence and on scene activation.
- Add regressions for launch and foreground-transfer recovery.