### PR TITLE
test(remote): prove automatic renewal continuity

### DIFF
--- a/tests/remote_daemon_e2e.rs
+++ b/tests/remote_daemon_e2e.rs
@@ -21,6 +21,8 @@ use rcgen::{
     BasicConstraints, CertificateParams, CertifiedIssuer, DistinguishedName, DnType, IsCa, KeyPair,
     KeyUsagePurpose,
 };
+use rustls::pki_types::CertificateDer;
+use rustls::pki_types::pem::PemObject as _;
 use serde_json::Value;
 use std::env;
 use std::time::Duration;
@@ -61,6 +63,7 @@ async fn run_aftermarket_failed_issuance_case() -> Result<(), String> {
         https_port: environment.https_port(),
         dns_log: environment.dns_log().to_path_buf(),
         ca_root: environment.acme_ca_root().to_path_buf(),
+        certificate_validity_days: 90,
     })
     .await?;
     let aftermarket = AftermarketDnsEnvironment {
@@ -111,6 +114,7 @@ async fn run_remote_daemon_case(challenge: AcmeChallenge) -> Result<(), String> 
         https_port: environment.https_port(),
         dns_log: environment.dns_log().to_path_buf(),
         ca_root: environment.acme_ca_root().to_path_buf(),
+        certificate_validity_days: 90,
     })
     .await?;
     let mut daemon = RemoteDaemonProcess::spawn(&environment, challenge, acme.directory_url())?;
@@ -158,6 +162,128 @@ async fn run_remote_daemon_case(challenge: AcmeChallenge) -> Result<(), String> 
     daemon.wait_for_exit().await?;
     acme.shutdown().await?;
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "run with mise run remote-daemon:e2e"]
+async fn remote_daemon_e2e_proves_automatic_acme_renewal() {
+    for challenge in AcmeChallenge::ALL {
+        run_automatic_renewal_case(challenge)
+            .await
+            .unwrap_or_else(|error| {
+                panic!(
+                    "{} automatic ACME renewal e2e failed: {error}",
+                    challenge.cli_name()
+                )
+            });
+    }
+}
+
+async fn run_automatic_renewal_case(challenge: AcmeChallenge) -> Result<(), String> {
+    let environment = RemoteDaemonEnvironment::new(challenge)?;
+    let acme = FakeAcmeServer::start(AcmeChallengeConfig {
+        challenge,
+        domain: DOMAIN.to_string(),
+        http_port: environment.http_port(),
+        https_port: environment.https_port(),
+        dns_log: environment.dns_log().to_path_buf(),
+        ca_root: environment.acme_ca_root().to_path_buf(),
+        certificate_validity_days: 7,
+    })
+    .await?;
+    let mut daemon = RemoteDaemonProcess::spawn(&environment, challenge, acme.directory_url())?;
+    acme.wait_for_certificate_downloads(2)
+        .await
+        .map_err(|error| format!("{error}; daemon output: {}", daemon.diagnostics()))?;
+    acme.assert_complete().await?;
+    daemon.ensure_running()?;
+    let issued = acme.issued_certificate_pems()?;
+    let [initial_pem, renewed_pem] = issued.as_slice() else {
+        return Err(format!(
+            "fake ACME issued {} certificates, expected exactly 2",
+            issued.len()
+        ));
+    };
+    let initial_leaf = leaf_certificate_der(initial_pem)?;
+    let renewed_leaf = leaf_certificate_der(renewed_pem)?;
+    if initial_leaf == renewed_leaf {
+        return Err("automatic renewal did not replace the leaf certificate".to_string());
+    }
+    if certificate_spki(&initial_leaf)? != certificate_spki(&renewed_leaf)? {
+        return Err("automatic renewal changed the pinned server SPKI".to_string());
+    }
+
+    let client = RemoteDaemonClient::new(DOMAIN, environment.https_port(), acme.ca_pem())?;
+    wait_for_served_certificate(&client, &renewed_leaf).await?;
+    let invitation = daemon.create_pairing("admin")?;
+    let expected_pin = certificate_spki_sha256_pin(&renewed_leaf)?;
+    if required_string(&invitation, "server_spki_sha256")? != expected_pin {
+        return Err("pairing invitation did not publish the renewed server SPKI".to_string());
+    }
+    let admin = client
+        .claim_pairing(
+            required_string(&invitation, "code")?,
+            "renewal-admin",
+            "admin",
+        )
+        .await
+        .map_err(|error| format!("{error}; daemon output: {}", daemon.diagnostics()))?;
+    client.expect_health(&admin, 200).await?;
+    let operator_invitation = daemon.create_pairing("operator")?;
+    let operator = client
+        .claim_pairing(
+            required_string(&operator_invitation, "code")?,
+            "renewal-operator",
+            "operator",
+        )
+        .await?;
+    client
+        .expect_websocket_health_and_admin_denial(&operator)
+        .await?;
+    client.stop(&admin).await?;
+    daemon.wait_for_exit().await?;
+    acme.shutdown().await
+}
+
+async fn wait_for_served_certificate(
+    client: &RemoteDaemonClient,
+    expected: &[u8],
+) -> Result<(), String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if client.verified_leaf_certificate_der().await.as_deref() == Ok(expected) {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err("remote TLS listener did not serve the renewed certificate".to_string());
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+fn leaf_certificate_der(certificate_pem: &str) -> Result<Vec<u8>, String> {
+    CertificateDer::pem_slice_iter(certificate_pem.as_bytes())
+        .next()
+        .ok_or_else(|| "fake ACME certificate chain omitted leaf PEM".to_string())?
+        .map(|certificate| certificate.to_vec())
+        .map_err(|error| format!("parse fake ACME leaf PEM: {error}"))
+}
+
+fn certificate_spki(certificate_der: &[u8]) -> Result<Vec<u8>, String> {
+    let (_, certificate) = x509_parser::parse_x509_certificate(certificate_der)
+        .map_err(|error| format!("parse fake ACME leaf certificate: {error}"))?;
+    Ok(certificate.public_key().raw.to_vec())
+}
+
+fn certificate_spki_sha256_pin(certificate_der: &[u8]) -> Result<String, String> {
+    use base64::Engine as _;
+    use sha2::Digest as _;
+
+    let spki = certificate_spki(certificate_der)?;
+    Ok(format!(
+        "sha256/{}",
+        base64::engine::general_purpose::STANDARD.encode(sha2::Sha256::digest(spki))
+    ))
 }
 
 async fn expect_untrusted_ca_rejected(port: u16) -> Result<(), String> {

--- a/tests/remote_daemon_e2e.rs
+++ b/tests/remote_daemon_e2e.rs
@@ -192,7 +192,7 @@ async fn run_automatic_renewal_case(challenge: AcmeChallenge) -> Result<(), Stri
     })
     .await?;
     let mut daemon = RemoteDaemonProcess::spawn(&environment, challenge, acme.directory_url())?;
-    acme.wait_for_certificate_downloads(2)
+    acme.wait_for_issued_certificates(2)
         .await
         .map_err(|error| format!("{error}; daemon output: {}", daemon.diagnostics()))?;
     acme.assert_complete().await?;

--- a/tests/remote_daemon_e2e/acme/mod.rs
+++ b/tests/remote_daemon_e2e/acme/mod.rs
@@ -60,6 +60,7 @@ pub struct AcmeChallengeConfig {
     pub https_port: u16,
     pub dns_log: PathBuf,
     pub ca_root: PathBuf,
+    pub certificate_validity_days: u64,
 }
 
 pub struct FakeAcmeServer {
@@ -157,6 +158,44 @@ impl FakeAcmeServer {
         }
     }
 
+    pub async fn wait_for_certificate_downloads(&self, expected: usize) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let (orders, downloads, validation_error) = {
+                let progress = self
+                    .state
+                    .progress
+                    .lock()
+                    .map_err(|_| "fake ACME progress lock poisoned".to_string())?;
+                (
+                    progress.order_count,
+                    progress.certificate_download_count,
+                    progress.validation_error.clone(),
+                )
+            };
+            if let Some(error) = validation_error {
+                return Err(format!("fake ACME validation failed: {error}"));
+            }
+            if downloads >= expected {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "fake ACME started {orders} orders and downloaded {downloads} certificates, expected {expected}"
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    pub fn issued_certificate_pems(&self) -> Result<Vec<String>, String> {
+        self.state
+            .progress
+            .lock()
+            .map_err(|_| "fake ACME progress lock poisoned".to_string())
+            .map(|progress| progress.issued_certificate_pems.clone())
+    }
+
     pub async fn shutdown(mut self) -> Result<(), String> {
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
@@ -186,10 +225,13 @@ pub(super) struct FakeAcmeState {
 
 #[derive(Default)]
 pub(super) struct FakeAcmeProgress {
+    pub(super) order_count: usize,
     pub(super) challenge_validated: bool,
     pub(super) finalized: bool,
     pub(super) certificate_pem: Option<String>,
     pub(super) certificate_downloaded: bool,
+    pub(super) certificate_download_count: usize,
+    pub(super) issued_certificate_pems: Vec<String>,
     pub(super) validation_error: Option<String>,
 }
 

--- a/tests/remote_daemon_e2e/acme/mod.rs
+++ b/tests/remote_daemon_e2e/acme/mod.rs
@@ -158,10 +158,10 @@ impl FakeAcmeServer {
         }
     }
 
-    pub async fn wait_for_certificate_downloads(&self, expected: usize) -> Result<(), String> {
+    pub async fn wait_for_issued_certificates(&self, expected: usize) -> Result<(), String> {
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
-            let (orders, downloads, validation_error) = {
+            let (orders, downloads, issued, validation_error) = {
                 let progress = self
                     .state
                     .progress
@@ -170,18 +170,19 @@ impl FakeAcmeServer {
                 (
                     progress.order_count,
                     progress.certificate_download_count,
+                    progress.issued_certificate_pems.len(),
                     progress.validation_error.clone(),
                 )
             };
             if let Some(error) = validation_error {
                 return Err(format!("fake ACME validation failed: {error}"));
             }
-            if downloads >= expected {
+            if issued >= expected {
                 return Ok(());
             }
             if Instant::now() >= deadline {
                 return Err(format!(
-                    "fake ACME started {orders} orders and downloaded {downloads} certificates, expected {expected}"
+                    "fake ACME started {orders} orders, handled {downloads} downloads, and issued {issued} certificates, expected {expected}"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(25)).await;

--- a/tests/remote_daemon_e2e/acme/protocol.rs
+++ b/tests/remote_daemon_e2e/acme/protocol.rs
@@ -7,7 +7,8 @@ use axum::http::{HeaderValue, Method, StatusCode, Uri};
 use axum::response::Response;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use rcgen::CertificateSigningRequestParams;
+use chrono::{Datelike as _, Duration as ChronoDuration, Utc};
+use rcgen::{CertificateSigningRequestParams, ExtendedKeyUsagePurpose, date_time_ymd};
 use rustls::pki_types::CertificateSigningRequestDer;
 use serde_json::{Value, json};
 
@@ -59,11 +60,7 @@ async fn route_acme_request(
             &json!({}),
             Some(format!("{}/acct/1", state.origin)),
         )),
-        "/new-order" => Ok(json_response(
-            StatusCode::CREATED,
-            &order_body(state, "pending", false),
-            Some(format!("{}/order/1", state.origin)),
-        )),
+        "/new-order" => begin_order(state),
         "/authz/1" => Ok(json_response(
             StatusCode::OK,
             &authorization_body(state),
@@ -89,6 +86,25 @@ async fn route_acme_request(
     }
 }
 
+fn begin_order(state: &FakeAcmeState) -> Result<Response<Body>, String> {
+    let mut progress = state
+        .progress
+        .lock()
+        .map_err(|_| "fake ACME progress lock poisoned".to_string())?;
+    progress.order_count += 1;
+    progress.challenge_validated = false;
+    progress.finalized = false;
+    progress.certificate_pem = None;
+    progress.certificate_downloaded = false;
+    progress.validation_error = None;
+    drop(progress);
+    Ok(json_response(
+        StatusCode::CREATED,
+        &order_body(state, "pending", false),
+        Some(format!("{}/order/1", state.origin)),
+    ))
+}
+
 fn order_status(state: &FakeAcmeState) -> Result<Response<Body>, String> {
     let finalized = state
         .progress
@@ -111,8 +127,28 @@ fn finalize_order(state: &FakeAcmeState, body: &[u8]) -> Result<Response<Body>, 
         .decode(csr)
         .map_err(|error| format!("decode fake ACME CSR: {error}"))?;
     let csr = CertificateSigningRequestDer::from(csr);
-    let request = CertificateSigningRequestParams::from_der(&csr)
+    let mut request = CertificateSigningRequestParams::from_der(&csr)
         .map_err(|error| format!("parse fake ACME CSR: {error}"))?;
+    let now = Utc::now().date_naive();
+    let not_before = now
+        .checked_sub_signed(ChronoDuration::days(1))
+        .ok_or_else(|| "build fake ACME certificate start date".to_string())?;
+    let validity_days = i64::try_from(state.config.certificate_validity_days)
+        .map_err(|_| "fake ACME certificate validity is too large".to_string())?;
+    let not_after = now
+        .checked_add_signed(ChronoDuration::days(validity_days))
+        .ok_or_else(|| "build fake ACME certificate expiry date".to_string())?;
+    request.params.not_before = date_time_ymd(
+        not_before.year(),
+        not_before.month() as u8,
+        not_before.day() as u8,
+    );
+    request.params.not_after = date_time_ymd(
+        not_after.year(),
+        not_after.month() as u8,
+        not_after.day() as u8,
+    );
+    request.params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
     let certificate = request
         .signed_by(&state.issuer)
         .map_err(|error| format!("sign fake ACME CSR: {error}"))?;
@@ -140,6 +176,8 @@ fn download_certificate(state: &FakeAcmeState) -> Result<Response<Body>, String>
         .clone()
         .ok_or_else(|| "fake ACME certificate requested before finalize".to_string())?;
     progress.certificate_downloaded = true;
+    progress.certificate_download_count += 1;
+    progress.issued_certificate_pems.push(certificate.clone());
     Ok(acme_response(
         StatusCode::OK,
         "application/pem-certificate-chain",

--- a/tests/remote_daemon_e2e/acme/protocol.rs
+++ b/tests/remote_daemon_e2e/acme/protocol.rs
@@ -91,18 +91,21 @@ fn begin_order(state: &FakeAcmeState) -> Result<Response<Body>, String> {
         .progress
         .lock()
         .map_err(|_| "fake ACME progress lock poisoned".to_string())?;
-    progress.order_count += 1;
-    progress.challenge_validated = false;
-    progress.finalized = false;
-    progress.certificate_pem = None;
-    progress.certificate_downloaded = false;
-    progress.validation_error = None;
+    reset_for_new_order(&mut progress);
     drop(progress);
     Ok(json_response(
         StatusCode::CREATED,
         &order_body(state, "pending", false),
         Some(format!("{}/order/1", state.origin)),
     ))
+}
+
+fn reset_for_new_order(progress: &mut super::FakeAcmeProgress) {
+    progress.order_count += 1;
+    progress.challenge_validated = false;
+    progress.finalized = false;
+    progress.certificate_pem = None;
+    progress.certificate_downloaded = false;
 }
 
 fn order_status(state: &FakeAcmeState) -> Result<Response<Body>, String> {
@@ -175,15 +178,24 @@ fn download_certificate(state: &FakeAcmeState) -> Result<Response<Body>, String>
         .certificate_pem
         .clone()
         .ok_or_else(|| "fake ACME certificate requested before finalize".to_string())?;
-    progress.certificate_downloaded = true;
-    progress.certificate_download_count += 1;
-    progress.issued_certificate_pems.push(certificate.clone());
+    record_certificate_download(&mut progress, &certificate);
     Ok(acme_response(
         StatusCode::OK,
         "application/pem-certificate-chain",
         certificate,
         None,
     ))
+}
+
+fn record_certificate_download(progress: &mut super::FakeAcmeProgress, certificate: &str) {
+    let first_download_for_order = !progress.certificate_downloaded;
+    progress.certificate_downloaded = true;
+    progress.certificate_download_count += 1;
+    if first_download_for_order {
+        progress
+            .issued_certificate_pems
+            .push(certificate.to_string());
+    }
 }
 
 fn directory_body(origin: &str) -> Value {
@@ -286,4 +298,46 @@ fn jws_payload(body: &[u8]) -> Result<Value, String> {
         .map_err(|error| format!("decode fake ACME JWS payload: {error}"))?;
     serde_json::from_slice(&payload)
         .map_err(|error| format!("decode fake ACME JWS payload JSON: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{record_certificate_download, reset_for_new_order};
+    use crate::acme::FakeAcmeProgress;
+
+    #[test]
+    fn new_order_preserves_prior_protocol_failure() {
+        let mut progress = FakeAcmeProgress {
+            validation_error: Some("challenge validation failed".to_string()),
+            ..FakeAcmeProgress::default()
+        };
+
+        reset_for_new_order(&mut progress);
+
+        assert_eq!(
+            progress.validation_error.as_deref(),
+            Some("challenge validation failed")
+        );
+    }
+
+    #[test]
+    fn certificate_download_retry_records_one_issued_chain_per_order() {
+        let mut progress = FakeAcmeProgress::default();
+        reset_for_new_order(&mut progress);
+
+        record_certificate_download(&mut progress, "first-chain");
+        record_certificate_download(&mut progress, "first-chain");
+
+        assert_eq!(progress.certificate_download_count, 2);
+        assert_eq!(progress.issued_certificate_pems, ["first-chain"]);
+
+        reset_for_new_order(&mut progress);
+        record_certificate_download(&mut progress, "second-chain");
+
+        assert_eq!(progress.certificate_download_count, 3);
+        assert_eq!(
+            progress.issued_certificate_pems,
+            ["first-chain", "second-chain"]
+        );
+    }
 }

--- a/tests/remote_daemon_e2e/client/pairing.rs
+++ b/tests/remote_daemon_e2e/client/pairing.rs
@@ -22,7 +22,7 @@ impl RemoteDaemonClient {
             }))
             .send()
             .await
-            .map_err(|error| format!("claim remote pairing: {error}"))?;
+            .map_err(|error| format!("claim remote pairing: {error:?}"))?;
         let status = response.status();
         let body = response
             .json::<Value>()

--- a/tests/remote_systemd_e2e.rs
+++ b/tests/remote_systemd_e2e.rs
@@ -45,6 +45,7 @@ async fn run_systemd_case() -> Result<(), String> {
         https_port: host.https_port(),
         dns_log: host.dns_log().to_path_buf(),
         ca_root: host.fake_ca_root().to_path_buf(),
+        certificate_validity_days: 90,
     })
     .await?;
     host.prepare(acme.directory_url(), acme.ca_pem())?;


### PR DESCRIPTION
## Motivation

Automatic ACME renewal and TLS reload were covered only in-process. There was no executable proof that a running remote daemon renews through each challenge type without changing the SPKI pinned by Apple clients.

## Implementation

- Extend the fake ACME server to handle sequential orders and bounded server-auth certificates.
- Prove TLS-ALPN-01, HTTP-01, and DNS-01 automatic renewal, hot TLS reload, stable SPKI, pairing-link pin continuity, HTTPS, and WSS.
- Keep the Linux systemd proof on the shared fake-certificate contract and retain richer pairing transport diagnostics.
- Validate with the focused renewal test, `mise run remote-daemon:e2e`, and `mise run harness:check`.