### PR TITLE
fix(remote): enforce complete authorization matrix

### DIFF
--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -45,6 +45,7 @@ mod remote_actor;
 mod remote_authz;
 mod remote_authz_audit;
 mod remote_authz_audit_contention;
+mod remote_authz_matrix;
 mod remote_clients;
 mod remote_limits;
 mod remote_limits_support;

--- a/src/daemon/http/tests/remote_authz_matrix.rs
+++ b/src/daemon/http/tests/remote_authz_matrix.rs
@@ -64,6 +64,14 @@ async fn remote_http_authz_matrix_protects_every_sse_route() {
     let _ = server.await;
 }
 
+#[test]
+fn remote_http_authz_matrix_accepts_sse_content_type_parameters() {
+    assert!(is_sse_content_type("text/event-stream"));
+    assert!(is_sse_content_type("text/event-stream; charset=utf-8"));
+    assert!(is_sse_content_type("TEXT/EVENT-STREAM; charset=UTF-8"));
+    assert!(!is_sse_content_type("text/plain; charset=utf-8"));
+}
+
 fn assert_missing_credentials_denied(
     state: &crate::daemon::http::DaemonHttpState,
     route: &HttpApiRouteContract,
@@ -210,14 +218,22 @@ async fn assert_sse_status(
         .expect("send SSE request");
     assert_eq!(response.status(), expected, "GET {path}");
     if expected == StatusCode::OK {
-        assert_eq!(
-            response
-                .headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok()),
-            Some("text/event-stream")
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok());
+        assert!(
+            content_type.is_some_and(is_sse_content_type),
+            "GET {path} returned invalid SSE Content-Type {content_type:?}"
         );
     }
+}
+
+fn is_sse_content_type(value: &str) -> bool {
+    value
+        .split(';')
+        .next()
+        .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("text/event-stream"))
 }
 
 async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {

--- a/src/daemon/http/tests/remote_authz_matrix.rs
+++ b/src/daemon/http/tests/remote_authz_matrix.rs
@@ -1,0 +1,237 @@
+use axum::Router;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, timeout};
+
+use crate::daemon::http::auth::{DaemonHttpAuthMode, authorize_http_route};
+use crate::daemon::protocol::{
+    HTTP_API_CONTRACT, HttpApiRouteContract, HttpRouteMethod, http_paths,
+};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole, remote_http_scopes};
+use crate::daemon::remote_auth::REMOTE_CLIENT_ID_HEADER;
+use crate::daemon::remote_identity::RemoteClientRegistration;
+
+use super::test_http_state_with_db;
+
+#[test]
+fn remote_http_authz_matrix_enforces_every_private_route() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_matrix_clients(&state);
+
+    let public_routes = HTTP_API_CONTRACT
+        .iter()
+        .filter(|route| is_public_pairing_route(route))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        public_routes
+            .iter()
+            .map(|route| route.path)
+            .collect::<Vec<_>>(),
+        vec![
+            http_paths::REMOTE_PAIR_CLAIM,
+            http_paths::REMOTE_PAIR_STATUS,
+        ]
+    );
+
+    for route in HTTP_API_CONTRACT
+        .iter()
+        .filter(|route| !is_public_pairing_route(route))
+    {
+        assert_missing_credentials_denied(&state, route);
+        let required_scope = required_scope(route);
+        assert_insufficient_scope_denied(&state, route, required_scope);
+        assert_allowed_scope_accepted(&state, route, required_scope);
+    }
+}
+
+#[tokio::test]
+async fn remote_http_authz_matrix_protects_every_sse_route() {
+    let mut state = test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    register_matrix_clients(&state);
+    let (base_url, server) = serve_http(state).await;
+
+    for path in [http_paths::STREAM, http_paths::SESSION_STREAM] {
+        let path = path.replace("{session_id}", "missing-session");
+        assert_sse_status(&base_url, &path, None, StatusCode::UNAUTHORIZED).await;
+        assert_sse_status(&base_url, &path, Some("write-only"), StatusCode::FORBIDDEN).await;
+        assert_sse_status(&base_url, &path, Some("viewer"), StatusCode::OK).await;
+    }
+
+    server.abort();
+    let _ = server.await;
+}
+
+fn assert_missing_credentials_denied(
+    state: &crate::daemon::http::DaemonHttpState,
+    route: &HttpApiRouteContract,
+) {
+    let response = authorize_http_route(&HeaderMap::new(), state, route)
+        .expect_err("missing credentials must be denied");
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "{} {}",
+        route.method.as_str(),
+        route.path
+    );
+}
+
+fn assert_insufficient_scope_denied(
+    state: &crate::daemon::http::DaemonHttpState,
+    route: &HttpApiRouteContract,
+    required_scope: RemoteAccessScope,
+) {
+    let client_id = match required_scope {
+        RemoteAccessScope::Read | RemoteAccessScope::Admin => "write-only",
+        RemoteAccessScope::Write => "viewer",
+    };
+    let response = authorize_http_route(&remote_headers(client_id), state, route)
+        .expect_err("insufficient scope must be denied");
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "{} {} requires {}",
+        route.method.as_str(),
+        route.path,
+        required_scope.as_str()
+    );
+}
+
+fn assert_allowed_scope_accepted(
+    state: &crate::daemon::http::DaemonHttpState,
+    route: &HttpApiRouteContract,
+    required_scope: RemoteAccessScope,
+) {
+    let client_id = match required_scope {
+        RemoteAccessScope::Read => "viewer",
+        RemoteAccessScope::Write => "operator",
+        RemoteAccessScope::Admin => "admin",
+    };
+    authorize_http_route(&remote_headers(client_id), state, route).unwrap_or_else(|response| {
+        panic!(
+            "{} {} rejected allowed {} scope with {}",
+            route.method.as_str(),
+            route.path,
+            required_scope.as_str(),
+            response.status()
+        );
+    });
+}
+
+fn required_scope(route: &HttpApiRouteContract) -> RemoteAccessScope {
+    remote_http_scopes(route)
+        .and_then(|scopes| scopes.first().copied())
+        .unwrap_or_else(|| {
+            panic!(
+                "{} {} is missing a remote scope",
+                route.method.as_str(),
+                route.path
+            );
+        })
+}
+
+fn is_public_pairing_route(route: &HttpApiRouteContract) -> bool {
+    route.method == HttpRouteMethod::Post
+        && matches!(
+            route.path,
+            http_paths::REMOTE_PAIR_CLAIM | http_paths::REMOTE_PAIR_STATUS
+        )
+}
+
+fn register_matrix_clients(state: &crate::daemon::http::DaemonHttpState) {
+    for (client_id, role, scopes) in [
+        ("viewer", RemoteRole::Viewer, &[][..]),
+        ("operator", RemoteRole::Operator, &[][..]),
+        ("admin", RemoteRole::Admin, &[][..]),
+        (
+            "write-only",
+            RemoteRole::Operator,
+            &[RemoteAccessScope::Write][..],
+        ),
+    ] {
+        let registration = RemoteClientRegistration::new_for_tests(
+            client_id,
+            "Authorization Matrix",
+            "test",
+            role,
+            scopes,
+            &remote_token(client_id),
+            "2026-07-14T08:00:00Z",
+        )
+        .expect("matrix registration");
+        state
+            .db
+            .get()
+            .expect("db slot")
+            .lock()
+            .expect("db lock")
+            .register_remote_client(&registration)
+            .expect("register matrix client");
+    }
+}
+
+fn remote_headers(client_id: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        REMOTE_CLIENT_ID_HEADER,
+        HeaderValue::from_str(client_id).expect("client id header"),
+    );
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {}", remote_token(client_id)))
+            .expect("authorization header"),
+    );
+    headers
+}
+
+fn remote_token(client_id: &str) -> String {
+    format!("remote-authz-matrix-token-{client_id}-abcdefghijklmnopqrstuvwxyz")
+}
+
+async fn assert_sse_status(
+    base_url: &str,
+    path: &str,
+    client_id: Option<&str>,
+    expected: StatusCode,
+) {
+    let client = reqwest::Client::new();
+    let mut request = client.get(format!("{base_url}{path}"));
+    if let Some(client_id) = client_id {
+        request = request
+            .header(REMOTE_CLIENT_ID_HEADER, client_id)
+            .bearer_auth(remote_token(client_id));
+    }
+    let response = timeout(Duration::from_secs(5), request.send())
+        .await
+        .expect("SSE auth response timed out")
+        .expect("send SSE request");
+    assert_eq!(response.status(), expected, "GET {path}");
+    if expected == StatusCode::OK {
+        assert_eq!(
+            response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+    }
+}
+
+async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {
+    let app = super::super::daemon_http_router(state);
+    serve_router(app).await
+}
+
+async fn serve_router(app: Router) -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener address");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve router");
+    });
+    (format!("http://{addr}"), server)
+}

--- a/src/daemon/websocket/dispatch/routing.rs
+++ b/src/daemon/websocket/dispatch/routing.rs
@@ -126,6 +126,7 @@ async fn dispatch_read_method(
         request.method.as_str(),
         ws_methods::HEALTH
             | ws_methods::DIAGNOSTICS
+            | ws_methods::GITHUB_STATUS
             | ws_methods::CONFIG
             | ws_methods::AUDIT_EVENTS
             | ws_methods::DAEMON_STOP

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -10,6 +10,8 @@ use crate::daemon::remote_identity::{
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+mod remote_authz_matrix;
+
 #[test]
 fn websocket_activity_logging_uses_debug_level() {
     assert_eq!(ws_activity_log_level(), tracing::Level::DEBUG);

--- a/src/daemon/websocket/dispatch/tests/remote_authz_matrix.rs
+++ b/src/daemon/websocket/dispatch/tests/remote_authz_matrix.rs
@@ -1,0 +1,172 @@
+use std::sync::{Arc, Mutex};
+
+use crate::daemon::http::{DaemonHttpAuthMode, DaemonHttpState};
+use crate::daemon::protocol::{WsRequest, ws_methods};
+use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+use crate::daemon::remote_auth::remote_ws_required_scope;
+use crate::daemon::remote_identity::{RemoteClientRegistration, RemoteStoredClient};
+use crate::daemon::websocket::connection::ConnectionState;
+
+use super::super::{RemoteWsAllowedAudit, authorize_remote_ws_request, dispatch};
+
+#[tokio::test]
+async fn remote_ws_authz_matrix_denies_missing_client_for_every_method() {
+    let mut state = crate::daemon::websocket::test_support::test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let connection = Arc::new(Mutex::new(ConnectionState::new()));
+
+    for method in ws_methods::ALL {
+        let request = ws_request(method);
+        let response = authorize_remote_ws_request(
+            &request,
+            &state,
+            &connection,
+            RemoteWsAllowedAudit::Success,
+        )
+        .await
+        .expect_err("missing remote client must be denied");
+        assert_remote_auth_error(&response, 401, method);
+    }
+}
+
+#[tokio::test]
+async fn remote_ws_authz_matrix_enforces_every_method_scope() {
+    let mut state = crate::daemon::websocket::test_support::test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let clients = MatrixClients::register(&state);
+
+    for method in ws_methods::ALL {
+        let required_scope = remote_ws_required_scope(method).expect("declared method scope");
+        let denied = clients.denied(required_scope);
+        let request = ws_request(method);
+        let response =
+            authorize_remote_ws_request(&request, &state, denied, RemoteWsAllowedAudit::Success)
+                .await
+                .expect_err("insufficient remote scope must be denied");
+        assert_remote_auth_error(&response, 403, method);
+
+        authorize_remote_ws_request(
+            &request,
+            &state,
+            clients.allowed(required_scope),
+            RemoteWsAllowedAudit::Success,
+        )
+        .await
+        .unwrap_or_else(|response| {
+            panic!(
+                "{method} rejected allowed {} scope: {response:?}",
+                required_scope.as_str()
+            );
+        });
+    }
+}
+
+#[tokio::test]
+async fn remote_ws_authz_matrix_routes_github_status_after_authorization() {
+    let mut state = crate::daemon::websocket::test_support::test_http_state_with_db();
+    state.auth_mode = DaemonHttpAuthMode::Remote;
+    let viewer = registered_client(&state, "github-viewer", RemoteRole::Viewer, &[]);
+    let connection = Arc::new(Mutex::new(ConnectionState::new_remote(viewer)));
+    let response = dispatch(&ws_request(ws_methods::GITHUB_STATUS), &state, &connection).await;
+
+    assert!(
+        response.error.is_none(),
+        "github.status did not reach its declared websocket handler: {:?}",
+        response.error
+    );
+}
+
+struct MatrixClients {
+    viewer: Arc<Mutex<ConnectionState>>,
+    operator: Arc<Mutex<ConnectionState>>,
+    admin: Arc<Mutex<ConnectionState>>,
+    write_only: Arc<Mutex<ConnectionState>>,
+}
+
+impl MatrixClients {
+    fn register(state: &DaemonHttpState) -> Self {
+        Self {
+            viewer: connection(registered_client(state, "viewer", RemoteRole::Viewer, &[])),
+            operator: connection(registered_client(
+                state,
+                "operator",
+                RemoteRole::Operator,
+                &[],
+            )),
+            admin: connection(registered_client(state, "admin", RemoteRole::Admin, &[])),
+            write_only: connection(registered_client(
+                state,
+                "write-only",
+                RemoteRole::Operator,
+                &[RemoteAccessScope::Write],
+            )),
+        }
+    }
+
+    fn allowed(&self, scope: RemoteAccessScope) -> &Arc<Mutex<ConnectionState>> {
+        match scope {
+            RemoteAccessScope::Read => &self.viewer,
+            RemoteAccessScope::Write => &self.operator,
+            RemoteAccessScope::Admin => &self.admin,
+        }
+    }
+
+    fn denied(&self, scope: RemoteAccessScope) -> &Arc<Mutex<ConnectionState>> {
+        match scope {
+            RemoteAccessScope::Read | RemoteAccessScope::Admin => &self.write_only,
+            RemoteAccessScope::Write => &self.viewer,
+        }
+    }
+}
+
+fn registered_client(
+    state: &DaemonHttpState,
+    client_id: &str,
+    role: RemoteRole,
+    scopes: &[RemoteAccessScope],
+) -> RemoteStoredClient {
+    let registration = RemoteClientRegistration::new_for_tests(
+        client_id,
+        "Authorization Matrix",
+        "test",
+        role,
+        scopes,
+        &format!("remote-authz-matrix-token-{client_id}-abcdefghijklmnopqrstuvwxyz"),
+        "2026-07-14T08:00:00Z",
+    )
+    .expect("matrix registration");
+    state
+        .db
+        .get()
+        .expect("db slot")
+        .lock()
+        .expect("db lock")
+        .register_remote_client(&registration)
+        .expect("register matrix client")
+}
+
+fn connection(client: RemoteStoredClient) -> Arc<Mutex<ConnectionState>> {
+    Arc::new(Mutex::new(ConnectionState::new_remote(client)))
+}
+
+fn ws_request(method: &str) -> WsRequest {
+    WsRequest {
+        id: format!("authz-matrix-{method}"),
+        method: method.to_string(),
+        params: serde_json::json!({}),
+        trace_context: None,
+    }
+}
+
+fn assert_remote_auth_error(
+    response: &crate::daemon::protocol::WsResponse,
+    status: u16,
+    method: &str,
+) {
+    let error = response.error.as_ref().unwrap_or_else(|| {
+        panic!("{method} did not return a remote authorization error");
+    });
+    assert_eq!(error.code, "REMOTE_AUTH", "{method}");
+    assert_eq!(error.status_code, Some(status), "{method}");
+    assert!(response.result.is_none(), "{method}");
+}


### PR DESCRIPTION
## Motivation

Remote authorization tests sampled representative routes, so they did not prove the full HTTP and WebSocket contract. The audit also found that `github.status` passed remote authorization but fell through to `UNKNOWN_METHOD` because the WS read router omitted it.

## Implementation

- Add contract-driven 401, 403, and allowed-scope matrices for every private HTTP route and declared WS method.
- Exercise both SSE routes through the real remote HTTP middleware.
- Route authenticated `github.status` WS requests to the existing read handler.
- Preserve the red proof for `github.status`, then pass the 5-test matrix, the 28-test remote auth slice, and `mise run harness:check`.