### PR TITLE
fix(monitor): recover after remote daemon restart

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Streaming.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Streaming.swift
@@ -50,7 +50,7 @@ extension HarnessMonitorStore {
               kind: .reconnecting,
               detail: "Transport closed, re-bootstrapping global stream"
             )
-            await reconnect()
+            scheduleReconnectAfterStreamFailure()
             return
           }
         }
@@ -64,7 +64,7 @@ extension HarnessMonitorStore {
             kind: .reconnecting,
             detail: "Global stream failed \(attempt) times, re-bootstrapping"
           )
-          await reconnect()
+          scheduleReconnectAfterStreamFailure()
           return
         }
 
@@ -114,7 +114,7 @@ extension HarnessMonitorStore {
               kind: .reconnecting,
               detail: "Transport closed, re-bootstrapping session stream"
             )
-            await reconnect()
+            scheduleReconnectAfterStreamFailure()
             return
           }
         }
@@ -128,7 +128,7 @@ extension HarnessMonitorStore {
             kind: .reconnecting,
             detail: "Session stream failed \(attempt) times, re-bootstrapping"
           )
-          await reconnect()
+          scheduleReconnectAfterStreamFailure()
           return
         }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingSupport.swift
@@ -5,6 +5,14 @@ extension HarnessMonitorStore {
     Self.streamReconnectDelays[min(attempt, Self.streamReconnectDelays.count - 1)]
   }
 
+  func scheduleReconnectAfterStreamFailure() {
+    // reconnect() cancels every stream task, including the caller. Move the
+    // replacement bootstrap to an independent task before the dead stream exits.
+    Task { @MainActor [weak self] in
+      await self?.reconnect()
+    }
+  }
+
   /// True when `error` means the WebSocket transport has been torn down
   /// (the `webSocketTask` is nil or the actor was shut down). The store's
   /// stream loops short-circuit on this so they do not burn the full

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorActionTestSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorActionTestSupport.swift
@@ -377,6 +377,7 @@ final class RecordingHarnessClient: HarnessMonitorClientProtocol, @unchecked Sen
   var hostBridgeStatusReport = BridgeStatusReport(running: false)
   var globalStreamEvents: [DaemonPushEvent] = []
   var globalStreamError: (any Error)?
+  var globalStreamErrorRemainingUses: Int?
   var sessionStreamEventsBySessionID: [String: [DaemonPushEvent]] = [:]
   var sessionStreamErrorsBySessionID: [String: any Error] = [:]
   var recordedShutdownCallCount = 0

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests.swift
@@ -25,6 +25,43 @@ struct HarnessMonitorStoreRemoteConnectionTests {
     #expect(await daemon.recordedLaunchAgentStateCallCount() == 0)
   }
 
+  @Test("Remote stream closure reconnects after a server restart")
+  func remoteStreamClosureReconnectsAfterServerRestart() async throws {
+    let fixture = try RemoteStoreFixture()
+    let client = RecordingHarnessClient()
+    let daemon = RecordingDaemonController(
+      client: client,
+      bootstrapChecksCancellation: true
+    )
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+
+    await store.bootstrap()
+    #expect(store.connectionState == .online)
+    #expect(await daemon.recordedBootstrapCallCount() == 1)
+
+    client.configureGlobalStream(
+      events: [],
+      error: WebSocketTransportError.connectionClosed,
+      failureCount: 1
+    )
+    store.startGlobalStream(using: client)
+
+    for _ in 0..<100 {
+      if await daemon.recordedBootstrapCallCount() >= 2, !store.isReconnecting {
+        break
+      }
+      try await Task.sleep(for: .milliseconds(20))
+    }
+
+    #expect(await daemon.recordedBootstrapCallCount() == 2)
+    #expect(store.connectionState == .online)
+    #expect(store.globalStreamTask != nil)
+    await store.prepareForTermination()
+  }
+
   @Test("Mobile relay uses the remote client without local daemon warm-up")
   func mobileRelayUsesRemoteClient() async throws {
     let fixture = try RemoteStoreFixture()

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingDaemonController.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingDaemonController.swift
@@ -8,6 +8,7 @@ actor RecordingDaemonController: DaemonControlling {
   private let registrationStateOverride: DaemonLaunchAgentRegistrationState?
   private let statusReportOverride: DaemonStatusReport?
   private let bootstrapError: (any Error)?
+  private let bootstrapChecksCancellation: Bool
   private let warmUpError: (any Error)?
   private let deferredManagedLaunchAgentRefreshResult: Bool
   private var lastEventMessage = "daemon ready"
@@ -24,6 +25,7 @@ actor RecordingDaemonController: DaemonControlling {
     registrationState: DaemonLaunchAgentRegistrationState? = nil,
     statusReport: DaemonStatusReport? = nil,
     bootstrapError: (any Error)? = nil,
+    bootstrapChecksCancellation: Bool = false,
     warmUpError: (any Error)? = nil,
     usesWarmUpErrorForBootstrap: Bool = true,
     deferredManagedLaunchAgentRefreshResult: Bool = false
@@ -33,12 +35,16 @@ actor RecordingDaemonController: DaemonControlling {
     self.registrationStateOverride = registrationState
     self.statusReportOverride = statusReport
     self.bootstrapError = bootstrapError ?? (usesWarmUpErrorForBootstrap ? warmUpError : nil)
+    self.bootstrapChecksCancellation = bootstrapChecksCancellation
     self.warmUpError = warmUpError
     self.deferredManagedLaunchAgentRefreshResult = deferredManagedLaunchAgentRefreshResult
   }
 
   func bootstrapClient() async throws -> any HarnessMonitorClientProtocol {
     bootstrapCallCount += 1
+    if bootstrapChecksCancellation {
+      try Task.checkCancellation()
+    }
     if let bootstrapError {
       throw bootstrapError
     }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+Base.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+Base.swift
@@ -130,7 +130,7 @@ extension RecordingHarnessClient {
   nonisolated func globalStream() -> DaemonPushEventStream {
     makeStream(
       events: configuredGlobalStreamEvents(),
-      error: configuredGlobalStreamError()
+      error: takeConfiguredGlobalStreamError()
     )
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+Config.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+Config.swift
@@ -312,31 +312,6 @@ extension RecordingHarnessClient {
     lock.withLock { timelineWindowErrorsBySessionID[sessionID] }
   }
 
-  func configureGlobalStream(
-    events: [DaemonPushEvent],
-    error: (any Error)? = nil
-  ) {
-    lock.withLock {
-      globalStreamEvents = events
-      globalStreamError = error
-    }
-  }
-
-  func configureSessionStream(
-    events: [DaemonPushEvent],
-    error: (any Error)? = nil,
-    for sessionID: String
-  ) {
-    lock.withLock {
-      sessionStreamEventsBySessionID[sessionID] = events
-      if let error {
-        sessionStreamErrorsBySessionID[sessionID] = error
-      } else {
-        sessionStreamErrorsBySessionID.removeValue(forKey: sessionID)
-      }
-    }
-  }
-
   func configureCodexRuns(_ runs: [CodexRunSnapshot], for sessionID: String) {
     lock.withLock {
       codexRunsBySessionID[sessionID] = runs

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+State.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+State.swift
@@ -175,8 +175,22 @@ extension RecordingHarnessClient {
     lock.withLock { globalStreamEvents }
   }
 
-  func configuredGlobalStreamError() -> (any Error)? {
-    lock.withLock { globalStreamError }
+  func takeConfiguredGlobalStreamError() -> (any Error)? {
+    lock.withLock {
+      guard let error = globalStreamError else {
+        return nil
+      }
+      guard let remainingUses = globalStreamErrorRemainingUses else {
+        return error
+      }
+      if remainingUses <= 1 {
+        globalStreamError = nil
+        globalStreamErrorRemainingUses = nil
+      } else {
+        globalStreamErrorRemainingUses = remainingUses - 1
+      }
+      return error
+    }
   }
 
   func configuredSessionStreamEvents(for sessionID: String) -> [DaemonPushEvent] {

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+StreamingConfig.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+StreamingConfig.swift
@@ -1,0 +1,30 @@
+@testable import HarnessMonitorKit
+
+extension RecordingHarnessClient {
+  func configureGlobalStream(
+    events: [DaemonPushEvent],
+    error: (any Error)? = nil,
+    failureCount: Int? = nil
+  ) {
+    lock.withLock {
+      globalStreamEvents = events
+      globalStreamError = error
+      globalStreamErrorRemainingUses = error == nil ? nil : failureCount
+    }
+  }
+
+  func configureSessionStream(
+    events: [DaemonPushEvent],
+    error: (any Error)? = nil,
+    for sessionID: String
+  ) {
+    lock.withLock {
+      sessionStreamEventsBySessionID[sessionID] = events
+      if let error {
+        sessionStreamErrorsBySessionID[sessionID] = error
+      } else {
+        sessionStreamErrorsBySessionID.removeValue(forKey: sessionID)
+      }
+    }
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+StreamingConfig.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+StreamingConfig.swift
@@ -8,8 +8,13 @@ extension RecordingHarnessClient {
   ) {
     lock.withLock {
       globalStreamEvents = events
-      globalStreamError = error
-      globalStreamErrorRemainingUses = error == nil ? nil : failureCount
+      if let failureCount, failureCount <= 0 {
+        globalStreamError = nil
+        globalStreamErrorRemainingUses = nil
+      } else {
+        globalStreamError = error
+        globalStreamErrorRemainingUses = error == nil ? nil : failureCount
+      }
     }
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClientStreamingConfigTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClientStreamingConfigTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+@testable import HarnessMonitorKit
+
+@Suite("Recording client stream configuration")
+struct RecordingHarnessClientStreamingConfigTests {
+  @Test("Zero global stream failures does not inject an error")
+  func zeroGlobalStreamFailuresDoesNotInjectError() async throws {
+    let client = RecordingHarnessClient()
+    client.configureGlobalStream(
+      events: [.ready(recordedAt: "2026-07-14T14:00:00Z")],
+      error: WebSocketTransportError.connectionClosed,
+      failureCount: 0
+    )
+
+    var iterator = client.globalStream().makeAsyncIterator()
+
+    #expect(try await iterator.next() != nil)
+    #expect(try await iterator.next() == nil)
+  }
+}


### PR DESCRIPTION
## Motivation

A remote daemon restart closes the Monitor global WebSocket. The stream task called `reconnect()` from inside itself, and `reconnect()` cancelled that same task before the replacement bootstrap completed, leaving the app offline until a manual reconnect.

## Implementation

- Schedule stream-failure reconnects on an independent MainActor task so stream teardown cannot cancel replacement bootstrap.
- Add a cancellation-sensitive remote-profile regression that proves one closed stream returns online.
- Split streaming configuration into a focused test-support companion and verify the fix against a real `smyk.la` systemd restart.
