### PR TITLE
fix(remote): audit pairing lifecycle

### DIFF
--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -61,6 +61,7 @@ mod remote_acme_cas;
 mod remote_identity;
 mod remote_identity_async;
 mod remote_pairing;
+mod remote_pairing_expiry;
 mod review_writes;
 mod runtime;
 mod schema;

--- a/src/daemon/db/remote_pairing.rs
+++ b/src/daemon/db/remote_pairing.rs
@@ -221,10 +221,12 @@ impl DaemonDb {
         {
             let error = RemotePairingError::Expired;
             let error_detail = error.to_string();
+            self.record_remote_pairing_expiration(pairing.pairing_id.as_str(), now)
+                .map_err(RemotePairingClaimCodeError::store)?;
             self.record_remote_audit_event(&RemoteAuditEvent::new(
                 claim.audit_event_id.as_str(),
                 now,
-                None,
+                claim.request_id.as_deref(),
                 Some(claim.client_id.as_str()),
                 ROUTE_REMOTE_PAIR_EXPIRE,
                 RemoteAccessScope::Read,
@@ -306,7 +308,7 @@ impl DaemonDb {
             &RemoteAuditEvent::new(
                 claim.audit_event_id.as_str(),
                 now,
-                None,
+                claim.request_id.as_deref(),
                 Some(claim.client_id.as_str()),
                 ROUTE_REMOTE_PAIR_CLAIM,
                 RemoteAccessScope::Read,
@@ -345,7 +347,7 @@ impl DaemonDb {
         self.record_remote_audit_event(&RemoteAuditEvent::new(
             claim.audit_event_id.as_str(),
             now,
-            None,
+            claim.request_id.as_deref(),
             Some(claim.client_id.as_str()),
             route_or_method,
             RemoteAccessScope::Read,

--- a/src/daemon/db/remote_pairing/status.rs
+++ b/src/daemon/db/remote_pairing/status.rs
@@ -40,6 +40,7 @@ impl DaemonDb {
             return Ok(RemotePairingStatus::Claimed);
         }
         if pairing_is_expired(&expires_at, now)? {
+            self.record_remote_pairing_expiration(pairing_id, now)?;
             return Ok(RemotePairingStatus::Expired);
         }
         Ok(RemotePairingStatus::Pending)

--- a/src/daemon/db/remote_pairing_expiry.rs
+++ b/src/daemon/db/remote_pairing_expiry.rs
@@ -1,0 +1,87 @@
+use rusqlite::params;
+use sqlx::query;
+
+use super::{AsyncDaemonDb, CliError, DaemonDb, db_error};
+
+const INSERT_REMOTE_PAIRING_EXPIRATION_SQL: &str = "
+INSERT OR IGNORE INTO remote_audit_events (
+    event_id, recorded_at, request_id, client_id, route_or_method, scope,
+    scope_decision, outcome, remote_addr, error_detail, metadata_json
+)
+SELECT
+    'remote-pair-expire-' || pairing_id,
+    expires_at,
+    NULL,
+    NULL,
+    'remote.pair.expire',
+    'read',
+    'denied',
+    'failure',
+    NULL,
+    'remote pairing code expired',
+    '{}'
+FROM remote_pairing_codes
+WHERE pairing_id = ?1
+  AND claimed_at IS NULL
+  AND unixepoch(expires_at) <= unixepoch(?2)";
+
+const INSERT_EXPIRED_REMOTE_PAIRINGS_SQL: &str = "
+INSERT OR IGNORE INTO remote_audit_events (
+    event_id, recorded_at, request_id, client_id, route_or_method, scope,
+    scope_decision, outcome, remote_addr, error_detail, metadata_json
+)
+SELECT
+    'remote-pair-expire-' || pairing_id,
+    expires_at,
+    NULL,
+    NULL,
+    'remote.pair.expire',
+    'read',
+    'denied',
+    'failure',
+    NULL,
+    'remote pairing code expired',
+    '{}'
+FROM remote_pairing_codes
+WHERE claimed_at IS NULL
+  AND unixepoch(expires_at) <= unixepoch(?1)";
+
+impl DaemonDb {
+    /// Record one pairing's lifecycle expiration at most once.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the expiration audit cannot be persisted.
+    pub(crate) fn record_remote_pairing_expiration(
+        &self,
+        pairing_id: &str,
+        now: &str,
+    ) -> Result<bool, CliError> {
+        let changed = self
+            .conn
+            .execute(
+                INSERT_REMOTE_PAIRING_EXPIRATION_SQL,
+                params![pairing_id, now],
+            )
+            .map_err(|error| {
+                db_error(format!(
+                    "record remote pairing expiration {pairing_id}: {error}"
+                ))
+            })?;
+        Ok(changed == 1)
+    }
+}
+
+impl AsyncDaemonDb {
+    /// Record every currently expired, unclaimed pairing at most once.
+    ///
+    /// # Errors
+    /// Returns [`CliError`] when the expiration sweep cannot be persisted.
+    pub(crate) async fn record_expired_remote_pairings(&self, now: &str) -> Result<u64, CliError> {
+        query(INSERT_EXPIRED_REMOTE_PAIRINGS_SQL)
+            .bind(now)
+            .execute(self.pool())
+            .await
+            .map(|result| result.rows_affected())
+            .map_err(|error| db_error(format!("record expired remote pairings: {error}")))
+    }
+}

--- a/src/daemon/db/tests/remote_pairing_status.rs
+++ b/src/daemon/db/tests/remote_pairing_status.rs
@@ -55,6 +55,23 @@ fn remote_pairing_status_classifies_lifecycle_without_exposing_records() {
         RemotePairingStatus::Expired
     );
     assert_eq!(
+        db.load_remote_pairing_status("pairing-status-expired", now)
+            .expect("repeated expired status"),
+        RemotePairingStatus::Expired
+    );
+    let expiration_events = db
+        .load_remote_audit_events(20)
+        .expect("pairing expiration audits")
+        .into_iter()
+        .filter(|event| event.route_or_method == "remote.pair.expire")
+        .collect::<Vec<_>>();
+    assert_eq!(expiration_events.len(), 1);
+    assert_eq!(
+        expiration_events[0].event_id,
+        "remote-pair-expire-pairing-status-expired"
+    );
+    assert_eq!(expiration_events[0].recorded_at, "2026-07-13T12:01:00Z");
+    assert_eq!(
         db.load_remote_pairing_status("unknown-pairing-id", now)
             .expect("unknown status"),
         RemotePairingStatus::Unavailable

--- a/src/daemon/http/remote_pairing.rs
+++ b/src/daemon/http/remote_pairing.rs
@@ -220,14 +220,24 @@ fn check_claim_rate_limit(
     drop(limiter);
     attempt.map_err(|error| match error {
         RemotePairingError::RateLimited => {
-            if record_rate_limit_audit(state, client_id, request_id, remote_addr).is_ok() {
-                RemotePairClaimHttpError::RateLimited
-            } else {
-                RemotePairClaimHttpError::StoreUnavailable
+            match record_rate_limit_audit(state, client_id, request_id, remote_addr) {
+                Ok(()) => RemotePairClaimHttpError::RateLimited,
+                Err(error) => {
+                    log_rate_limit_audit_failure(&error);
+                    RemotePairClaimHttpError::StoreUnavailable
+                }
             }
         }
         other => RemotePairClaimHttpError::Pairing(other),
     })
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+fn log_rate_limit_audit_failure(error: &CliError) {
+    tracing::error!(%error, "remote pairing rate-limit audit failed");
 }
 
 fn record_rate_limit_audit(

--- a/src/daemon/http/remote_pairing.rs
+++ b/src/daemon/http/remote_pairing.rs
@@ -104,7 +104,7 @@ fn claim_remote_pairing_for_addr(
     request_id: &str,
     remote_addr: &str,
 ) -> Result<RemotePairClaimHttpResponse, RemotePairClaimHttpError> {
-    let claim = authorize_pairing_claim(state, request, remote_addr)?;
+    let claim = authorize_pairing_claim(state, request, request_id, remote_addr)?;
     let claimed = claim_pairing_client(state, request.code.as_str(), &claim)?;
     log_remote_pairing_claimed(request_id, claimed.client.client_id.as_str());
     Ok(remote_pair_claim_response(claimed))
@@ -121,11 +121,18 @@ fn log_remote_pairing_claimed(request_id: &str, client_id: &str) {
 fn authorize_pairing_claim(
     state: &DaemonHttpState,
     request: &RemotePairClaimHttpRequest,
+    request_id: &str,
     remote_addr: &str,
 ) -> Result<RemotePairingClaimRequest, RemotePairClaimHttpError> {
-    check_claim_rate_limit(state, request.code.as_str(), remote_addr)?;
+    check_claim_rate_limit(
+        state,
+        request.code.as_str(),
+        request.client_id.as_str(),
+        request_id,
+        remote_addr,
+    )?;
     let expected_domain = expected_remote_domain(state)?;
-    build_pairing_claim(expected_domain, request, remote_addr)
+    build_pairing_claim(expected_domain, request, request_id, remote_addr)
 }
 
 fn expected_remote_domain(state: &DaemonHttpState) -> Result<&str, RemotePairClaimHttpError> {
@@ -140,6 +147,7 @@ fn expected_remote_domain(state: &DaemonHttpState) -> Result<&str, RemotePairCla
 fn build_pairing_claim(
     expected_domain: &str,
     request: &RemotePairClaimHttpRequest,
+    request_id: &str,
     remote_addr: &str,
 ) -> Result<RemotePairingClaimRequest, RemotePairClaimHttpError> {
     let audit_event_id = format!("remote-pair-claim-{}", Uuid::new_v4());
@@ -149,6 +157,7 @@ fn build_pairing_claim(
         request.client_id.as_str(),
         request.display_name.as_str(),
         request.platform.as_str(),
+        Some(request_id),
         Some(remote_addr),
         audit_event_id,
     )
@@ -195,6 +204,8 @@ fn remote_pair_claim_response(claimed: RemotePairingClaimedClient) -> RemotePair
 fn check_claim_rate_limit(
     state: &DaemonHttpState,
     code: &str,
+    client_id: &str,
+    request_id: &str,
     remote_addr: &str,
 ) -> Result<(), RemotePairClaimHttpError> {
     let code_fingerprint = RemotePairingCodeHash::from_code(code).map_or_else(
@@ -205,21 +216,30 @@ fn check_claim_rate_limit(
         .remote_pairing_limiter
         .lock()
         .map_err(|_| RemotePairClaimHttpError::StoreUnavailable)?;
-    limiter
-        .record_attempt(remote_addr, code_fingerprint.as_str())
-        .map_err(|error| match error {
-            RemotePairingError::RateLimited => {
-                let _ = record_rate_limit_audit(state, remote_addr);
+    let attempt = limiter.record_attempt(remote_addr, code_fingerprint.as_str());
+    drop(limiter);
+    attempt.map_err(|error| match error {
+        RemotePairingError::RateLimited => {
+            if record_rate_limit_audit(state, client_id, request_id, remote_addr).is_ok() {
                 RemotePairClaimHttpError::RateLimited
+            } else {
+                RemotePairClaimHttpError::StoreUnavailable
             }
-            other => RemotePairClaimHttpError::Pairing(other),
-        })
+        }
+        other => RemotePairClaimHttpError::Pairing(other),
+    })
 }
 
-fn record_rate_limit_audit(state: &DaemonHttpState, remote_addr: &str) -> Result<(), CliError> {
-    let Some(db) = state.db.get() else {
-        return Ok(());
-    };
+fn record_rate_limit_audit(
+    state: &DaemonHttpState,
+    client_id: &str,
+    request_id: &str,
+    remote_addr: &str,
+) -> Result<(), CliError> {
+    let db = state
+        .db
+        .get()
+        .ok_or_else(|| CliErrorKind::workflow_io("remote pairing audit store is unavailable"))?;
     let db = db
         .lock()
         .map_err(|error| CliErrorKind::workflow_io(format!("remote pairing db lock: {error}")))?;
@@ -227,8 +247,8 @@ fn record_rate_limit_audit(state: &DaemonHttpState, remote_addr: &str) -> Result
     db.record_remote_audit_event(&RemoteAuditEvent::new(
         event_id.as_str(),
         utc_now().as_str(),
-        None,
-        None,
+        Some(request_id),
+        Some(client_id),
         "remote.pair.rate_limit",
         RemoteAccessScope::Read,
         RemoteAuditScopeDecision::Denied,

--- a/src/daemon/http/response.rs
+++ b/src/daemon/http/response.rs
@@ -6,6 +6,7 @@ use axum::response::{IntoResponse, Response};
 use tracing::field::display;
 use uuid::Uuid;
 
+use crate::daemon::remote_identity::bounded_remote_request_id;
 use crate::errors::{CliError, CliErrorKind};
 use crate::telemetry::record_daemon_http_metrics;
 
@@ -147,5 +148,8 @@ pub(crate) fn extract_request_id(headers: &HeaderMap) -> String {
         .and_then(|value| value.to_str().ok())
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map_or_else(|| format!("daemon-{}", Uuid::new_v4()), ToString::to_string)
+        .map_or_else(
+            || format!("daemon-{}", Uuid::new_v4()),
+            bounded_remote_request_id,
+        )
 }

--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -150,6 +150,20 @@ fn extract_request_id_preserves_supplied_header() {
 }
 
 #[test]
+fn extract_request_id_bounds_supplied_header() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-request-id",
+        "r".repeat(300).parse().expect("long request id header"),
+    );
+
+    let request_id = extract_request_id(&headers);
+
+    assert_eq!(request_id.len(), 256);
+    assert!(request_id.ends_with("..."));
+}
+
+#[test]
 fn extract_request_id_generates_fallback_when_header_missing() {
     let first = extract_request_id(&HeaderMap::new());
     let second = extract_request_id(&HeaderMap::new());

--- a/src/daemon/http/tests.rs
+++ b/src/daemon/http/tests.rs
@@ -50,6 +50,7 @@ mod remote_clients;
 mod remote_limits;
 mod remote_limits_support;
 mod remote_pairing;
+mod remote_pairing_audit;
 mod remote_pairing_status;
 mod remote_viewer_diagnostics;
 mod remote_viewer_support;

--- a/src/daemon/http/tests/remote_pairing.rs
+++ b/src/daemon/http/tests/remote_pairing.rs
@@ -1,4 +1,3 @@
-use std::sync::{Arc, Mutex};
 use std::thread;
 
 use axum::http::StatusCode;
@@ -9,9 +8,7 @@ use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::protocol::http_paths;
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 use crate::daemon::remote_identity::{RemoteBearerToken, RemoteClientRegistration};
-use crate::daemon::remote_pairing::{
-    RemotePairingCode, RemotePairingRateLimiter, RemotePairingRecord,
-};
+use crate::daemon::remote_pairing::{RemotePairingCode, RemotePairingRecord};
 use crate::reviews::ReviewsQueryRequest;
 
 use super::test_http_state_with_db;
@@ -33,6 +30,7 @@ async fn remote_pair_claim_is_public_and_returns_one_time_client_token() {
 
     let response = reqwest::Client::new()
         .post(format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM))
+        .header("x-request-id", "pairing-http-success-request")
         .header("x-forwarded-for", "203.0.113.90")
         .json(&serde_json::json!({
             "code": code.expose(),
@@ -72,6 +70,10 @@ async fn remote_pair_claim_is_public_and_returns_one_time_client_token() {
         .into_iter()
         .find(|event| event.route_or_method == "remote.pair.claim")
         .expect("claim audit event");
+    assert_eq!(
+        claim_event.request_id.as_deref(),
+        Some("pairing-http-success-request")
+    );
     assert_eq!(claim_event.remote_addr.as_deref(), Some("127.0.0.1"));
 
     server.abort();
@@ -123,113 +125,6 @@ async fn remote_pair_claim_returns_server_owned_reviews_query() {
     );
     assert_eq!(body["reviews_query"]["cache_max_age_seconds"], 45);
     assert!(!body.to_string().contains(code.expose()));
-
-    server.abort();
-    let _ = server.await;
-}
-
-#[tokio::test]
-async fn remote_pair_claim_rejects_replay_and_audits_without_leaking_code() {
-    let state = remote_pairing_state();
-    let code = seed_pairing_code(
-        &state,
-        "pairing-http-replay",
-        RemoteRole::Viewer,
-        &[],
-        "http-replay-secret",
-        "2026-06-21T18:00:00Z",
-        "2099-06-21T18:10:00Z",
-    );
-    let db = state.db.get().expect("db slot").clone();
-    let (base_url, server) = serve_http(state).await;
-    let client = reqwest::Client::new();
-    let url = format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM);
-
-    let first = client
-        .post(&url)
-        .json(&serde_json::json!({
-            "code": code.expose(),
-            "domain": "daemon.example.com",
-            "client_id": "viewer-1",
-            "display_name": "Viewer iPhone",
-            "platform": "ios",
-        }))
-        .send()
-        .await
-        .expect("send first claim");
-    assert_eq!(first.status(), StatusCode::OK);
-
-    let replay = client
-        .post(&url)
-        .json(&serde_json::json!({
-            "code": code.expose(),
-            "domain": "daemon.example.com",
-            "client_id": "viewer-2",
-            "display_name": "Viewer iPad",
-            "platform": "ios",
-        }))
-        .send()
-        .await
-        .expect("send replay claim");
-
-    assert_eq!(replay.status(), StatusCode::CONFLICT);
-    let body = replay.json::<serde_json::Value>().await.expect("json body");
-    assert_eq!(body["error"]["code"], "REMOTE_PAIRING");
-    assert!(!body.to_string().contains(code.expose()));
-    let routes: Vec<_> = db
-        .lock()
-        .expect("db lock")
-        .load_remote_audit_events(10)
-        .expect("audit events")
-        .into_iter()
-        .map(|event| event.route_or_method)
-        .collect();
-    assert!(routes.contains(&"remote.pair.claim".to_string()));
-    assert!(routes.contains(&"remote.pair.replay".to_string()));
-
-    server.abort();
-    let _ = server.await;
-}
-
-#[tokio::test]
-async fn remote_pair_claim_rate_limits_one_ip_across_rotating_bad_codes() {
-    let mut state = remote_pairing_state();
-    state.remote_pairing_limiter = Arc::new(Mutex::new(RemotePairingRateLimiter::new_for_tests(2)));
-    let db = state.db.get().expect("db slot").clone();
-    let (base_url, server) = serve_http(state).await;
-    let client = reqwest::Client::new();
-    let url = format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM);
-
-    for (code, expected_status) in [
-        ("not-a-real-code-1", StatusCode::BAD_REQUEST),
-        ("not-a-real-code-2", StatusCode::BAD_REQUEST),
-        ("not-a-real-code-3", StatusCode::TOO_MANY_REQUESTS),
-    ] {
-        let response = client
-            .post(&url)
-            .json(&serde_json::json!({
-                "code": code,
-                "domain": "daemon.example.com",
-                "client_id": "ios-rate-limit",
-                "display_name": "iPhone",
-                "platform": "ios",
-            }))
-            .send()
-            .await
-            .expect("send bad claim");
-        assert_eq!(response.status(), expected_status);
-    }
-
-    let routes: Vec<_> = db
-        .lock()
-        .expect("db lock")
-        .load_remote_audit_events(10)
-        .expect("audit events")
-        .into_iter()
-        .map(|event| event.route_or_method)
-        .collect();
-    assert!(routes.contains(&"remote.pair.unknown".to_string()));
-    assert!(routes.contains(&"remote.pair.rate_limit".to_string()));
 
     server.abort();
     let _ = server.await;
@@ -432,14 +327,14 @@ async fn remote_pair_claim_replaces_existing_stable_client() {
     let _ = server.await;
 }
 
-fn remote_pairing_state() -> crate::daemon::http::DaemonHttpState {
+pub(super) fn remote_pairing_state() -> crate::daemon::http::DaemonHttpState {
     let mut state = test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
     state.remote_domain = Some("daemon.example.com".to_string());
     state
 }
 
-fn seed_pairing_code(
+pub(super) fn seed_pairing_code(
     state: &crate::daemon::http::DaemonHttpState,
     pairing_id: &str,
     role: RemoteRole,
@@ -489,7 +384,9 @@ fn seed_pairing_code_with_reviews_query(
     code
 }
 
-async fn serve_http(state: crate::daemon::http::DaemonHttpState) -> (String, JoinHandle<()>) {
+pub(super) async fn serve_http(
+    state: crate::daemon::http::DaemonHttpState,
+) -> (String, JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");

--- a/src/daemon/http/tests/remote_pairing_audit.rs
+++ b/src/daemon/http/tests/remote_pairing_audit.rs
@@ -1,11 +1,13 @@
 use std::sync::{Arc, Mutex};
 
 use axum::http::StatusCode;
+use tracing_subscriber::prelude::*;
 
 use crate::daemon::protocol::http_paths;
 use crate::daemon::remote::RemoteRole;
 use crate::daemon::remote_pairing::RemotePairingRateLimiter;
 
+use super::SharedOutput;
 use super::remote_pairing::{remote_pairing_state, seed_pairing_code, serve_http};
 
 #[tokio::test]
@@ -209,6 +211,14 @@ async fn remote_pair_claim_rate_limit_fails_closed_without_audit_storage() {
         .connection()
         .execute("DROP TABLE remote_audit_events", [])
         .expect("drop remote audit table");
+    let output = SharedOutput::default();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_target(false)
+            .with_writer(output.clone()),
+    );
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
     let (base_url, server) = serve_http(state).await;
 
     let response = reqwest::Client::new()
@@ -236,6 +246,10 @@ async fn remote_pair_claim_rate_limit_fails_closed_without_audit_storage() {
         "remote pairing store is unavailable"
     );
     assert!(!body.to_string().contains("rate-limited-client"));
+    let logs = output.contents();
+    assert!(logs.contains("remote pairing rate-limit audit failed"));
+    assert!(!logs.contains("rate-limited-client"));
+    assert!(!logs.contains("rate-limited-code"));
 
     server.abort();
     let _ = server.await;

--- a/src/daemon/http/tests/remote_pairing_audit.rs
+++ b/src/daemon/http/tests/remote_pairing_audit.rs
@@ -1,0 +1,242 @@
+use std::sync::{Arc, Mutex};
+
+use axum::http::StatusCode;
+
+use crate::daemon::protocol::http_paths;
+use crate::daemon::remote::RemoteRole;
+use crate::daemon::remote_pairing::RemotePairingRateLimiter;
+
+use super::remote_pairing::{remote_pairing_state, seed_pairing_code, serve_http};
+
+#[tokio::test]
+async fn remote_pair_claim_replay_preserves_request_provenance() {
+    let state = remote_pairing_state();
+    let code = seed_pairing_code(
+        &state,
+        "pairing-http-replay",
+        RemoteRole::Viewer,
+        &[],
+        "http-replay-secret",
+        "2026-06-21T18:00:00Z",
+        "2099-06-21T18:10:00Z",
+    );
+    let db = state.db.get().expect("db slot").clone();
+    let (base_url, server) = serve_http(state).await;
+    let client = reqwest::Client::new();
+    let url = format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM);
+
+    let first = client
+        .post(&url)
+        .json(&serde_json::json!({
+            "code": code.expose(),
+            "domain": "daemon.example.com",
+            "client_id": "viewer-1",
+            "display_name": "Viewer iPhone",
+            "platform": "ios",
+        }))
+        .send()
+        .await
+        .expect("send first claim");
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let replay = client
+        .post(&url)
+        .header("x-request-id", "pairing-http-replay-request")
+        .json(&serde_json::json!({
+            "code": code.expose(),
+            "domain": "daemon.example.com",
+            "client_id": "viewer-2",
+            "display_name": "Viewer iPad",
+            "platform": "ios",
+        }))
+        .send()
+        .await
+        .expect("send replay claim");
+
+    assert_eq!(replay.status(), StatusCode::CONFLICT);
+    let body = replay.json::<serde_json::Value>().await.expect("json body");
+    assert_eq!(body["error"]["code"], "REMOTE_PAIRING");
+    assert!(!body.to_string().contains(code.expose()));
+    let events = db
+        .lock()
+        .expect("db lock")
+        .load_remote_audit_events(10)
+        .expect("audit events");
+    let replay_event = events
+        .iter()
+        .find(|event| event.route_or_method == "remote.pair.replay")
+        .expect("replay audit event");
+    assert_eq!(
+        replay_event.request_id.as_deref(),
+        Some("pairing-http-replay-request")
+    );
+    assert_eq!(replay_event.client_id.as_deref(), Some("viewer-2"));
+    assert_eq!(replay_event.remote_addr.as_deref(), Some("127.0.0.1"));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn remote_pair_claim_rate_limit_preserves_request_provenance() {
+    let mut state = remote_pairing_state();
+    state.remote_pairing_limiter = Arc::new(Mutex::new(RemotePairingRateLimiter::new_for_tests(2)));
+    let db = state.db.get().expect("db slot").clone();
+    let (base_url, server) = serve_http(state).await;
+    let client = reqwest::Client::new();
+    let url = format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM);
+
+    for (index, expected_status) in [
+        StatusCode::BAD_REQUEST,
+        StatusCode::BAD_REQUEST,
+        StatusCode::TOO_MANY_REQUESTS,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let attempt = index + 1;
+        let response = client
+            .post(&url)
+            .header(
+                "x-request-id",
+                format!("pairing-rate-limit-request-{attempt}"),
+            )
+            .json(&serde_json::json!({
+                "code": format!("not-a-real-code-{attempt}"),
+                "domain": "daemon.example.com",
+                "client_id": "ios-rate-limit",
+                "display_name": "iPhone",
+                "platform": "ios",
+            }))
+            .send()
+            .await
+            .expect("send bad claim");
+        assert_eq!(response.status(), expected_status);
+    }
+
+    let events = db
+        .lock()
+        .expect("db lock")
+        .load_remote_audit_events(10)
+        .expect("audit events");
+    let rate_limit_event = events
+        .iter()
+        .find(|event| event.route_or_method == "remote.pair.rate_limit")
+        .expect("rate-limit audit event");
+    assert_eq!(
+        rate_limit_event.request_id.as_deref(),
+        Some("pairing-rate-limit-request-3")
+    );
+    assert_eq!(
+        rate_limit_event.client_id.as_deref(),
+        Some("ios-rate-limit")
+    );
+    assert_eq!(rate_limit_event.remote_addr.as_deref(), Some("127.0.0.1"));
+    assert!(
+        events
+            .iter()
+            .any(|event| event.route_or_method == "remote.pair.unknown")
+    );
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn remote_pair_claim_bounds_persisted_request_id() {
+    let state = remote_pairing_state();
+    let code = seed_pairing_code(
+        &state,
+        "pairing-http-bounded-request",
+        RemoteRole::Viewer,
+        &[],
+        "http-bounded-request-secret",
+        "2026-06-21T18:00:00Z",
+        "2099-06-21T18:10:00Z",
+    );
+    let db = state.db.get().expect("db slot").clone();
+    let (base_url, server) = serve_http(state).await;
+    let request_id = "r".repeat(300);
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM))
+        .header("x-request-id", request_id)
+        .json(&serde_json::json!({
+            "code": code.expose(),
+            "domain": "daemon.example.com",
+            "client_id": "bounded-request-viewer",
+            "display_name": "Viewer iPhone",
+            "platform": "ios",
+        }))
+        .send()
+        .await
+        .expect("send pairing claim");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let events = db
+        .lock()
+        .expect("db lock")
+        .load_remote_audit_events(10)
+        .expect("audit events");
+    let claim_event = events
+        .iter()
+        .find(|event| event.route_or_method == "remote.pair.claim")
+        .expect("claim audit event");
+    let stored_request_id = claim_event.request_id.as_deref().expect("request id");
+    assert_eq!(stored_request_id.len(), 256);
+    assert!(stored_request_id.ends_with("..."));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn remote_pair_claim_rate_limit_fails_closed_without_audit_storage() {
+    let mut state = remote_pairing_state();
+    state.remote_pairing_limiter = Arc::new(Mutex::new(RemotePairingRateLimiter::new_for_tests(1)));
+    state
+        .remote_pairing_limiter
+        .lock()
+        .expect("pairing limiter lock")
+        .record_attempt("127.0.0.1", "primed-code-fingerprint")
+        .expect("prime pairing limiter");
+    state
+        .db
+        .get()
+        .expect("db slot")
+        .lock()
+        .expect("db lock")
+        .connection()
+        .execute("DROP TABLE remote_audit_events", [])
+        .expect("drop remote audit table");
+    let (base_url, server) = serve_http(state).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}{}", http_paths::REMOTE_PAIR_CLAIM))
+        .header("x-request-id", "pairing-rate-limit-no-audit")
+        .json(&serde_json::json!({
+            "code": "rate-limited-code",
+            "domain": "daemon.example.com",
+            "client_id": "rate-limited-client",
+            "display_name": "Rate Limited Client",
+            "platform": "ios",
+        }))
+        .send()
+        .await
+        .expect("send rate-limited claim without audit storage");
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = response
+        .json::<serde_json::Value>()
+        .await
+        .expect("json body");
+    assert_eq!(body["error"]["code"], "REMOTE_PAIRING_STORE");
+    assert_eq!(
+        body["error"]["message"],
+        "remote pairing store is unavailable"
+    );
+    assert!(!body.to_string().contains("rate-limited-client"));
+
+    server.abort();
+    let _ = server.await;
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -51,6 +51,7 @@ pub(crate) mod remote_crypto;
 pub(crate) mod remote_diagnostics;
 pub mod remote_identity;
 pub mod remote_pairing;
+mod remote_pairing_expiry_loop;
 pub(crate) mod remote_redaction;
 pub(crate) mod remote_request_audit;
 pub(crate) mod remote_task_board;

--- a/src/daemon/remote_identity.rs
+++ b/src/daemon/remote_identity.rs
@@ -18,8 +18,8 @@ mod tests;
 const TOKEN_RANDOM_BYTES: usize = 32;
 const TOKEN_HINT_CHARS: usize = 6;
 const REDACTED_TOKEN_HINT: &str = "<redacted>";
-const REMOTE_AUDIT_REQUEST_ID_MAX_BYTES: usize = 256;
-const REMOTE_AUDIT_TRUNCATION_MARKER: &str = "...";
+const REMOTE_REQUEST_ID_MAX_BYTES: usize = 256;
+const REMOTE_REQUEST_ID_TRUNCATION_MARKER: &str = "...";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteIdentityError {
@@ -324,7 +324,7 @@ impl RemoteAuditEvent {
         Self {
             event_id: event_id.into(),
             recorded_at: recorded_at.into(),
-            request_id: request_id.map(bounded_remote_audit_request_id),
+            request_id: request_id.map(bounded_remote_request_id),
             client_id: client_id.map(ToOwned::to_owned),
             route_or_method: route_or_method.into(),
             scope,
@@ -341,17 +341,17 @@ impl RemoteAuditEvent {
     }
 }
 
-fn bounded_remote_audit_request_id(request_id: &str) -> String {
-    if request_id.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES {
+pub(crate) fn bounded_remote_request_id(request_id: &str) -> String {
+    if request_id.len() <= REMOTE_REQUEST_ID_MAX_BYTES {
         return request_id.to_owned();
     }
-    let mut boundary = REMOTE_AUDIT_REQUEST_ID_MAX_BYTES - REMOTE_AUDIT_TRUNCATION_MARKER.len();
+    let mut boundary = REMOTE_REQUEST_ID_MAX_BYTES - REMOTE_REQUEST_ID_TRUNCATION_MARKER.len();
     while !request_id.is_char_boundary(boundary) {
         boundary -= 1;
     }
-    let mut bounded = String::with_capacity(REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
+    let mut bounded = String::with_capacity(REMOTE_REQUEST_ID_MAX_BYTES);
     bounded.push_str(&request_id[..boundary]);
-    bounded.push_str(REMOTE_AUDIT_TRUNCATION_MARKER);
+    bounded.push_str(REMOTE_REQUEST_ID_TRUNCATION_MARKER);
     bounded
 }
 

--- a/src/daemon/remote_identity.rs
+++ b/src/daemon/remote_identity.rs
@@ -18,6 +18,8 @@ mod tests;
 const TOKEN_RANDOM_BYTES: usize = 32;
 const TOKEN_HINT_CHARS: usize = 6;
 const REDACTED_TOKEN_HINT: &str = "<redacted>";
+const REMOTE_AUDIT_REQUEST_ID_MAX_BYTES: usize = 256;
+const REMOTE_AUDIT_TRUNCATION_MARKER: &str = "...";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteIdentityError {
@@ -322,7 +324,7 @@ impl RemoteAuditEvent {
         Self {
             event_id: event_id.into(),
             recorded_at: recorded_at.into(),
-            request_id: request_id.map(ToOwned::to_owned),
+            request_id: request_id.map(bounded_remote_audit_request_id),
             client_id: client_id.map(ToOwned::to_owned),
             route_or_method: route_or_method.into(),
             scope,
@@ -337,6 +339,20 @@ impl RemoteAuditEvent {
     pub fn error_detail(&self) -> Option<&str> {
         self.error_detail.as_deref()
     }
+}
+
+fn bounded_remote_audit_request_id(request_id: &str) -> String {
+    if request_id.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES {
+        return request_id.to_owned();
+    }
+    let mut boundary = REMOTE_AUDIT_REQUEST_ID_MAX_BYTES - REMOTE_AUDIT_TRUNCATION_MARKER.len();
+    while !request_id.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    let mut bounded = String::with_capacity(REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
+    bounded.push_str(&request_id[..boundary]);
+    bounded.push_str(REMOTE_AUDIT_TRUNCATION_MARKER);
+    bounded
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/daemon/remote_identity_tests.rs
+++ b/src/daemon/remote_identity_tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteBearerToken,
-    RemoteClientRegistration, RemoteTokenHash, expand_client_scopes,
+    REMOTE_AUDIT_REQUEST_ID_MAX_BYTES, REMOTE_AUDIT_TRUNCATION_MARKER, RemoteAuditEvent,
+    RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteBearerToken, RemoteClientRegistration,
+    RemoteTokenHash, expand_client_scopes,
 };
 use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
 
@@ -98,4 +99,26 @@ fn remote_audit_event_redacts_secret_error_detail() {
         event.error_detail(),
         Some("upstream token=<redacted>&retry=1 secret=<redacted>")
     );
+}
+
+#[test]
+fn remote_audit_event_bounds_unicode_request_ids_on_a_character_boundary() {
+    let request_id = "\u{17c}".repeat(256);
+    let event = RemoteAuditEvent::new(
+        "event-bounded-request-id",
+        "2026-06-21T12:31:00Z",
+        Some(request_id.as_str()),
+        Some("client-1"),
+        "/v1/sessions",
+        RemoteAccessScope::Read,
+        RemoteAuditScopeDecision::Allowed,
+        RemoteAuditOutcome::Success,
+        Some("203.0.113.10"),
+        None,
+    );
+
+    let bounded = event.request_id.expect("bounded request id");
+    assert!(bounded.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
+    assert!(bounded.ends_with(REMOTE_AUDIT_TRUNCATION_MARKER));
+    assert!(bounded.is_char_boundary(bounded.len()));
 }

--- a/src/daemon/remote_identity_tests.rs
+++ b/src/daemon/remote_identity_tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    REMOTE_AUDIT_REQUEST_ID_MAX_BYTES, REMOTE_AUDIT_TRUNCATION_MARKER, RemoteAuditEvent,
+    REMOTE_REQUEST_ID_MAX_BYTES, REMOTE_REQUEST_ID_TRUNCATION_MARKER, RemoteAuditEvent,
     RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteBearerToken, RemoteClientRegistration,
     RemoteTokenHash, expand_client_scopes,
 };
@@ -118,7 +118,7 @@ fn remote_audit_event_bounds_unicode_request_ids_on_a_character_boundary() {
     );
 
     let bounded = event.request_id.expect("bounded request id");
-    assert!(bounded.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
-    assert!(bounded.ends_with(REMOTE_AUDIT_TRUNCATION_MARKER));
+    assert!(bounded.len() <= REMOTE_REQUEST_ID_MAX_BYTES);
+    assert!(bounded.ends_with(REMOTE_REQUEST_ID_TRUNCATION_MARKER));
     assert!(bounded.is_char_boundary(bounded.len()));
 }

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -279,6 +279,7 @@ pub struct RemotePairingClaimRequest {
     pub client_id: String,
     pub display_name: String,
     pub platform: String,
+    pub request_id: Option<String>,
     pub remote_addr: Option<String>,
     pub audit_event_id: String,
 }
@@ -292,12 +293,17 @@ impl RemotePairingClaimRequest {
     /// # Errors
     /// Returns [`RemotePairingError`] when the domains, client id, display name,
     /// platform, or audit event id are blank.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "pairing claims keep client identity and audit provenance explicit"
+    )]
     pub fn new(
         expected_domain: impl Into<String>,
         claimed_domain: impl Into<String>,
         client_id: impl Into<String>,
         display_name: impl Into<String>,
         platform: impl Into<String>,
+        request_id: Option<&str>,
         remote_addr: Option<&str>,
         audit_event_id: impl Into<String>,
     ) -> Result<Self, RemotePairingError> {
@@ -326,6 +332,7 @@ impl RemotePairingClaimRequest {
             client_id,
             display_name,
             platform,
+            request_id: request_id.map(ToOwned::to_owned),
             remote_addr: remote_addr.map(ToOwned::to_owned),
             audit_event_id,
         })
@@ -347,6 +354,7 @@ impl RemotePairingClaimRequest {
             client_id,
             display_name,
             platform,
+            None,
             remote_addr,
             audit_event_id,
         )

--- a/src/daemon/remote_pairing.rs
+++ b/src/daemon/remote_pairing.rs
@@ -9,7 +9,9 @@ use super::remote::{RemoteAccessScope, RemoteRole};
 use super::remote_crypto::{
     parse_sha256_storage_digest, sha256_storage_value, verify_sha256_storage_value,
 };
-use super::remote_identity::{RemoteBearerToken, RemoteIdentityError, RemoteStoredClient};
+use super::remote_identity::{
+    RemoteBearerToken, RemoteIdentityError, RemoteStoredClient, bounded_remote_request_id,
+};
 use crate::reviews::ReviewsQueryRequest;
 
 mod reviews;
@@ -332,7 +334,7 @@ impl RemotePairingClaimRequest {
             client_id,
             display_name,
             platform,
-            request_id: request_id.map(ToOwned::to_owned),
+            request_id: request_id.map(bounded_remote_request_id),
             remote_addr: remote_addr.map(ToOwned::to_owned),
             audit_event_id,
         })

--- a/src/daemon/remote_pairing_expiry_loop.rs
+++ b/src/daemon/remote_pairing_expiry_loop.rs
@@ -1,0 +1,180 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio::time::{MissedTickBehavior, interval};
+
+use super::db::AsyncDaemonDb;
+use crate::workspace::utc_now;
+
+const REMOTE_PAIRING_EXPIRY_INTERVAL: Duration = Duration::from_secs(30);
+
+pub(crate) fn spawn_remote_pairing_expiry_loop(
+    db: Arc<AsyncDaemonDb>,
+    shutdown_rx: watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    tokio::spawn(run_remote_pairing_expiry_loop(db, shutdown_rx))
+}
+
+async fn run_remote_pairing_expiry_loop(
+    db: Arc<AsyncDaemonDb>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let mut ticker = interval(REMOTE_PAIRING_EXPIRY_INTERVAL);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            () = wait_for_shutdown(&mut shutdown_rx) => break,
+            _ = ticker.tick() => record_expired_pairings(&db).await,
+        }
+    }
+}
+
+async fn wait_for_shutdown(shutdown_rx: &mut watch::Receiver<bool>) {
+    if *shutdown_rx.borrow() {
+        return;
+    }
+    while shutdown_rx.changed().await.is_ok() {
+        if *shutdown_rx.borrow() {
+            break;
+        }
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+async fn record_expired_pairings(db: &AsyncDaemonDb) {
+    match db.record_expired_remote_pairings(&utc_now()).await {
+        Ok(0) => {}
+        Ok(expired) => tracing::info!(expired, "recorded remote pairing expirations"),
+        Err(error) => tracing::error!(%error, "record remote pairing expirations"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::daemon::db::DaemonDb;
+    use crate::daemon::remote::{RemoteAccessScope, RemoteRole};
+    use crate::daemon::remote_pairing::{RemotePairingCode, RemotePairingRecord};
+
+    #[tokio::test]
+    async fn remote_pairing_expiry_loop_records_unused_expiration_once() {
+        let temp = tempdir().expect("create pairing expiry tempdir");
+        let db_path = temp.path().join("harness.db");
+        seed_expired_pairing(&db_path);
+        let async_db = Arc::new(
+            AsyncDaemonDb::connect(&db_path)
+                .await
+                .expect("open async pairing expiry database"),
+        );
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let handle = spawn_remote_pairing_expiry_loop(async_db, shutdown_rx);
+        wait_for_expiration(&db_path).await;
+        shutdown_tx.send(true).expect("signal expiry loop shutdown");
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("expiry loop shutdown timeout")
+            .expect("join expiry loop");
+
+        let events = DaemonDb::open(&db_path)
+            .expect("reopen pairing expiry database")
+            .load_remote_audit_events(20)
+            .expect("load pairing expiry audits");
+        let expiration_events = events
+            .iter()
+            .filter(|event| event.route_or_method == "remote.pair.expire")
+            .collect::<Vec<_>>();
+        assert_eq!(expiration_events.len(), 1);
+        assert_eq!(
+            expiration_events[0].event_id,
+            "remote-pair-expire-pairing-background-expired"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_pairing_expiration_sweep_is_idempotent() {
+        let temp = tempdir().expect("create pairing expiry sweep tempdir");
+        let db_path = temp.path().join("harness.db");
+        seed_expired_pairing(&db_path);
+        let db = AsyncDaemonDb::connect(&db_path)
+            .await
+            .expect("open async pairing expiry sweep database");
+
+        assert_eq!(
+            db.record_expired_remote_pairings("2026-07-14T12:00:00Z")
+                .await
+                .expect("record first pairing expiration sweep"),
+            1
+        );
+        assert_eq!(
+            db.record_expired_remote_pairings("2026-07-14T12:00:30Z")
+                .await
+                .expect("record repeated pairing expiration sweep"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_pairing_expiry_loop_honors_presignaled_shutdown() {
+        let temp = tempdir().expect("create presignaled shutdown tempdir");
+        let db_path = temp.path().join("harness.db");
+        seed_expired_pairing(&db_path);
+        let async_db = Arc::new(
+            AsyncDaemonDb::connect(&db_path)
+                .await
+                .expect("open presignaled shutdown database"),
+        );
+        let (_shutdown_tx, shutdown_rx) = watch::channel(true);
+
+        let handle = spawn_remote_pairing_expiry_loop(async_db, shutdown_rx);
+
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("presignaled expiry loop shutdown timeout")
+            .expect("join presignaled expiry loop");
+    }
+
+    async fn wait_for_expiration(db_path: &std::path::Path) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let recorded = DaemonDb::open(db_path)
+                    .expect("open pairing expiry poll database")
+                    .load_remote_audit_events(20)
+                    .expect("load pairing expiry poll audits")
+                    .iter()
+                    .any(|event| event.route_or_method == "remote.pair.expire");
+                if recorded {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("pairing expiration audit timeout");
+    }
+
+    fn seed_expired_pairing(db_path: &std::path::Path) {
+        let db = DaemonDb::open(db_path).expect("open pairing expiry database");
+        let code = RemotePairingCode::from_value_for_tests("background-expired-secret");
+        let record = RemotePairingRecord::new_for_tests(
+            "pairing-background-expired",
+            RemoteRole::Viewer,
+            &[RemoteAccessScope::Read],
+            code.expose(),
+            "2020-01-01T00:00:00Z",
+            "2020-01-01T00:10:00Z",
+        )
+        .expect("build expired pairing");
+        db.create_remote_pairing_code(&record, "audit-create-background-expired")
+            .expect("seed expired pairing");
+    }
+}

--- a/src/daemon/remote_pairing_expiry_loop.rs
+++ b/src/daemon/remote_pairing_expiry_loop.rs
@@ -47,7 +47,8 @@ async fn wait_for_shutdown(shutdown_rx: &mut watch::Receiver<bool>) {
     reason = "tracing macro expansion; tokio-rs/tracing#553"
 )]
 async fn record_expired_pairings(db: &AsyncDaemonDb) {
-    match db.record_expired_remote_pairings(&utc_now()).await {
+    let now = utc_now();
+    match db.record_expired_remote_pairings(now.as_str()).await {
         Ok(0) => {}
         Ok(expired) => tracing::info!(expired, "recorded remote pairing expirations"),
         Err(error) => tracing::error!(%error, "record remote pairing expirations"),

--- a/src/daemon/remote_pairing_tests.rs
+++ b/src/daemon/remote_pairing_tests.rs
@@ -131,6 +131,26 @@ fn remote_pairing_claim_request_separates_config_and_claim_domains() {
 }
 
 #[test]
+fn remote_pairing_claim_request_bounds_request_id() {
+    let request_id = "r".repeat(300);
+    let claim = RemotePairingClaimRequest::new(
+        "daemon.example.com",
+        "daemon.example.com",
+        "client-1",
+        "MacBook Pro",
+        "macos",
+        Some(request_id.as_str()),
+        Some("203.0.113.10"),
+        "audit-claim-bounded-request",
+    )
+    .expect("claim request");
+
+    let stored_request_id = claim.request_id.as_deref().expect("request id");
+    assert_eq!(stored_request_id.len(), 256);
+    assert!(stored_request_id.ends_with("..."));
+}
+
+#[test]
 fn remote_pairing_claim_request_rejects_blank_display_name_and_platform() {
     assert!(
         RemotePairingClaimRequest::new_for_tests(

--- a/src/daemon/remote_request_audit.rs
+++ b/src/daemon/remote_request_audit.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::sync::Arc;
 
 use uuid::Uuid;
@@ -8,9 +7,6 @@ use super::remote::RemoteAccessScope;
 use super::remote_identity::{RemoteAuditEvent, RemoteAuditOutcome, RemoteAuditScopeDecision};
 use crate::errors::{CliError, CliErrorKind};
 use crate::workspace::utc_now;
-
-const REMOTE_AUDIT_REQUEST_ID_MAX_BYTES: usize = 256;
-const REMOTE_AUDIT_TRUNCATION_MARKER: &str = "...";
 
 pub(crate) struct RemoteAuthorizationAudit<'a> {
     request_id: &'a str,
@@ -113,12 +109,11 @@ impl<'a> RemoteAuthorizationAudit<'a> {
         db: Option<&Arc<AsyncDaemonDb>>,
     ) -> Result<RemoteAuthorizationAuditReceipt, CliError> {
         let db = db.ok_or_else(remote_audit_store_unavailable)?;
-        let request_id = bounded_request_id(self.request_id);
         let event_id = format!("remote-auth-{}", Uuid::new_v4());
         let event = RemoteAuditEvent::new(
             event_id.clone(),
             utc_now(),
-            Some(request_id.as_ref()),
+            Some(self.request_id),
             self.client_id,
             self.target,
             self.scope,
@@ -141,20 +136,6 @@ fn remote_audit_store_unavailable() -> CliError {
     ))
 }
 
-fn bounded_request_id(request_id: &str) -> Cow<'_, str> {
-    if request_id.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES {
-        return Cow::Borrowed(request_id);
-    }
-    let mut boundary = REMOTE_AUDIT_REQUEST_ID_MAX_BYTES - REMOTE_AUDIT_TRUNCATION_MARKER.len();
-    while !request_id.is_char_boundary(boundary) {
-        boundary -= 1;
-    }
-    let mut bounded = String::with_capacity(REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
-    bounded.push_str(&request_id[..boundary]);
-    bounded.push_str(REMOTE_AUDIT_TRUNCATION_MARKER);
-    Cow::Owned(bounded)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,17 +147,6 @@ mod tests {
     use tempfile::tempdir;
 
     use super::super::db::DaemonDb;
-
-    #[test]
-    fn remote_authorization_audit_bounds_unicode_request_ids_on_a_character_boundary() {
-        let request_id = "\u{17c}".repeat(256);
-
-        let bounded = bounded_request_id(&request_id);
-
-        assert!(bounded.len() <= REMOTE_AUDIT_REQUEST_ID_MAX_BYTES);
-        assert!(bounded.ends_with(REMOTE_AUDIT_TRUNCATION_MARKER));
-        assert!(bounded.is_char_boundary(bounded.len()));
-    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn remote_authorization_audit_yields_while_sqlite_writer_finishes() {

--- a/src/daemon/service/serve/background_tasks.rs
+++ b/src/daemon/service/serve/background_tasks.rs
@@ -5,8 +5,10 @@ use tokio::sync::broadcast;
 use tokio::sync::watch as tokio_watch;
 use tokio::task::JoinHandle;
 
+use crate::daemon::http::DaemonHttpAuthMode;
 use crate::daemon::http::DaemonHttpState;
 use crate::daemon::protocol::StreamEvent;
+use crate::daemon::remote_pairing_expiry_loop::spawn_remote_pairing_expiry_loop;
 use crate::daemon::websocket::{PreparedBroadcast, ReplayBuffer, run_broadcast_fanout};
 
 use super::acp_inspect_publisher::spawn_acp_inspect_publisher;
@@ -36,6 +38,7 @@ pub(super) struct BackgroundTaskHandles {
     pub _acp_inspect_push: JoinHandle<()>,
     pub _github_data_change_push: JoinHandle<()>,
     pub _machine_heartbeat: Option<JoinHandle<()>>,
+    pub _remote_pairing_expiry: Option<JoinHandle<()>>,
     pub _task_board_dispatch_loop: Option<JoinHandle<()>>,
     pub _task_board_orchestrator_loop: Option<JoinHandle<()>>,
 }
@@ -46,6 +49,13 @@ pub(super) fn spawn_background_tasks(
     shutdown_rx: tokio_watch::Receiver<bool>,
 ) -> BackgroundTaskHandles {
     let async_db = app_state.async_db.get().cloned();
+    let remote_pairing_expiry = if app_state.auth_mode == DaemonHttpAuthMode::Remote {
+        async_db
+            .as_ref()
+            .map(|db| spawn_remote_pairing_expiry_loop(Arc::clone(db), shutdown_rx.clone()))
+    } else {
+        None
+    };
     BackgroundTaskHandles {
         _acp_inspect_push: spawn_acp_inspect_publisher(
             app_state.sender.clone(),
@@ -59,6 +69,7 @@ pub(super) fn spawn_background_tasks(
         _machine_heartbeat: async_db
             .as_ref()
             .map(|db| spawn_machine_heartbeat_loop(Arc::clone(db), shutdown_rx.clone())),
+        _remote_pairing_expiry: remote_pairing_expiry,
         _task_board_dispatch_loop: async_db
             .as_ref()
             .map(|_| spawn_task_board_dispatch_loop(app_state.clone(), shutdown_rx.clone())),


### PR DESCRIPTION
## Motivation
Public pairing decisions did not preserve request provenance, and unused codes could expire without a durable lifecycle event. Rate-limit denial also ignored audit storage failures.

## Implementation
- propagate bounded request IDs through claim, replay, and rate-limit audit records
- record each unclaimed expiry once and sweep them in remote mode with a shutdown-aware task
- fail closed when rate-limit audit storage is unavailable
- add TDD coverage for provenance, expiry idempotency, shutdown, and fail-closed behavior