### PR TITLE
fix(remote): persist request failure outcomes

### DIFF
--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -185,10 +185,10 @@ async fn complete_remote_http_audit(
         return response;
     }
     let error_detail = format!("remote HTTP handler returned status {}", status.as_u16());
-    match audit.mark_handler_failure(state, &error_detail).await {
-        Ok(()) => response,
-        Err(error) => auth_audit::unavailable_response(&error),
+    if let Err(error) = audit.mark_handler_failure(state, &error_detail).await {
+        auth_audit::log_update_failure(&error);
     }
+    response
 }
 
 async fn authenticate_and_audit_remote_http_request(

--- a/src/daemon/http/auth.rs
+++ b/src/daemon/http/auth.rs
@@ -131,6 +131,14 @@ pub(crate) async fn authorize_remote_http_request(
     if state.auth_mode == DaemonHttpAuthMode::Local {
         return next.run(request).await;
     }
+    authorize_remote_http_request_inner(&state, request, next).await
+}
+
+async fn authorize_remote_http_request_inner(
+    state: &DaemonHttpState,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
     let Some(route_path) = request
         .extensions()
         .get::<MatchedPath>()
@@ -148,17 +156,39 @@ pub(crate) async fn authorize_remote_http_request(
         Ok(audit) => audit,
         Err(error) => return remote_auth_error_response(error),
     };
-    let verification = verify_remote_client(request.headers(), &state);
-    let client =
-        match authenticate_and_audit_remote_http_request(&audit, verification, &state, route).await
-        {
-            Ok(client) => client,
-            Err(response) => return *response,
-        };
+    let verification = verify_remote_client(request.headers(), state);
+    let client = match authenticate_and_audit_remote_http_request(
+        &audit,
+        verification,
+        state,
+        route,
+    )
+    .await
+    {
+        Ok(client) => client,
+        Err(response) => return *response,
+    };
     let actor = client.control_plane_actor_id();
-    REMOTE_HTTP_CLIENT
+    let response = REMOTE_HTTP_CLIENT
         .scope(client, with_control_plane_actor(actor, next.run(request)))
-        .await
+        .await;
+    complete_remote_http_audit(&audit, state, response).await
+}
+
+async fn complete_remote_http_audit(
+    audit: &RemoteHttpAuditContext,
+    state: &DaemonHttpState,
+    response: Response,
+) -> Response {
+    let status = response.status();
+    if !status.is_client_error() && !status.is_server_error() {
+        return response;
+    }
+    let error_detail = format!("remote HTTP handler returned status {}", status.as_u16());
+    match audit.mark_handler_failure(state, &error_detail).await {
+        Ok(()) => response,
+        Err(error) => auth_audit::unavailable_response(&error),
+    }
 }
 
 async fn authenticate_and_audit_remote_http_request(

--- a/src/daemon/http/auth_audit.rs
+++ b/src/daemon/http/auth_audit.rs
@@ -14,7 +14,7 @@ use crate::daemon::remote_auth::{
 use crate::daemon::remote_request_audit::{
     RemoteAuthorizationAudit, RemoteAuthorizationAuditReceipt,
 };
-use crate::errors::CliError;
+use crate::errors::{CliError, CliErrorKind};
 
 use super::{DaemonConnectInfo, DaemonHttpState};
 
@@ -41,6 +41,7 @@ pub(super) struct RemoteHttpAuditContext {
     scope: RemoteAccessScope,
     remote_addr: Option<String>,
     marker: Option<RemoteHttpAuditMarker>,
+    receipt: OnceLock<RemoteAuthorizationAuditReceipt>,
 }
 
 impl RemoteHttpAuditContext {
@@ -58,6 +59,7 @@ impl RemoteHttpAuditContext {
                 .get::<ConnectInfo<DaemonConnectInfo>>()
                 .map(|ConnectInfo(info)| info.remote_addr().ip().to_string()),
             marker: request.extensions().get::<RemoteHttpAuditMarker>().cloned(),
+            receipt: OnceLock::new(),
         })
     }
 
@@ -134,11 +136,27 @@ impl RemoteHttpAuditContext {
         Ok(true)
     }
 
+    pub(super) async fn mark_handler_failure(
+        &self,
+        state: &DaemonHttpState,
+        error_detail: &str,
+    ) -> Result<(), CliError> {
+        let receipt = self.receipt.get().ok_or_else(|| {
+            CliError::from(CliErrorKind::workflow_io(
+                "remote authorization audit receipt is unavailable",
+            ))
+        })?;
+        receipt
+            .mark_failed(state.async_db.get(), error_detail)
+            .await
+    }
+
     fn finish_record(
         &self,
         result: Result<RemoteAuthorizationAuditReceipt, CliError>,
     ) -> Result<(), CliError> {
         let receipt = result?;
+        drop(self.receipt.set(receipt.clone()));
         if let Some(marker) = &self.marker {
             marker.mark_recorded(receipt);
         }

--- a/src/daemon/http/auth_audit.rs
+++ b/src/daemon/http/auth_audit.rs
@@ -190,6 +190,14 @@ pub(super) fn unavailable_response(error: &CliError) -> Response {
     clippy::cognitive_complexity,
     reason = "tracing macro expansion inflates the score; tokio-rs/tracing#553"
 )]
+pub(super) fn log_update_failure(error: &CliError) {
+    tracing::error!(error = %error, "remote authorization audit update failed");
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion inflates the score; tokio-rs/tracing#553"
+)]
 fn log_unavailable(error: &CliError) {
     tracing::error!(error = %error, "remote authorization audit failed");
 }

--- a/src/daemon/http/tests/remote_authz_audit.rs
+++ b/src/daemon/http/tests/remote_authz_audit.rs
@@ -78,6 +78,48 @@ async fn remote_authorization_audit_records_http_allow_and_deny() {
 }
 
 #[tokio::test]
+async fn remote_authorization_audit_records_http_handler_failures() {
+    const MISSING_SESSION_ID: &str = "00000000-0000-4000-8000-000000000001";
+
+    let state = remote_state_with_viewer();
+    let audit_state = state.clone();
+    let (base_url, server) = serve_remote(state).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{base_url}/v1/sessions/{MISSING_SESSION_ID}"))
+        .header("x-request-id", "audit-http-handler-failure")
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .send()
+        .await
+        .expect("send failing authorized request");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let events = remote_audits(&audit_state);
+    let event = audit_for_request(&events, "audit-http-handler-failure");
+    assert_eq!(
+        event.route_or_method,
+        format!("GET {}", http_paths::SESSION_DETAIL)
+    );
+    assert_eq!(event.scope, RemoteAccessScope::Read);
+    assert_eq!(event.scope_decision, RemoteAuditScopeDecision::Allowed);
+    assert_eq!(event.outcome, RemoteAuditOutcome::Failure);
+    assert_eq!(
+        event.error_detail.as_deref(),
+        Some("remote HTTP handler returned status 400")
+    );
+    assert!(
+        !event
+            .error_detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains(MISSING_SESSION_ID)
+    );
+
+    stop_server(server).await;
+}
+
+#[tokio::test]
 async fn remote_authorization_audit_redacts_unauthenticated_attempts() {
     let mut state = test_http_state_with_db();
     state.auth_mode = DaemonHttpAuthMode::Remote;
@@ -208,6 +250,44 @@ async fn remote_authorization_audit_records_websocket_methods() {
     assert_eq!(
         write.error_detail.as_deref(),
         Some("remote client scope is insufficient")
+    );
+
+    let _ = socket.close(None).await;
+    stop_server(server).await;
+}
+
+#[tokio::test]
+async fn remote_authorization_audit_records_websocket_handler_failures() {
+    let state = remote_state_with_viewer();
+    let audit_state = state.clone();
+    let (base_url, server) = serve_remote(state).await;
+    let request = remote_ws_request(&base_url, "viewer", "audit-ws-failure-handshake");
+    let (mut socket, _) = connect_async(request).await.expect("connect websocket");
+
+    let response = ws_rpc(
+        &mut socket,
+        "audit-ws-handler-failure",
+        ws_methods::SESSION_DETAIL,
+    )
+    .await;
+    assert_eq!(response["error"]["code"], "MISSING_PARAM");
+
+    let events = remote_audits(&audit_state);
+    let event = audit_for_request(&events, "audit-ws-handler-failure");
+    assert_eq!(event.route_or_method, ws_methods::SESSION_DETAIL);
+    assert_eq!(event.scope, RemoteAccessScope::Read);
+    assert_eq!(event.scope_decision, RemoteAuditScopeDecision::Allowed);
+    assert_eq!(event.outcome, RemoteAuditOutcome::Failure);
+    assert_eq!(
+        event.error_detail.as_deref(),
+        Some("remote WebSocket handler returned error MISSING_PARAM")
+    );
+    assert!(
+        !event
+            .error_detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("session_id")
     );
 
     let _ = socket.close(None).await;

--- a/src/daemon/http/tests/remote_authz_audit.rs
+++ b/src/daemon/http/tests/remote_authz_audit.rs
@@ -1,4 +1,9 @@
+use axum::extract::State;
 use axum::http::{Request, StatusCode};
+use axum::middleware;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
 use futures_util::{Sink, SinkExt as _, Stream, StreamExt as _};
 use rusqlite::Connection;
 use serde_json::json;
@@ -115,6 +120,36 @@ async fn remote_authorization_audit_records_http_handler_failures() {
             .unwrap_or_default()
             .contains(MISSING_SESSION_ID)
     );
+
+    stop_server(server).await;
+}
+
+#[tokio::test]
+async fn remote_authorization_audit_update_failure_preserves_http_response() {
+    let state = remote_state_with_viewer();
+    let app = Router::new()
+        .route(http_paths::HEALTH, get(drop_audit_store_then_fail))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            super::super::auth::authorize_remote_http_request,
+        ))
+        .with_state(state);
+    let (base_url, server) = serve_router(app).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{base_url}{}", http_paths::HEALTH))
+        .header("x-request-id", "audit-http-update-failure")
+        .header(REMOTE_CLIENT_ID_HEADER, "viewer")
+        .bearer_auth(remote_token("viewer"))
+        .send()
+        .await
+        .expect("send request whose audit update fails");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response
+        .json::<serde_json::Value>()
+        .await
+        .expect("handler error json");
+    assert_eq!(body["error"]["code"], "HANDLER_FAILURE");
 
     stop_server(server).await;
 }
@@ -370,6 +405,14 @@ fn drop_remote_audit_table(state: &DaemonHttpState) {
         .expect("drop remote audit table");
 }
 
+async fn drop_audit_store_then_fail(State(state): State<DaemonHttpState>) -> impl IntoResponse {
+    drop_remote_audit_table(&state);
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({"error": {"code": "HANDLER_FAILURE"}})),
+    )
+}
+
 fn remote_token(client_id: &str) -> String {
     format!("remote-token-secret-{client_id}")
 }
@@ -430,11 +473,14 @@ where
 }
 
 async fn serve_remote(state: DaemonHttpState) -> (String, JoinHandle<()>) {
+    serve_router(super::super::daemon_http_router(state)).await
+}
+
+async fn serve_router(app: Router) -> (String, JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener address");
-    let app = super::super::daemon_http_router(state);
     let server = tokio::spawn(async move {
         axum::serve(
             listener,

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -12,7 +12,9 @@ use crate::daemon::remote_auth::{
     RemoteAuthError, authorize_remote_ws_method, remote_ws_required_scope,
 };
 use crate::daemon::remote_identity::RemoteStoredClient;
-use crate::daemon::remote_request_audit::RemoteAuthorizationAudit;
+use crate::daemon::remote_request_audit::{
+    RemoteAuthorizationAudit, RemoteAuthorizationAuditReceipt,
+};
 use crate::daemon::remote_viewer::is_remote_viewer;
 use crate::errors::CliError;
 use crate::telemetry::{
@@ -184,25 +186,52 @@ async fn dispatch_inner(
     state: &DaemonHttpState,
     connection: &Arc<Mutex<ConnectionState>>,
 ) -> WsResponse {
-    if let Err(response) =
-        authorize_remote_ws_request(request, state, connection, RemoteWsAllowedAudit::Success).await
+    let audit_receipt = match authorize_remote_ws_request(
+        request,
+        state,
+        connection,
+        RemoteWsAllowedAudit::Success,
+    )
+    .await
     {
-        return *response;
-    }
-    if let Some(response) = with_connection_actor(
+        Ok(receipt) => receipt,
+        Err(response) => return *response,
+    };
+    let response = if let Some(response) = with_connection_actor(
         state,
         connection,
         routing::dispatch_known_method(request, state, connection),
     )
     .await
     {
+        response
+    } else {
+        error_response(
+            &request.id,
+            "UNKNOWN_METHOD",
+            &format!("unknown method: {}", request.method),
+        )
+    };
+    complete_remote_ws_audit(request, state, audit_receipt, response).await
+}
+
+async fn complete_remote_ws_audit(
+    request: &WsRequest,
+    state: &DaemonHttpState,
+    receipt: Option<RemoteAuthorizationAuditReceipt>,
+    response: WsResponse,
+) -> WsResponse {
+    let (Some(receipt), Some(error)) = (receipt, response.error.as_ref()) else {
         return response;
+    };
+    let error_detail = format!("remote WebSocket handler returned error {}", error.code);
+    match receipt
+        .mark_failed(state.async_db.get(), &error_detail)
+        .await
+    {
+        Ok(()) => response,
+        Err(error) => *remote_ws_audit_error_response(request, &error),
     }
-    error_response(
-        &request.id,
-        "UNKNOWN_METHOD",
-        &format!("unknown method: {}", request.method),
-    )
 }
 
 async fn with_connection_actor<T>(
@@ -232,9 +261,9 @@ async fn authorize_remote_ws_request(
     state: &DaemonHttpState,
     connection: &Arc<Mutex<ConnectionState>>,
     allowed_audit: RemoteWsAllowedAudit<'_>,
-) -> Result<(), Box<WsResponse>> {
+) -> Result<Option<RemoteAuthorizationAuditReceipt>, Box<WsResponse>> {
     if state.auth_mode == DaemonHttpAuthMode::Local || !is_declared_ws_method(&request.method) {
-        return Ok(());
+        return Ok(None);
     }
     let required_scope = remote_ws_required_scope(&request.method)
         .map_err(|error| Box::new(remote_ws_auth_error_response(&request.id, error)))?;
@@ -290,10 +319,11 @@ async fn authorize_remote_ws_request(
                     )
                 }
             };
+            let track_handler_outcome = matches!(allowed_audit, RemoteWsAllowedAudit::Success);
             audit
                 .record(state.async_db.get())
                 .await
-                .map(|_| ())
+                .map(|receipt| track_handler_outcome.then_some(receipt))
                 .map_err(|error| remote_ws_audit_error_response(request, &error))
         }
         Err(error) => {

--- a/src/daemon/websocket/dispatch.rs
+++ b/src/daemon/websocket/dispatch.rs
@@ -225,13 +225,13 @@ async fn complete_remote_ws_audit(
         return response;
     };
     let error_detail = format!("remote WebSocket handler returned error {}", error.code);
-    match receipt
+    if let Err(error) = receipt
         .mark_failed(state.async_db.get(), &error_detail)
         .await
     {
-        Ok(()) => response,
-        Err(error) => *remote_ws_audit_error_response(request, &error),
+        log_remote_ws_audit_error(request, &error);
     }
+    response
 }
 
 async fn with_connection_actor<T>(

--- a/src/daemon/websocket/dispatch/tests.rs
+++ b/src/daemon/websocket/dispatch/tests.rs
@@ -7,6 +7,7 @@ use crate::daemon::remote_identity::{
     RemoteAuditOutcome, RemoteAuditScopeDecision, RemoteClientRegistration, RemoteStoredClient,
     RemoteTokenHash,
 };
+use rusqlite::Connection;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -176,6 +177,35 @@ async fn remote_ws_dispatch_preserves_unknown_method_errors() {
     assert_eq!(error.code, "UNKNOWN_METHOD");
     assert!(error.message.contains("remote.unscoped"));
     assert_eq!(error.status_code, None);
+}
+
+#[tokio::test]
+async fn remote_ws_audit_update_failure_preserves_handler_response() {
+    let state = super::super::test_support::test_http_state_with_db();
+    let request = ws_request("req-audit-update-failure", ws_methods::PING);
+    let receipt = RemoteAuthorizationAudit::allowed(
+        &request.id,
+        "viewer",
+        &request.method,
+        RemoteAccessScope::Read,
+        Some("127.0.0.1"),
+    )
+    .record(state.async_db.get())
+    .await
+    .expect("record allowed websocket audit");
+    Connection::open(state.db_path.as_ref().expect("db path"))
+        .expect("open audit database")
+        .execute("DROP TABLE remote_audit_events", [])
+        .expect("drop remote audit table");
+    let handler_response =
+        error_response(&request.id, "HANDLER_FAILURE", "original handler failure");
+
+    let response =
+        complete_remote_ws_audit(&request, &state, Some(receipt), handler_response).await;
+    let error = response.error.expect("handler error");
+
+    assert_eq!(error.code, "HANDLER_FAILURE");
+    assert_eq!(error.message, "original handler failure");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation
Remote authorization audit events were persisted before dispatch as successful and never updated when an authorized HTTP or WebSocket handler failed. This made failed remote operations look successful.

## Implementation
- retain allowed authorization audit receipts through handler completion
- mark HTTP 4xx/5xx and WebSocket error responses as failed with redacted status/code detail
- add black-box HTTP and WebSocket outcome tests while preserving pre-dispatch fail-closed behavior