### PR TITLE
fix(remote): finish issuance before DNS cleanup

### DIFF
--- a/src/daemon/remote_acme_issuer.rs
+++ b/src/daemon/remote_acme_issuer.rs
@@ -1,9 +1,7 @@
 use std::env;
 use std::fmt;
-use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::thread;
 
 use async_trait::async_trait;
 use instant_acme::{
@@ -11,22 +9,23 @@ use instant_acme::{
     ChallengeType, Identifier, LetsEncrypt, NewAccount, NewOrder, Order, OrderStatus, RetryPolicy,
 };
 use rcgen::{CertificateParams, DistinguishedName, KeyPair};
-use tokio::runtime::{Handle, Runtime};
 
 use super::remote::{
     RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider, validate_remote_serve_config,
 };
-use super::remote_acme::{
-    RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
-    RemoteCertificateBundle,
-};
-use super::remote_acme_challenge::SystemRemoteAcmeChallengeProvisioner;
+use super::remote_acme::{RemoteAcmeAccountCredentials, RemoteCertificateBundle};
 use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use super::remote_acme_lease_guard::RemoteAcmeChallengeLeaseGuard;
 use super::remote_redaction::redact_secret_detail;
 use super::remote_tls::ensure_rustls_provider;
 
 type AccountBuilderFactory = dyn Fn() -> Result<AccountBuilder, String> + Send + Sync + 'static;
+
+#[derive(Clone, Copy)]
+enum SuccessfulCleanupMode {
+    Await,
+    Track,
+}
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) enum RemoteAcmeChallengeMaterial {
@@ -196,11 +195,12 @@ where
         config: &RemoteDaemonServeConfig,
         previous_private_key_pem: Option<&str>,
     ) -> Result<RemoteCertificateBundle, String> {
-        self.issue_certificate_with_cleanup(
+        self.issue_certificate_with_cleanup_mode(
             credentials,
             config,
             previous_private_key_pem,
             RemoteAcmeCleanupTracker::default(),
+            SuccessfulCleanupMode::Await,
         )
         .await
     }
@@ -212,6 +212,40 @@ where
         previous_private_key_pem: Option<&str>,
         cleanup_tracker: RemoteAcmeCleanupTracker,
     ) -> Result<RemoteCertificateBundle, String> {
+        self.issue_certificate_with_cleanup_mode(
+            credentials,
+            config,
+            previous_private_key_pem,
+            cleanup_tracker,
+            SuccessfulCleanupMode::Track,
+        )
+        .await
+    }
+
+    pub(crate) async fn issue_certificate_and_await_cleanup(
+        &self,
+        credentials: &RemoteAcmeAccountCredentials,
+        config: &RemoteDaemonServeConfig,
+        previous_private_key_pem: Option<&str>,
+    ) -> Result<RemoteCertificateBundle, String> {
+        self.issue_certificate_with_cleanup_mode(
+            credentials,
+            config,
+            previous_private_key_pem,
+            RemoteAcmeCleanupTracker::default(),
+            SuccessfulCleanupMode::Await,
+        )
+        .await
+    }
+
+    async fn issue_certificate_with_cleanup_mode(
+        &self,
+        credentials: &RemoteAcmeAccountCredentials,
+        config: &RemoteDaemonServeConfig,
+        previous_private_key_pem: Option<&str>,
+        cleanup_tracker: RemoteAcmeCleanupTracker,
+        cleanup_mode: SuccessfulCleanupMode,
+    ) -> Result<RemoteCertificateBundle, String> {
         validate_remote_serve_config(config).map_err(|error| error.to_string())?;
         let account = self.restore_account(credentials).await?;
         let identifiers = [Identifier::Dns(config.domain.trim().to_string())];
@@ -219,8 +253,45 @@ where
             .new_order(&NewOrder::new(&identifiers))
             .await
             .map_err(|error| redacted_acme_error(&error))?;
-        self.complete_authorizations(&mut order, config, cleanup_tracker)
+        let leases = self
+            .complete_authorizations(&mut order, config, cleanup_tracker)
             .await?;
+        let issuance = self
+            .finalize_certificate(&mut order, config, previous_private_key_pem)
+            .await;
+        Self::finish_issuance(issuance, leases, cleanup_mode).await
+    }
+
+    async fn finish_issuance(
+        issuance: Result<RemoteCertificateBundle, String>,
+        leases: RemoteAcmeChallengeLeaseGuard<P>,
+        cleanup_mode: SuccessfulCleanupMode,
+    ) -> Result<RemoteCertificateBundle, String> {
+        let bundle = match issuance {
+            Ok(bundle) => bundle,
+            Err(error) => return Self::cleanup_after_error(leases, error).await,
+        };
+        Self::finish_successful_cleanup(leases, cleanup_mode).await?;
+        Ok(bundle)
+    }
+
+    async fn finish_successful_cleanup(
+        leases: RemoteAcmeChallengeLeaseGuard<P>,
+        cleanup_mode: SuccessfulCleanupMode,
+    ) -> Result<(), String> {
+        match cleanup_mode {
+            SuccessfulCleanupMode::Await => leases.cleanup().await?,
+            SuccessfulCleanupMode::Track => leases.cleanup_in_background(),
+        }
+        Ok(())
+    }
+
+    async fn finalize_certificate(
+        &self,
+        order: &mut Order,
+        config: &RemoteDaemonServeConfig,
+        previous_private_key_pem: Option<&str>,
+    ) -> Result<RemoteCertificateBundle, String> {
         let private_key = previous_private_key_pem.map_or_else(
             || KeyPair::generate().map_err(|error| error.to_string()),
             |pem| KeyPair::from_pem(pem).map_err(|error| error.to_string()),
@@ -260,7 +331,7 @@ where
         order: &mut Order,
         config: &RemoteDaemonServeConfig,
         cleanup_tracker: RemoteAcmeCleanupTracker,
-    ) -> Result<(), String> {
+    ) -> Result<RemoteAcmeChallengeLeaseGuard<P>, String> {
         let mut leases =
             RemoteAcmeChallengeLeaseGuard::new(Arc::clone(&self.provisioner), cleanup_tracker);
         let authorization_result = self
@@ -280,12 +351,9 @@ where
                     Err(format!("remote ACME order became {status:?}"))
                 }
             });
-        match (poll_result, leases.cleanup().await) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
-            (Err(issue), Err(cleanup)) => Err(format!(
-                "{issue}; remote ACME challenge cleanup also failed: {cleanup}"
-            )),
+        match poll_result {
+            Ok(()) => Ok(leases),
+            Err(error) => Self::cleanup_after_error(leases, error).await,
         }
     }
 
@@ -328,10 +396,10 @@ where
         Ok(())
     }
 
-    async fn cleanup_after_error(
+    async fn cleanup_after_error<T>(
         leases: RemoteAcmeChallengeLeaseGuard<P>,
         issue: String,
-    ) -> Result<(), String> {
+    ) -> Result<T, String> {
         match leases.cleanup().await {
             Ok(()) => Err(issue),
             Err(cleanup) => Err(format!(
@@ -404,77 +472,10 @@ fn redacted_acme_error(error: &instant_acme::Error) -> String {
     redact_secret_detail(&error.to_string())
 }
 
-pub(crate) struct SystemRemoteAcmeIssuer;
+#[path = "remote_acme_system_issuer.rs"]
+mod system;
 
-impl SystemRemoteAcmeIssuer {
-    pub(crate) async fn create_account_async(
-        &self,
-        config: &RemoteDaemonServeConfig,
-    ) -> Result<RemoteAcmeAccountCredentials, String> {
-        let provisioner = SystemRemoteAcmeChallengeProvisioner::from_environment(config)?;
-        InstantAcmeIssuer::production(provisioner)
-            .create_account(config.acme_email.as_str())
-            .await
-    }
-
-    pub(crate) async fn renew_certificate_async(
-        &self,
-        request: &RemoteAcmeRenewalRequest,
-        cleanup_tracker: RemoteAcmeCleanupTracker,
-    ) -> Result<RemoteCertificateBundle, String> {
-        let provisioner =
-            SystemRemoteAcmeChallengeProvisioner::from_environment(request.serve_config())?;
-        InstantAcmeIssuer::production(provisioner)
-            .issue_certificate_with_cleanup(
-                request.account(),
-                request.serve_config(),
-                request.previous_private_key_pem(),
-                cleanup_tracker,
-            )
-            .await
-    }
-}
-
-impl RemoteAcmeRenewalIssuer for SystemRemoteAcmeIssuer {
-    fn create_account(
-        &self,
-        config: &RemoteDaemonServeConfig,
-    ) -> Result<RemoteAcmeAccountCredentials, String> {
-        run_acme_future(self.create_account_async(config))
-    }
-
-    fn renew_certificate(
-        &self,
-        request: &RemoteAcmeRenewalRequest,
-    ) -> Result<RemoteCertificateBundle, String> {
-        run_acme_future(self.renew_certificate_async(request, RemoteAcmeCleanupTracker::default()))
-    }
-}
-
-pub(crate) fn run_acme_future<T, F>(future: F) -> Result<T, String>
-where
-    T: Send,
-    F: Future<Output = Result<T, String>> + Send,
-{
-    if Handle::try_current().is_ok() {
-        return thread::scope(|scope| {
-            scope
-                .spawn(move || run_acme_future_on_runtime(future))
-                .join()
-                .map_err(|_| "remote ACME runtime thread panicked".to_string())?
-        });
-    }
-    run_acme_future_on_runtime(future)
-}
-
-fn run_acme_future_on_runtime<T, F>(future: F) -> Result<T, String>
-where
-    F: Future<Output = Result<T, String>>,
-{
-    Runtime::new()
-        .map_err(|error| format!("create remote ACME runtime: {error}"))?
-        .block_on(future)
-}
+pub(crate) use system::{SystemRemoteAcmeIssuer, run_acme_future};
 
 #[cfg(test)]
 #[path = "remote_acme_issuer_tests.rs"]

--- a/src/daemon/remote_acme_issuer_test_support.rs
+++ b/src/daemon/remote_acme_issuer_test_support.rs
@@ -2,7 +2,9 @@ use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use async_trait::async_trait;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use bytes::Bytes;
@@ -16,8 +18,12 @@ use rcgen::{
 };
 use rustls::pki_types::CertificateSigningRequestDer;
 use tokio::sync::Notify;
+use tokio::time::sleep;
 
 use crate::daemon::remote::RemoteAcmeChallenge;
+use crate::daemon::remote_acme_issuer::{
+    RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner,
+};
 
 pub(super) const DIRECTORY_URL: &str = "https://acme.test/directory";
 pub(super) const ACCOUNT_URL: &str = "https://acme.test/acct/1";
@@ -45,6 +51,118 @@ struct ScriptedAcmeHttpState {
     responses: VecDeque<ScriptedResponse>,
     requests: Vec<RecordedRequest>,
     issued_certificate: Option<String>,
+}
+
+#[derive(Clone, Default)]
+pub(super) struct RecordingProvisioner {
+    inner: Arc<Mutex<RecordingProvisionerState>>,
+}
+
+#[derive(Default)]
+struct RecordingProvisionerState {
+    materials: Vec<RemoteAcmeChallengeMaterial>,
+    cleanup_count: usize,
+    cleanup_delay: Duration,
+    cleanup_release: Option<Arc<Notify>>,
+    cleanup_started: bool,
+    cleanup_error: Option<String>,
+    wait_ready_error: Option<String>,
+}
+
+impl RecordingProvisioner {
+    pub(super) fn with_cleanup_error(error: &str) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RecordingProvisionerState {
+                cleanup_error: Some(error.to_string()),
+                ..RecordingProvisionerState::default()
+            })),
+        }
+    }
+
+    pub(super) fn with_cleanup_delay(delay: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RecordingProvisionerState {
+                cleanup_delay: delay,
+                ..RecordingProvisionerState::default()
+            })),
+        }
+    }
+
+    pub(super) fn with_cleanup_gate(release: Arc<Notify>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RecordingProvisionerState {
+                cleanup_release: Some(release),
+                ..RecordingProvisionerState::default()
+            })),
+        }
+    }
+
+    pub(super) fn with_wait_ready_error_and_cleanup_gate(
+        error: &str,
+        release: Arc<Notify>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RecordingProvisionerState {
+                cleanup_release: Some(release),
+                wait_ready_error: Some(error.to_string()),
+                ..RecordingProvisionerState::default()
+            })),
+        }
+    }
+
+    pub(super) fn materials(&self) -> Vec<RemoteAcmeChallengeMaterial> {
+        self.inner
+            .lock()
+            .expect("lock provisioner")
+            .materials
+            .clone()
+    }
+
+    pub(super) fn cleanup_count(&self) -> usize {
+        self.inner.lock().expect("lock provisioner").cleanup_count
+    }
+
+    pub(super) fn cleanup_started(&self) -> bool {
+        self.inner.lock().expect("lock provisioner").cleanup_started
+    }
+}
+
+#[async_trait]
+impl RemoteAcmeChallengeProvisioner for RecordingProvisioner {
+    type Lease = ();
+
+    async fn present(&self, material: RemoteAcmeChallengeMaterial) -> Result<Self::Lease, String> {
+        self.inner
+            .lock()
+            .map_err(|error| error.to_string())?
+            .materials
+            .push(material);
+        Ok(())
+    }
+
+    async fn wait_ready(&self, _lease: &Self::Lease) -> Result<(), String> {
+        self.inner
+            .lock()
+            .map_err(|error| error.to_string())?
+            .wait_ready_error
+            .clone()
+            .map_or(Ok(()), Err)
+    }
+
+    async fn cleanup(&self, _lease: Self::Lease) -> Result<(), String> {
+        let (delay, release) = {
+            let mut state = self.inner.lock().map_err(|error| error.to_string())?;
+            state.cleanup_started = true;
+            (state.cleanup_delay, state.cleanup_release.clone())
+        };
+        if let Some(release) = release {
+            release.notified().await;
+        }
+        sleep(delay).await;
+        let mut state = self.inner.lock().map_err(|error| error.to_string())?;
+        state.cleanup_count += 1;
+        state.cleanup_error.clone().map_or(Ok(()), Err)
+    }
 }
 
 impl ScriptedAcmeHttp {

--- a/src/daemon/remote_acme_issuer_tests.rs
+++ b/src/daemon/remote_acme_issuer_tests.rs
@@ -1,23 +1,22 @@
 use std::env;
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use async_trait::async_trait;
 use instant_acme::{Account, RetryPolicy};
 use rcgen::KeyPair;
 use tokio::sync::Notify;
-use tokio::time::{sleep, timeout};
+use tokio::time::timeout;
 
 #[path = "remote_acme_issuer_test_support.rs"]
 mod support;
 
 use support::{
-    ACCOUNT_URL, DIRECTORY_URL, ScriptedAcmeHttp, acme_happy_path, acme_happy_path_for,
-    acme_rejected_order_path, jws_payload,
+    ACCOUNT_URL, DIRECTORY_URL, RecordingProvisioner, ScriptedAcmeHttp, acme_happy_path,
+    acme_happy_path_for, acme_rejected_order_path, jws_payload,
 };
 
-use super::{InstantAcmeIssuer, RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner};
+use super::{InstantAcmeIssuer, RemoteAcmeChallengeMaterial};
 use crate::daemon::remote::{RemoteAcmeChallenge, RemoteDaemonServeConfig, RemoteDnsProvider};
 use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use crate::daemon::remote_tls::build_remote_tls_server_config;
@@ -181,6 +180,92 @@ async fn instant_acme_issuer_cleanup_does_not_block_runtime() {
         .await
         .expect("ACME issuance cleanup timeout")
         .expect("join ACME issuance")
+        .expect("issue ACME certificate");
+
+    assert_eq!(provisioner.cleanup_count(), 1);
+}
+
+#[tokio::test]
+async fn instant_acme_issuer_returns_success_before_cleanup_visibility_confirmation() {
+    let http = ScriptedAcmeHttp::new(acme_happy_path());
+    let cleanup_release = Arc::new(Notify::new());
+    let provisioner = RecordingProvisioner::with_cleanup_gate(Arc::clone(&cleanup_release));
+    let issuer = test_issuer(http, provisioner.clone());
+    let config = http_serve_config();
+    let account = issuer
+        .create_account(config.acme_email.as_str())
+        .await
+        .expect("create ACME account");
+    let cleanup_tracker = RemoteAcmeCleanupTracker::default();
+    let task_cleanup_tracker = cleanup_tracker.clone();
+    let task = tokio::spawn(async move {
+        issuer
+            .issue_certificate_with_cleanup(&account, &config, None, task_cleanup_tracker)
+            .await
+    });
+
+    timeout(Duration::from_secs(2), async {
+        while !provisioner.cleanup_started() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("successful issuance did not start cleanup");
+    let completed_before_cleanup = timeout(Duration::from_millis(250), async {
+        while !task.is_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .is_ok();
+
+    cleanup_release.notify_one();
+    timeout(Duration::from_secs(2), cleanup_tracker.wait_for_cleanup())
+        .await
+        .expect("tracked cleanup did not finish");
+    timeout(Duration::from_secs(2), task)
+        .await
+        .expect("issuance task did not finish")
+        .expect("join issuance task")
+        .expect("issue ACME certificate");
+
+    assert!(
+        completed_before_cleanup,
+        "successful issuance waited for authoritative cleanup visibility"
+    );
+    assert_eq!(provisioner.cleanup_count(), 1);
+}
+
+#[tokio::test]
+async fn instant_acme_issuer_awaits_success_cleanup_without_tracker() {
+    let http = ScriptedAcmeHttp::new(acme_happy_path());
+    let cleanup_release = Arc::new(Notify::new());
+    let provisioner = RecordingProvisioner::with_cleanup_gate(Arc::clone(&cleanup_release));
+    let issuer = test_issuer(http, provisioner.clone());
+    let config = http_serve_config();
+    let account = issuer
+        .create_account(config.acme_email.as_str())
+        .await
+        .expect("create ACME account");
+    let task = tokio::spawn(async move { issuer.issue_certificate(&account, &config, None).await });
+
+    timeout(Duration::from_secs(2), async {
+        while !provisioner.cleanup_started() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("successful issuance did not start cleanup");
+    assert!(
+        !task.is_finished(),
+        "untracked issuance returned before cleanup finished"
+    );
+
+    cleanup_release.notify_one();
+    timeout(Duration::from_secs(2), task)
+        .await
+        .expect("issuance cleanup did not finish")
+        .expect("join issuance task")
         .expect("issue ACME certificate");
 
     assert_eq!(provisioner.cleanup_count(), 1);
@@ -377,106 +462,6 @@ fn test_issuer(
             .timeout(Duration::from_secs(1)),
         move || Ok(Account::builder_with_http(Box::new(http.clone()))),
     )
-}
-
-#[derive(Clone, Default)]
-struct RecordingProvisioner {
-    inner: Arc<Mutex<RecordingProvisionerState>>,
-}
-
-#[derive(Default)]
-struct RecordingProvisionerState {
-    materials: Vec<RemoteAcmeChallengeMaterial>,
-    cleanup_count: usize,
-    cleanup_delay: Duration,
-    cleanup_release: Option<Arc<Notify>>,
-    cleanup_started: bool,
-    cleanup_error: Option<String>,
-    wait_ready_error: Option<String>,
-}
-
-impl RecordingProvisioner {
-    fn with_cleanup_error(error: &str) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(RecordingProvisionerState {
-                cleanup_error: Some(error.to_string()),
-                ..RecordingProvisionerState::default()
-            })),
-        }
-    }
-
-    fn with_cleanup_delay(delay: Duration) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(RecordingProvisionerState {
-                cleanup_delay: delay,
-                ..RecordingProvisionerState::default()
-            })),
-        }
-    }
-
-    fn with_wait_ready_error_and_cleanup_gate(error: &str, release: Arc<Notify>) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(RecordingProvisionerState {
-                cleanup_release: Some(release),
-                wait_ready_error: Some(error.to_string()),
-                ..RecordingProvisionerState::default()
-            })),
-        }
-    }
-
-    fn materials(&self) -> Vec<RemoteAcmeChallengeMaterial> {
-        self.inner
-            .lock()
-            .expect("lock provisioner")
-            .materials
-            .clone()
-    }
-
-    fn cleanup_count(&self) -> usize {
-        self.inner.lock().expect("lock provisioner").cleanup_count
-    }
-
-    fn cleanup_started(&self) -> bool {
-        self.inner.lock().expect("lock provisioner").cleanup_started
-    }
-}
-
-#[async_trait]
-impl RemoteAcmeChallengeProvisioner for RecordingProvisioner {
-    type Lease = ();
-
-    async fn present(&self, material: RemoteAcmeChallengeMaterial) -> Result<Self::Lease, String> {
-        self.inner
-            .lock()
-            .map_err(|error| error.to_string())?
-            .materials
-            .push(material);
-        Ok(())
-    }
-
-    async fn wait_ready(&self, _lease: &Self::Lease) -> Result<(), String> {
-        self.inner
-            .lock()
-            .map_err(|error| error.to_string())?
-            .wait_ready_error
-            .clone()
-            .map_or(Ok(()), Err)
-    }
-
-    async fn cleanup(&self, _lease: Self::Lease) -> Result<(), String> {
-        let (delay, release) = {
-            let mut state = self.inner.lock().map_err(|error| error.to_string())?;
-            state.cleanup_started = true;
-            (state.cleanup_delay, state.cleanup_release.clone())
-        };
-        if let Some(release) = release {
-            release.notified().await;
-        }
-        sleep(delay).await;
-        let mut state = self.inner.lock().map_err(|error| error.to_string())?;
-        state.cleanup_count += 1;
-        state.cleanup_error.clone().map_or(Ok(()), Err)
-    }
 }
 
 fn http_serve_config() -> RemoteDaemonServeConfig {

--- a/src/daemon/remote_acme_issuer_tests.rs
+++ b/src/daemon/remote_acme_issuer_tests.rs
@@ -211,7 +211,7 @@ async fn instant_acme_issuer_returns_success_before_cleanup_visibility_confirmat
     })
     .await
     .expect("successful issuance did not start cleanup");
-    let completed_before_cleanup = timeout(Duration::from_millis(250), async {
+    let completed_before_cleanup = timeout(Duration::from_secs(2), async {
         while !task.is_finished() {
             tokio::task::yield_now().await;
         }

--- a/src/daemon/remote_acme_lease_guard.rs
+++ b/src/daemon/remote_acme_lease_guard.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use tokio::sync::oneshot;
+
 use super::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use super::remote_acme_issuer::RemoteAcmeChallengeProvisioner;
 use super::remote_redaction::redact_secret_detail;
@@ -49,7 +51,8 @@ where
 
     pub(crate) fn cleanup_in_background(mut self) {
         if let Some(cleanup) = self.take_cleanup() {
-            drop(self.cleanup_tracker.spawn_cleanup(cleanup));
+            let completion = self.cleanup_tracker.spawn_cleanup(cleanup);
+            drop(tokio::spawn(observe_background_cleanup(completion)));
         }
     }
 
@@ -72,6 +75,24 @@ where
     }
 }
 
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+async fn observe_background_cleanup(completion: oneshot::Receiver<Result<(), String>>) {
+    match completion.await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => tracing::warn!(
+            error = %redact_secret_detail(&error),
+            "remote ACME challenge cleanup after successful issuance failed",
+        ),
+        Err(error) => tracing::warn!(
+            %error,
+            "observe remote ACME challenge cleanup after successful issuance",
+        ),
+    }
+}
+
 async fn cleanup_leases<P>(provisioner: Arc<P>, leases: Vec<P::Lease>) -> Result<(), String>
 where
     P: RemoteAcmeChallengeProvisioner + 'static,
@@ -88,3 +109,7 @@ where
         Err(failures.join("; "))
     }
 }
+
+#[cfg(test)]
+#[path = "remote_acme_lease_guard_tests.rs"]
+mod tests;

--- a/src/daemon/remote_acme_lease_guard.rs
+++ b/src/daemon/remote_acme_lease_guard.rs
@@ -47,6 +47,12 @@ where
             .map_err(|error| format!("join remote ACME challenge cleanup: {error}"))?
     }
 
+    pub(crate) fn cleanup_in_background(mut self) {
+        if let Some(cleanup) = self.take_cleanup() {
+            drop(self.cleanup_tracker.spawn_cleanup(cleanup));
+        }
+    }
+
     fn take_cleanup(
         &mut self,
     ) -> Option<impl Future<Output = Result<(), String>> + Send + 'static> {

--- a/src/daemon/remote_acme_lease_guard.rs
+++ b/src/daemon/remote_acme_lease_guard.rs
@@ -88,7 +88,7 @@ async fn observe_background_cleanup(completion: oneshot::Receiver<Result<(), Str
         ),
         Err(error) => tracing::warn!(
             %error,
-            "observe remote ACME challenge cleanup after successful issuance",
+            "remote ACME challenge cleanup observation after successful issuance failed",
         ),
     }
 }

--- a/src/daemon/remote_acme_lease_guard_tests.rs
+++ b/src/daemon/remote_acme_lease_guard_tests.rs
@@ -1,0 +1,93 @@
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::time::timeout;
+use tracing_subscriber::fmt::writer::MakeWriter;
+use tracing_subscriber::layer::SubscriberExt as _;
+
+use super::RemoteAcmeChallengeLeaseGuard;
+use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
+use crate::daemon::remote_acme_issuer::{
+    RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn background_cleanup_failure_has_accurate_redacted_log_context() {
+    let output = SharedOutput::default();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_target(false)
+            .with_writer(output.clone()),
+    );
+    let _subscriber = tracing::subscriber::set_default(subscriber);
+    let tracker = RemoteAcmeCleanupTracker::default();
+    let mut leases =
+        RemoteAcmeChallengeLeaseGuard::new(Arc::new(FailingProvisioner), tracker.clone());
+    leases.push(());
+
+    leases.cleanup_in_background();
+    timeout(Duration::from_secs(2), tracker.wait_for_cleanup())
+        .await
+        .expect("background cleanup did not finish");
+    let logs = output.contents();
+
+    assert!(
+        logs.contains("remote ACME challenge cleanup after successful issuance failed"),
+        "missing accurate cleanup context: {logs}"
+    );
+    assert!(!logs.contains("after cancellation failed"));
+    assert!(logs.contains("<redacted>"));
+    assert!(!logs.contains("cleanup-secret"));
+}
+
+#[derive(Clone, Copy)]
+struct FailingProvisioner;
+
+#[async_trait]
+impl RemoteAcmeChallengeProvisioner for FailingProvisioner {
+    type Lease = ();
+
+    async fn present(&self, _material: RemoteAcmeChallengeMaterial) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn cleanup(&self, _lease: ()) -> Result<(), String> {
+        Err("provider cleanup token=cleanup-secret".to_string())
+    }
+}
+
+#[derive(Clone, Default)]
+struct SharedOutput(Arc<Mutex<Vec<u8>>>);
+
+impl SharedOutput {
+    fn contents(&self) -> String {
+        String::from_utf8(self.0.lock().expect("buffer lock").clone()).expect("utf8 output")
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedOutput {
+    type Writer = SharedOutputWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        SharedOutputWriter(Arc::clone(&self.0))
+    }
+}
+
+struct SharedOutputWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedOutputWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("buffer lock")
+            .extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/daemon/remote_acme_lease_guard_tests.rs
+++ b/src/daemon/remote_acme_lease_guard_tests.rs
@@ -32,7 +32,11 @@ async fn background_cleanup_failure_has_accurate_redacted_log_context() {
     timeout(Duration::from_secs(2), tracker.wait_for_cleanup())
         .await
         .expect("background cleanup did not finish");
-    let logs = output.contents();
+    let logs = wait_for_log(
+        &output,
+        "remote ACME challenge cleanup after successful issuance failed",
+    )
+    .await;
 
     assert!(
         logs.contains("remote ACME challenge cleanup after successful issuance failed"),
@@ -41,6 +45,20 @@ async fn background_cleanup_failure_has_accurate_redacted_log_context() {
     assert!(!logs.contains("after cancellation failed"));
     assert!(logs.contains("<redacted>"));
     assert!(!logs.contains("cleanup-secret"));
+}
+
+async fn wait_for_log(output: &SharedOutput, expected: &str) -> String {
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let logs = output.contents();
+            if logs.contains(expected) {
+                return logs;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("missing expected cleanup log: {}", output.contents()))
 }
 
 #[derive(Clone, Copy)]

--- a/src/daemon/remote_acme_lease_guard_tests.rs
+++ b/src/daemon/remote_acme_lease_guard_tests.rs
@@ -7,7 +7,7 @@ use tokio::time::timeout;
 use tracing_subscriber::fmt::writer::MakeWriter;
 use tracing_subscriber::layer::SubscriberExt as _;
 
-use super::RemoteAcmeChallengeLeaseGuard;
+use super::{RemoteAcmeChallengeLeaseGuard, observe_background_cleanup};
 use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
 use crate::daemon::remote_acme_issuer::{
     RemoteAcmeChallengeMaterial, RemoteAcmeChallengeProvisioner,
@@ -45,6 +45,28 @@ async fn background_cleanup_failure_has_accurate_redacted_log_context() {
     assert!(!logs.contains("after cancellation failed"));
     assert!(logs.contains("<redacted>"));
     assert!(!logs.contains("cleanup-secret"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn background_cleanup_observation_failure_is_explicit() {
+    let output = SharedOutput::default();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_target(false)
+            .with_writer(output.clone()),
+    );
+    let _subscriber = tracing::subscriber::set_default(subscriber);
+    let (completion, observation) = tokio::sync::oneshot::channel();
+    drop(completion);
+
+    observe_background_cleanup(observation).await;
+    let logs = output.contents();
+
+    assert!(
+        logs.contains("remote ACME challenge cleanup observation after successful issuance failed"),
+        "missing explicit observation failure context: {logs}"
+    );
 }
 
 async fn wait_for_log(output: &SharedOutput, expected: &str) -> String {

--- a/src/daemon/remote_acme_live.rs
+++ b/src/daemon/remote_acme_live.rs
@@ -142,6 +142,23 @@ impl LiveRemoteAcmeIssuer {
             )
             .await
     }
+
+    async fn issue_certificate_and_await_cleanup(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        let provisioner = LiveRemoteAcmeChallengeProvisioner::from_environment(
+            request.serve_config(),
+            self.tls.clone(),
+        )?;
+        InstantAcmeIssuer::production(provisioner)
+            .issue_certificate_and_await_cleanup(
+                request.account(),
+                request.serve_config(),
+                request.previous_private_key_pem(),
+            )
+            .await
+    }
 }
 
 impl RemoteAcmeRenewalIssuer for LiveRemoteAcmeIssuer {
@@ -156,7 +173,7 @@ impl RemoteAcmeRenewalIssuer for LiveRemoteAcmeIssuer {
         &self,
         request: &RemoteAcmeRenewalRequest,
     ) -> Result<RemoteCertificateBundle, String> {
-        run_acme_future(self.issue_certificate(request, RemoteAcmeCleanupTracker::default()))
+        run_acme_future(self.issue_certificate_and_await_cleanup(request))
     }
 }
 

--- a/src/daemon/remote_acme_system_issuer.rs
+++ b/src/daemon/remote_acme_system_issuer.rs
@@ -1,0 +1,101 @@
+use std::future::Future;
+use std::thread;
+
+use tokio::runtime::{Handle, Runtime};
+
+use crate::daemon::remote::RemoteDaemonServeConfig;
+use crate::daemon::remote_acme::{
+    RemoteAcmeAccountCredentials, RemoteAcmeRenewalIssuer, RemoteAcmeRenewalRequest,
+    RemoteCertificateBundle,
+};
+use crate::daemon::remote_acme_challenge::SystemRemoteAcmeChallengeProvisioner;
+use crate::daemon::remote_acme_cleanup::RemoteAcmeCleanupTracker;
+
+use super::InstantAcmeIssuer;
+
+pub(crate) struct SystemRemoteAcmeIssuer;
+
+impl SystemRemoteAcmeIssuer {
+    pub(crate) async fn create_account_async(
+        &self,
+        config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        let provisioner = SystemRemoteAcmeChallengeProvisioner::from_environment(config)?;
+        InstantAcmeIssuer::production(provisioner)
+            .create_account(config.acme_email.as_str())
+            .await
+    }
+
+    pub(crate) async fn renew_certificate_async(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+        cleanup_tracker: RemoteAcmeCleanupTracker,
+    ) -> Result<RemoteCertificateBundle, String> {
+        let provisioner =
+            SystemRemoteAcmeChallengeProvisioner::from_environment(request.serve_config())?;
+        InstantAcmeIssuer::production(provisioner)
+            .issue_certificate_with_cleanup(
+                request.account(),
+                request.serve_config(),
+                request.previous_private_key_pem(),
+                cleanup_tracker,
+            )
+            .await
+    }
+
+    async fn renew_certificate_and_await_cleanup_async(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        let provisioner =
+            SystemRemoteAcmeChallengeProvisioner::from_environment(request.serve_config())?;
+        InstantAcmeIssuer::production(provisioner)
+            .issue_certificate_and_await_cleanup(
+                request.account(),
+                request.serve_config(),
+                request.previous_private_key_pem(),
+            )
+            .await
+    }
+}
+
+impl RemoteAcmeRenewalIssuer for SystemRemoteAcmeIssuer {
+    fn create_account(
+        &self,
+        config: &RemoteDaemonServeConfig,
+    ) -> Result<RemoteAcmeAccountCredentials, String> {
+        run_acme_future(self.create_account_async(config))
+    }
+
+    fn renew_certificate(
+        &self,
+        request: &RemoteAcmeRenewalRequest,
+    ) -> Result<RemoteCertificateBundle, String> {
+        run_acme_future(self.renew_certificate_and_await_cleanup_async(request))
+    }
+}
+
+pub(crate) fn run_acme_future<T, F>(future: F) -> Result<T, String>
+where
+    T: Send,
+    F: Future<Output = Result<T, String>> + Send,
+{
+    if Handle::try_current().is_ok() {
+        return thread::scope(|scope| {
+            scope
+                .spawn(move || run_acme_future_on_runtime(future))
+                .join()
+                .map_err(|_| "remote ACME runtime thread panicked".to_string())?
+        });
+    }
+    run_acme_future_on_runtime(future)
+}
+
+fn run_acme_future_on_runtime<T, F>(future: F) -> Result<T, String>
+where
+    F: Future<Output = Result<T, String>>,
+{
+    Runtime::new()
+        .map_err(|error| format!("create remote ACME runtime: {error}"))?
+        .block_on(future)
+}


### PR DESCRIPTION
## Motivation

A live DNS-01 issuance on `smyk.la` reached a ready ACME order, but Aftermarket authoritative servers continued serving the deleted TXT record. Startup waited 900 seconds for deletion visibility before finalizing the certificate, then exited without opening HTTPS.

## Implementation

- Finalize and return a successful certificate before tracked challenge cleanup finishes.
- Keep cleanup awaited for issuance failures and one-shot renewal runtimes.
- Split the system issuer adapter so the issuance state machine stays within repository size limits.
- Add TDD coverage for tracked background cleanup and awaited untracked cleanup.
- Verify with focused issuer, live provisioner, startup lifecycle tests, and `mise run harness:check`.