### PR TITLE
fix(monitor): truncate server SPKI in settings

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRemoteDaemonSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRemoteDaemonSection.swift
@@ -128,6 +128,8 @@ struct SettingsRemoteDaemonSection: View {
     LabeledContent("Token", value: profile.tokenHint)
     LabeledContent("Server SPKI") {
       Text(profile.serverSPKISHA256.value)
+        .lineLimit(1)
+        .truncationMode(.middle)
         .multilineTextAlignment(.trailing)
         .textSelection(.enabled)
     }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
@@ -23,4 +23,18 @@ extension SessionSwiftUISourceTests {
     #expect(source.contains("removes its bearer token from Keychain"))
     #expect(source.contains("returns to the local daemon mode"))
   }
+
+  @Test("Server SPKI middle-truncates while retaining its full selectable value")
+  func serverSPKIRetainsFullSelectableValue() throws {
+    let source = try sourceFile(at: "Views/Settings/SettingsRemoteDaemonSection.swift")
+    let row = try #require(
+      source.components(separatedBy: "LabeledContent(\"Server SPKI\") {").last?
+        .components(separatedBy: "    }").first
+    )
+
+    #expect(row.contains("Text(profile.serverSPKISHA256.value)"))
+    #expect(row.contains(".lineLimit(1)"))
+    #expect(row.contains(".truncationMode(.middle)"))
+    #expect(row.contains(".textSelection(.enabled)"))
+  }
 }


### PR DESCRIPTION
## Motivation
Long Server SPKI values wrapped onto a second line in remote daemon settings, making the form harder to scan.

## Implementation
- Keep the Server SPKI on one line and truncate overflowing text in the middle.
- Preserve the full selectable value so copying writes the complete SPKI to the clipboard.
- Add focused source coverage and validate the Monitor build.