### PR TITLE
fix(monitor): keep server SPKI inside its settings row

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRemoteDaemonSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRemoteDaemonSection.swift
@@ -126,12 +126,16 @@ struct SettingsRemoteDaemonSection: View {
     LabeledContent("Scopes", value: profile.scopes.joined(separator: ", "))
       .textSelection(.enabled)
     LabeledContent("Token", value: profile.tokenHint)
-    LabeledContent("Server SPKI") {
+    HStack(alignment: .firstTextBaseline, spacing: HarnessMonitorTheme.spacingMD) {
+      Text("Server SPKI")
+        .fixedSize(horizontal: true, vertical: false)
       Text(profile.serverSPKISHA256.value)
         .lineLimit(1)
         .truncationMode(.middle)
-        .multilineTextAlignment(.trailing)
+        .foregroundStyle(.secondary)
         .textSelection(.enabled)
+        .frame(minWidth: 0, maxWidth: .infinity, alignment: .trailing)
+        .clipped()
     }
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRemoteDaemonSection.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsRemoteDaemonSection.swift
@@ -137,6 +137,9 @@ struct SettingsRemoteDaemonSection: View {
         .frame(minWidth: 0, maxWidth: .infinity, alignment: .trailing)
         .clipped()
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Server SPKI")
+    .accessibilityValue(profile.serverSPKISHA256.value)
   }
 
   private var pairingInput: RemoteDaemonPairingInput {

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
@@ -24,17 +24,32 @@ extension SessionSwiftUISourceTests {
     #expect(source.contains("returns to the local daemon mode"))
   }
 
-  @Test("Server SPKI middle-truncates while retaining its full selectable value")
-  func serverSPKIRetainsFullSelectableValue() throws {
+  @Test("Server SPKI stays inline while retaining its full selectable value")
+  func serverSPKIStaysInlineWithFullSelectableValue() throws {
     let source = try sourceFile(at: "Views/Settings/SettingsRemoteDaemonSection.swift")
-    let row = try #require(
-      source.components(separatedBy: "LabeledContent(\"Server SPKI\") {").last?
-        .components(separatedBy: "    }").first
+    let profileRows = try #require(
+      source.components(separatedBy: "private func profileRows").last?
+        .components(separatedBy: "  private var pairingInput").first
     )
 
-    #expect(row.contains("Text(profile.serverSPKISHA256.value)"))
-    #expect(row.contains(".lineLimit(1)"))
-    #expect(row.contains(".truncationMode(.middle)"))
-    #expect(row.contains(".textSelection(.enabled)"))
+    #expect(!profileRows.contains("LabeledContent(\"Server SPKI\")"))
+    #expect(
+      profileRows.contains(
+        """
+        HStack(alignment: .firstTextBaseline, spacing: HarnessMonitorTheme.spacingMD) {
+              Text("Server SPKI")
+                .fixedSize(horizontal: true, vertical: false)
+              Text(profile.serverSPKISHA256.value)
+        """
+      )
+    )
+    #expect(profileRows.contains(".lineLimit(1)"))
+    #expect(profileRows.contains(".truncationMode(.middle)"))
+    #expect(profileRows.contains(".foregroundStyle(.secondary)"))
+    #expect(profileRows.contains(".textSelection(.enabled)"))
+    #expect(
+      profileRows.contains(".frame(minWidth: 0, maxWidth: .infinity, alignment: .trailing)")
+    )
+    #expect(profileRows.contains(".clipped()"))
   }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
@@ -29,40 +29,32 @@ extension SessionSwiftUISourceTests {
     let source = try sourceFile(at: "Views/Settings/SettingsRemoteDaemonSection.swift")
     let profileRows = try #require(
       source.components(separatedBy: "private func profileRows").last?
-        .components(separatedBy: "  private var pairingInput").first
+        .components(separatedBy: "private var pairingInput").first
+    )
+    let spkiRow = try #require(
+      profileRows.components(
+        separatedBy: "HStack(alignment: .firstTextBaseline, spacing: HarnessMonitorTheme.spacingMD) {"
+      ).dropFirst().first
+    )
+    let valueModifiers = try #require(
+      spkiRow.components(separatedBy: "Text(profile.serverSPKISHA256.value)")
+        .dropFirst().first?
+        .components(separatedBy: ".clipped()").first
     )
 
     #expect(!profileRows.contains("LabeledContent(\"Server SPKI\")"))
+    #expect(spkiRow.contains("Text(\"Server SPKI\")"))
+    #expect(spkiRow.contains(".fixedSize(horizontal: true, vertical: false)"))
+    #expect(valueModifiers.contains(".lineLimit(1)"))
+    #expect(valueModifiers.contains(".truncationMode(.middle)"))
+    #expect(valueModifiers.contains(".foregroundStyle(.secondary)"))
+    #expect(valueModifiers.contains(".textSelection(.enabled)"))
     #expect(
-      profileRows.contains(
-        """
-        HStack(alignment: .firstTextBaseline, spacing: HarnessMonitorTheme.spacingMD) {
-              Text("Server SPKI")
-                .fixedSize(horizontal: true, vertical: false)
-        """
-      )
+      valueModifiers.contains(".frame(minWidth: 0, maxWidth: .infinity, alignment: .trailing)")
     )
-    #expect(
-      profileRows.contains(
-        """
-        Text(profile.serverSPKISHA256.value)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .foregroundStyle(.secondary)
-                .textSelection(.enabled)
-                .frame(minWidth: 0, maxWidth: .infinity, alignment: .trailing)
-                .clipped()
-        """
-      )
-    )
-    #expect(
-      profileRows.contains(
-        """
-        .accessibilityElement(children: .combine)
-            .accessibilityLabel("Server SPKI")
-            .accessibilityValue(profile.serverSPKISHA256.value)
-        """
-      )
-    )
+    #expect(spkiRow.contains(".clipped()"))
+    #expect(spkiRow.contains(".accessibilityElement(children: .combine)"))
+    #expect(spkiRow.contains(".accessibilityLabel(\"Server SPKI\")"))
+    #expect(spkiRow.contains(".accessibilityValue(profile.serverSPKISHA256.value)"))
   }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/SessionSwiftUISourceTests+RemoteDaemonSettings.swift
@@ -39,17 +39,30 @@ extension SessionSwiftUISourceTests {
         HStack(alignment: .firstTextBaseline, spacing: HarnessMonitorTheme.spacingMD) {
               Text("Server SPKI")
                 .fixedSize(horizontal: true, vertical: false)
-              Text(profile.serverSPKISHA256.value)
         """
       )
     )
-    #expect(profileRows.contains(".lineLimit(1)"))
-    #expect(profileRows.contains(".truncationMode(.middle)"))
-    #expect(profileRows.contains(".foregroundStyle(.secondary)"))
-    #expect(profileRows.contains(".textSelection(.enabled)"))
     #expect(
-      profileRows.contains(".frame(minWidth: 0, maxWidth: .infinity, alignment: .trailing)")
+      profileRows.contains(
+        """
+        Text(profile.serverSPKISHA256.value)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .frame(minWidth: 0, maxWidth: .infinity, alignment: .trailing)
+                .clipped()
+        """
+      )
     )
-    #expect(profileRows.contains(".clipped()"))
+    #expect(
+      profileRows.contains(
+        """
+        .accessibilityElement(children: .combine)
+            .accessibilityLabel("Server SPKI")
+            .accessibilityValue(profile.serverSPKISHA256.value)
+        """
+      )
+    )
   }
 }


### PR DESCRIPTION
## Motivation

Long Server SPKI values could wrap or escape their settings row during text selection, making the form hard to scan.

## Implementation

- Keep the Server SPKI on one line and middle-truncate overflow.
- Clip selection rendering to the row while preserving the full copyable value.
- Add focused source coverage and validate the interaction in the rebuilt Monitor.