### PR TITLE
fix(monitor): keep remote daemon reconnecting

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+AppLifecycle.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+AppLifecycle.swift
@@ -47,9 +47,11 @@ extension HarnessMonitorStore {
   }
 
   public func prepareForTermination() async {
+    connection.isPreparingForTermination = true
     await flushSessionWindowsOpenAtQuit()
     toast.dismissAll()
     cancelPendingAppInactivitySuspend()
+    stopRemoteDaemonReconnect()
     stopAllStreams()
     stopManifestWatcher()
     #if HARNESS_FEATURE_OTEL

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Bootstrap.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Bootstrap.swift
@@ -277,9 +277,14 @@ extension HarnessMonitorStore {
         await connect(using: client)
       }
     } catch {
+      guard !shouldAbandonConnectionAttempt, !(error is CancellationError) else {
+        connectionState = .idle
+        return
+      }
       handleRemoteDaemonConnectionFailure(error)
       markConnectionOffline(error.localizedDescription)
       await restorePersistedSessionState()
+      scheduleRemoteDaemonReconnect(after: error)
     }
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ConnectionProbe.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ConnectionProbe.swift
@@ -67,7 +67,7 @@ extension HarnessMonitorStore {
               kind: .reconnecting,
               detail: "Probe failed \(consecutiveFailures) times, re-bootstrapping"
             )
-            await reconnect()
+            scheduleReconnectAfterConnectionFailure()
             return
           }
         }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ConnectionRecovery.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ConnectionRecovery.swift
@@ -1,0 +1,104 @@
+extension HarnessMonitorStore {
+  var shouldAbandonConnectionAttempt: Bool {
+    Task.isCancelled || isAppLifecycleSuspended || connection.isPreparingForTermination
+  }
+
+  var hasLiveConnectionActivity: Bool {
+    client != nil
+      || globalStreamTask != nil
+      || connectionProbeTask != nil
+      || isBootstrapping
+      || isReconnecting
+      || remoteDaemonReconnectTask != nil
+      || connectionRecoveryTask != nil
+  }
+
+  var connectionRecoveryTask: Task<Void, Never>? {
+    get { connection.connectionRecoveryTask }
+    set { connection.connectionRecoveryTask = newValue }
+  }
+
+  var connectionRecoveryGeneration: UInt64 {
+    get { connection.connectionRecoveryGeneration }
+    set { connection.connectionRecoveryGeneration = newValue }
+  }
+
+  func scheduleReconnectAfterConnectionFailure() {
+    guard
+      connectionRecoveryTask == nil,
+      !isBootstrapping,
+      !isReconnecting,
+      !isAppLifecycleSuspended,
+      !connection.isPreparingForTermination
+    else {
+      return
+    }
+
+    connectionRecoveryGeneration &+= 1
+    let generation = connectionRecoveryGeneration
+    connectionRecoveryTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      defer { self.finishConnectionRecovery(generation: generation) }
+      guard self.shouldRunConnectionRecovery(generation: generation) else {
+        return
+      }
+      await self.reconnect()
+    }
+  }
+
+  func stopConnectionRecovery() {
+    connectionRecoveryGeneration &+= 1
+    connectionRecoveryTask?.cancel()
+    connectionRecoveryTask = nil
+  }
+
+  func abandonConnectionAttempt(
+    using client: any HarnessMonitorClientProtocol,
+    wasAdopted: Bool
+  ) async {
+    if wasAdopted {
+      await discardActiveConnection()
+    } else {
+      await client.shutdown()
+      self.client = nil
+      taskBoardDatabaseInstanceID = nil
+    }
+    connectionState = .idle
+  }
+
+  func discardActiveConnection() async {
+    guard let disconnectedClient = disconnectActiveConnection() else {
+      return
+    }
+    await disconnectedClient.shutdown()
+  }
+
+  func applyConnectionFailure(_ error: any Error) async {
+    let underlyingError = Self.underlyingRefreshSnapshotError(error)
+    let wasUsingRemoteDaemon = usesRemoteDaemon
+    if wasUsingRemoteDaemon {
+      handleRemoteDaemonConnectionFailure(underlyingError)
+    }
+    markConnectionOffline(Self.describeRefreshSnapshotError(error))
+    await restorePersistedSessionState()
+    if wasUsingRemoteDaemon {
+      scheduleRemoteDaemonReconnect(after: underlyingError)
+    }
+  }
+
+  private func shouldRunConnectionRecovery(generation: UInt64) -> Bool {
+    !Task.isCancelled
+      && generation == connectionRecoveryGeneration
+      && !isBootstrapping
+      && !isReconnecting
+      && !isAppLifecycleSuspended
+      && !connection.isPreparingForTermination
+  }
+
+  private func finishConnectionRecovery(generation: UInt64) {
+    guard generation == connectionRecoveryGeneration else {
+      return
+    }
+    connectionRecoveryTask = nil
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ConnectionSlice.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ConnectionSlice.swift
@@ -29,6 +29,11 @@ extension HarnessMonitorStore {
         onChanged?(.remoteDaemon)
       }
     }
+    @ObservationIgnored var remoteDaemonReconnectTask: Task<Void, Never>?
+    @ObservationIgnored var remoteDaemonReconnectGeneration: UInt64 = 0
+    @ObservationIgnored var connectionRecoveryTask: Task<Void, Never>?
+    @ObservationIgnored var connectionRecoveryGeneration: UInt64 = 0
+    @ObservationIgnored var isPreparingForTermination = false
     public var connectionState: ConnectionState = .idle {
       didSet {
         guard oldValue != connectionState else { return }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ConnectionTelemetry.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+ConnectionTelemetry.swift
@@ -204,6 +204,9 @@ extension HarnessMonitorStore {
     }
     connectionMetrics.connectedSince = recordedAt
     connectionMetrics.disconnectedSince = nil
+    if usesRemoteDaemon {
+      stopRemoteDaemonReconnect()
+    }
     dismissDaemonDisconnectDecisionsAfterReconnect()
     refreshExternalManifestDiscoveryTask()
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+DaemonControl.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+DaemonControl.swift
@@ -6,14 +6,6 @@ extension HarnessMonitorStore {
     }
   }
 
-  var hasLiveConnectionActivity: Bool {
-    client != nil
-      || globalStreamTask != nil
-      || connectionProbeTask != nil
-      || isBootstrapping
-      || isReconnecting
-  }
-
   func cancelPendingAppInactivitySuspend() {
     appInactivitySuspendTask?.cancel()
     appInactivitySuspendTask = nil
@@ -28,6 +20,7 @@ extension HarnessMonitorStore {
     }
 
     isAppLifecycleSuspended = true
+    stopRemoteDaemonReconnect()
     stopManifestWatcher()
     stopAllStreams()
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefresh.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefresh.swift
@@ -10,6 +10,7 @@ extension HarnessMonitorStore {
   private struct RefreshSnapshotLoadError: LocalizedError, Sendable {
     let source: RefreshSnapshotSource
     let failureDescription: String
+    let underlyingError: any Error
 
     var errorDescription: String? {
       "Startup snapshot \(source.rawValue) failed: \(failureDescription)"
@@ -33,10 +34,8 @@ extension HarnessMonitorStore {
   }
 
   func connect(using client: any HarnessMonitorClientProtocol) async {
-    if isAppLifecycleSuspended {
-      await client.shutdown()
-      self.client = nil
-      connectionState = .idle
+    if shouldAbandonConnectionAttempt {
+      await abandonConnectionAttempt(using: client, wasAdopted: false)
       return
     }
     do {
@@ -45,7 +44,15 @@ extension HarnessMonitorStore {
       await client.shutdown()
       self.client = nil
       taskBoardDatabaseInstanceID = nil
-      markConnectionOffline(Self.describeRefreshSnapshotError(error))
+      guard !shouldAbandonConnectionAttempt else {
+        connectionState = .idle
+        return
+      }
+      await applyConnectionFailure(error)
+      return
+    }
+    guard !shouldAbandonConnectionAttempt else {
+      await abandonConnectionAttempt(using: client, wasAdopted: false)
       return
     }
     self.client = client
@@ -60,18 +67,29 @@ extension HarnessMonitorStore {
     do {
       try await performPreviewConnectRefresh(using: client, preserveSelection: true)
     } catch {
-      _ = disconnectActiveConnection()
-      markConnectionOffline(Self.describeRefreshSnapshotError(error))
-      await restorePersistedSessionState()
+      await discardActiveConnection()
+      guard !shouldAbandonConnectionAttempt else {
+        connectionState = .idle
+        return
+      }
+      await applyConnectionFailure(error)
       return
     }
 
+    guard !shouldAbandonConnectionAttempt else {
+      await abandonConnectionAttempt(using: client, wasAdopted: true)
+      return
+    }
     withUISyncBatch {
       connectionState = .online
     }
   }
 
   private func connectLive(using client: any HarnessMonitorClientProtocol) async {
+    guard !shouldAbandonConnectionAttempt else {
+      await abandonConnectionAttempt(using: client, wasAdopted: true)
+      return
+    }
     withUISyncBatch {
       connectionState = .connecting
     }
@@ -82,12 +100,19 @@ extension HarnessMonitorStore {
     do {
       try await performInitialConnectRefresh(using: client, preserveSelection: true)
     } catch {
-      _ = disconnectActiveConnection()
-      markConnectionOffline(Self.describeRefreshSnapshotError(error))
-      await restorePersistedSessionState()
+      await discardActiveConnection()
+      guard !shouldAbandonConnectionAttempt else {
+        connectionState = .idle
+        return
+      }
+      await applyConnectionFailure(error)
       return
     }
 
+    guard !shouldAbandonConnectionAttempt else {
+      await abandonConnectionAttempt(using: client, wasAdopted: true)
+      return
+    }
     withUISyncBatch {
       connectionState = .online
       markConnectionOnline()
@@ -127,9 +152,12 @@ extension HarnessMonitorStore {
         isInitialConnect: false
       )
     } catch {
-      _ = disconnectActiveConnection()
-      markConnectionOffline(Self.describeRefreshSnapshotError(error))
-      await restorePersistedSessionState()
+      await discardActiveConnection()
+      guard !shouldAbandonConnectionAttempt else {
+        connectionState = .idle
+        return
+      }
+      await applyConnectionFailure(error)
     }
   }
 
@@ -309,7 +337,8 @@ extension HarnessMonitorStore {
   ) -> RefreshSnapshotLoadError {
     let wrapped = RefreshSnapshotLoadError(
       source: source,
-      failureDescription: RefreshSnapshotErrorFormatting.describeUnderlying(error)
+      failureDescription: RefreshSnapshotErrorFormatting.describeUnderlying(error),
+      underlyingError: error
     )
     HarnessMonitorLogger.store.warning(
       "\(wrapped.localizedDescription, privacy: .public)"
@@ -317,7 +346,16 @@ extension HarnessMonitorStore {
     return wrapped
   }
 
-  nonisolated private static func describeRefreshSnapshotError(_ error: any Error) -> String {
+  nonisolated static func underlyingRefreshSnapshotError(
+    _ error: any Error
+  ) -> any Error {
+    if let wrapped = error as? RefreshSnapshotLoadError {
+      return wrapped.underlyingError
+    }
+    return error
+  }
+
+  nonisolated static func describeRefreshSnapshotError(_ error: any Error) -> String {
     if let wrapped = error as? RefreshSnapshotLoadError {
       return wrapped.localizedDescription
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+RemoteDaemon.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+RemoteDaemon.swift
@@ -98,6 +98,9 @@ extension HarnessMonitorStore {
       remoteDaemonProfile = nil
       remoteDaemonActionState = .failed(error.localizedDescription)
     }
+    if remoteDaemonProfile?.status != .active {
+      stopRemoteDaemonReconnect()
+    }
   }
 
   func handleRemoteDaemonConnectionFailure(_ error: any Error) {
@@ -123,12 +126,14 @@ extension HarnessMonitorStore {
   }
 
   private func completeRemoteDaemonPairing(_ profile: RemoteDaemonProfile) async {
+    stopRemoteDaemonReconnect()
     remoteDaemonProfile = profile
     remoteDaemonActionState = .idle
     await reconnect()
   }
 
   private func completeRemoteDaemonForget() async {
+    stopRemoteDaemonReconnect()
     remoteDaemonProfile = nil
     remoteDaemonActionState = .idle
     resetLocalManifestURL()

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+RemoteDaemonReconnect.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+RemoteDaemonReconnect.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+extension HarnessMonitorStore {
+  var remoteDaemonReconnectTask: Task<Void, Never>? {
+    get { connection.remoteDaemonReconnectTask }
+    set { connection.remoteDaemonReconnectTask = newValue }
+  }
+
+  var remoteDaemonReconnectGeneration: UInt64 {
+    get { connection.remoteDaemonReconnectGeneration }
+    set { connection.remoteDaemonReconnectGeneration = newValue }
+  }
+
+  func scheduleRemoteDaemonReconnect(after error: (any Error)? = nil) {
+    guard shouldRetryRemoteDaemonConnection(after: error) else {
+      stopRemoteDaemonReconnect()
+      return
+    }
+    guard remoteDaemonReconnectTask == nil else {
+      return
+    }
+
+    remoteDaemonReconnectGeneration &+= 1
+    let generation = remoteDaemonReconnectGeneration
+    remoteDaemonReconnectTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      await self.runRemoteDaemonReconnectLoop(generation: generation)
+    }
+  }
+
+  func stopRemoteDaemonReconnect() {
+    stopConnectionRecovery()
+    remoteDaemonReconnectGeneration &+= 1
+    remoteDaemonReconnectTask?.cancel()
+    remoteDaemonReconnectTask = nil
+  }
+
+  private func runRemoteDaemonReconnectLoop(generation: UInt64) async {
+    defer { finishRemoteDaemonReconnect(generation: generation) }
+    var attempt = 0
+
+    while shouldContinueRemoteDaemonReconnect(generation: generation) {
+      let delay = reconnectDelay(for: attempt)
+      appendConnectionEvent(
+        kind: .reconnecting,
+        detail: "Remote daemon unavailable; retrying after \(delay) (attempt \(attempt + 1))"
+      )
+      do {
+        try await Task.sleep(for: delay)
+      } catch {
+        return
+      }
+      guard shouldContinueRemoteDaemonReconnect(generation: generation) else {
+        return
+      }
+
+      await reconnect()
+      guard connectionState != .online else {
+        return
+      }
+      attempt += 1
+    }
+  }
+
+  private func shouldContinueRemoteDaemonReconnect(generation: UInt64) -> Bool {
+    !Task.isCancelled
+      && generation == remoteDaemonReconnectGeneration
+      && maintainsLiveDaemonObservation
+      && !isAppLifecycleSuspended
+      && !connection.isPreparingForTermination
+      && remoteDaemonProfile?.status == .active
+      && connectionState != .online
+  }
+
+  private func shouldRetryRemoteDaemonConnection(after error: (any Error)?) -> Bool {
+    guard
+      !Task.isCancelled,
+      maintainsLiveDaemonObservation,
+      !isAppLifecycleSuspended,
+      !connection.isPreparingForTermination,
+      remoteDaemonProfile?.status == .active,
+      connectionState != .online
+    else {
+      return false
+    }
+    guard let error else {
+      return true
+    }
+    if error is CancellationError || error is RemoteDaemonProfileError {
+      return false
+    }
+    if let urlError = error as? URLError, urlError.code == .cancelled {
+      return false
+    }
+    if let apiError = error as? HarnessMonitorAPIError,
+      case .server(let code, _) = apiError
+    {
+      return code == 408 || code == 429 || !(400..<500).contains(code)
+    }
+    return true
+  }
+
+  private func finishRemoteDaemonReconnect(generation: UInt64) {
+    guard generation == remoteDaemonReconnectGeneration else {
+      return
+    }
+    remoteDaemonReconnectTask = nil
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Streaming.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+Streaming.swift
@@ -50,7 +50,7 @@ extension HarnessMonitorStore {
               kind: .reconnecting,
               detail: "Transport closed, re-bootstrapping global stream"
             )
-            scheduleReconnectAfterStreamFailure()
+            scheduleReconnectAfterConnectionFailure()
             return
           }
         }
@@ -64,7 +64,7 @@ extension HarnessMonitorStore {
             kind: .reconnecting,
             detail: "Global stream failed \(attempt) times, re-bootstrapping"
           )
-          scheduleReconnectAfterStreamFailure()
+          scheduleReconnectAfterConnectionFailure()
           return
         }
 
@@ -114,7 +114,7 @@ extension HarnessMonitorStore {
               kind: .reconnecting,
               detail: "Transport closed, re-bootstrapping session stream"
             )
-            scheduleReconnectAfterStreamFailure()
+            scheduleReconnectAfterConnectionFailure()
             return
           }
         }
@@ -128,7 +128,7 @@ extension HarnessMonitorStore {
             kind: .reconnecting,
             detail: "Session stream failed \(attempt) times, re-bootstrapping"
           )
-          scheduleReconnectAfterStreamFailure()
+          scheduleReconnectAfterConnectionFailure()
           return
         }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingRecovery.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingRecovery.swift
@@ -11,7 +11,7 @@ extension HarnessMonitorStore {
     if hasSeenReady {
       guard await syncStoredTaskBoardCredentialsForNewDaemon(using: client) else {
         markConnectionOffline("Connected daemon has no database-backed Task Board")
-        await reconnect()
+        scheduleReconnectAfterConnectionFailure()
         return false
       }
     } else {

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+StreamingSupport.swift
@@ -5,14 +5,6 @@ extension HarnessMonitorStore {
     Self.streamReconnectDelays[min(attempt, Self.streamReconnectDelays.count - 1)]
   }
 
-  func scheduleReconnectAfterStreamFailure() {
-    // reconnect() cancels every stream task, including the caller. Move the
-    // replacement bootstrap to an independent task before the dead stream exits.
-    Task { @MainActor [weak self] in
-      await self?.reconnect()
-    }
-  }
-
   /// True when `error` means the WebSocket transport has been torn down
   /// (the `webSocketTask` is nil or the actor was shut down). The store's
   /// stream loops short-circuit on this so they do not burn the full

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests+Reconnect.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests+Reconnect.swift
@@ -1,0 +1,354 @@
+import Foundation
+import Testing
+
+@testable import HarnessMonitorKit
+
+extension HarnessMonitorStoreRemoteConnectionTests {
+  @Test("Remote stream closure keeps retrying until the server returns")
+  func remoteStreamClosureKeepsRetryingUntilServerReturns() async throws {
+    let fixture = try RemoteStoreFixture()
+    let initialClient = RecordingHarnessClient()
+    let replacementClient = RecordingHarnessClient()
+    let daemon = RecordingDaemonController(
+      bootstrapOutcomes: [
+        .success(initialClient),
+        .failure(URLError(.cannotConnectToHost)),
+        .success(replacementClient),
+      ],
+      bootstrapChecksCancellation: true
+    )
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+
+    await store.bootstrap()
+    #expect(store.connectionState == .online)
+    #expect(await daemon.recordedBootstrapCallCount() == 1)
+
+    initialClient.configureGlobalStream(
+      events: [],
+      error: WebSocketTransportError.connectionClosed,
+      failureCount: 1
+    )
+    initialClient.configureSessionStream(
+      events: [],
+      error: WebSocketTransportError.connectionClosed,
+      for: PreviewFixtures.summary.sessionId
+    )
+    let disconnectedAt = ContinuousClock.now
+    store.startGlobalStream(using: initialClient)
+    store.startSessionStream(using: initialClient, sessionID: PreviewFixtures.summary.sessionId)
+
+    for _ in 0..<100 {
+      if await daemon.recordedBootstrapCallCount() >= 3,
+        store.connectionState == .online,
+        !store.isReconnecting
+      {
+        break
+      }
+      try await Task.sleep(for: .milliseconds(20))
+    }
+
+    #expect(disconnectedAt.duration(to: .now) >= .milliseconds(450))
+    #expect(await daemon.recordedBootstrapCallCount() == 3)
+    #expect(store.connectionState == .online)
+    #expect((store.apiClient as? RecordingHarnessClient) === replacementClient)
+    #expect(store.globalStreamTask != nil)
+    #expect(initialClient.shutdownCallCount() == 1)
+    await store.prepareForTermination()
+  }
+
+  @Test("Remote initial snapshot failure closes discarded client before retry")
+  func remoteInitialSnapshotFailureClosesDiscardedClientBeforeRetry() async throws {
+    let fixture = try RemoteStoreFixture()
+    let failingClient = RecordingHarnessClient()
+    failingClient.configureDiagnosticsErrors([URLError(.cannotConnectToHost)])
+    let replacementClient = RecordingHarnessClient()
+    let daemon = RecordingDaemonController(
+      bootstrapOutcomes: [
+        .success(failingClient),
+        .success(replacementClient),
+      ]
+    )
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+    store.initialConnectRefreshRetryGracePeriod = .zero
+
+    await store.bootstrap()
+    #expect(failingClient.shutdownCallCount() == 1)
+
+    for _ in 0..<100 {
+      if await daemon.recordedBootstrapCallCount() == 2,
+        store.connectionState == .online
+      {
+        break
+      }
+      try await Task.sleep(for: .milliseconds(20))
+    }
+
+    #expect(await daemon.recordedBootstrapCallCount() == 2)
+    #expect(store.connectionState == .online)
+    #expect((store.apiClient as? RecordingHarnessClient) === replacementClient)
+    await store.prepareForTermination()
+  }
+
+  @Test("Remote refresh failure closes discarded client before retry")
+  func remoteRefreshFailureClosesDiscardedClientBeforeRetry() async throws {
+    let fixture = try RemoteStoreFixture()
+    let initialClient = RecordingHarnessClient()
+    let replacementClient = RecordingHarnessClient()
+    let daemon = RecordingDaemonController(
+      bootstrapOutcomes: [
+        .success(initialClient),
+        .success(replacementClient),
+      ]
+    )
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+    await store.bootstrap()
+    initialClient.configureDiagnosticsErrors([URLError(.cannotConnectToHost)])
+
+    await store.refresh(using: initialClient, preserveSelection: true)
+    #expect(initialClient.shutdownCallCount() == 1)
+
+    for _ in 0..<100 {
+      if await daemon.recordedBootstrapCallCount() == 2,
+        store.connectionState == .online
+      {
+        break
+      }
+      try await Task.sleep(for: .milliseconds(20))
+    }
+
+    #expect(await daemon.recordedBootstrapCallCount() == 2)
+    #expect(store.connectionState == .online)
+    #expect((store.apiClient as? RecordingHarnessClient) === replacementClient)
+    await store.prepareForTermination()
+  }
+
+  @Test("Remote snapshot 401 revokes the profile without retrying")
+  func remoteSnapshotUnauthorizedRevokesProfileWithoutRetrying() async throws {
+    let fixture = try RemoteStoreFixture()
+    let client = RecordingHarnessClient()
+    client.configureDiagnosticsErrors([
+      HarnessMonitorAPIError.server(code: 401, message: "unauthorized")
+    ])
+    let daemon = RecordingDaemonController(client: client)
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+    store.initialConnectRefreshRetryGracePeriod = .zero
+
+    await store.bootstrap()
+
+    #expect(client.shutdownCallCount() == 1)
+    #expect(store.remoteDaemonProfile?.status == .revoked)
+    #expect(try fixture.tokenStore.loadToken(profileID: fixture.profile.id) == nil)
+    #expect(store.remoteDaemonReconnectTask == nil)
+    #expect(await daemon.recordedBootstrapCallCount() == 1)
+  }
+
+  @Test("Remote incompatible task board stops retrying")
+  func remoteIncompatibleTaskBoardStopsRetrying() async throws {
+    let fixture = try RemoteStoreFixture()
+    let client = RecordingHarnessClient()
+    client.taskBoardCapabilitiesValue = TaskBoardCapabilities(
+      storage: "files",
+      revision: 1,
+      instanceID: "legacy-files"
+    )
+    let daemon = RecordingDaemonController(client: client)
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+
+    await store.bootstrap()
+
+    #expect(client.shutdownCallCount() == 1)
+    #expect(store.remoteDaemonProfile?.status == .active)
+    #expect(store.remoteDaemonReconnectTask == nil)
+    #expect(await daemon.recordedBootstrapCallCount() == 1)
+  }
+
+  @Test("Termination during remote connect cannot republish the connection")
+  func terminationDuringRemoteConnectCannotRepublishConnection() async throws {
+    let fixture = try RemoteStoreFixture()
+    let client = RecordingHarnessClient()
+    client.configureDiagnosticsDelay(.milliseconds(200))
+    let store = HarnessMonitorStore(
+      daemonController: RecordingDaemonController(client: client),
+      remoteDaemonServices: fixture.services
+    )
+    let bootstrapTask = Task { @MainActor in
+      await store.bootstrap()
+    }
+
+    for _ in 0..<100 {
+      if client.readCallCount(.diagnostics) > 0 {
+        break
+      }
+      try await Task.sleep(for: .milliseconds(5))
+    }
+    await store.prepareForTermination()
+    await bootstrapTask.value
+
+    #expect(client.shutdownCallCount() == 1)
+    #expect(store.apiClient == nil)
+    #expect(store.connectionState == .idle)
+    #expect(store.globalStreamTask == nil)
+    #expect(store.connectionProbeTask == nil)
+    #expect(store.remoteDaemonReconnectTask == nil)
+  }
+
+  @Test("App inactivity during remote connect cannot republish the connection")
+  func appInactivityDuringRemoteConnectCannotRepublishConnection() async throws {
+    let fixture = try RemoteStoreFixture()
+    let client = RecordingHarnessClient()
+    client.configureDiagnosticsDelay(.milliseconds(200))
+    let store = HarnessMonitorStore(
+      daemonController: RecordingDaemonController(client: client),
+      remoteDaemonServices: fixture.services
+    )
+    store.appInactivitySuspendDelay = .zero
+    let bootstrapTask = Task { @MainActor in
+      await store.bootstrap()
+    }
+
+    for _ in 0..<100 {
+      if client.readCallCount(.diagnostics) > 0 {
+        break
+      }
+      try await Task.sleep(for: .milliseconds(5))
+    }
+    await store.suspendLiveConnectionForAppInactivity()
+    await bootstrapTask.value
+
+    #expect(client.shutdownCallCount() == 1)
+    #expect(store.isAppLifecycleSuspended)
+    #expect(store.apiClient == nil)
+    #expect(store.connectionState == .idle)
+    #expect(store.globalStreamTask == nil)
+    #expect(store.connectionProbeTask == nil)
+    #expect(store.remoteDaemonReconnectTask == nil)
+  }
+
+  @Test("Remote cancelled request does not retry")
+  func remoteCancelledRequestDoesNotRetry() async throws {
+    let fixture = try RemoteStoreFixture()
+    let daemon = RecordingDaemonController(bootstrapError: URLError(.cancelled))
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+
+    await store.bootstrap()
+
+    #expect(store.remoteDaemonReconnectTask == nil)
+    #expect(await daemon.recordedBootstrapCallCount() == 1)
+  }
+
+  @Test("Remote reconnect uses capped exponential backoff")
+  func remoteReconnectUsesCappedExponentialBackoff() {
+    let store = HarnessMonitorStore(daemonController: RecordingDaemonController())
+
+    let delays = (0...6).map { store.reconnectDelay(for: $0) }
+
+    #expect(
+      delays == [
+        .milliseconds(500), .seconds(1), .seconds(2), .seconds(4), .seconds(8),
+        .seconds(8), .seconds(8),
+      ]
+    )
+  }
+
+  @Test("Termination cancels pending remote reconnect backoff")
+  func terminationCancelsPendingRemoteReconnectBackoff() async throws {
+    let (store, daemon) = try await makePendingReconnectStore()
+
+    #expect(await daemon.recordedBootstrapCallCount() == 2)
+    #expect(store.remoteDaemonReconnectTask != nil)
+
+    await store.prepareForTermination()
+    try await Task.sleep(for: .milliseconds(600))
+
+    #expect(store.remoteDaemonReconnectTask == nil)
+    #expect(await daemon.recordedBootstrapCallCount() == 2)
+  }
+
+  @Test("App inactivity cancels pending remote reconnect backoff")
+  func appInactivityCancelsPendingRemoteReconnectBackoff() async throws {
+    let (store, daemon) = try await makePendingReconnectStore()
+    store.appInactivitySuspendDelay = .zero
+
+    await store.suspendLiveConnectionForAppInactivity()
+    try await Task.sleep(for: .milliseconds(600))
+
+    #expect(store.isAppLifecycleSuspended)
+    #expect(store.remoteDaemonReconnectTask == nil)
+    #expect(await daemon.recordedBootstrapCallCount() == 2)
+  }
+
+  @Test(
+    "Remote terminal client errors do not retry",
+    arguments: [403, 426]
+  )
+  func remoteTerminalClientErrorsDoNotRetry(code: Int) async throws {
+    let fixture = try RemoteStoreFixture()
+    let daemon = RecordingDaemonController(
+      bootstrapError: HarnessMonitorAPIError.server(code: code, message: "terminal failure")
+    )
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+
+    await store.bootstrap()
+
+    #expect(store.remoteDaemonProfile?.status == .active)
+    #expect(store.remoteDaemonReconnectTask == nil)
+    #expect(await daemon.recordedBootstrapCallCount() == 1)
+  }
+
+  private func makePendingReconnectStore() async throws -> (
+    HarnessMonitorStore, RecordingDaemonController
+  ) {
+    let fixture = try RemoteStoreFixture()
+    let initialClient = RecordingHarnessClient()
+    let daemon = RecordingDaemonController(
+      bootstrapOutcomes: [
+        .success(initialClient),
+        .failure(URLError(.cannotConnectToHost)),
+        .success(RecordingHarnessClient()),
+      ],
+      bootstrapChecksCancellation: true
+    )
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+    await store.bootstrap()
+    initialClient.configureGlobalStream(
+      events: [],
+      error: WebSocketTransportError.connectionClosed,
+      failureCount: 1
+    )
+    store.startGlobalStream(using: initialClient)
+
+    for _ in 0..<100 {
+      if await daemon.recordedBootstrapCallCount() == 2,
+        store.remoteDaemonReconnectTask != nil
+      {
+        break
+      }
+      try await Task.sleep(for: .milliseconds(20))
+    }
+    return (store, daemon)
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests.swift
@@ -25,43 +25,6 @@ struct HarnessMonitorStoreRemoteConnectionTests {
     #expect(await daemon.recordedLaunchAgentStateCallCount() == 0)
   }
 
-  @Test("Remote stream closure reconnects after a server restart")
-  func remoteStreamClosureReconnectsAfterServerRestart() async throws {
-    let fixture = try RemoteStoreFixture()
-    let client = RecordingHarnessClient()
-    let daemon = RecordingDaemonController(
-      client: client,
-      bootstrapChecksCancellation: true
-    )
-    let store = HarnessMonitorStore(
-      daemonController: daemon,
-      remoteDaemonServices: fixture.services
-    )
-
-    await store.bootstrap()
-    #expect(store.connectionState == .online)
-    #expect(await daemon.recordedBootstrapCallCount() == 1)
-
-    client.configureGlobalStream(
-      events: [],
-      error: WebSocketTransportError.connectionClosed,
-      failureCount: 1
-    )
-    store.startGlobalStream(using: client)
-
-    for _ in 0..<100 {
-      if await daemon.recordedBootstrapCallCount() >= 2, !store.isReconnecting {
-        break
-      }
-      try await Task.sleep(for: .milliseconds(20))
-    }
-
-    #expect(await daemon.recordedBootstrapCallCount() == 2)
-    #expect(store.connectionState == .online)
-    #expect(store.globalStreamTask != nil)
-    await store.prepareForTermination()
-  }
-
   @Test("Mobile relay uses the remote client without local daemon warm-up")
   func mobileRelayUsesRemoteClient() async throws {
     let fixture = try RemoteStoreFixture()
@@ -93,6 +56,8 @@ struct HarnessMonitorStoreRemoteConnectionTests {
 
     #expect(store.remoteDaemonProfile?.status == .revoked)
     #expect(try fixture.tokenStore.loadToken(profileID: fixture.profile.id) == nil)
+    #expect(store.remoteDaemonReconnectTask == nil)
+    #expect(await daemon.recordedBootstrapCallCount() == 1)
     if case .offline(let reason) = store.connectionState {
       #expect(reason.localizedCaseInsensitiveContains("unauthorized"))
     } else {
@@ -257,7 +222,7 @@ struct HarnessMonitorStoreRemoteConnectionTests {
   }
 }
 
-private struct RemoteStoreFixture {
+struct RemoteStoreFixture {
   let profile: RemoteDaemonProfile
   let tokenStore: RecordingRemoteDaemonTokenStore
   let services: RemoteDaemonServices

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingDaemonController.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingDaemonController.swift
@@ -3,7 +3,13 @@ import Foundation
 @testable import HarnessMonitorKit
 
 actor RecordingDaemonController: DaemonControlling {
+  enum BootstrapOutcome: Sendable {
+    case success(any HarnessMonitorClientProtocol)
+    case failure(any Error)
+  }
+
   private let client: any HarnessMonitorClientProtocol
+  private var bootstrapOutcomes: [BootstrapOutcome]
   private var launchAgentInstalled: Bool
   private let registrationStateOverride: DaemonLaunchAgentRegistrationState?
   private let statusReportOverride: DaemonStatusReport?
@@ -21,6 +27,7 @@ actor RecordingDaemonController: DaemonControlling {
 
   init(
     client: any HarnessMonitorClientProtocol = PreviewHarnessClient(),
+    bootstrapOutcomes: [BootstrapOutcome] = [],
     launchAgentInstalled: Bool = true,
     registrationState: DaemonLaunchAgentRegistrationState? = nil,
     statusReport: DaemonStatusReport? = nil,
@@ -31,6 +38,7 @@ actor RecordingDaemonController: DaemonControlling {
     deferredManagedLaunchAgentRefreshResult: Bool = false
   ) {
     self.client = client
+    self.bootstrapOutcomes = bootstrapOutcomes
     self.launchAgentInstalled = launchAgentInstalled
     self.registrationStateOverride = registrationState
     self.statusReportOverride = statusReport
@@ -44,6 +52,14 @@ actor RecordingDaemonController: DaemonControlling {
     bootstrapCallCount += 1
     if bootstrapChecksCancellation {
       try Task.checkCancellation()
+    }
+    if !bootstrapOutcomes.isEmpty {
+      switch bootstrapOutcomes.removeFirst() {
+      case .success(let client):
+        return client
+      case .failure(let error):
+        throw error
+      }
     }
     if let bootstrapError {
       throw bootstrapError


### PR DESCRIPTION
## Motivation

Harness Monitor stopped recovering its remote daemon connection after a transient disconnect, leaving the session offline until the user manually reconnected. Remote sessions should recover without user intervention.

## Implementation

- Add exponential-backoff retry scheduling for unexpected remote daemon disconnects.
- Reset backoff after successful recovery and cancel pending retries after intentional disconnects.
- Add focused coverage for retry progression, reconnection, reset, and cancellation.
