### PR TITLE
fix(monitor): show manual steps in step mode

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOrchestratorPresentation.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOrchestratorPresentation.swift
@@ -93,6 +93,27 @@ struct TaskBoardOrchestratorPresentation {
     guard run.evaluation != nil else { return .evaluation }
     return .automation
   }
+
+  static func showsManualSteps(
+    for status: TaskBoardOrchestratorStatus,
+    scopeSessionID: String?,
+    hasStore: Bool
+  ) -> Bool {
+    scopeSessionID == nil && hasStore && status.stepMode
+  }
+
+  static func stateTitle(for status: TaskBoardOrchestratorStatus) -> String {
+    if status.stepMode {
+      return "Paused (Step Mode)"
+    }
+    if !status.enabled {
+      return "Disabled"
+    }
+    if status.running {
+      return "Running"
+    }
+    return "Idle"
+  }
 }
 
 struct TaskBoardWorkflowCountPresentation: Identifiable, Equatable {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOrchestratorSummaryView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOrchestratorSummaryView.swift
@@ -235,24 +235,15 @@ struct TaskBoardOrchestratorSummaryView: View {
   }
 
   private var stateTitle: String {
-    if !status.enabled {
-      return "Disabled"
-    }
-    if status.stepMode {
-      return "Paused (Step Mode)"
-    }
-    if status.running {
-      return "Running"
-    }
-    return "Idle"
+    TaskBoardOrchestratorPresentation.stateTitle(for: status)
   }
 
   private var stateTint: Color {
-    if !status.enabled {
-      return HarnessMonitorTheme.secondaryInk
-    }
     if status.stepMode {
       return HarnessMonitorTheme.caution
+    }
+    if !status.enabled {
+      return HarnessMonitorTheme.secondaryInk
     }
     if status.running {
       return HarnessMonitorTheme.accent

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+Chrome.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewView+Chrome.swift
@@ -24,10 +24,12 @@ extension TaskBoardOverviewView {
         taskBoardDetailRow { evaluationSummaryRow(evaluationSummary) }
       }
     }
-    if taskBoardSessionID == nil,
-      let orchestratorStatus,
-      orchestratorStatus.enabled,
-      orchestratorStatus.stepMode,
+    if let orchestratorStatus,
+      TaskBoardOrchestratorPresentation.showsManualSteps(
+        for: orchestratorStatus,
+        scopeSessionID: taskBoardSessionID,
+        hasStore: store != nil
+      ),
       let store
     {
       taskBoardDetailRow {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardStepRailView.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardStepRailView.swift
@@ -39,6 +39,10 @@ struct TaskBoardStepRailView: View {
           .font(.caption.weight(.semibold))
           .foregroundStyle(HarnessMonitorTheme.caution)
           .accessibilityIdentifier("harness.task-board.step.live-mode")
+        Text("Use these controls one stage at a time; Start is not required while Step Mode is on.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .accessibilityIdentifier("harness.task-board.step.manual-mode-explanation")
         stepControls
         if let selection = state.pickedSelection {
           TaskBoardStepPromptPreview(prompt: selection.plan.renderedPrompt)

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOrchestratorPresentationTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardOrchestratorPresentationTests.swift
@@ -38,6 +38,51 @@ struct TaskBoardOrchestratorPresentationTests {
     #expect(TaskBoardOrchestratorPresentation.appliedItemCount(for: run) == 1)
   }
 
+  @Test("Step mode exposes manual steps without starting autonomous scheduling")
+  func stepModeExposesManualStepsWhileOrchestratorIsDisabled() {
+    let disabledStepMode = orchestratorStatus(enabled: false, stepMode: true)
+
+    #expect(
+      TaskBoardOrchestratorPresentation.showsManualSteps(
+        for: disabledStepMode,
+        scopeSessionID: nil,
+        hasStore: true
+      )
+    )
+    #expect(
+      TaskBoardOrchestratorPresentation.stateTitle(for: disabledStepMode)
+        == "Paused (Step Mode)"
+    )
+  }
+
+  @Test("Manual steps stay dashboard-only and require live step mode state")
+  func manualStepsRespectDashboardScopeAndStoreAvailability() {
+    let stepMode = orchestratorStatus(enabled: true, stepMode: true)
+    let automaticMode = orchestratorStatus(enabled: true, stepMode: false)
+
+    #expect(
+      !TaskBoardOrchestratorPresentation.showsManualSteps(
+        for: automaticMode,
+        scopeSessionID: nil,
+        hasStore: true
+      )
+    )
+    #expect(
+      !TaskBoardOrchestratorPresentation.showsManualSteps(
+        for: stepMode,
+        scopeSessionID: "session-1",
+        hasStore: true
+      )
+    )
+    #expect(
+      !TaskBoardOrchestratorPresentation.showsManualSteps(
+        for: stepMode,
+        scopeSessionID: nil,
+        hasStore: false
+      )
+    )
+  }
+
   @Test("Idle workflow count excludes completed board items with idle workflow state")
   func idleWorkflowCountExcludesCompletedItems() {
     let items = [
@@ -223,15 +268,19 @@ struct TaskBoardOrchestratorPresentationTests {
   }
 
   private func orchestratorStatus(
+    enabled: Bool = true,
+    running: Bool = false,
+    stepMode: Bool = false,
     lastRun: TaskBoardOrchestratorRunSummary? = nil,
     workflowCounts: [TaskBoardWorkflowExecutionCount] = []
   ) -> TaskBoardOrchestratorStatus {
     TaskBoardOrchestratorStatus(
-      enabled: true,
-      running: false,
+      enabled: enabled,
+      running: running,
+      stepMode: stepMode,
       lastRun: lastRun,
       workflowExecutionCounts: workflowCounts,
-      settings: TaskBoardOrchestratorSettings(policyVersion: "v1")
+      settings: TaskBoardOrchestratorSettings(stepMode: stepMode, policyVersion: "v1")
     )
   }
 


### PR DESCRIPTION
## Motivation
Step Mode pauses autonomous scheduling, but Harness Monitor hid the Manual Steps panel whenever the orchestrator was disabled. This left Step Mode active without the controls needed to advance the task board manually.

## Implementation
- Show Manual Steps for dashboard Step Mode whenever the task-board store is available.
- Present the state as Paused (Step Mode) and explain that Start is not required.
- Add focused coverage for panel visibility, dashboard scope, store availability, and state presentation.