### PR TITLE
feat(task-board): replace umbrella with backlog

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorCore/MobileCommandDraft.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCore/MobileCommandDraft.swift
@@ -1,5 +1,20 @@
 import Foundation
 
+private func canonicalTaskBoardDispatchStatus(_ status: String) -> String {
+  switch status {
+  case "new":
+    "todo"
+  case "plan_review":
+    "agentic_review"
+  case "needs_you":
+    "human_required"
+  case "blocked":
+    "failed"
+  default:
+    status
+  }
+}
+
 public enum MobileCommandDraftValidationError: Error, Equatable, CustomStringConvertible, Sendable {
   case missingStation
   case missingTarget(String)
@@ -199,7 +214,10 @@ public struct MobileCommandDraft: Equatable, Sendable {
       let key = trimmed(pair.key)
       let value = trimmed(pair.value)
       if !key.isEmpty, !value.isEmpty {
-        result[key] = value
+        result[key] =
+          kind == .taskBoardDispatch && key == "status"
+          ? canonicalTaskBoardDispatchStatus(value)
+          : value
       }
     }
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorCore/MobileCommandDraft.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCore/MobileCommandDraft.swift
@@ -222,8 +222,8 @@ public struct MobileCommandDraft: Equatable, Sendable {
 
   private var knownTaskBoardStatuses: Set<String> {
     [
-      "new", "planning", "plan_review", "needs_you", "todo", "in_progress", "in_review",
-      "done", "blocked",
+      "backlog", "todo", "planning", "in_progress", "agentic_review", "testing", "in_review",
+      "to_review", "human_required", "failed", "done",
     ]
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorCore/MobileMirrorModels+TaskBoardModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorCore/MobileMirrorModels+TaskBoardModels.swift
@@ -17,6 +17,24 @@ public struct MobileTaskBoardSummary: Codable, Equatable, Identifiable, Sendable
   public var needsYou: Bool
   public var updatedAt: Date
 
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case stationID
+    case title
+    case bodyPreview
+    case status
+    case statusTitle
+    case priority
+    case priorityTitle
+    case tags
+    case projectID
+    case sessionID
+    case workItemID
+    case agentMode
+    case needsYou
+    case updatedAt
+  }
+
   public init(
     id: String,
     stationID: String,
@@ -34,12 +52,16 @@ public struct MobileTaskBoardSummary: Codable, Equatable, Identifiable, Sendable
     needsYou: Bool,
     updatedAt: Date
   ) {
+    let canonicalStatus = Self.canonicalStatus(status)
     self.id = id
     self.stationID = stationID
     self.title = title
     self.bodyPreview = bodyPreview
-    self.status = status
-    self.statusTitle = statusTitle
+    self.status = canonicalStatus
+    self.statusTitle = Self.canonicalStatusTitle(
+      sourceStatus: status,
+      statusTitle: statusTitle
+    )
     self.priority = priority
     self.priorityTitle = priorityTitle
     self.tags = tags
@@ -49,6 +71,50 @@ public struct MobileTaskBoardSummary: Codable, Equatable, Identifiable, Sendable
     self.agentMode = agentMode
     self.needsYou = needsYou
     self.updatedAt = updatedAt
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      id: try container.decode(String.self, forKey: .id),
+      stationID: try container.decode(String.self, forKey: .stationID),
+      title: try container.decode(String.self, forKey: .title),
+      bodyPreview: try container.decode(String.self, forKey: .bodyPreview),
+      status: try container.decode(String.self, forKey: .status),
+      statusTitle: try container.decode(String.self, forKey: .statusTitle),
+      priority: try container.decode(String.self, forKey: .priority),
+      priorityTitle: try container.decode(String.self, forKey: .priorityTitle),
+      tags: try container.decode([String].self, forKey: .tags),
+      projectID: try container.decodeIfPresent(String.self, forKey: .projectID),
+      sessionID: try container.decodeIfPresent(String.self, forKey: .sessionID),
+      workItemID: try container.decodeIfPresent(String.self, forKey: .workItemID),
+      agentMode: try container.decode(String.self, forKey: .agentMode),
+      needsYou: try container.decode(Bool.self, forKey: .needsYou),
+      updatedAt: try container.decode(Date.self, forKey: .updatedAt)
+    )
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    let canonicalStatus = Self.canonicalStatus(status)
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(stationID, forKey: .stationID)
+    try container.encode(title, forKey: .title)
+    try container.encode(bodyPreview, forKey: .bodyPreview)
+    try container.encode(canonicalStatus, forKey: .status)
+    try container.encode(
+      Self.canonicalStatusTitle(sourceStatus: status, statusTitle: statusTitle),
+      forKey: .statusTitle
+    )
+    try container.encode(priority, forKey: .priority)
+    try container.encode(priorityTitle, forKey: .priorityTitle)
+    try container.encode(tags, forKey: .tags)
+    try container.encodeIfPresent(projectID, forKey: .projectID)
+    try container.encodeIfPresent(sessionID, forKey: .sessionID)
+    try container.encodeIfPresent(workItemID, forKey: .workItemID)
+    try container.encode(agentMode, forKey: .agentMode)
+    try container.encode(needsYou, forKey: .needsYou)
+    try container.encode(updatedAt, forKey: .updatedAt)
   }
 
   public func commandDraft(
@@ -78,7 +144,7 @@ public struct MobileTaskBoardSummary: Codable, Equatable, Identifiable, Sendable
   public var commandPayload: [String: String] {
     var payload: [String: String] = [
       "itemID": id,
-      "status": status,
+      "status": Self.canonicalStatus(status),
       "priority": priority,
       "agentMode": agentMode,
     ]
@@ -111,5 +177,21 @@ public struct MobileTaskBoardSummary: Codable, Equatable, Identifiable, Sendable
       return nil
     }
     return value
+  }
+
+  private static func canonicalStatus(_ status: String) -> String {
+    status == "umbrella" ? "backlog" : status
+  }
+
+  private static func canonicalStatusTitle(
+    sourceStatus: String,
+    statusTitle: String
+  ) -> String {
+    if sourceStatus == "umbrella"
+      || (sourceStatus == "backlog" && statusTitle == "Umbrella")
+    {
+      return "Backlog"
+    }
+    return statusTitle
   }
 }

--- a/apps/harness-monitor/Sources/HarnessMonitorIntents/Entities/TaskBoardItemEntity.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorIntents/Entities/TaskBoardItemEntity.swift
@@ -16,7 +16,7 @@ public struct TaskBoardItemEntity: AppEntity, Identifiable, Sendable {
   public let projectId: String?
 
   private static let symbolByStatus: [TaskBoardStatusEnum: String] = [
-    .umbrella: "umbrella",
+    .backlog: "tray",
     .todo: "tray.and.arrow.down",
     .planning: "list.clipboard",
     .inProgress: "arrow.triangle.2.circlepath",

--- a/apps/harness-monitor/Sources/HarnessMonitorIntents/Entities/TaskBoardStatusEnum.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorIntents/Entities/TaskBoardStatusEnum.swift
@@ -3,7 +3,7 @@ import Foundation
 import HarnessMonitorKit
 
 public enum TaskBoardStatusEnum: String, AppEnum, Sendable {
-  case umbrella
+  case backlog
   case todo
   case planning
   case inProgress
@@ -16,7 +16,7 @@ public enum TaskBoardStatusEnum: String, AppEnum, Sendable {
   case done
 
   private static let intentStatusByDaemonStatus: [TaskBoardStatus: Self] = [
-    .umbrella: .umbrella,
+    .backlog: .backlog,
     .todo: .todo,
     .planning: .planning,
     .inProgress: .inProgress,
@@ -39,7 +39,7 @@ public enum TaskBoardStatusEnum: String, AppEnum, Sendable {
 
   public static var caseDisplayRepresentations: [Self: DisplayRepresentation] {
     [
-      .umbrella: DisplayRepresentation(title: "Umbrella"),
+      .backlog: DisplayRepresentation(title: "Backlog"),
       .todo: DisplayRepresentation(title: "Todo"),
       .planning: DisplayRepresentation(title: "Planning"),
       .inProgress: DisplayRepresentation(title: "In Progress"),
@@ -54,12 +54,12 @@ public enum TaskBoardStatusEnum: String, AppEnum, Sendable {
   }
 
   public init(daemonValue: TaskBoardStatus) {
-    self = Self.intentStatusByDaemonStatus[daemonValue] ?? .todo
+    self = Self.intentStatusByDaemonStatus[daemonValue] ?? .backlog
   }
 
   public var daemonValue: TaskBoardStatus {
     switch self {
-    case .umbrella: .umbrella
+    case .backlog: .backlog
     case .todo: .todo
     case .planning: .planning
     case .inProgress: .inProgress

--- a/apps/harness-monitor/Sources/HarnessMonitorIntents/Intents/TaskBoard/ListTaskBoardItemsIntent.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorIntents/Intents/TaskBoard/ListTaskBoardItemsIntent.swift
@@ -8,10 +8,10 @@ public struct ListTaskBoardItemsIntent: AppIntent {
     IntentDescription(
       """
       Return Task Board items, optionally filtered to a single workflow \
-      status (Umbrella, Todo, In Progress, …).
+      status (Backlog, Todo, In Progress, …).
       """,
       categoryName: "Task Board",
-      searchKeywords: ["task", "todo", "board", "list"],
+      searchKeywords: ["task", "backlog", "todo", "board", "list"],
       resultValueName: "Task Board Items"
     )
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/TaskBoardEnums.generated.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/TaskBoardEnums.generated.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 public enum TaskBoardStatus: TaskBoardOpenEnum, CaseIterable, Identifiable {
-  case umbrella
+  case backlog
   case todo
   case planning
   case inProgress
@@ -22,11 +22,11 @@ public enum TaskBoardStatus: TaskBoardOpenEnum, CaseIterable, Identifiable {
   case blocked
   case unknown(String)
 
-  public static let allCases: [Self] = [.umbrella, .todo, .planning, .inProgress, .agenticReview, .testing, .inReview, .toReview, .humanRequired, .failed, .done, .new, .planReview, .needsYou, .blocked]
+  public static let allCases: [Self] = [.backlog, .todo, .planning, .inProgress, .agenticReview, .testing, .inReview, .toReview, .humanRequired, .failed, .done, .new, .planReview, .needsYou, .blocked]
 
   public var rawValue: String {
     switch self {
-    case .umbrella: "umbrella"
+    case .backlog: "backlog"
     case .todo: "todo"
     case .planning: "planning"
     case .inProgress: "in_progress"
@@ -47,7 +47,7 @@ public enum TaskBoardStatus: TaskBoardOpenEnum, CaseIterable, Identifiable {
 
   public init(rawValue: String) {
     switch rawValue {
-    case "umbrella": self = .umbrella
+    case "backlog": self = .backlog
     case "todo": self = .todo
     case "planning": self = .planning
     case "in_progress": self = .inProgress

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/HarnessMonitorTaskBoardModels.swift
@@ -20,7 +20,7 @@ public struct TaskBoardCapabilities: Codable, Equatable, Sendable {
 
 extension TaskBoardStatus {
   public static let currentLaneCases: [Self] = [
-    .umbrella,
+    .backlog,
     .todo,
     .planning,
     .inProgress,
@@ -49,8 +49,8 @@ extension TaskBoardStatus {
 
   public var title: String {
     switch self {
-    case .umbrella:
-      "Umbrella"
+    case .backlog:
+      "Backlog"
     case .todo:
       "Todo"
     case .new:

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/TaskBoardInboxModels.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/TaskBoardInboxModels.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @frozen
 public enum TaskBoardInboxLane: String, CaseIterable, Identifiable, Sendable {
-  case umbrella
+  case backlog
   case todo
   case planning
   case inProgress = "in_progress"
@@ -14,7 +14,7 @@ public enum TaskBoardInboxLane: String, CaseIterable, Identifiable, Sendable {
   case failed
 
   private static let orderedCases: [Self] = [
-    .umbrella,
+    .backlog,
     .todo,
     .planning,
     .inProgress,
@@ -27,7 +27,7 @@ public enum TaskBoardInboxLane: String, CaseIterable, Identifiable, Sendable {
   ]
 
   private static let laneByTaskBoardStatus: [TaskBoardStatus: Self] = [
-    .umbrella: .umbrella,
+    .backlog: .backlog,
     .todo: .todo,
     .planning: .planning,
     .inProgress: .inProgress,
@@ -48,14 +48,14 @@ public enum TaskBoardInboxLane: String, CaseIterable, Identifiable, Sendable {
   }
 
   public static var active: Self { .inProgress }
-  public static var open: Self { .todo }
+  public static var open: Self { .backlog }
 
   public var id: String { rawValue }
 
   public var title: String {
     switch self {
-    case .umbrella:
-      "Umbrella"
+    case .backlog:
+      "Backlog"
     case .todo:
       "Todo"
     case .planning:
@@ -79,8 +79,8 @@ public enum TaskBoardInboxLane: String, CaseIterable, Identifiable, Sendable {
 
   public var systemImage: String {
     switch self {
-    case .umbrella:
-      "umbrella"
+    case .backlog:
+      "tray"
     case .todo:
       "tray.and.arrow.down"
     case .planning:
@@ -113,7 +113,7 @@ public enum TaskBoardInboxLane: String, CaseIterable, Identifiable, Sendable {
     case .inProgress:
       self = .inProgress
     case .open:
-      self = .todo
+      self = task.assignedTo != nil || task.queuedAt != nil ? .todo : .backlog
     case .done:
       return nil
     }
@@ -130,7 +130,7 @@ public enum TaskBoardInboxLane: String, CaseIterable, Identifiable, Sendable {
     case .inProgress:
       self = .inProgress
     case .open:
-      self = .todo
+      self = .backlog
     case .done:
       return nil
     }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Support/PreviewHarnessClient+TaskBoard.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Support/PreviewHarnessClient+TaskBoard.swift
@@ -142,7 +142,7 @@ extension PreviewHarnessClient {
 
 extension TaskBoardStatus {
   private static let previewTaskStatusByBoardStatus: [Self: TaskStatus] = [
-    .umbrella: .open,
+    .backlog: .open,
     .todo: .open,
     .planning: .open,
     .agenticReview: .open,

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Support/PreviewHarnessClientFixtures+Defaults.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Support/PreviewHarnessClientFixtures+Defaults.swift
@@ -261,7 +261,7 @@ extension PreviewHarnessClient.Fixtures {
     id: "preview-board-only",
     title: "Board-only preview item",
     body: "Board item without a linked session task",
-    status: .todo,
+    status: .backlog,
     priority: .high,
     tags: ["preview"],
     projectId: "project-6ccf8d0a",

--- a/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonTaskBoardSnapshot.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorMirrorStore/MobileRemoteDaemonTaskBoardSnapshot.swift
@@ -74,7 +74,7 @@ struct MobileRemoteTaskBoardWire: Decodable, Sendable {
   }
 
   private static let statusTitles = [
-    "umbrella": "Umbrella",
+    "backlog": "Backlog",
     "todo": "Todo",
     "new": "New",
     "planning": "Planning",

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardDraftSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/Settings/SettingsTaskBoardDraftSupport.swift
@@ -3,7 +3,7 @@ import HarnessMonitorKit
 
 enum DispatchStatusFilterChoice: String, CaseIterable, Hashable {
   case all
-  case umbrella
+  case backlog
   case todo
   case planning
   case inProgress
@@ -15,7 +15,7 @@ enum DispatchStatusFilterChoice: String, CaseIterable, Hashable {
   case failed
 
   private static let statusChoices: [TaskBoardStatus: Self] = [
-    .umbrella: .umbrella,
+    .backlog: .backlog,
     .todo: .todo,
     .planning: .planning,
     .inProgress: .inProgress,
@@ -36,7 +36,7 @@ extension DispatchStatusFilterChoice {
   var title: String {
     switch self {
     case .all: "All Items"
-    case .umbrella: "Umbrella"
+    case .backlog: "Backlog"
     case .todo: "Todo"
     case .planning: "Planning"
     case .inProgress: "In Progress"
@@ -52,7 +52,7 @@ extension DispatchStatusFilterChoice {
   var status: TaskBoardStatus? {
     switch self {
     case .all: nil
-    case .umbrella: .umbrella
+    case .backlog: .backlog
     case .todo: .todo
     case .planning: .planning
     case .inProgress: .inProgress

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardDragSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardCardDragSupport.swift
@@ -73,7 +73,7 @@ extension TaskBoardInboxLane {
     switch self {
     case .todo, .inProgress, .inReview, .toReview, .failed:
       true
-    case .umbrella, .planning, .agenticReview, .testing, .humanRequired:
+    case .backlog, .planning, .agenticReview, .testing, .humanRequired:
       false
     }
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneAppearancePreferences.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneAppearancePreferences.swift
@@ -181,12 +181,20 @@ enum TaskBoardLaneAppearancePreferences {
     let decoded =
       (try? JSONDecoder()
         .decode([String: TaskBoardLaneAppearanceOverride].self, from: data)) ?? [:]
-    return decoded.reduce(into: [:]) { result, entry in
-      guard let lane = TaskBoardInboxLane(rawValue: entry.key), !entry.value.isEmpty else {
-        return
+    var overrides: [TaskBoardInboxLane: TaskBoardLaneAppearanceOverride] = [:]
+    for (key, value) in decoded where key != "umbrella" && !value.isEmpty {
+      guard let lane = TaskBoardInboxLane(rawValue: key) else {
+        continue
       }
-      result[lane] = entry.value
+      overrides[lane] = value
     }
+    if overrides[.backlog] == nil,
+      let legacyOverride = decoded["umbrella"],
+      !legacyOverride.isEmpty
+    {
+      overrides[.backlog] = legacyOverride
+    }
+    return overrides
   }
 
   static func rawValue(
@@ -325,7 +333,7 @@ enum TaskBoardLaneAppearancePreferences {
 
   static func defaultColorToken(for lane: TaskBoardInboxLane) -> TaskBoardLaneColorToken {
     switch lane {
-    case .umbrella:
+    case .backlog:
       .warmAccent
     case .todo:
       .secondaryInk

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneCollapsePreferences.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneCollapsePreferences.swift
@@ -10,12 +10,19 @@ enum TaskBoardLaneCollapsePreferences {
       return [:]
     }
     let decoded = (try? JSONDecoder().decode([String: Bool].self, from: data)) ?? [:]
-    return decoded.reduce(into: [:]) { result, entry in
+    var overrides: [TaskBoardInboxLane: Bool] = decoded.reduce(into: [:]) { result, entry in
+      guard entry.key != "umbrella" else {
+        return
+      }
       guard let lane = TaskBoardInboxLane(rawValue: entry.key) else {
         return
       }
       result[lane] = entry.value
     }
+    if overrides[.backlog] == nil, let legacyOverride = decoded["umbrella"] {
+      overrides[.backlog] = legacyOverride
+    }
+    return overrides
   }
 
   static func rawValue(for overrides: [TaskBoardInboxLane: Bool]) -> String {

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneColors.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardLaneColors.swift
@@ -35,7 +35,7 @@ func taskBoardStatusColor(for status: TaskBoardStatus) -> Color {
     HarnessMonitorTheme.danger
   case .planning, .inProgress:
     HarnessMonitorTheme.warmAccent
-  case .umbrella, .new, .todo:
+  case .backlog, .new, .todo:
     HarnessMonitorTheme.accent
   case .done:
     HarnessMonitorTheme.secondaryInk

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOperationsSupport.swift
@@ -2,7 +2,7 @@ import HarnessMonitorKit
 
 enum TaskBoardStatusFilterChoice: String, CaseIterable, Identifiable, Hashable {
   case all
-  case umbrella
+  case backlog
   case todo
   case planning
   case inProgress
@@ -20,7 +20,7 @@ enum TaskBoardStatusFilterChoice: String, CaseIterable, Identifiable, Hashable {
   static let stableAllCases: [Self] = Self.allCases
 
   private static let statusChoices: [TaskBoardStatus: Self] = [
-    .umbrella: .umbrella,
+    .backlog: .backlog,
     .todo: .todo,
     .planning: .planning,
     .inProgress: .inProgress,
@@ -46,8 +46,8 @@ enum TaskBoardStatusFilterChoice: String, CaseIterable, Identifiable, Hashable {
     switch self {
     case .all:
       nil
-    case .umbrella:
-      .umbrella
+    case .backlog:
+      .backlog
     case .todo:
       .todo
     case .planning:

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewPresentationWorker.swift
@@ -125,7 +125,7 @@ actor TaskBoardOverviewPresentationWorker {
       }
     let taskBoardItems = TaskBoardVisibleItems.sorted(scopedTaskBoardItems)
     let apiItemsByLane = Dictionary(grouping: taskBoardItems) { item in
-      TaskBoardInboxLane(status: item.status) ?? .todo
+      TaskBoardInboxLane(status: item.status) ?? .backlog
     }
     let inboxItems = uniqueInboxItems(input.snapshot.items)
     let inboxItemsByLane = Dictionary(grouping: inboxItems, by: \.lane)

--- a/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorUIPreviewable/Views/TaskBoard/TaskBoardOverviewSupport.swift
@@ -366,7 +366,7 @@ enum TaskBoardOverviewItemBehavior {
 extension TaskBoardInboxLane {
   var taskDropStatus: TaskStatus? {
     switch self {
-    case .umbrella, .todo, .planning:
+    case .backlog, .todo, .planning:
       .open
     case .inProgress:
       .inProgress
@@ -383,8 +383,8 @@ extension TaskBoardInboxLane {
 
   var taskBoardDropStatus: TaskBoardStatus {
     switch self {
-    case .umbrella:
-      .umbrella
+    case .backlog:
+      .backlog
     case .todo:
       .todo
     case .planning:

--- a/apps/harness-monitor/Tests/HarnessMonitorCoreTests/MobileMirrorModelsTests+CommandDraft.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCoreTests/MobileMirrorModelsTests+CommandDraft.swift
@@ -137,7 +137,7 @@ extension MobileMirrorModelsCommandTests {
     }
   }
 
-  func testCommandDraftAcceptsBacklogAndRejectsLegacyUmbrellaStatus() {
+  func testCommandDraftCanonicalizesLegacyStatusesAndRejectsUmbrella() throws {
     let target = MobileCommandTarget(
       stationID: "station",
       taskID: "task-1",
@@ -152,6 +152,23 @@ extension MobileMirrorModelsCommandTests {
         payload: ["status": "backlog"]
       ).validate()
     )
+    for (legacyStatus, canonicalStatus) in [
+      "new": "todo",
+      "plan_review": "agentic_review",
+      "needs_you": "human_required",
+      "blocked": "failed",
+    ] {
+      let command = try MobileCommandDraft(
+        kind: .taskBoardDispatch,
+        confirmationText: "Dispatch task.",
+        target: target,
+        payload: ["status": legacyStatus]
+      ).makeCommand(
+        id: "command-\(legacyStatus)",
+        createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+      )
+      XCTAssertEqual(command.payload["status"], canonicalStatus)
+    }
     XCTAssertThrowsError(
       try MobileCommandDraft(
         kind: .taskBoardDispatch,

--- a/apps/harness-monitor/Tests/HarnessMonitorCoreTests/MobileMirrorModelsTests+CommandDraft.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCoreTests/MobileMirrorModelsTests+CommandDraft.swift
@@ -137,6 +137,36 @@ extension MobileMirrorModelsCommandTests {
     }
   }
 
+  func testCommandDraftAcceptsBacklogAndRejectsLegacyUmbrellaStatus() {
+    let target = MobileCommandTarget(
+      stationID: "station",
+      taskID: "task-1",
+      targetRevision: 12
+    )
+
+    XCTAssertNoThrow(
+      try MobileCommandDraft(
+        kind: .taskBoardDispatch,
+        confirmationText: "Dispatch task.",
+        target: target,
+        payload: ["status": "backlog"]
+      ).validate()
+    )
+    XCTAssertThrowsError(
+      try MobileCommandDraft(
+        kind: .taskBoardDispatch,
+        confirmationText: "Dispatch task.",
+        target: target,
+        payload: ["status": "umbrella"]
+      ).validate()
+    ) { error in
+      XCTAssertEqual(
+        error as? MobileCommandDraftValidationError,
+        .invalidPayload(key: "status", value: "umbrella")
+      )
+    }
+  }
+
   func testCommandDraftRejectsInvalidAgentStartPayloads() {
     let target = MobileCommandTarget(
       stationID: "station",

--- a/apps/harness-monitor/Tests/HarnessMonitorCoreTests/MobileMirrorModelsTests+Summaries.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorCoreTests/MobileMirrorModelsTests+Summaries.swift
@@ -130,4 +130,42 @@ extension MobileMirrorModelsCommandTests {
     XCTAssertEqual(command.payload["projectID"], "project")
     XCTAssertEqual(command.payload["workItemID"], "work-1")
   }
+
+  func testTaskBoardSummaryCanonicalizesLegacyUmbrellaAcrossCodableRoundTrip() throws {
+    let payload = """
+      {
+        "id": "task-legacy",
+        "stationID": "station",
+        "title": "Legacy task",
+        "bodyPreview": "",
+        "status": "umbrella",
+        "statusTitle": "Umbrella",
+        "priority": "medium",
+        "priorityTitle": "Medium",
+        "tags": [],
+        "agentMode": "headless",
+        "needsYou": false,
+        "updatedAt": 1700000000
+      }
+      """
+
+    let item = try JSONDecoder().decode(MobileTaskBoardSummary.self, from: Data(payload.utf8))
+
+    XCTAssertEqual(item.status, "backlog")
+    XCTAssertEqual(item.statusTitle, "Backlog")
+    XCTAssertEqual(item.commandPayload["status"], "backlog")
+
+    var staleItem = item
+    staleItem.status = "umbrella"
+    staleItem.statusTitle = "Umbrella"
+    XCTAssertEqual(staleItem.commandPayload["status"], "backlog")
+
+    let encoded = try JSONEncoder().encode(staleItem)
+    let object = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+    )
+    XCTAssertEqual(object["status"] as? String, "backlog")
+    XCTAssertEqual(object["statusTitle"] as? String, "Backlog")
+    XCTAssertFalse(String(decoding: encoded, as: UTF8.self).lowercased().contains("umbrella"))
+  }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorIntentsTests/EntityDisplayImageTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorIntentsTests/EntityDisplayImageTests.swift
@@ -33,7 +33,7 @@ final class EntityDisplayImageTests: XCTestCase {
 
   func testTaskBoardImageMapsEachStatusToDistinctSymbol() {
     let cases: [(TaskBoardStatusEnum, String)] = [
-      (.umbrella, "umbrella"),
+      (.backlog, "tray"),
       (.todo, "tray.and.arrow.down"),
       (.planning, "list.clipboard"),
       (.inProgress, "arrow.triangle.2.circlepath"),
@@ -61,7 +61,7 @@ final class EntityDisplayImageTests: XCTestCase {
 
   func testTaskBoardImageCoversEveryEnumCase() {
     let statuses: [TaskBoardStatusEnum] = [
-      .umbrella, .todo, .planning, .inProgress, .agenticReview, .testing,
+      .backlog, .todo, .planning, .inProgress, .agenticReview, .testing,
       .inReview, .toReview, .humanRequired, .failed, .done,
     ]
 

--- a/apps/harness-monitor/Tests/HarnessMonitorIntentsTests/TaskBoardIntentTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorIntentsTests/TaskBoardIntentTests.swift
@@ -81,7 +81,7 @@ final class TaskBoardIntentTests: XCTestCase {
 
   func testTaskBoardStatusEnumRoundTripsWithDaemonValues() {
     let currentStatuses: [TaskBoardStatus] = [
-      .umbrella,
+      .backlog,
       .todo,
       .planning,
       .inProgress,
@@ -105,6 +105,13 @@ final class TaskBoardIntentTests: XCTestCase {
     XCTAssertEqual(TaskBoardStatusEnum(daemonValue: .planReview).daemonValue, .agenticReview)
     XCTAssertEqual(TaskBoardStatusEnum(daemonValue: .needsYou).daemonValue, .humanRequired)
     XCTAssertEqual(TaskBoardStatusEnum(daemonValue: .blocked).daemonValue, .failed)
+  }
+
+  func testTaskBoardStatusEnumMapsUnknownDaemonValuesToBacklog() {
+    XCTAssertEqual(
+      TaskBoardStatusEnum(daemonValue: .unknown("future_status")).daemonValue,
+      .backlog
+    )
   }
 
   // MARK: - helpers

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests+Reconnect.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests+Reconnect.swift
@@ -319,53 +319,53 @@ extension HarnessMonitorStoreRemoteConnectionTests {
 
   @Test("Termination cancels pending remote reconnect backoff")
   func terminationCancelsPendingRemoteReconnectBackoff() async throws {
-    let (store, daemon, sleeper) = try await makePendingReconnectStore()
+    let fixture = try await makePendingReconnectStore()
 
-    #expect(await daemon.recordedBootstrapCallCount() == 0)
-    #expect(store.remoteDaemonReconnectTask != nil)
+    #expect(await fixture.daemon.recordedBootstrapCallCount() == 0)
+    #expect(fixture.store.remoteDaemonReconnectTask != nil)
 
-    await store.prepareForTermination()
+    await fixture.store.prepareForTermination()
     try await waitForRemoteReconnect {
-      await sleeper.recordedCancellationCount() == 1
+      await fixture.sleeper.recordedCancellationCount() == 1
     }
 
-    #expect(store.remoteDaemonReconnectTask == nil)
-    #expect(await daemon.recordedBootstrapCallCount() == 0)
+    #expect(fixture.store.remoteDaemonReconnectTask == nil)
+    #expect(await fixture.daemon.recordedBootstrapCallCount() == 0)
   }
 
   @Test("App inactivity cancels pending remote reconnect backoff")
   func appInactivityCancelsPendingRemoteReconnectBackoff() async throws {
-    let (store, daemon, sleeper) = try await makePendingReconnectStore()
-    store.appInactivitySuspendDelay = .zero
+    let fixture = try await makePendingReconnectStore()
+    fixture.store.appInactivitySuspendDelay = .zero
 
-    await store.suspendLiveConnectionForAppInactivity()
+    await fixture.store.suspendLiveConnectionForAppInactivity()
     try await waitForRemoteReconnect {
-      await sleeper.recordedCancellationCount() == 1
+      await fixture.sleeper.recordedCancellationCount() == 1
     }
 
-    #expect(store.isAppLifecycleSuspended)
-    #expect(store.remoteDaemonReconnectTask == nil)
-    #expect(await daemon.recordedBootstrapCallCount() == 0)
+    #expect(fixture.store.isAppLifecycleSuspended)
+    #expect(fixture.store.remoteDaemonReconnectTask == nil)
+    #expect(await fixture.daemon.recordedBootstrapCallCount() == 0)
   }
 
   @Test("Repeated remote failures share one reconnect loop")
   func repeatedRemoteFailuresShareOneReconnectLoop() async throws {
-    let (store, daemon, sleeper) = try await makePendingReconnectStore()
-    let generation = store.remoteDaemonReconnectGeneration
+    let fixture = try await makePendingReconnectStore()
+    let generation = fixture.store.remoteDaemonReconnectGeneration
 
-    store.scheduleRemoteDaemonReconnect(after: URLError(.timedOut))
-    store.scheduleRemoteDaemonReconnect(after: URLError(.networkConnectionLost))
+    fixture.store.scheduleRemoteDaemonReconnect(after: URLError(.timedOut))
+    fixture.store.scheduleRemoteDaemonReconnect(after: URLError(.networkConnectionLost))
     for _ in 0..<10 {
       await Task.yield()
     }
 
-    #expect(store.remoteDaemonReconnectGeneration == generation)
-    #expect(await sleeper.recordedDelays() == [.milliseconds(500)])
-    #expect(await daemon.recordedBootstrapCallCount() == 0)
+    #expect(fixture.store.remoteDaemonReconnectGeneration == generation)
+    #expect(await fixture.sleeper.recordedDelays() == [.milliseconds(500)])
+    #expect(await fixture.daemon.recordedBootstrapCallCount() == 0)
 
-    store.stopRemoteDaemonReconnect()
+    fixture.store.stopRemoteDaemonReconnect()
     try await waitForRemoteReconnect {
-      await sleeper.recordedCancellationCount() == 1
+      await fixture.sleeper.recordedCancellationCount() == 1
     }
   }
 
@@ -388,75 +388,5 @@ extension HarnessMonitorStoreRemoteConnectionTests {
     #expect(store.remoteDaemonProfile?.status == .active)
     #expect(store.remoteDaemonReconnectTask == nil)
     #expect(await daemon.recordedBootstrapCallCount() == 1)
-  }
-
-  private func makePendingReconnectStore() async throws -> (
-    HarnessMonitorStore, RecordingDaemonController, RecordingRemoteDaemonReconnectSleeper
-  ) {
-    let fixture = try RemoteStoreFixture()
-    let daemon = RecordingDaemonController()
-    let sleeper = RecordingRemoteDaemonReconnectSleeper(behavior: .suspended)
-    let store = HarnessMonitorStore(
-      daemonController: daemon,
-      remoteDaemonServices: fixture.services
-    )
-    store.connection.remoteDaemonReconnectSleeper = sleeper
-    store.connectionState = .offline("remote unavailable")
-    store.scheduleRemoteDaemonReconnect(after: URLError(.cannotConnectToHost))
-    try await waitForRemoteReconnect {
-      await sleeper.recordedDelays() == [.milliseconds(500)]
-    }
-    return (store, daemon, sleeper)
-  }
-
-  private func waitForRemoteReconnect(
-    _ condition: @escaping @MainActor () async -> Bool
-  ) async throws {
-    for _ in 0..<100 {
-      if await condition() {
-        return
-      }
-      try await Task.sleep(for: .milliseconds(5))
-    }
-    Issue.record("Timed out waiting for remote daemon reconnect state")
-  }
-}
-
-private actor RecordingRemoteDaemonReconnectSleeper: RemoteDaemonReconnectSleeping {
-  enum Behavior: Sendable {
-    case immediate
-    case suspended
-  }
-
-  private let behavior: Behavior
-  private var delays: [Duration] = []
-  private var cancellationCount = 0
-
-  init(behavior: Behavior) {
-    self.behavior = behavior
-  }
-
-  func sleep(for delay: Duration) async throws {
-    delays.append(delay)
-    switch behavior {
-    case .immediate:
-      await Task.yield()
-      try Task.checkCancellation()
-    case .suspended:
-      do {
-        try await Task.sleep(for: .seconds(3_600))
-      } catch {
-        cancellationCount += 1
-        throw error
-      }
-    }
-  }
-
-  func recordedDelays() -> [Duration] {
-    delays
-  }
-
-  func recordedCancellationCount() -> Int {
-    cancellationCount
   }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests+ReconnectSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreRemoteConnectionTests+ReconnectSupport.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import HarnessMonitorKit
+
+extension HarnessMonitorStoreRemoteConnectionTests {
+  func makePendingReconnectStore() async throws -> PendingRemoteReconnectFixture {
+    let fixture = try RemoteStoreFixture()
+    let daemon = RecordingDaemonController()
+    let sleeper = RecordingRemoteDaemonReconnectSleeper(behavior: .suspended)
+    let store = HarnessMonitorStore(
+      daemonController: daemon,
+      remoteDaemonServices: fixture.services
+    )
+    store.connection.remoteDaemonReconnectSleeper = sleeper
+    store.connectionState = .offline("remote unavailable")
+    store.scheduleRemoteDaemonReconnect(after: URLError(.cannotConnectToHost))
+    try await waitForRemoteReconnect {
+      await sleeper.recordedDelays() == [.milliseconds(500)]
+    }
+    return PendingRemoteReconnectFixture(store: store, daemon: daemon, sleeper: sleeper)
+  }
+
+  func waitForRemoteReconnect(
+    _ condition: @escaping @MainActor () async -> Bool
+  ) async throws {
+    for _ in 0..<100 {
+      if await condition() {
+        return
+      }
+      try await Task.sleep(for: .milliseconds(5))
+    }
+    Issue.record("Timed out waiting for remote daemon reconnect state")
+  }
+}
+
+struct PendingRemoteReconnectFixture {
+  let store: HarnessMonitorStore
+  let daemon: RecordingDaemonController
+  let sleeper: RecordingRemoteDaemonReconnectSleeper
+}
+
+actor RecordingRemoteDaemonReconnectSleeper: RemoteDaemonReconnectSleeping {
+  enum Behavior: Sendable {
+    case immediate
+    case suspended
+  }
+
+  private let behavior: Behavior
+  private var delays: [Duration] = []
+  private var cancellationCount = 0
+
+  init(behavior: Behavior) {
+    self.behavior = behavior
+  }
+
+  func sleep(for delay: Duration) async throws {
+    delays.append(delay)
+    switch behavior {
+    case .immediate:
+      await Task.yield()
+      try Task.checkCancellation()
+    case .suspended:
+      do {
+        try await Task.sleep(for: .seconds(3_600))
+      } catch {
+        cancellationCount += 1
+        throw error
+      }
+    }
+  }
+
+  func recordedDelays() -> [Duration] {
+    delays
+  }
+
+  func recordedCancellationCount() -> Int {
+    cancellationCount
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardEnumsWireDecodingTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardEnumsWireDecodingTests.swift
@@ -17,7 +17,8 @@ struct TaskBoardEnumsWireDecodingTests {
 
   @Test("decodes task board status snake_case values")
   func decodesStatus() throws {
-    #expect(try decode(TaskBoardStatus.self, "umbrella") == .umbrella)
+    #expect(try decode(TaskBoardStatus.self, "backlog") == .backlog)
+    #expect(try decode(TaskBoardStatus.self, "umbrella") == .unknown("umbrella"))
     #expect(try decode(TaskBoardStatus.self, "agentic_review") == .agenticReview)
     #expect(try decode(TaskBoardStatus.self, "to_review") == .toReview)
     #expect(try decode(TaskBoardStatus.self, "human_required") == .humanRequired)
@@ -31,6 +32,7 @@ struct TaskBoardEnumsWireDecodingTests {
 
   @Test("encodes status back to its snake_case wire value")
   func encodesStatus() throws {
+    #expect(try wireString(TaskBoardStatus.backlog) == "backlog")
     #expect(try wireString(TaskBoardStatus.agenticReview) == "agentic_review")
     #expect(try wireString(TaskBoardStatus.humanRequired) == "human_required")
     #expect(try wireString(TaskBoardStatus.inReview) == "in_review")
@@ -39,6 +41,7 @@ struct TaskBoardEnumsWireDecodingTests {
 
   @Test("status title extension survives adoption")
   func statusTitle() {
+    #expect(TaskBoardStatus.backlog.title == "Backlog")
     #expect(TaskBoardStatus.agenticReview.title == "Agentic Review")
     #expect(TaskBoardStatus.humanRequired.title == "Human Required")
     #expect(TaskBoardStatus.inReview.title == "In Review")
@@ -50,7 +53,7 @@ struct TaskBoardEnumsWireDecodingTests {
   func currentLaneStatusChoicesExcludeLegacyAndHiddenStatuses() {
     #expect(
       TaskBoardStatus.currentLaneCases == [
-        .umbrella,
+        .backlog,
         .todo,
         .planning,
         .inProgress,

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardInboxTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardInboxTests.swift
@@ -10,7 +10,7 @@ struct TaskBoardInboxTests {
   func inboxLanesUseGlobalBoardOrdering() {
     #expect(
       TaskBoardInboxLane.allCases == [
-        .umbrella,
+        .backlog,
         .todo,
         .planning,
         .inProgress,
@@ -90,7 +90,7 @@ struct TaskBoardInboxTests {
       ])
     #expect(
       snapshot.items.map(\.lane) == [
-        .todo,
+        .backlog,
         .todo,
         .inProgress,
         .toReview,
@@ -111,9 +111,19 @@ struct TaskBoardInboxTests {
     #expect(TaskBoardInboxLane(status: TaskStatus.awaitingReview) == .toReview)
     #expect(TaskBoardInboxLane(status: TaskStatus.inReview) == .inReview)
     #expect(TaskBoardInboxLane(status: TaskStatus.inProgress) == .inProgress)
-    #expect(TaskBoardInboxLane(status: TaskStatus.open) == .todo)
+    #expect(TaskBoardInboxLane(status: TaskStatus.open) == .backlog)
     #expect(TaskBoardInboxLane(status: TaskStatus.done) == nil)
 
+    #expect(
+      TaskBoardInboxLane(
+        task: makeTask(
+          id: "unassigned",
+          status: .open,
+          severity: .medium,
+          updatedAt: "2026-05-14T08:00:00Z"
+        )
+      ) == .backlog
+    )
     #expect(
       TaskBoardInboxLane(
         task: makeTask(
@@ -140,7 +150,7 @@ struct TaskBoardInboxTests {
 
   @Test("Task board item status maps to global board lanes")
   func taskBoardItemStatusMapsToGlobalBoardLanes() {
-    #expect(TaskBoardInboxLane(status: TaskBoardStatus.umbrella) == .umbrella)
+    #expect(TaskBoardInboxLane(status: TaskBoardStatus.backlog) == .backlog)
     #expect(TaskBoardInboxLane(status: TaskBoardStatus.todo) == .todo)
     #expect(TaskBoardInboxLane(status: TaskBoardStatus.planning) == .planning)
     #expect(TaskBoardInboxLane(status: TaskBoardStatus.inProgress) == .inProgress)

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardItemEditorDraftTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardItemEditorDraftTests.swift
@@ -64,7 +64,7 @@ struct TaskBoardItemEditorDraftTests {
   func statusMenusExposeOnlyCurrentTaskBoardLanes() {
     let expectedFilterTitles = [
       "All Items",
-      "Umbrella",
+      "Backlog",
       "Todo",
       "Planning",
       "In Progress",

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneAppearancePreferencesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneAppearancePreferencesTests.swift
@@ -57,6 +57,19 @@ struct TaskBoardLaneAppearancePreferencesTests {
     #expect(restoredAppearance.hasOverride(for: .agenticReview))
   }
 
+  @Test("Legacy Umbrella override loads as Backlog and writes canonically")
+  func legacyUmbrellaOverrideLoadsAsBacklogAndWritesCanonically() {
+    let legacyRawValue = #"{"umbrella":{"colorToken":"purple","symbolName":"archivebox"}}"#
+
+    let overrides = TaskBoardLaneAppearancePreferences.overrides(from: legacyRawValue)
+    let canonicalRawValue = TaskBoardLaneAppearancePreferences.rawValue(for: overrides)
+
+    #expect(overrides[.backlog]?.colorToken == .purple)
+    #expect(overrides[.backlog]?.symbolName == "archivebox")
+    #expect(canonicalRawValue.contains(#""backlog""#))
+    #expect(!canonicalRawValue.contains("umbrella"))
+  }
+
   @Test("Hidden symbols persist through UserDefaults")
   func hiddenSymbolsPersistThroughUserDefaults() throws {
     let suiteName = "TaskBoardLaneAppearancePreferencesTests.\(UUID().uuidString)"

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneCollapsePreferencesTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardLaneCollapsePreferencesTests.swift
@@ -70,4 +70,15 @@ struct TaskBoardLaneCollapsePreferencesTests {
       )
     )
   }
+
+  @Test("Legacy Umbrella override loads as Backlog and writes canonically")
+  func legacyUmbrellaOverrideLoadsAsBacklogAndWritesCanonically() {
+    let overrides = TaskBoardLaneCollapsePreferences.overrides(
+      from: #"{"umbrella":false}"#
+    )
+    let canonicalRawValue = TaskBoardLaneCollapsePreferences.rawValue(for: overrides)
+
+    #expect(overrides[.backlog] == false)
+    #expect(canonicalRawValue == #"{"backlog":false}"#)
+  }
 }

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSwiftUXCorrectnessTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardSwiftUXCorrectnessTests.swift
@@ -201,25 +201,25 @@ struct TaskBoardSwiftUXCorrectnessTests {
 
   // MARK: - #31 drag preserves source status
 
-  @Test("Dragging a planning item into Umbrella applies umbrella status")
-  func draggingPlanningItemIntoUmbrellaAppliesUmbrellaStatus() {
+  @Test("Dragging a planning item into Backlog applies backlog status")
+  func draggingPlanningItemIntoBacklogAppliesBacklogStatus() {
     let item = sampleTaskBoardItem(status: .planning)
-    let resolved = TaskBoardInboxLane.umbrella.taskBoardDropStatus(for: item)
-    #expect(resolved == .umbrella)
+    let resolved = TaskBoardInboxLane.backlog.taskBoardDropStatus(for: item)
+    #expect(resolved == .backlog)
   }
 
-  @Test("Dragging a new item into Umbrella applies umbrella status")
-  func draggingNewItemIntoUmbrellaAppliesUmbrellaStatus() {
+  @Test("Dragging a new item into Backlog applies backlog status")
+  func draggingNewItemIntoBacklogAppliesBacklogStatus() {
     let item = sampleTaskBoardItem(status: .new)
-    let resolved = TaskBoardInboxLane.umbrella.taskBoardDropStatus(for: item)
-    #expect(resolved == .umbrella)
+    let resolved = TaskBoardInboxLane.backlog.taskBoardDropStatus(for: item)
+    #expect(resolved == .backlog)
   }
 
-  @Test("Dragging a todo item into Umbrella applies umbrella status")
-  func draggingTodoItemIntoUmbrellaAppliesUmbrellaStatus() {
+  @Test("Dragging a todo item into Backlog applies backlog status")
+  func draggingTodoItemIntoBacklogAppliesBacklogStatus() {
     let item = sampleTaskBoardItem(status: .todo)
-    let resolved = TaskBoardInboxLane.umbrella.taskBoardDropStatus(for: item)
-    #expect(resolved == .umbrella)
+    let resolved = TaskBoardInboxLane.backlog.taskBoardDropStatus(for: item)
+    #expect(resolved == .backlog)
   }
 
   // MARK: - #33 ordered unique lines

--- a/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorMirrorStoreTests/MobileRemoteDaemonSyncClientTests.swift
@@ -127,6 +127,11 @@ final class MobileRemoteDaemonSyncClientTests: XCTestCase {
     )
     XCTAssertEqual(futureItem.statusTitle, "future_status")
     XCTAssertEqual(futureItem.priorityTitle, "hyper_priority")
+    let legacyItem = try XCTUnwrap(
+      snapshot.taskBoardItems.first { $0.id == "board-legacy-umbrella" }
+    )
+    XCTAssertEqual(legacyItem.status, "backlog")
+    XCTAssertEqual(legacyItem.statusTitle, "Backlog")
     XCTAssertEqual(snapshot.stations.first?.needsYouCount, 2)
     XCTAssertEqual(snapshot.needsYouCount, 2)
   }
@@ -459,6 +464,17 @@ private let taskBoardResponse = """
         "agent_mode": "headless",
         "created_at": "2026-07-10T12:00:00Z",
         "updated_at": "2026-07-10T13:03:00Z"
+      },
+      {
+        "schema_version": 1,
+        "id": "board-legacy-umbrella",
+        "title": "Legacy status",
+        "body": "",
+        "status": "umbrella",
+        "priority": "medium",
+        "agent_mode": "headless",
+        "created_at": "2026-07-10T12:00:00Z",
+        "updated_at": "2026-07-10T13:04:00Z"
       }
     ]
   }

--- a/docs/agent-guides/task-board-workflow.md
+++ b/docs/agent-guides/task-board-workflow.md
@@ -47,8 +47,7 @@ Common read flag: `--json`.
 Each task carries:
 
 - `id`, `title`, `body`
-- `status`: `new`, `planning`, `plan_review`, `needs_you`, `todo`,
-  `in_progress`, `in_review`, `done`, `blocked`
+- `status`: `backlog`, `todo`, `planning`, `in_progress`, `agentic_review`, `testing`, `in_review`, `to_review`, `human_required`, `failed`, `done`
 - `priority`: `low`, `medium`, `high`, `critical`
 - `agent_mode`: `headless`, `interactive`, `planning`, `evaluate`
 - `tags`, optional `project_id`, external refs, planning metadata, and optional
@@ -66,14 +65,13 @@ Priority maps to dispatch severity when session plans are built:
 ## Status Flow
 
 ```text
-new -> planning -> plan_review -> todo -> in_progress -> in_review -> done
-           |                         |          |
-           v                         v          v
-        blocked                   blocked    blocked
+backlog -> planning -> agentic_review -> todo -> in_progress -> testing -> in_review -> done
+                                               |              |
+                                               v              v
+                                         human_required     failed
 ```
 
-`blocked` means the task cannot proceed without new input, an external
-dependency, or a planning/review decision.
+`backlog` is unprocessed intake. `todo` means the task has been prioritized and ordered for planning approval or dispatch. `human_required` means the task needs human input or a planning/review decision, while `failed` records unsuccessful workflow execution.
 
 Dispatch readiness requires:
 
@@ -85,12 +83,7 @@ Dispatch readiness requires:
 
 The CLI sets `approved_at` when `--approved-by` is provided.
 
-Standard GitHub issue sync still imports repo-scoped `todo` items with a
-synthesized planning summary. The separate GitHub inbox flow for selected repos
-imports issues assigned to you and pull requests requesting your review as
-repo-scoped `todo` items. Imported items still require planning approval before
-dispatch. Review-request inbox items that GitHub no longer reports for you are
-automatically resolved on the next pull sync.
+Standard GitHub issue sync imports new open repo-scoped items into `backlog` with a synthesized planning summary. The separate GitHub inbox flow for selected repos imports new issues assigned to you and pull requests requesting your review into `backlog`. Todoist imports also enter `backlog`. Backlog items are not dispatchable; take an item through planning and approval, which moves the approved prioritized item to `todo`. Existing synced Todo items are not moved automatically. Closed external items map to `done`, and review-request inbox items that GitHub no longer reports for you are automatically resolved on the next pull sync.
 
 ## Intake And Planning
 
@@ -226,11 +219,7 @@ harness task-board orchestrator settings --json
 - `audit` gives total, ready, blocked, and by-status counts.
 - `project` groups local items by `project_id` and ready count.
 - `machine` groups local items by `agent_mode` and ready count.
-- `sync` reports external-provider configuration, linked, pushable, and blocked
-  counts plus previewed/applied operations. `--provider` narrows the provider,
-  `--direction` narrows pull/push intent, and `--apply` persists external
-  changes instead of previewing them. GitHub pull imports preserve `owner/repo`
-  in `project_id` and synthesize dispatch-ready planning approval.
+- `sync` reports external-provider configuration, linked, pushable, and blocked counts plus previewed/applied operations. `--provider` narrows the provider, `--direction` narrows pull/push intent, and `--apply` persists external changes instead of previewing them. GitHub pull imports preserve `owner/repo` in `project_id`, enter `backlog`, and synthesize a planning summary without approving or dispatching the task.
 - `dispatch` reports the session, worker, reviewer, and evaluator intent for
   each selected board item, including readiness block reasons. Daemon HTTP and
   WebSocket dispatch routes use the same executor, so apply/broadcast behavior
@@ -381,8 +370,7 @@ harness task-board policy grant-resolve <grant-id> --deny --actor <actor> --json
 
 - Prefer many small tasks over one broad task. Each task needs one clear close
   condition.
-- Do not dispatch `new`, `planning`, `plan_review`, `needs_you`,
-  `in_progress`, `in_review`, `done`, or `blocked` items.
+- Do not dispatch `backlog`, `planning`, `agentic_review`, `in_progress`, `testing`, `in_review`, `to_review`, `human_required`, `failed`, or `done` items.
 - Do not bypass the planning/review gate by setting `todo` without
   `--planning-summary` and `--approved-by`.
 - Use `delete` for tombstones; do not mutate task-board storage directly.

--- a/src/app/cli/tests.rs
+++ b/src/app/cli/tests.rs
@@ -224,6 +224,22 @@ fn parse_task_board_update_planning_fields() {
 }
 
 #[test]
+fn parse_task_board_backlog_status_and_reject_legacy_umbrella() {
+    let cli = Cli::try_parse_from(["harness", "task-board", "list", "--status", "backlog"])
+        .expect("parse backlog status");
+    match task_board_command(cli.command) {
+        TaskBoardCommand::List(args) => {
+            assert_eq!(args.status, Some(TaskBoardStatus::Backlog));
+        }
+        _ => panic!("expected TaskBoard List"),
+    }
+
+    assert!(
+        Cli::try_parse_from(["harness", "task-board", "list", "--status", "umbrella",]).is_err()
+    );
+}
+
+#[test]
 fn parse_task_board_orchestrator_runtime_config_and_tokens() {
     let runtime_config = Cli::try_parse_from([
         "harness",

--- a/src/daemon/client/task_board_tests.rs
+++ b/src/daemon/client/task_board_tests.rs
@@ -128,7 +128,7 @@ fn task_board_list_serializes_status_as_query() {
 
     let items = client_with(endpoint)
         .list_task_board_items(&TaskBoardListItemsRequest {
-            status: Some(TaskBoardStatus::Todo),
+            status: Some(TaskBoardStatus::Backlog),
         })
         .expect("list items");
     handle.join().expect("server");
@@ -136,7 +136,7 @@ fn task_board_list_serializes_status_as_query() {
     assert_eq!(items.len(), 1);
     assert_eq!(
         *request_line.lock().expect("request line"),
-        "GET /v1/task-board/items?status=todo HTTP/1.1"
+        "GET /v1/task-board/items?status=backlog HTTP/1.1"
     );
 }
 

--- a/src/daemon/db/async_bootstrap.rs
+++ b/src/daemon/db/async_bootstrap.rs
@@ -133,6 +133,7 @@ const fn migration_floor_version(migration_version: i64) -> u64 {
         28 => 34,
         29 => 35,
         30 => 36,
+        31 => 37,
         _ => u64::MAX,
     }
 }

--- a/src/daemon/db/migrations/0031_daemon_v37_task_board_backlog.sql
+++ b/src/daemon/db/migrations/0031_daemon_v37_task_board_backlog.sql
@@ -1,0 +1,152 @@
+UPDATE task_board_items
+SET status = 'backlog'
+WHERE status = 'umbrella';
+
+UPDATE task_board_external_refs
+SET sync_state_json = json_set(sync_state_json, '$.status', 'backlog')
+WHERE json_valid(sync_state_json)
+  AND json_extract(sync_state_json, '$.status') = 'umbrella';
+
+UPDATE task_board_orchestrator_settings
+SET settings_json = json_set(settings_json, '$.dispatch_status_filter', 'backlog')
+WHERE json_valid(settings_json)
+  AND json_extract(settings_json, '$.dispatch_status_filter') = 'umbrella';
+
+UPDATE task_board_orchestrator_runs
+SET scope_json = json_set(scope_json, '$.status', 'backlog')
+WHERE json_valid(scope_json)
+  AND json_extract(scope_json, '$.status') = 'umbrella';
+
+WITH RECURSIVE
+status_paths(singleton, ordinal, path) AS (
+    SELECT state.singleton,
+           ROW_NUMBER() OVER (PARTITION BY state.singleton ORDER BY tree.fullkey),
+           tree.fullkey
+    FROM task_board_orchestrator_state AS state,
+         json_tree(state.state_json) AS tree
+    WHERE json_valid(state.state_json)
+      AND tree.type = 'text'
+      AND tree.value = 'umbrella'
+      AND tree.key IN ('status', 'board_status', 'from_status', 'to_status')
+),
+rewritten(singleton, ordinal, state_json) AS (
+    SELECT singleton, 0, state_json
+    FROM task_board_orchestrator_state
+    UNION ALL
+    SELECT rewritten.singleton,
+           rewritten.ordinal + 1,
+           json_set(rewritten.state_json, status_paths.path, 'backlog')
+    FROM rewritten
+    JOIN status_paths
+      ON status_paths.singleton = rewritten.singleton
+     AND status_paths.ordinal = rewritten.ordinal + 1
+)
+UPDATE task_board_orchestrator_state
+SET state_json = (
+    SELECT rewritten.state_json
+    FROM rewritten
+    WHERE rewritten.singleton = task_board_orchestrator_state.singleton
+    ORDER BY rewritten.ordinal DESC
+    LIMIT 1
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM status_paths
+    WHERE status_paths.singleton = task_board_orchestrator_state.singleton
+);
+
+WITH RECURSIVE
+status_paths(intent_id, ordinal, path) AS (
+    SELECT intent.intent_id,
+           ROW_NUMBER() OVER (PARTITION BY intent.intent_id ORDER BY tree.fullkey),
+           tree.fullkey
+    FROM task_board_dispatch_intents AS intent,
+         json_tree(intent.payload_json) AS tree
+    WHERE json_valid(intent.payload_json)
+      AND tree.type = 'text'
+      AND tree.value = 'umbrella'
+      AND tree.key IN ('status', 'board_status', 'from_status', 'to_status')
+),
+rewritten(intent_id, ordinal, payload_json) AS (
+    SELECT intent_id, 0, payload_json
+    FROM task_board_dispatch_intents
+    UNION ALL
+    SELECT rewritten.intent_id,
+           rewritten.ordinal + 1,
+           json_set(rewritten.payload_json, status_paths.path, 'backlog')
+    FROM rewritten
+    JOIN status_paths
+      ON status_paths.intent_id = rewritten.intent_id
+     AND status_paths.ordinal = rewritten.ordinal + 1
+)
+UPDATE task_board_dispatch_intents
+SET payload_json = (
+    SELECT rewritten.payload_json
+    FROM rewritten
+    WHERE rewritten.intent_id = task_board_dispatch_intents.intent_id
+    ORDER BY rewritten.ordinal DESC
+    LIMIT 1
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM status_paths
+    WHERE status_paths.intent_id = task_board_dispatch_intents.intent_id
+);
+
+WITH RECURSIVE
+status_paths(run_id, ordinal, path) AS (
+    SELECT run.run_id,
+           ROW_NUMBER() OVER (PARTITION BY run.run_id ORDER BY tree.fullkey),
+           tree.fullkey
+    FROM task_board_orchestrator_runs AS run,
+         json_tree(run.stage_summary_json) AS tree
+    WHERE json_valid(run.stage_summary_json)
+      AND tree.type = 'text'
+      AND tree.value = 'umbrella'
+      AND tree.key IN ('status', 'board_status', 'from_status', 'to_status')
+),
+rewritten(run_id, ordinal, stage_summary_json) AS (
+    SELECT run_id, 0, stage_summary_json
+    FROM task_board_orchestrator_runs
+    UNION ALL
+    SELECT rewritten.run_id,
+           rewritten.ordinal + 1,
+           json_set(rewritten.stage_summary_json, status_paths.path, 'backlog')
+    FROM rewritten
+    JOIN status_paths
+      ON status_paths.run_id = rewritten.run_id
+     AND status_paths.ordinal = rewritten.ordinal + 1
+)
+UPDATE task_board_orchestrator_runs
+SET stage_summary_json = (
+    SELECT rewritten.stage_summary_json
+    FROM rewritten
+    WHERE rewritten.run_id = task_board_orchestrator_runs.run_id
+    ORDER BY rewritten.ordinal DESC
+    LIMIT 1
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM status_paths
+    WHERE status_paths.run_id = task_board_orchestrator_runs.run_id
+);
+
+UPDATE task_board_sync_conflicts
+SET base_value_json = json_quote('backlog')
+WHERE field = 'status'
+  AND json_valid(base_value_json)
+  AND json_extract(base_value_json, '$') = 'umbrella';
+
+UPDATE task_board_sync_conflicts
+SET local_value_json = json_quote('backlog')
+WHERE field = 'status'
+  AND json_valid(local_value_json)
+  AND json_extract(local_value_json, '$') = 'umbrella';
+
+UPDATE task_board_sync_conflicts
+SET remote_value_json = json_quote('backlog')
+WHERE field = 'status'
+  AND json_valid(remote_value_json)
+  AND json_extract(remote_value_json, '$') = 'umbrella';
+
+UPDATE schema_meta SET value = '37' WHERE key = 'version';

--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -95,6 +95,7 @@ mod schema_v33;
 mod schema_v34;
 mod schema_v35;
 mod schema_v36;
+mod schema_v37;
 #[allow(dead_code)]
 mod task_board;
 #[allow(unused_imports)]
@@ -296,7 +297,7 @@ impl fmt::Debug for DaemonDb {
     }
 }
 
-pub(crate) const SCHEMA_VERSION: &str = "36";
+pub(crate) const SCHEMA_VERSION: &str = "37";
 
 /// Summary of what was imported from file-based storage.
 #[derive(Debug, Default)]

--- a/src/daemon/db/schema.rs
+++ b/src/daemon/db/schema.rs
@@ -208,6 +208,9 @@ impl DaemonDb {
         if version_number <= 35 {
             self.migrate_v35_to_v36()?;
         }
+        if version_number <= 36 {
+            self.migrate_v36_to_v37()?;
+        }
         Ok(())
     }
 
@@ -343,6 +346,10 @@ impl DaemonDb {
 
     fn migrate_v35_to_v36(&self) -> Result<(), CliError> {
         super::schema_v36::run(&self.conn)
+    }
+
+    fn migrate_v36_to_v37(&self) -> Result<(), CliError> {
+        super::schema_v37::run(&self.conn)
     }
 }
 

--- a/src/daemon/db/schema_repairs.rs
+++ b/src/daemon/db/schema_repairs.rs
@@ -161,6 +161,7 @@ pub(super) fn repair_current_schema_shape(db: &DaemonDb) -> Result<(), CliError>
     super::schema_v34::run(&db.conn)?;
     super::schema_v35::run(&db.conn)?;
     super::schema_v36::run(&db.conn)?;
+    super::schema_v37::run(&db.conn)?;
     db.conn
         .execute(
             "UPDATE schema_meta SET value = ?1 WHERE key = 'version'",

--- a/src/daemon/db/schema_v37.rs
+++ b/src/daemon/db/schema_v37.rs
@@ -1,0 +1,152 @@
+use rusqlite::Connection;
+
+use super::{CliError, db_error};
+
+const BACKLOG_MIGRATION_SQL: &str =
+    include_str!("migrations/0031_daemon_v37_task_board_backlog.sql");
+
+pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
+    conn.execute_batch(BACKLOG_MIGRATION_SQL)
+        .map_err(|error| db_error(format!("migrate task board umbrella statuses: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::db::DaemonDb;
+
+    #[test]
+    fn migration_rewrites_only_persisted_task_board_status_fields() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+        seed_legacy_umbrella_rows(db.connection());
+
+        run(db.connection()).expect("run backlog migration");
+
+        assert_eq!(db.schema_version().expect("schema version"), "37");
+        assert_eq!(
+            text(
+                db.connection(),
+                "SELECT status FROM task_board_items WHERE item_id = 'legacy-item'"
+            ),
+            "backlog"
+        );
+        assert_eq!(
+            text(
+                db.connection(),
+                "SELECT status FROM task_board_items WHERE item_id = 'prioritized-item'"
+            ),
+            "todo",
+            "the migration must not move existing prioritized Todo items"
+        );
+        for query in backlog_json_queries() {
+            assert_eq!(text(db.connection(), query), "backlog", "{query}");
+        }
+        assert_eq!(
+            text(
+                db.connection(),
+                "SELECT json_extract(stage_summary_json, '$.label')
+                 FROM task_board_orchestrator_runs"
+            ),
+            "umbrella",
+            "non-status text must not be rewritten"
+        );
+    }
+
+    fn seed_legacy_umbrella_rows(conn: &Connection) {
+        conn.execute_batch(
+            "INSERT INTO task_board_items (
+                 item_id, schema_version, title, body, status, priority, tags_json,
+                 project_id, target_project_types_json, agent_mode, imported_from_provider,
+                 planning_json, workflow_json, session_id, work_item_id, usage_json,
+                 created_at, updated_at, deleted_at, revision, workflow_kind
+             ) VALUES
+             (
+                 'legacy-item', 1, 'Legacy', '', 'umbrella', 'medium', '[]',
+                 NULL, '[]', 'headless', 'github', '{}', '{}', NULL, NULL, '{}',
+                 '2026-07-16T00:00:00Z', '2026-07-16T00:00:00Z', NULL, 1, 'review'
+             ),
+             (
+                 'prioritized-item', 1, 'Prioritized', '', 'todo', 'high', '[]',
+                 NULL, '[]', 'headless', NULL, '{}', '{}', NULL, NULL, '{}',
+                 '2026-07-16T00:00:00Z', '2026-07-16T00:00:00Z', NULL, 1, 'default_task'
+             );
+             INSERT INTO task_board_external_refs (
+                 item_id, position, provider, external_id, sync_state_json
+             ) VALUES (
+                 'legacy-item', 0, 'github', '42', '{\"status\":\"umbrella\"}'
+             );
+             INSERT INTO task_board_orchestrator_settings (
+                 singleton, settings_json, revision, updated_at
+             ) VALUES (
+                 1, '{\"dispatch_status_filter\":\"umbrella\"}', 1,
+                 '2026-07-16T00:00:00Z'
+             );
+             INSERT INTO task_board_orchestrator_state (
+                 singleton, state_json, enabled, running, revision, updated_at
+             ) VALUES (
+                 1, '{\"last_run\":{\"audit\":{\"by_status\":[{\"status\":\"umbrella\"}]},
+                 \"evaluation\":{\"records\":[{\"board_status\":\"umbrella\",
+                 \"item\":{\"status\":\"umbrella\"}}]}}}', 0, 0, 1,
+                 '2026-07-16T00:00:00Z'
+             );
+             INSERT INTO task_board_orchestrator_runs (
+                 run_id, trigger, dry_run, scope_json, state, lease_owner, lease_epoch,
+                 lease_expires_at, stop_generation, started_at, heartbeat_at,
+                 stage_summary_json, revision
+             ) VALUES (
+                 'legacy-run', 'manual', 0, '{\"status\":\"umbrella\"}', 'terminal',
+                 'host', 1, '2026-07-16T01:00:00Z', 0, '2026-07-16T00:00:00Z',
+                 '2026-07-16T00:00:00Z',
+                 '{\"status\":\"umbrella\",\"label\":\"umbrella\"}', 1
+             );
+             INSERT INTO task_board_dispatch_intents (
+                 intent_id, item_id, session_id, work_item_id, workflow_execution_id,
+                 payload_json, status, attempts, available_at, created_at, updated_at
+             ) VALUES (
+                 'legacy-intent', 'legacy-item', 'session', 'work', 'execution',
+                 '{\"item\":{\"status\":\"umbrella\"},
+                 \"readiness\":{\"reason\":{\"status\":\"umbrella\"}}}',
+                 'pending', 0, '2026-07-16T00:00:00Z', '2026-07-16T00:00:00Z',
+                 '2026-07-16T00:00:00Z'
+             );
+             INSERT INTO task_board_sync_conflicts (
+                 conflict_id, item_id, provider, external_ref, field, base_value_json,
+                 local_value_json, remote_value_json, item_revision, state, detected_at
+             ) VALUES (
+                 'legacy-conflict', 'legacy-item', 'github', '42', 'status',
+                 '\"umbrella\"', '\"umbrella\"', '\"umbrella\"', 1, 'open',
+                 '2026-07-16T00:00:00Z'
+             );",
+        )
+        .expect("seed legacy task board statuses");
+    }
+
+    fn backlog_json_queries() -> [&'static str; 12] {
+        [
+            "SELECT json_extract(sync_state_json, '$.status') FROM task_board_external_refs",
+            "SELECT json_extract(settings_json, '$.dispatch_status_filter')
+             FROM task_board_orchestrator_settings",
+            "SELECT json_extract(state_json, '$.last_run.audit.by_status[0].status')
+             FROM task_board_orchestrator_state",
+            "SELECT json_extract(state_json, '$.last_run.evaluation.records[0].board_status')
+             FROM task_board_orchestrator_state",
+            "SELECT json_extract(state_json, '$.last_run.evaluation.records[0].item.status')
+             FROM task_board_orchestrator_state",
+            "SELECT json_extract(scope_json, '$.status') FROM task_board_orchestrator_runs",
+            "SELECT json_extract(stage_summary_json, '$.status')
+             FROM task_board_orchestrator_runs",
+            "SELECT json_extract(payload_json, '$.item.status')
+             FROM task_board_dispatch_intents",
+            "SELECT json_extract(payload_json, '$.readiness.reason.status')
+             FROM task_board_dispatch_intents",
+            "SELECT json_extract(base_value_json, '$') FROM task_board_sync_conflicts",
+            "SELECT json_extract(local_value_json, '$') FROM task_board_sync_conflicts",
+            "SELECT json_extract(remote_value_json, '$') FROM task_board_sync_conflicts",
+        ]
+    }
+
+    fn text(conn: &Connection, query: &str) -> String {
+        conn.query_row(query, [], |row| row.get(0))
+            .expect("read migrated value")
+    }
+}

--- a/src/daemon/db/task_board/mapper.rs
+++ b/src/daemon/db/task_board/mapper.rs
@@ -4,10 +4,7 @@ use serde_json::Value;
 
 use super::rows::{ExternalRefRow, ItemRow, MachineRow};
 use crate::daemon::db::{CliError, db_error};
-use crate::task_board::{
-    AgentMode, ExternalRef, ExternalRefProvider, Machine, PlanningState, TaskBoardItem,
-    TaskBoardPriority, TaskBoardStatus, TaskBoardWorkflowKind, TaskBoardWorkflowState, TaskUsage,
-};
+use crate::task_board::{ExternalRef, Machine, TaskBoardItem};
 
 pub(super) fn item_from_rows(
     row: ItemRow,
@@ -98,17 +95,4 @@ pub(super) fn label<T: Serialize>(value: T, context: &str) -> Result<String, Cli
 fn parse_label<T: DeserializeOwned>(value: &str, context: &str) -> Result<T, CliError> {
     serde_json::from_value(Value::String(value.to_owned()))
         .map_err(|error| db_error(format!("parse {context}: {error}")))
-}
-
-#[allow(dead_code)]
-fn assert_mapper_types_are_used(
-    _status: TaskBoardStatus,
-    _priority: TaskBoardPriority,
-    _mode: AgentMode,
-    _workflow_kind: TaskBoardWorkflowKind,
-    _provider: ExternalRefProvider,
-    _planning: PlanningState,
-    _workflow: TaskBoardWorkflowState,
-    _usage: TaskUsage,
-) {
 }

--- a/src/daemon/db/tests/async_pool.rs
+++ b/src/daemon/db/tests/async_pool.rs
@@ -26,7 +26,7 @@ async fn connect_reads_current_schema_version() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=30).collect::<Vec<i64>>()
+        (1..=31).collect::<Vec<i64>>()
     );
 }
 
@@ -51,7 +51,7 @@ async fn connect_bootstraps_empty_database_with_sqlx_migrations() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=30).collect::<Vec<i64>>()
+        (1..=31).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -143,7 +143,7 @@ async fn connect_migrates_legacy_schema_before_opening_pool() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=30).collect::<Vec<i64>>()
+        (1..=31).collect::<Vec<i64>>()
     );
 }
 
@@ -187,7 +187,7 @@ async fn connect_preserves_existing_db_when_baseline_checksum_drifted() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=30).collect::<Vec<i64>>()
+        (1..=31).collect::<Vec<i64>>()
     );
 }
 
@@ -246,7 +246,7 @@ async fn connect_accepts_v22_db_with_recorded_policy_snapshot_migration() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=30).collect::<Vec<i64>>()
+        (1..=31).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -279,7 +279,7 @@ async fn connect_seeds_v18_sqlx_ledger_when_sync_schema_already_applied() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=30).collect::<Vec<i64>>()
+        (1..=31).collect::<Vec<i64>>()
     );
 }
 
@@ -369,7 +369,7 @@ async fn connect_repairs_v8_active_sessions_without_leader_before_opening_pool()
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=30).collect::<Vec<i64>>()
+        (1..=31).collect::<Vec<i64>>()
     );
     drop(async_db);
 

--- a/src/daemon/db/tests/async_pool_migrations.rs
+++ b/src/daemon/db/tests/async_pool_migrations.rs
@@ -74,7 +74,7 @@ async fn connect_upgrades_applied_original_v34_migration() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=30).collect::<Vec<i64>>()
+        (1..=31).collect::<Vec<i64>>()
     );
     let requires_live = query_scalar::<_, bool>(
         "SELECT spawn_requires_live_policy FROM policy_workspace WHERE singleton = 1",
@@ -172,6 +172,10 @@ fn shipped_daemon_async_migration_checksums_remain_stable() {
         (
             "0030_daemon_v36_task_board_automation.sql",
             "10587AC9F726A588A6B57955793ED4BA4AE8EE53CE787411B7B2E7CE967F14C9F00A740837BF73828A345756C068237B",
+        ),
+        (
+            "0031_daemon_v37_task_board_backlog.sql",
+            "D55E7ECAA6D350295FB1955CFD42592FAB8026205AEA7E714330E1DD293867F4150FDC52BE3169CE7B3037A569C0AB89",
         ),
     ];
     let migrations_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/daemon/db/migrations");

--- a/src/daemon/db/tests/task_board.rs
+++ b/src/daemon/db/tests/task_board.rs
@@ -114,6 +114,73 @@ async fn task_board_items_round_trip_and_mutate_atomically() {
 }
 
 #[tokio::test]
+async fn v36_umbrella_rows_open_and_rewrite_as_backlog() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("harness.db");
+    {
+        let db = DaemonDb::open(&path).expect("create current database");
+        db.connection()
+            .execute_batch(
+                "INSERT INTO task_board_items (
+                     item_id, schema_version, title, body, status, priority, tags_json,
+                     project_id, target_project_types_json, agent_mode, imported_from_provider,
+                     planning_json, workflow_json, session_id, work_item_id, usage_json,
+                     created_at, updated_at, deleted_at, revision, workflow_kind
+                 ) VALUES (
+                     'legacy-umbrella', 1, 'Legacy', '', 'umbrella', 'medium', '[]',
+                     NULL, '[]', 'headless', 'github', '{}', '{}', NULL, NULL, '{}',
+                     '2026-07-16T00:00:00Z', '2026-07-16T00:00:00Z', NULL, 1, 'review'
+                 );
+                 INSERT INTO task_board_external_refs (
+                     item_id, position, provider, external_id, sync_state_json
+                 ) VALUES (
+                     'legacy-umbrella', 0, 'github', '42', '{\"status\":\"umbrella\"}'
+                 );
+                 UPDATE schema_meta SET value = '36' WHERE key = 'version';",
+            )
+            .expect("seed v36 umbrella rows");
+    }
+
+    let db = AsyncDaemonDb::connect(&path)
+        .await
+        .expect("open migrated database");
+    let loaded = db
+        .task_board_item("legacy-umbrella")
+        .await
+        .expect("load migrated item");
+    assert_eq!(loaded.status, TaskBoardStatus::Backlog);
+    assert_eq!(
+        loaded.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::Backlog)
+    );
+    db.update_task_board_item("legacy-umbrella", |item| {
+        item.title = "Canonical".to_string();
+        Ok(true)
+    })
+    .await
+    .expect("rewrite migrated item")
+    .expect("item changed");
+    drop(db);
+
+    let conn = Connection::open(&path).expect("inspect migrated database");
+    let (status, sync_status): (String, String) = conn
+        .query_row(
+            "SELECT item.status, json_extract(reference.sync_state_json, '$.status')
+             FROM task_board_items AS item
+             JOIN task_board_external_refs AS reference ON reference.item_id = item.item_id
+             WHERE item.item_id = 'legacy-umbrella'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read canonical status values");
+    assert_eq!(status, "backlog");
+    assert_eq!(sync_status, "backlog");
+}
+
+#[tokio::test]
 async fn task_board_singletons_and_machine_registry_round_trip() {
     let dir = tempdir().expect("tempdir");
     let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))

--- a/src/daemon/http/tests/policy_io_route_parity.rs
+++ b/src/daemon/http/tests/policy_io_route_parity.rs
@@ -55,9 +55,7 @@ async fn run_policy_transfer_dump_above_remote_body_limit() {
         .async_db
         .get()
         .expect("test async db")
-        .replace_policy_workspace(
-            &crate::task_board::policy_graph::PolicyCanvasWorkspace::seeded(),
-        )
+        .replace_policy_workspace(&crate::task_board::policy_graph::PolicyCanvasWorkspace::seeded())
         .await
         .expect("seed policy workspace");
     let (base_url, server) = serve_http(state).await;
@@ -91,9 +89,7 @@ async fn run_policy_transfer_larger_remote_body() {
         .async_db
         .get()
         .expect("test async db")
-        .replace_policy_workspace(
-            &crate::task_board::policy_graph::PolicyCanvasWorkspace::seeded(),
-        )
+        .replace_policy_workspace(&crate::task_board::policy_graph::PolicyCanvasWorkspace::seeded())
         .await
         .expect("seed policy workspace");
     let (base_url, server) = serve_http(state).await;

--- a/src/daemon/service/reviews_tests/projection.rs
+++ b/src/daemon/service/reviews_tests/projection.rs
@@ -207,7 +207,7 @@ async fn cached_reviews_query_creates_only_matching_task_board_reviews_idempoten
     assert_eq!(revision_after_second, revision_after_first);
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].title, "Review acme/api#17");
-    assert_eq!(items[0].status, TaskBoardStatus::Todo);
+    assert_eq!(items[0].status, TaskBoardStatus::Backlog);
     assert_eq!(items[0].project_id.as_deref(), Some("acme/api"));
     assert_eq!(
         items[0].external_refs[0].external_id, "acme/api#17",
@@ -239,7 +239,7 @@ async fn cached_reviews_projection_preserves_user_selected_status() {
         .expect("initial cached projection");
     let item = db.list_task_board_items(None).await.expect("list board")[0].clone();
     for status in [
-        TaskBoardStatus::Umbrella,
+        TaskBoardStatus::Backlog,
         TaskBoardStatus::Todo,
         TaskBoardStatus::Planning,
         TaskBoardStatus::InProgress,
@@ -313,7 +313,7 @@ async fn cached_reviews_projection_reopens_done_task_when_review_is_requested_ag
     let updated = db.task_board_item(&item.id).await.expect("load task");
 
     assert!(projected.from_cache);
-    assert_eq!(updated.status, TaskBoardStatus::Todo);
+    assert_eq!(updated.status, TaskBoardStatus::Backlog);
 }
 
 #[tokio::test]
@@ -404,13 +404,13 @@ async fn targeted_missing_refresh_completes_only_matching_imported_review() {
             .and_then(|state| state.status),
         Some(TaskBoardStatus::Done)
     );
-    assert_eq!(unrelated.status, TaskBoardStatus::HumanRequired);
+    assert_eq!(unrelated.status, TaskBoardStatus::Backlog);
     assert_eq!(
         unrelated.external_refs[0]
             .sync_state
             .as_ref()
             .and_then(|state| state.status),
-        Some(TaskBoardStatus::HumanRequired)
+        Some(TaskBoardStatus::Backlog)
     );
 
     let revision_after_first = db.task_board_revision().await.expect("first revision");
@@ -455,7 +455,7 @@ async fn create_imported_review(db: &AsyncDaemonDb, item_id: &str, repository: &
         String::new(),
         "2026-07-11T12:00:00Z".into(),
     );
-    item.status = TaskBoardStatus::HumanRequired;
+    item.status = TaskBoardStatus::Backlog;
     item.project_id = Some(repository.to_owned());
     item.imported_from_provider = Some(ExternalRefProvider::GitHub);
     item.external_refs = vec![ExternalRef {
@@ -463,7 +463,7 @@ async fn create_imported_review(db: &AsyncDaemonDb, item_id: &str, repository: &
         external_id: format!("{repository}#{number}"),
         url: Some(format!("https://github.com/{repository}/pull/{number}")),
         sync_state: Some(ExternalRefSyncState {
-            status: Some(TaskBoardStatus::HumanRequired),
+            status: Some(TaskBoardStatus::Backlog),
             updated_at: Some("2026-07-11T12:00:00Z".into()),
             ..ExternalRefSyncState::default()
         }),

--- a/src/daemon/service/reviews_tests/projection/eligibility.rs
+++ b/src/daemon/service/reviews_tests/projection/eligibility.rs
@@ -53,7 +53,7 @@ async fn observed_label_and_repository_eligibility_loss_completes_only_matching_
     );
     assert_eq!(
         status_for_repository(&after_label_loss, "eligibility/web"),
-        TaskBoardStatus::Todo,
+        TaskBoardStatus::Backlog,
         "a per-repository observation must not globally stale unrelated tasks"
     );
 

--- a/src/daemon/service/task_board/policy_transfer.rs
+++ b/src/daemon/service/task_board/policy_transfer.rs
@@ -169,11 +169,7 @@ fn validate_document(policy_id: &str, field: &str, document: &PolicyGraph) -> Re
 }
 
 fn validate_layout(policy_id: &str, field: &str, document: &PolicyGraph) -> Result<(), CliError> {
-    let node_ids: HashSet<&str> = document
-        .nodes
-        .iter()
-        .map(|node| node.id.as_str())
-        .collect();
+    let node_ids: HashSet<&str> = document.nodes.iter().map(|node| node.id.as_str()).collect();
     let mut seen = HashSet::with_capacity(document.layout.nodes.len());
     let mut actual = Vec::with_capacity(document.layout.nodes.len());
     for layout in &document.layout.nodes {

--- a/src/daemon/service/task_board/policy_transfer/tests.rs
+++ b/src/daemon/service/task_board/policy_transfer/tests.rs
@@ -6,8 +6,7 @@ use crate::daemon::protocol::{
     PolicyTransferDumpRequest, PolicyTransferImportRequest, PolicyTransferWorkspaceMetadata,
 };
 use crate::task_board::policy_graph::{
-    PolicyCanvasRecord, PolicyCanvasWorkspace, PolicyGraphMode, apply_rename,
-    apply_scenario_create,
+    PolicyCanvasRecord, PolicyCanvasWorkspace, PolicyGraphMode, apply_rename, apply_scenario_create,
 };
 
 use super::{dump_policies, import_policies};

--- a/src/daemon/service/task_board_db/reviews_sync.rs
+++ b/src/daemon/service/task_board_db/reviews_sync.rs
@@ -210,7 +210,7 @@ fn review_external_task(item: &ReviewItem) -> ExternalTask {
         .with_url(item.url.clone()),
         title: item.title.clone(),
         body: String::new(),
-        status: TaskBoardStatus::Todo,
+        status: TaskBoardStatus::Backlog,
         project_id: Some(item.repository.clone()),
         updated_at: Some(item.updated_at.to_rfc3339_opts(SecondsFormat::Secs, true)),
     }

--- a/src/task_board/dispatch_tests.rs
+++ b/src/task_board/dispatch_tests.rs
@@ -206,6 +206,23 @@ fn ready_dispatch_plan_maps_board_fields_to_session_task_intent() {
 }
 
 #[test]
+fn backlog_items_are_not_dispatchable() {
+    let mut item = ready_item();
+    item.status = TaskBoardStatus::Backlog;
+
+    let plan = build_dispatch_plan(&item);
+
+    assert_eq!(
+        plan.readiness,
+        DispatchReadiness::Blocked {
+            reason: DispatchBlockReason::Status {
+                status: TaskBoardStatus::Backlog,
+            },
+        }
+    );
+}
+
+#[test]
 fn dispatch_plan_decodes_legacy_payload_without_rendered_prompt() {
     let plan = build_dispatch_plan(&ready_item());
     let mut value = serde_json::to_value(&plan).expect("serialize plan");

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -142,6 +142,22 @@ pub struct ExternalTask {
     pub updated_at: Option<String>,
 }
 
+pub(super) fn canonical_external_status(status: TaskBoardStatus) -> TaskBoardStatus {
+    if status.canonical_persisted_status() == TaskBoardStatus::Done {
+        TaskBoardStatus::Done
+    } else {
+        TaskBoardStatus::Backlog
+    }
+}
+
+pub(super) fn local_external_status(status: TaskBoardStatus) -> Option<TaskBoardStatus> {
+    match status.canonical_persisted_status() {
+        TaskBoardStatus::Backlog | TaskBoardStatus::Todo => Some(TaskBoardStatus::Backlog),
+        TaskBoardStatus::Done => Some(TaskBoardStatus::Done),
+        _ => None,
+    }
+}
+
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct ExternalSyncConfig {
     pub github_token: Option<String>,

--- a/src/task_board/external/github.rs
+++ b/src/task_board/external/github.rs
@@ -28,7 +28,7 @@ use errors::{github_sync_error_with_context, warn_github_message};
 pub use inbox::GitHubInboxSyncClient;
 pub(crate) use review_projection::{
     imported_review_references_from_items, reconcile_review_item_from_snapshots,
-    reconciled_review_status,
+    reconciled_external_status,
 };
 #[derive(Clone)]
 pub struct GitHubSyncClient {
@@ -372,7 +372,7 @@ fn github_issue_search_status(state: &str) -> TaskBoardStatus {
     if state.eq_ignore_ascii_case("closed") {
         TaskBoardStatus::Done
     } else {
-        TaskBoardStatus::Todo
+        TaskBoardStatus::Backlog
     }
 }
 
@@ -401,7 +401,7 @@ fn github_inbox_issue_status(state: &str) -> TaskBoardStatus {
     if state.eq_ignore_ascii_case("closed") {
         TaskBoardStatus::Done
     } else {
-        TaskBoardStatus::Todo
+        TaskBoardStatus::Backlog
     }
 }
 
@@ -444,4 +444,15 @@ pub(super) fn search_label_matches_filter(
             .iter()
             .any(|wanted| name.eq_ignore_ascii_case(wanted.trim()))
     })
+}
+
+#[cfg(test)]
+mod status_tests {
+    use super::*;
+
+    #[test]
+    fn github_issue_search_status_maps_open_to_backlog_and_closed_to_done() {
+        assert_eq!(github_issue_search_status("OPEN"), TaskBoardStatus::Backlog);
+        assert_eq!(github_issue_search_status("closed"), TaskBoardStatus::Done);
+    }
 }

--- a/src/task_board/external/github/inbox.rs
+++ b/src/task_board/external/github/inbox.rs
@@ -208,7 +208,7 @@ impl GitHubInboxSyncClient {
                 reference: github_task_ref(repository, item.number, item.url),
                 title: item.title,
                 body: item.body.unwrap_or_default(),
-                status: TaskBoardStatus::Todo,
+                status: TaskBoardStatus::Backlog,
                 project_id: Some(project_id.clone()),
                 updated_at: Some(item.updated_at),
             })

--- a/src/task_board/external/github/inbox/tests.rs
+++ b/src/task_board/external/github/inbox/tests.rs
@@ -74,11 +74,11 @@ async fn github_inbox_pull_skips_failed_repository_and_keeps_pullable_tasks() {
     assert!(requests[2].contains("repo:good/repo"));
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].reference.external_id, "good/repo#7");
-    assert_eq!(tasks[0].status, TaskBoardStatus::Todo);
+    assert_eq!(tasks[0].status, TaskBoardStatus::Backlog);
 }
 
 #[tokio::test]
-async fn github_inbox_pull_imports_review_requests_as_todo() {
+async fn github_inbox_pull_imports_review_requests_as_backlog() {
     let (endpoint, requests, handle) = spawn_sequence_mock(vec![
         MockResponse::json(200, viewer_response("octo-user")),
         MockResponse::json(200, empty_search_response()),
@@ -96,7 +96,26 @@ async fn github_inbox_pull_imports_review_requests_as_todo() {
     assert_eq!(requests.len(), 3);
     assert!(requests[2].contains("review-requested:octo-user"));
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].status, TaskBoardStatus::Todo);
+    assert_eq!(tasks[0].status, TaskBoardStatus::Backlog);
+}
+
+#[tokio::test]
+async fn github_inbox_pull_maps_closed_assigned_issues_to_done() {
+    let (endpoint, _requests, handle) = spawn_sequence_mock(vec![
+        MockResponse::json(200, viewer_response("octo-user")),
+        MockResponse::json(
+            200,
+            search_response_with_issue_state("https://example.test/good/7", "CLOSED"),
+        ),
+        MockResponse::json(200, empty_search_response()),
+    ]);
+    let client = inbox_client_with_base_uri(endpoint, &["good/repo"]);
+
+    let tasks = client.pull_tasks().await.expect("inbox pull");
+
+    handle.join().expect("mock server");
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].status, TaskBoardStatus::Done);
 }
 
 #[tokio::test]
@@ -156,6 +175,10 @@ fn inbox_client_with_base_uri(base_uri: String, repositories: &[&str]) -> GitHub
 }
 
 fn search_response_with_issue(url: &str) -> serde_json::Value {
+    search_response_with_issue_state(url, "OPEN")
+}
+
+fn search_response_with_issue_state(url: &str, state: &str) -> serde_json::Value {
     json!({
         "data": {
             "search": {
@@ -168,7 +191,7 @@ fn search_response_with_issue(url: &str) -> serde_json::Value {
                     "title": "Keep pullable repo",
                     "body": null,
                     "url": url,
-                    "state": "OPEN",
+                    "state": state,
                     "updatedAt": "2026-05-19T00:00:00Z",
                     "labels": { "nodes": [] }
                 }]

--- a/src/task_board/external/github/review_projection.rs
+++ b/src/task_board/external/github/review_projection.rs
@@ -9,6 +9,8 @@ use crate::task_board::store::TaskBoardStore;
 use crate::task_board::types::{ExternalRef, ExternalRefProvider, TaskBoardItem, TaskBoardStatus};
 use crate::workspace::utc_now;
 
+use super::super::{canonical_external_status, local_external_status};
+
 #[cfg(test)]
 pub(crate) fn reconcile_pull_request_snapshots(
     board: &TaskBoardStore,
@@ -117,7 +119,7 @@ fn projection_patch(
         .sync_state
         .as_ref()
         .and_then(|state| state.status);
-    let status = reconciled_review_status(item.status, last_synced_status, observed_status);
+    let status = reconciled_external_status(item.status, last_synced_status, observed_status);
     let mut external_refs = item.external_refs.clone();
     let sync_state_changed = update_sync_state(
         &mut external_refs[reference_index],
@@ -191,22 +193,30 @@ fn observed_review_status(snapshot: &GitHubPullRequestSnapshot) -> Option<TaskBo
         return Some(TaskBoardStatus::Done);
     }
     if snapshot.viewer_review_requested == Some(true) {
-        return Some(TaskBoardStatus::Todo);
+        return Some(TaskBoardStatus::Backlog);
     }
     None
 }
 
-pub(crate) fn reconciled_review_status(
+pub(crate) fn reconciled_external_status(
     current: TaskBoardStatus,
     last_synced: Option<TaskBoardStatus>,
     observed: TaskBoardStatus,
 ) -> TaskBoardStatus {
     let current = current.canonical_persisted_status();
-    let observed = observed.canonical_persisted_status();
-    let last_synced = last_synced
-        .unwrap_or(TaskBoardStatus::Todo)
-        .canonical_persisted_status();
-    if current == last_synced {
+    let observed = canonical_external_status(observed);
+    let Some(current_external) = local_external_status(current) else {
+        return current;
+    };
+    let Some(last_external) = last_synced.map(canonical_external_status) else {
+        return if current_external == TaskBoardStatus::Backlog && observed == TaskBoardStatus::Done
+        {
+            TaskBoardStatus::Done
+        } else {
+            current
+        };
+    };
+    if current_external == last_external && observed != current_external {
         observed
     } else {
         current

--- a/src/task_board/external/github/review_projection/tests.rs
+++ b/src/task_board/external/github/review_projection/tests.rs
@@ -3,70 +3,13 @@ use tempfile::tempdir;
 use super::*;
 use crate::task_board::types::{ExternalRefSyncState, PlanningState, TaskBoardItem};
 
+mod status_tests;
+
 fn review_sync_state(status: TaskBoardStatus, updated_at: &str) -> ExternalRefSyncState {
     ExternalRefSyncState {
         status: Some(status),
         updated_at: Some(updated_at.to_owned()),
         ..ExternalRefSyncState::default()
-    }
-}
-
-#[test]
-fn review_status_reconciliation_uses_the_last_sync_as_shared_truth() {
-    assert_eq!(
-        reconciled_review_status(
-            TaskBoardStatus::InProgress,
-            Some(TaskBoardStatus::Todo),
-            TaskBoardStatus::Todo,
-        ),
-        TaskBoardStatus::InProgress
-    );
-    assert_eq!(
-        reconciled_review_status(
-            TaskBoardStatus::Todo,
-            Some(TaskBoardStatus::Todo),
-            TaskBoardStatus::Done,
-        ),
-        TaskBoardStatus::Done
-    );
-    assert_eq!(
-        reconciled_review_status(
-            TaskBoardStatus::InProgress,
-            Some(TaskBoardStatus::Todo),
-            TaskBoardStatus::Done,
-        ),
-        TaskBoardStatus::InProgress
-    );
-    assert_eq!(
-        reconciled_review_status(
-            TaskBoardStatus::Done,
-            Some(TaskBoardStatus::Done),
-            TaskBoardStatus::Todo,
-        ),
-        TaskBoardStatus::Todo
-    );
-    assert_eq!(
-        reconciled_review_status(TaskBoardStatus::Todo, None, TaskBoardStatus::Done),
-        TaskBoardStatus::Done
-    );
-    assert_eq!(
-        reconciled_review_status(TaskBoardStatus::InProgress, None, TaskBoardStatus::Done),
-        TaskBoardStatus::InProgress
-    );
-}
-
-#[test]
-fn review_status_reconciliation_canonicalizes_legacy_shared_truth() {
-    for (current, last_synced) in [
-        (TaskBoardStatus::Todo, TaskBoardStatus::New),
-        (TaskBoardStatus::AgenticReview, TaskBoardStatus::PlanReview),
-        (TaskBoardStatus::HumanRequired, TaskBoardStatus::NeedsYou),
-        (TaskBoardStatus::Failed, TaskBoardStatus::Blocked),
-    ] {
-        assert_eq!(
-            reconciled_review_status(current, Some(last_synced), TaskBoardStatus::Done),
-            TaskBoardStatus::Done
-        );
     }
 }
 
@@ -183,7 +126,7 @@ fn active_review_request_preserves_local_workflow_progress() {
         external_id: "example/repo#42".into(),
         url: Some("https://github.com/example/repo/pull/42".into()),
         sync_state: Some(review_sync_state(
-            TaskBoardStatus::Todo,
+            TaskBoardStatus::Backlog,
             "2026-07-11T10:00:00Z",
         )),
     }];
@@ -272,7 +215,7 @@ fn completed_remote_review_does_not_interrupt_active_execution() {
         external_id: "example/repo#42".into(),
         url: Some("https://github.com/example/repo/pull/42".into()),
         sync_state: Some(review_sync_state(
-            TaskBoardStatus::Todo,
+            TaskBoardStatus::Backlog,
             "2026-07-11T10:00:00Z",
         )),
     }];
@@ -328,7 +271,7 @@ fn candidate_projection_reloads_refs_edited_after_listing() {
         external_id: "example/repo#42".into(),
         url: Some("https://github.com/example/repo/pull/42".into()),
         sync_state: Some(review_sync_state(
-            TaskBoardStatus::Todo,
+            TaskBoardStatus::Backlog,
             "2026-07-11T10:00:00Z",
         )),
     }];
@@ -413,7 +356,7 @@ fn active_imported_reviews_are_discovered_for_exact_resolution() {
         external_id: "Example/Repo#42".into(),
         url: Some("https://github.com/Example/Repo/pull/42".into()),
         sync_state: Some(review_sync_state(
-            TaskBoardStatus::Todo,
+            TaskBoardStatus::Backlog,
             "2026-07-11T10:00:00Z",
         )),
     }];

--- a/src/task_board/external/github/review_projection/tests/status_tests.rs
+++ b/src/task_board/external/github/review_projection/tests/status_tests.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+#[test]
+fn external_status_reconciliation_preserves_workflow_and_tracks_provider_terminality() {
+    assert_eq!(
+        reconciled_external_status(
+            TaskBoardStatus::InProgress,
+            Some(TaskBoardStatus::Backlog),
+            TaskBoardStatus::Backlog,
+        ),
+        TaskBoardStatus::InProgress
+    );
+    assert_eq!(
+        reconciled_external_status(
+            TaskBoardStatus::Backlog,
+            Some(TaskBoardStatus::Backlog),
+            TaskBoardStatus::Done,
+        ),
+        TaskBoardStatus::Done
+    );
+    for observed in [TaskBoardStatus::Backlog, TaskBoardStatus::Done] {
+        assert_eq!(
+            reconciled_external_status(
+                TaskBoardStatus::InProgress,
+                Some(TaskBoardStatus::InProgress),
+                observed,
+            ),
+            TaskBoardStatus::InProgress
+        );
+    }
+    assert_eq!(
+        reconciled_external_status(
+            TaskBoardStatus::Done,
+            Some(TaskBoardStatus::Done),
+            TaskBoardStatus::Backlog,
+        ),
+        TaskBoardStatus::Backlog
+    );
+    for last_synced in [TaskBoardStatus::Todo, TaskBoardStatus::Backlog] {
+        assert_eq!(
+            reconciled_external_status(
+                TaskBoardStatus::Todo,
+                Some(last_synced),
+                TaskBoardStatus::Backlog,
+            ),
+            TaskBoardStatus::Todo
+        );
+    }
+    for current in [TaskBoardStatus::Todo, TaskBoardStatus::Backlog] {
+        assert_eq!(
+            reconciled_external_status(current, None, TaskBoardStatus::Done),
+            TaskBoardStatus::Done
+        );
+        assert_eq!(
+            reconciled_external_status(current, Some(TaskBoardStatus::Done), TaskBoardStatus::Done,),
+            current
+        );
+    }
+    assert_eq!(
+        reconciled_external_status(TaskBoardStatus::InProgress, None, TaskBoardStatus::Done),
+        TaskBoardStatus::InProgress
+    );
+    assert_eq!(
+        reconciled_external_status(
+            TaskBoardStatus::Done,
+            Some(TaskBoardStatus::Backlog),
+            TaskBoardStatus::Backlog,
+        ),
+        TaskBoardStatus::Done
+    );
+    assert_eq!(
+        reconciled_external_status(TaskBoardStatus::Done, None, TaskBoardStatus::Backlog),
+        TaskBoardStatus::Done
+    );
+}
+
+#[test]
+fn external_status_reconciliation_canonicalizes_legacy_shared_truth() {
+    for (current, last_synced, expected) in [
+        (
+            TaskBoardStatus::Todo,
+            TaskBoardStatus::New,
+            TaskBoardStatus::Done,
+        ),
+        (
+            TaskBoardStatus::AgenticReview,
+            TaskBoardStatus::PlanReview,
+            TaskBoardStatus::AgenticReview,
+        ),
+        (
+            TaskBoardStatus::HumanRequired,
+            TaskBoardStatus::NeedsYou,
+            TaskBoardStatus::HumanRequired,
+        ),
+        (
+            TaskBoardStatus::Failed,
+            TaskBoardStatus::Blocked,
+            TaskBoardStatus::Failed,
+        ),
+    ] {
+        assert_eq!(
+            reconciled_external_status(current, Some(last_synced), TaskBoardStatus::Done),
+            expected
+        );
+    }
+}

--- a/src/task_board/external/sync.rs
+++ b/src/task_board/external/sync.rs
@@ -11,7 +11,7 @@ use crate::workspace::utc_now;
 use super::{
     ExternalProvider, ExternalSyncClient, ExternalSyncConfig, ExternalSyncConflictPolicy,
     ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome,
-    GitHubInboxSyncClient, GitHubSyncClient, TodoistSyncClient,
+    GitHubInboxSyncClient, GitHubSyncClient, TodoistSyncClient, canonical_external_status,
 };
 
 mod delete;
@@ -245,12 +245,7 @@ async fn pull_provider_tasks(
     client: &dyn ExternalSyncClient,
     operations: &mut Vec<ExternalSyncOperation>,
 ) -> Result<(), CliError> {
-    let tasks = client
-        .pull_tasks()
-        .await?
-        .into_iter()
-        .filter(|task| options.status.is_none_or(|status| task.status == status))
-        .collect::<Vec<_>>();
+    let tasks = client.pull_tasks().await?;
     let board_items = board.list_items(None).await?;
     let item_index = build_external_ref_index(&board_items);
     for task in tasks.iter().cloned() {
@@ -260,8 +255,14 @@ async fn pull_provider_tasks(
             &task.reference,
             task.project_id.as_deref(),
         ) {
+            if !existing_pull_matches_status_filter(options.status, item, &task) {
+                continue;
+            }
             reconcile_existing_item(board, options, client.provider(), item, task, operations)
                 .await?;
+            continue;
+        }
+        if !new_pull_matches_status_filter(options.status, &task) {
             continue;
         }
         if options.dry_run {
@@ -311,6 +312,25 @@ async fn pull_provider_tasks(
     )
     .await?;
     Ok(())
+}
+
+fn existing_pull_matches_status_filter(
+    filter: Option<TaskBoardStatus>,
+    item: &TaskBoardItem,
+    task: &ExternalTask,
+) -> bool {
+    filter.is_none_or(|filter| {
+        let filter = filter.canonical_persisted_status();
+        filter == TaskBoardStatus::Todo
+            || item.status.canonical_persisted_status() == filter
+            || task.status.canonical_persisted_status() == filter
+    })
+}
+
+fn new_pull_matches_status_filter(filter: Option<TaskBoardStatus>, task: &ExternalTask) -> bool {
+    filter.is_none_or(|filter| {
+        task.status.canonical_persisted_status() == filter.canonical_persisted_status()
+    })
 }
 
 async fn find_item_for_task(
@@ -365,7 +385,7 @@ async fn create_remote_item(
     let reference = client.push_task(item).await?;
     let mut refs = item.external_refs.clone();
     refs.push(synced_ref_from_item(reference.clone(), item));
-    board
+    let linked = board
         .update_item(
             item,
             TaskBoardItemPatch {
@@ -379,12 +399,15 @@ async fn create_remote_item(
         provider: client.provider(),
         action: ExternalSyncAction::Push,
         board_item_id: Some(item.id.clone()),
-        reference,
+        reference: reference.clone(),
         dry_run: false,
         applied: true,
         changed_fields: push_create_fields(item),
         unsupported_fields: Vec::new(),
     }));
+    if canonical_external_status(item.status) == TaskBoardStatus::Done {
+        update_linked_remote(board, options, client, &linked, reference, operations).await?;
+    }
     Ok(())
 }
 
@@ -436,6 +459,7 @@ async fn update_linked_remote(
             return Ok(());
         }
     };
+    let refs = replace_synced_ref(item, &reference, &updated_ref, &supported);
     operations.push(operation(OperationDraft {
         provider: client.provider(),
         action: ExternalSyncAction::Push,
@@ -446,7 +470,6 @@ async fn update_linked_remote(
         changed_fields: supported,
         unsupported_fields: unsupported,
     }));
-    let refs = replace_synced_ref(item, &reference, &updated_ref);
     board
         .update_item(
             item,
@@ -480,7 +503,7 @@ fn create_item_from_external(task: &ExternalTask) -> TaskBoardItem {
         task.body.clone(),
         now,
     );
-    item.status = task.status;
+    item.status = canonical_external_status(task.status);
     item.project_id.clone_from(&task.project_id);
     let mut reference = task.reference.clone().into_core_ref();
     reference.sync_state = Some(sync_state_from_task(task));

--- a/src/task_board/external/sync/merge.rs
+++ b/src/task_board/external/sync/merge.rs
@@ -1,12 +1,13 @@
 use crate::task_board::store::{OptionalFieldPatch, TaskBoardItemPatch};
 use crate::task_board::types::{
-    ExternalRef, ExternalRefProvider, ExternalRefSyncState, TaskBoardItem,
+    ExternalRef, ExternalRefProvider, ExternalRefSyncState, TaskBoardItem, TaskBoardStatus,
 };
 use crate::workspace::utc_now;
 
 use crate::task_board::external::{
     ExternalProvider, ExternalProviderCapabilities, ExternalSyncAction, ExternalSyncField,
-    ExternalSyncOperation, ExternalTask, ExternalTaskRef,
+    ExternalSyncOperation, ExternalTask, ExternalTaskRef, canonical_external_status,
+    local_external_status,
 };
 
 pub(super) fn has_reported_conflict(
@@ -65,13 +66,14 @@ pub(super) fn replace_synced_ref(
     item: &TaskBoardItem,
     current: &ExternalTaskRef,
     updated: &ExternalTaskRef,
+    changed_fields: &[ExternalSyncField],
 ) -> Vec<ExternalRef> {
     let provider = current.provider.into();
     item.external_refs
         .iter()
         .map(|candidate| {
             if candidate.provider == provider && candidate.external_id == current.external_id {
-                synced_ref_from_item(updated.clone(), item)
+                synced_ref_from_update(candidate, updated.clone(), item, changed_fields)
             } else {
                 candidate.clone()
             }
@@ -84,7 +86,7 @@ pub(super) fn synced_ref_from_item(
     item: &TaskBoardItem,
 ) -> ExternalRef {
     let mut reference = reference.into_core_ref();
-    reference.sync_state = Some(sync_state_from_item(item));
+    reference.sync_state = Some(sync_state_from_created_item(item));
     reference
 }
 
@@ -92,7 +94,7 @@ pub(super) fn sync_state_from_task(task: &ExternalTask) -> ExternalRefSyncState 
     ExternalRefSyncState {
         title: Some(task.title.clone()),
         body: Some(task.body.clone()),
-        status: Some(task.status),
+        status: Some(canonical_external_status(task.status)),
         project_id: task.project_id.clone(),
         updated_at: task.updated_at.clone(),
         synced_at: Some(utc_now()),
@@ -115,11 +117,10 @@ pub(super) fn pull_create_fields(task: &ExternalTask) -> Vec<ExternalSyncField> 
 }
 
 pub(super) fn push_create_fields(item: &TaskBoardItem) -> Vec<ExternalSyncField> {
-    let mut fields = vec![
-        ExternalSyncField::Title,
-        ExternalSyncField::Body,
-        ExternalSyncField::Status,
-    ];
+    let mut fields = vec![ExternalSyncField::Title, ExternalSyncField::Body];
+    if canonical_external_status(item.status) != TaskBoardStatus::Done {
+        fields.push(ExternalSyncField::Status);
+    }
     if item.project_id.is_some() {
         fields.push(ExternalSyncField::Project);
     }
@@ -143,15 +144,42 @@ pub(super) fn changed_fields(patch: &TaskBoardItemPatch) -> Vec<ExternalSyncFiel
     fields
 }
 
-fn sync_state_from_item(item: &TaskBoardItem) -> ExternalRefSyncState {
+fn sync_state_from_created_item(item: &TaskBoardItem) -> ExternalRefSyncState {
     ExternalRefSyncState {
         title: Some(item.title.clone()),
         body: Some(item.body.clone()),
-        status: Some(item.status),
+        status: Some(TaskBoardStatus::Backlog),
         project_id: item.project_id.clone(),
         updated_at: None,
         synced_at: Some(utc_now()),
     }
+}
+
+fn synced_ref_from_update(
+    current: &ExternalRef,
+    updated: ExternalTaskRef,
+    item: &TaskBoardItem,
+    changed_fields: &[ExternalSyncField],
+) -> ExternalRef {
+    let mut reference = updated.into_core_ref();
+    let mut state = current.sync_state.clone().unwrap_or_default();
+    state.status = state.status.map(canonical_external_status);
+    if changed_fields.contains(&ExternalSyncField::Title) {
+        state.title = Some(item.title.clone());
+    }
+    if changed_fields.contains(&ExternalSyncField::Body) {
+        state.body = Some(item.body.clone());
+    }
+    if changed_fields.contains(&ExternalSyncField::Status) {
+        state.status = Some(canonical_external_status(item.status));
+    }
+    if changed_fields.contains(&ExternalSyncField::Project) {
+        state.project_id.clone_from(&item.project_id);
+    }
+    state.updated_at = None;
+    state.synced_at = Some(utc_now());
+    reference.sync_state = Some(state);
+    reference
 }
 
 fn item_remote_diff_fields(item: &TaskBoardItem, task: &ExternalTask) -> Vec<ExternalSyncField> {
@@ -164,7 +192,7 @@ fn item_remote_diff_fields(item: &TaskBoardItem, task: &ExternalTask) -> Vec<Ext
     push_if(&mut fields, item.body != task.body, ExternalSyncField::Body);
     push_if(
         &mut fields,
-        item.status != task.status,
+        local_status_differs_from_remote(item.status, task.status),
         ExternalSyncField::Status,
     );
     push_if(
@@ -192,7 +220,7 @@ fn local_fields_changed_since_sync(
     );
     push_if(
         &mut fields,
-        state.status != Some(item.status),
+        local_status_changed(item.status, state.status),
         ExternalSyncField::Status,
     );
     push_if(
@@ -220,7 +248,7 @@ fn remote_fields_changed_since_sync(
     );
     push_if(
         &mut fields,
-        state.status != Some(task.status),
+        remote_status_changed(task.status, state.status),
         ExternalSyncField::Status,
     );
     push_if(
@@ -244,6 +272,24 @@ fn push_if(fields: &mut Vec<ExternalSyncField>, condition: bool, field: External
     if condition {
         fields.push(field);
     }
+}
+
+fn local_status_differs_from_remote(local: TaskBoardStatus, remote: TaskBoardStatus) -> bool {
+    local_external_status(local).is_some_and(|local| local != canonical_external_status(remote))
+}
+
+fn local_status_changed(local: TaskBoardStatus, last_synced: Option<TaskBoardStatus>) -> bool {
+    local_external_status(local).is_some_and(|local| {
+        last_synced
+            .map(canonical_external_status)
+            .is_none_or(|last_synced| local != last_synced)
+    })
+}
+
+fn remote_status_changed(remote: TaskBoardStatus, last_synced: Option<TaskBoardStatus>) -> bool {
+    last_synced
+        .map(canonical_external_status)
+        .is_none_or(|last_synced| canonical_external_status(remote) != last_synced)
 }
 
 pub(super) fn matching_ref<'a>(

--- a/src/task_board/external/sync/reconcile.rs
+++ b/src/task_board/external/sync/reconcile.rs
@@ -3,11 +3,9 @@ use crate::task_board::external::{
     ExternalProvider, ExternalSyncConflictPolicy, ExternalTask, ExternalTaskRef,
 };
 use crate::task_board::store::{OptionalFieldPatch, TaskBoardItemPatch};
-use crate::task_board::types::{
-    ExternalRef, ExternalRefProvider, ExternalRefSyncState, TaskBoardItem, TaskBoardStatus,
-};
+use crate::task_board::types::{ExternalRef, ExternalRefSyncState, TaskBoardItem, TaskBoardStatus};
 
-use super::super::github::reconciled_review_status;
+use super::super::github::reconciled_external_status;
 use super::merge::{
     changed_fields, external_ref_matches, matching_ref, pull_conflict_fields, sync_state_from_task,
 };
@@ -120,23 +118,10 @@ fn reconciliation_patch(item: &TaskBoardItem, task: &ExternalTask) -> TaskBoardI
 }
 
 fn reconciled_status(item: &TaskBoardItem, task: &ExternalTask) -> TaskBoardStatus {
-    if !is_github_review_request(item, task) {
-        return task.status;
-    }
     let last_synced_status = matching_ref(item, &task.reference, task.project_id.as_deref())
         .and_then(|reference| reference.sync_state.as_ref())
         .and_then(|state| state.status);
-    reconciled_review_status(item.status, last_synced_status, task.status)
-}
-
-fn is_github_review_request(item: &TaskBoardItem, task: &ExternalTask) -> bool {
-    item.imported_from_provider == Some(ExternalRefProvider::GitHub)
-        && task.reference.provider == ExternalProvider::GitHub
-        && task
-            .reference
-            .url
-            .as_deref()
-            .is_some_and(|url| url.contains("/pull/"))
+    reconciled_external_status(item.status, last_synced_status, task.status)
 }
 
 fn has_reconciliation_change(patch: &TaskBoardItemPatch) -> bool {

--- a/src/task_board/external/sync/stale_reviews.rs
+++ b/src/task_board/external/sync/stale_reviews.rs
@@ -6,7 +6,7 @@ use crate::task_board::store::TaskBoardItemPatch;
 use crate::task_board::types::{ExternalRefProvider, TaskBoardItem, TaskBoardStatus};
 use crate::workspace::utc_now;
 
-use super::super::github::reconciled_review_status;
+use super::super::github::reconciled_external_status;
 use super::merge::{external_ref_matches, matching_ref};
 use super::{ExternalSyncAction, ExternalSyncOperation, ExternalSyncOptions, TaskBoardSyncStore};
 
@@ -50,9 +50,12 @@ pub(super) async fn reconcile_stale_github_review_requests(
 }
 
 fn allows_stale_review_reconcile(options: ExternalSyncOptions) -> bool {
-    options
-        .status
-        .is_none_or(|status| status == TaskBoardStatus::Todo)
+    options.status.is_none_or(|status| {
+        matches!(
+            status.canonical_persisted_status(),
+            TaskBoardStatus::Backlog | TaskBoardStatus::Todo
+        )
+    })
 }
 
 fn stale_review_request_operation(
@@ -81,7 +84,7 @@ fn stale_review_request_patch(
     let last_synced_status = matching_ref(item, reference, item.project_id.as_deref())
         .and_then(|reference| reference.sync_state.as_ref())
         .and_then(|state| state.status);
-    let status = reconciled_review_status(item.status, last_synced_status, TaskBoardStatus::Done);
+    let status = reconciled_external_status(item.status, last_synced_status, TaskBoardStatus::Done);
     let mut patch = TaskBoardItemPatch {
         status: (item.status != status).then_some(status),
         ..TaskBoardItemPatch::default()

--- a/src/task_board/external/sync_tests.rs
+++ b/src/task_board/external/sync_tests.rs
@@ -7,6 +7,8 @@ use super::*;
 use crate::task_board::store::TaskBoardStore;
 use crate::task_board::types::{ExternalRefSyncState, TaskBoardItem, TaskBoardStatus};
 
+mod status_roundtrip_tests;
+
 #[tokio::test]
 async fn push_updates_existing_linked_remote_and_records_changed_fields() {
     let temp = tempdir().expect("tempdir");
@@ -48,6 +50,7 @@ async fn push_updates_existing_linked_remote_and_records_changed_fields() {
         .as_ref()
         .expect("sync state");
     assert_eq!(state.title.as_deref(), Some("Local title"));
+    assert_eq!(state.status, Some(TaskBoardStatus::Backlog));
 }
 
 #[tokio::test]
@@ -68,7 +71,7 @@ async fn both_direction_reports_conflict_by_default_without_writing() {
             "remote-1",
             "Remote edit",
             "Old body",
-            TaskBoardStatus::Todo,
+            TaskBoardStatus::Backlog,
         )],
     ))];
 
@@ -111,7 +114,7 @@ async fn prefer_remote_applies_remote_conflict_side() {
             "remote-1",
             "Remote edit",
             "Old body",
-            TaskBoardStatus::Todo,
+            TaskBoardStatus::Backlog,
         )],
     ))];
 
@@ -156,7 +159,7 @@ async fn prefer_local_updates_remote_conflict_side() {
             "remote-1",
             "Remote edit",
             "Old body",
-            TaskBoardStatus::Todo,
+            TaskBoardStatus::Backlog,
         )],
     );
     let updates = client.updates.clone();

--- a/src/task_board/external/sync_tests/status_roundtrip_tests.rs
+++ b/src/task_board/external/sync_tests/status_roundtrip_tests.rs
@@ -1,0 +1,167 @@
+use super::*;
+
+#[tokio::test]
+async fn no_baseline_workflow_status_push_records_canonical_backlog_truth() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "task-1".to_string(),
+        "Local task".to_string(),
+        String::new(),
+        "2026-05-14T00:00:00Z".to_string(),
+    );
+    item.status = TaskBoardStatus::InProgress;
+    item.external_refs =
+        vec![ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1").into_core_ref()];
+    board
+        .create("Local task", "", item)
+        .expect("create local task");
+    let client = UpdateFakeSyncClient::new(
+        ExternalProvider::Todoist,
+        vec![ExternalSyncField::Status],
+        Vec::new(),
+    );
+    let updates = client.updates.clone();
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
+
+    sync_external_tasks(
+        &board,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::Todoist),
+            direction: ExternalSyncDirection::Push,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            status: None,
+        },
+        &clients,
+    )
+    .await
+    .expect("sync external tasks");
+
+    assert_eq!(
+        *updates.lock().expect("updates"),
+        vec![("remote-1".to_string(), vec![ExternalSyncField::Status])]
+    );
+    assert_eq!(
+        board.get("task-1").expect("updated task").external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::Backlog)
+    );
+}
+
+#[tokio::test]
+async fn remote_completion_does_not_reopen_an_active_workflow_lane() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    board
+        .create(
+            "Old title",
+            "Old body",
+            linked_item(
+                "task-1",
+                "Old title",
+                "Old body",
+                TaskBoardStatus::InProgress,
+            ),
+        )
+        .expect("create local task");
+    let client = UpdateFakeSyncClient::new(
+        ExternalProvider::Todoist,
+        vec![ExternalSyncField::Status],
+        vec![remote_task(
+            "remote-1",
+            "Old title",
+            "Old body",
+            TaskBoardStatus::Done,
+        )],
+    );
+    let updates = client.updates.clone();
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
+
+    let operations = sync_external_tasks(
+        &board,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::Todoist),
+            direction: ExternalSyncDirection::Both,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            status: None,
+        },
+        &clients,
+    )
+    .await
+    .expect("sync external tasks");
+
+    assert_eq!(operations.len(), 1);
+    assert_eq!(operations[0].action, ExternalSyncAction::Pull);
+    assert!(updates.lock().expect("updates").is_empty());
+    let updated = board.get("task-1").expect("updated task");
+    assert_eq!(updated.status, TaskBoardStatus::InProgress);
+    assert_eq!(
+        updated.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::Done)
+    );
+}
+
+#[tokio::test]
+async fn local_todo_reopen_survives_pull_and_pushes_remote_open() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = linked_item("task-1", "Old title", "Old body", TaskBoardStatus::Todo);
+    item.external_refs[0]
+        .sync_state
+        .as_mut()
+        .expect("sync state")
+        .status = Some(TaskBoardStatus::Done);
+    board
+        .create("Old title", "Old body", item)
+        .expect("create local task");
+    let client = UpdateFakeSyncClient::new(
+        ExternalProvider::Todoist,
+        vec![ExternalSyncField::Status],
+        vec![remote_task(
+            "remote-1",
+            "Old title",
+            "Old body",
+            TaskBoardStatus::Done,
+        )],
+    );
+    let updates = client.updates.clone();
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
+
+    let operations = sync_external_tasks(
+        &board,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::Todoist),
+            direction: ExternalSyncDirection::Both,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            status: None,
+        },
+        &clients,
+    )
+    .await
+    .expect("sync external tasks");
+
+    assert_eq!(operations.len(), 2);
+    assert_eq!(operations[0].action, ExternalSyncAction::Pull);
+    assert_eq!(operations[1].action, ExternalSyncAction::Push);
+    assert_eq!(
+        *updates.lock().expect("updates"),
+        vec![("remote-1".to_string(), vec![ExternalSyncField::Status])]
+    );
+    let updated = board.get("task-1").expect("updated task");
+    assert_eq!(updated.status, TaskBoardStatus::Todo);
+    assert_eq!(
+        updated.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::Backlog)
+    );
+}

--- a/src/task_board/external/tests.rs
+++ b/src/task_board/external/tests.rs
@@ -1,6 +1,8 @@
 mod config;
+mod create_done;
 mod delete;
 mod github;
 mod support;
 mod sync;
+mod sync_backlog;
 mod wire;

--- a/src/task_board/external/tests/create_done.rs
+++ b/src/task_board/external/tests/create_done.rs
@@ -1,0 +1,215 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tempfile::tempdir;
+
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::{
+    ExternalProvider, ExternalProviderCapabilities, ExternalSyncAction, ExternalSyncClient,
+    ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncField, ExternalSyncOptions,
+    ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome, TaskBoardItem,
+    TaskBoardStatus, TaskBoardStore, sync_external_tasks,
+};
+
+#[tokio::test]
+async fn newly_created_done_item_is_linked_then_closed() {
+    let temp = tempdir().expect("tempdir");
+    let board = board_with_done_item(temp.path());
+    let client = CreateDoneClient::with_status_updates();
+    let pushes = client.pushes.clone();
+    let updates = client.updates.clone();
+
+    let operations = sync(&board, client).await.expect("push Done item");
+
+    assert_eq!(pushes.lock().expect("push log").as_slice(), ["done-1"]);
+    assert_eq!(
+        updates.lock().expect("update log").as_slice(),
+        [vec![ExternalSyncField::Status]]
+    );
+    assert_eq!(operations.len(), 2);
+    assert_eq!(
+        operations[0].changed_fields,
+        vec![ExternalSyncField::Title, ExternalSyncField::Body]
+    );
+    assert_eq!(
+        operations[1].changed_fields,
+        vec![ExternalSyncField::Status]
+    );
+    assert_eq!(stored_sync_status(&board), TaskBoardStatus::Done);
+}
+
+#[tokio::test]
+async fn failed_close_keeps_link_and_retry_does_not_create_duplicate() {
+    let temp = tempdir().expect("tempdir");
+    let board = board_with_done_item(temp.path());
+    let client = CreateDoneClient::with_status_updates().fail_next_update();
+    let pushes = client.pushes.clone();
+    let updates = client.updates.clone();
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
+
+    sync_external_tasks(&board, push_options(), &clients)
+        .await
+        .expect_err("first close should fail");
+
+    assert_eq!(pushes.lock().expect("push log").as_slice(), ["done-1"]);
+    assert_eq!(stored_sync_status(&board), TaskBoardStatus::Backlog);
+    assert_eq!(
+        board
+            .get("done-1")
+            .expect("linked item after failure")
+            .external_refs
+            .len(),
+        1
+    );
+
+    sync_external_tasks(&board, push_options(), &clients)
+        .await
+        .expect("retry closes linked item");
+
+    assert_eq!(pushes.lock().expect("push log").as_slice(), ["done-1"]);
+    assert_eq!(updates.lock().expect("update log").len(), 2);
+    assert_eq!(stored_sync_status(&board), TaskBoardStatus::Done);
+}
+
+#[tokio::test]
+async fn create_only_provider_reports_done_status_as_unsupported() {
+    let temp = tempdir().expect("tempdir");
+    let board = board_with_done_item(temp.path());
+
+    let operations = sync(&board, CreateDoneClient::creates_only())
+        .await
+        .expect("link item without status support");
+
+    assert_eq!(operations.len(), 2);
+    assert_eq!(operations[0].action, ExternalSyncAction::Push);
+    assert_eq!(
+        operations[0].changed_fields,
+        vec![ExternalSyncField::Title, ExternalSyncField::Body]
+    );
+    assert_eq!(
+        operations[1].unsupported_fields,
+        vec![ExternalSyncField::Status]
+    );
+    assert!(!operations[1].applied);
+    assert_eq!(stored_sync_status(&board), TaskBoardStatus::Backlog);
+}
+
+async fn sync(
+    board: &TaskBoardStore,
+    client: CreateDoneClient,
+) -> Result<Vec<crate::task_board::ExternalSyncOperation>, CliError> {
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
+    sync_external_tasks(board, push_options(), &clients).await
+}
+
+fn push_options() -> ExternalSyncOptions {
+    ExternalSyncOptions {
+        provider: Some(ExternalProvider::Todoist),
+        direction: ExternalSyncDirection::Push,
+        conflict_policy: ExternalSyncConflictPolicy::Report,
+        dry_run: false,
+        status: None,
+    }
+}
+
+fn board_with_done_item(path: &std::path::Path) -> TaskBoardStore {
+    let board = TaskBoardStore::new(path.join("board"));
+    let mut item = TaskBoardItem::new(
+        "done-1".to_owned(),
+        "Finished task".to_owned(),
+        "Completed locally.".to_owned(),
+        "2026-07-16T00:00:00Z".to_owned(),
+    );
+    item.status = TaskBoardStatus::Done;
+    board
+        .create("Finished task", "Completed locally.", item)
+        .expect("create Done item");
+    board
+}
+
+fn stored_sync_status(board: &TaskBoardStore) -> TaskBoardStatus {
+    board
+        .get("done-1")
+        .expect("stored item")
+        .external_refs
+        .first()
+        .expect("external reference")
+        .sync_state
+        .as_ref()
+        .expect("sync state")
+        .status
+        .expect("sync status")
+}
+
+struct CreateDoneClient {
+    capabilities: ExternalProviderCapabilities,
+    pushes: Arc<Mutex<Vec<String>>>,
+    updates: Arc<Mutex<Vec<Vec<ExternalSyncField>>>>,
+    fail_next_update: AtomicBool,
+}
+
+impl CreateDoneClient {
+    fn with_status_updates() -> Self {
+        Self::new(ExternalProviderCapabilities::with_update_fields([
+            ExternalSyncField::Status,
+        ]))
+    }
+
+    fn creates_only() -> Self {
+        Self::new(ExternalProviderCapabilities::creates_only())
+    }
+
+    fn new(capabilities: ExternalProviderCapabilities) -> Self {
+        Self {
+            capabilities,
+            pushes: Arc::new(Mutex::new(Vec::new())),
+            updates: Arc::new(Mutex::new(Vec::new())),
+            fail_next_update: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_next_update(self) -> Self {
+        self.fail_next_update.store(true, Ordering::SeqCst);
+        self
+    }
+}
+
+#[async_trait]
+impl ExternalSyncClient for CreateDoneClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    fn capabilities(&self) -> ExternalProviderCapabilities {
+        self.capabilities.clone()
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        Ok(Vec::new())
+    }
+
+    async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        self.pushes.lock().expect("push log").push(item.id.clone());
+        Ok(ExternalTaskRef::new(
+            ExternalProvider::Todoist,
+            format!("remote-{}", item.id),
+        ))
+    }
+
+    async fn update_task(
+        &self,
+        _item: &TaskBoardItem,
+        reference: &ExternalTaskRef,
+        update: ExternalTaskUpdate,
+    ) -> Result<ExternalUpdateOutcome, CliError> {
+        self.updates
+            .lock()
+            .expect("update log")
+            .push(update.changed_fields);
+        if self.fail_next_update.swap(false, Ordering::SeqCst) {
+            return Err(CliErrorKind::workflow_io("simulated status update failure").into());
+        }
+        Ok(ExternalUpdateOutcome::Applied(reference.clone()))
+    }
+}

--- a/src/task_board/external/tests/github.rs
+++ b/src/task_board/external/tests/github.rs
@@ -34,6 +34,7 @@ async fn sync_external_tasks_imports_github_tasks_with_plan_pending_approval() {
     let item = board
         .get("github-7-7902699be42c8a8e46fbbb4501726517")
         .expect("load imported github task");
+    assert_eq!(item.status, TaskBoardStatus::Backlog);
     assert_eq!(item.project_id.as_deref(), Some("owner/repo"));
     assert!(item.planning.approved_by.is_none());
     assert!(item.planning.approved_at.is_none());
@@ -50,7 +51,7 @@ async fn sync_external_tasks_imports_github_tasks_with_plan_pending_approval() {
 }
 
 #[tokio::test]
-async fn sync_external_tasks_imports_github_inbox_items_as_todo_with_plan_pending_approval() {
+async fn sync_external_tasks_imports_github_inbox_items_as_backlog_with_plan_pending_approval() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
@@ -59,7 +60,7 @@ async fn sync_external_tasks_imports_github_inbox_items_as_todo_with_plan_pendin
             "owner/repo#19",
             "Review requested",
             "owner/repo",
-            TaskBoardStatus::Todo,
+            TaskBoardStatus::Backlog,
         )],
     ))];
 
@@ -80,7 +81,7 @@ async fn sync_external_tasks_imports_github_inbox_items_as_todo_with_plan_pendin
     let item = board
         .get("github-owner-repo-19-983c1507241b6007ac5729cfcea78b64")
         .expect("load imported github inbox task");
-    assert_eq!(item.status, TaskBoardStatus::Todo);
+    assert_eq!(item.status, TaskBoardStatus::Backlog);
     assert_eq!(item.project_id.as_deref(), Some("owner/repo"));
     assert!(item.planning.summary.is_some());
     assert!(item.planning.approved_by.is_none());

--- a/src/task_board/external/tests/support.rs
+++ b/src/task_board/external/tests/support.rs
@@ -95,7 +95,7 @@ pub(super) fn external_task(external_id: &str, title: &str) -> ExternalTask {
         reference: ExternalTaskRef::new(ExternalProvider::Todoist, external_id),
         title: title.to_owned(),
         body: String::new(),
-        status: TaskBoardStatus::Todo,
+        status: TaskBoardStatus::Backlog,
         project_id: None,
         updated_at: None,
     }
@@ -106,7 +106,7 @@ pub(super) fn github_external_task(
     title: &str,
     project_id: &str,
 ) -> ExternalTask {
-    github_external_task_with_status(external_id, title, project_id, TaskBoardStatus::Todo)
+    github_external_task_with_status(external_id, title, project_id, TaskBoardStatus::Backlog)
 }
 
 pub(super) fn github_external_task_with_status(
@@ -152,7 +152,7 @@ fn github_review_request_ref(external_id: &str) -> ExternalRef {
     reference.sync_state = Some(ExternalRefSyncState {
         title: Some("Review requested".to_owned()),
         body: Some("Please review the pull request.".to_owned()),
-        status: Some(TaskBoardStatus::Todo),
+        status: Some(TaskBoardStatus::Backlog),
         project_id: Some("owner/repo".to_owned()),
         updated_at: Some("2026-05-14T03:00:00Z".to_owned()),
         synced_at: Some("2026-05-14T03:00:00Z".to_owned()),

--- a/src/task_board/external/tests/sync.rs
+++ b/src/task_board/external/tests/sync.rs
@@ -20,6 +20,7 @@ async fn fake_client_pulls_tasks_without_network() {
     assert_eq!(client.provider(), ExternalProvider::Todoist);
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].title, "Remote task");
+    assert_eq!(tasks[0].status, TaskBoardStatus::Backlog);
 }
 
 #[tokio::test]
@@ -152,7 +153,7 @@ async fn sync_external_tasks_dry_run_does_not_write_board() {
 }
 
 #[tokio::test]
-async fn sync_external_tasks_reconciles_existing_provider_ref() {
+async fn sync_external_tasks_reconciles_closed_existing_provider_ref() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let mut local = TaskBoardItem::new(
@@ -175,7 +176,7 @@ async fn sync_external_tasks_reconciles_existing_provider_ref() {
             .with_url("https://example.test/new"),
         title: "New title".to_owned(),
         body: "New body".to_owned(),
-        status: TaskBoardStatus::Failed,
+        status: TaskBoardStatus::Done,
         project_id: Some("provider/project".to_owned()),
         updated_at: Some("2026-05-14T03:00:00Z".to_string()),
     };
@@ -205,7 +206,7 @@ async fn sync_external_tasks_reconciles_existing_provider_ref() {
     let updated = board.get("local-1").expect("load reconciled task");
     assert_eq!(updated.title, "New title");
     assert_eq!(updated.body, "New body");
-    assert_eq!(updated.status, TaskBoardStatus::Failed);
+    assert_eq!(updated.status, TaskBoardStatus::Done);
     assert_eq!(updated.project_id.as_deref(), Some("provider/project"));
     assert!(updated.external_refs.iter().any(|reference| {
         reference.provider == ExternalRefProvider::Todoist

--- a/src/task_board/external/tests/sync_backlog.rs
+++ b/src/task_board/external/tests/sync_backlog.rs
@@ -1,0 +1,220 @@
+use tempfile::tempdir;
+
+use super::support::{FakeSyncClient, external_task, github_review_request_item};
+use crate::task_board::{
+    ExternalProvider, ExternalSyncAction, ExternalSyncClient, ExternalSyncConflictPolicy,
+    ExternalSyncDirection, ExternalSyncOptions, ExternalTask, ExternalTaskRef, TaskBoardStatus,
+    TaskBoardStore, sync_external_tasks,
+};
+
+#[tokio::test]
+async fn todo_filtered_sync_does_not_import_new_backlog_tasks() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
+        ExternalProvider::Todoist,
+        vec![external_task("remote-backlog", "Unprocessed task")],
+    ))];
+
+    let operations = sync_external_tasks(
+        &board,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::Todoist),
+            direction: ExternalSyncDirection::Pull,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            status: Some(TaskBoardStatus::Todo),
+        },
+        &clients,
+    )
+    .await
+    .expect("sync external tasks");
+
+    assert!(operations.is_empty());
+    assert!(board.list(None).expect("list board").is_empty());
+}
+
+#[tokio::test]
+async fn todo_filtered_bidirectional_sync_preserves_legacy_todo_without_stale_churn() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = github_review_request_item(
+        "github-owner-repo-74",
+        "owner/repo#74",
+        TaskBoardStatus::Todo,
+    );
+    item.external_refs[0]
+        .sync_state
+        .as_mut()
+        .expect("sync state")
+        .status = Some(TaskBoardStatus::Todo);
+    board
+        .create("Review requested", "Please review the pull request.", item)
+        .expect("create legacy todo review");
+    let remote = ExternalTask {
+        reference: ExternalTaskRef::new(ExternalProvider::GitHub, "owner/repo#74")
+            .with_url("https://example.test/pull/owner/repo#74"),
+        title: "Review requested".to_owned(),
+        body: "Please review the pull request.".to_owned(),
+        status: TaskBoardStatus::Backlog,
+        project_id: Some("owner/repo".to_owned()),
+        updated_at: Some("2026-05-14T04:00:00Z".to_owned()),
+    };
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(
+        FakeSyncClient::new(ExternalProvider::GitHub, vec![remote])
+            .with_authoritative_review_inbox(),
+    )];
+    let options = ExternalSyncOptions {
+        provider: Some(ExternalProvider::GitHub),
+        direction: ExternalSyncDirection::Both,
+        conflict_policy: ExternalSyncConflictPolicy::Report,
+        dry_run: false,
+        status: Some(TaskBoardStatus::Todo),
+    };
+
+    let first = sync_external_tasks(&board, options, &clients)
+        .await
+        .expect("sync legacy todo");
+    let updated = board.get("github-owner-repo-74").expect("load legacy todo");
+
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].action, ExternalSyncAction::Pull);
+    assert_eq!(updated.status, TaskBoardStatus::Todo);
+    assert_eq!(
+        updated.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::Backlog)
+    );
+
+    let repeated = sync_external_tasks(&board, options, &clients)
+        .await
+        .expect("repeat legacy todo sync");
+    assert!(repeated.is_empty());
+}
+
+#[tokio::test]
+async fn todo_filtered_bidirectional_sync_preserves_open_workflow_lane_without_churn() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let item = github_review_request_item(
+        "github-owner-repo-75",
+        "owner/repo#75",
+        TaskBoardStatus::InProgress,
+    );
+    board
+        .create("Review requested", "Please review the pull request.", item)
+        .expect("create in-progress review");
+    let remote = ExternalTask {
+        reference: ExternalTaskRef::new(ExternalProvider::GitHub, "owner/repo#75")
+            .with_url("https://example.test/pull/owner/repo#75"),
+        title: "Review requested".to_owned(),
+        body: "Please review the pull request.".to_owned(),
+        status: TaskBoardStatus::Backlog,
+        project_id: Some("owner/repo".to_owned()),
+        updated_at: Some("2026-05-14T03:00:00Z".to_owned()),
+    };
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(
+        FakeSyncClient::new(ExternalProvider::GitHub, vec![remote])
+            .with_authoritative_review_inbox(),
+    )];
+
+    let operations = sync_external_tasks(
+        &board,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::GitHub),
+            direction: ExternalSyncDirection::Both,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            status: Some(TaskBoardStatus::Todo),
+        },
+        &clients,
+    )
+    .await
+    .expect("sync in-progress review");
+
+    assert!(operations.is_empty());
+    assert_eq!(
+        board
+            .get("github-owner-repo-75")
+            .expect("load in-progress review")
+            .status,
+        TaskBoardStatus::InProgress
+    );
+}
+
+#[tokio::test]
+async fn todo_filtered_sync_reconciles_terminal_truth_for_every_existing_item() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    for (id, external_id, status) in [
+        (
+            "github-owner-repo-76",
+            "owner/repo#76",
+            TaskBoardStatus::Backlog,
+        ),
+        (
+            "github-owner-repo-77",
+            "owner/repo#77",
+            TaskBoardStatus::InProgress,
+        ),
+    ] {
+        let item = github_review_request_item(id, external_id, status);
+        board
+            .create("Review requested", "Please review the pull request.", item)
+            .expect("create existing review");
+    }
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
+        ExternalProvider::GitHub,
+        vec![
+            terminal_review_task("owner/repo#76"),
+            terminal_review_task("owner/repo#77"),
+        ],
+    ))];
+
+    let operations = sync_external_tasks(
+        &board,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::GitHub),
+            direction: ExternalSyncDirection::Pull,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            status: Some(TaskBoardStatus::Todo),
+        },
+        &clients,
+    )
+    .await
+    .expect("sync terminal reviews");
+
+    assert_eq!(operations.len(), 2);
+    let backlog = board
+        .get("github-owner-repo-76")
+        .expect("load backlog review");
+    let in_progress = board
+        .get("github-owner-repo-77")
+        .expect("load in-progress review");
+    assert_eq!(backlog.status, TaskBoardStatus::Done);
+    assert_eq!(in_progress.status, TaskBoardStatus::InProgress);
+    for item in [&backlog, &in_progress] {
+        assert_eq!(
+            item.external_refs[0]
+                .sync_state
+                .as_ref()
+                .and_then(|state| state.status),
+            Some(TaskBoardStatus::Done)
+        );
+    }
+}
+
+fn terminal_review_task(external_id: &str) -> ExternalTask {
+    ExternalTask {
+        reference: ExternalTaskRef::new(ExternalProvider::GitHub, external_id)
+            .with_url(format!("https://example.test/pull/{external_id}")),
+        title: "Review requested".to_owned(),
+        body: "Please review the pull request.".to_owned(),
+        status: TaskBoardStatus::Done,
+        project_id: Some("owner/repo".to_owned()),
+        updated_at: Some("2026-05-14T04:00:00Z".to_owned()),
+    }
+}

--- a/src/task_board/external/todoist.rs
+++ b/src/task_board/external/todoist.rs
@@ -332,7 +332,7 @@ impl From<TodoistTask> for ExternalTask {
             reference: task.reference(),
             title: task.content,
             body: task.description,
-            status: TaskBoardStatus::Todo,
+            status: TaskBoardStatus::Backlog,
             project_id: task.project_id,
             updated_at: task.updated_at,
         }

--- a/src/task_board/external/todoist/todoist_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests.rs
@@ -36,6 +36,10 @@ fn todoist_status_endpoint_closes_done_and_reopens_other_statuses() {
         status_endpoint("task-1", TaskBoardStatus::Todo),
         "tasks/task-1/reopen"
     );
+    assert_eq!(
+        status_endpoint("task-1", TaskBoardStatus::Backlog),
+        "tasks/task-1/reopen"
+    );
 }
 
 #[tokio::test]
@@ -187,6 +191,7 @@ async fn todoist_pull_drops_tasks_outside_project_filter() {
     handle.join().expect("mock server");
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].reference.external_id, "a");
+    assert_eq!(tasks[0].status, TaskBoardStatus::Backlog);
     assert_eq!(tasks[0].project_id.as_deref(), Some("proj-keep"));
 }
 

--- a/src/task_board/legacy_import.rs
+++ b/src/task_board/legacy_import.rs
@@ -35,6 +35,8 @@ use super::types::{CURRENT_TASK_BOARD_ITEM_VERSION, TaskBoardItem};
 use crate::errors::{CliError, CliErrorKind, io_for};
 use crate::infra::io::read_json_typed;
 
+mod status_compat;
+
 const SETTINGS_FILE: &str = "orchestrator-settings.json";
 const STATE_FILE: &str = "orchestrator-state.json";
 const RUNS_FILE: &str = "policy-workflow-runs-v1.json";
@@ -93,7 +95,7 @@ impl LegacyTaskBoardSnapshot {
         let settings_path = root.join(SETTINGS_FILE);
         track_if_file(&settings_path, &mut source_paths)?;
         let settings = parse_persisted_settings_read_only(&settings_path)?.unwrap_or_default();
-        let state = load_optional(root, STATE_FILE, &mut source_paths)?;
+        let state = status_compat::load_orchestrator_state(root, STATE_FILE, &mut source_paths)?;
         let runs: PolicyWorkflowRunsDocument = load_optional(root, RUNS_FILE, &mut source_paths)?;
         ensure_schema(
             RUNS_FILE,

--- a/src/task_board/legacy_import/status_compat.rs
+++ b/src/task_board/legacy_import/status_compat.rs
@@ -1,0 +1,71 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::super::orchestrator::TaskBoardOrchestratorState;
+use crate::errors::{CliError, CliErrorKind};
+use crate::infra::io::read_json_typed;
+
+pub(super) fn load_orchestrator_state(
+    root: &Path,
+    name: &str,
+    source_paths: &mut Vec<PathBuf>,
+) -> Result<TaskBoardOrchestratorState, CliError> {
+    let path = root.join(name);
+    if !path.exists() {
+        return Ok(TaskBoardOrchestratorState::default());
+    }
+    super::ensure_plain_file(&path, "legacy task board document")?;
+    source_paths.push(path.clone());
+    let mut document: Value = read_json_typed(&path)?;
+    normalize_status_fields(&mut document);
+    serde_json::from_value(document).map_err(|error| {
+        CliErrorKind::invalid_json(path.display().to_string()).with_details(error.to_string())
+    })
+}
+
+fn normalize_status_fields(value: &mut Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                normalize_status_fields(value);
+            }
+        }
+        Value::Object(fields) => {
+            for (key, value) in fields {
+                if is_task_board_status_key(key) && value.as_str() == Some("umbrella") {
+                    *value = Value::String("backlog".to_string());
+                } else {
+                    normalize_status_fields(value);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_task_board_status_key(key: &str) -> bool {
+    matches!(key, "status" | "board_status" | "from_status" | "to_status")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_state_normalizes_task_board_status_fields_only() {
+        let mut document = serde_json::json!({
+            "status": "umbrella",
+            "records": [{
+                "board_status": "umbrella",
+                "label": "umbrella"
+            }]
+        });
+
+        normalize_status_fields(&mut document);
+
+        assert_eq!(document["status"], "backlog");
+        assert_eq!(document["records"][0]["board_status"], "backlog");
+        assert_eq!(document["records"][0]["label"], "umbrella");
+    }
+}

--- a/src/task_board/orchestrator/settings.rs
+++ b/src/task_board/orchestrator/settings.rs
@@ -104,6 +104,10 @@ fn repair_dispatch_status_filter(document: &mut Value) -> bool {
     else {
         return false;
     };
+    if status_value.as_str() == Some("umbrella") {
+        document["dispatch_status_filter"] = Value::String("backlog".to_string());
+        return true;
+    }
     let Ok(status) = serde_json::from_value::<TaskBoardStatus>(status_value) else {
         return false;
     };

--- a/src/task_board/orchestrator/tests.rs
+++ b/src/task_board/orchestrator/tests.rs
@@ -242,6 +242,33 @@ fn settings_read_repairs_legacy_dispatch_status_filter_on_disk() {
 }
 
 #[test]
+fn settings_read_repairs_umbrella_filter_to_backlog_on_disk() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("board");
+    fs::create_dir_all(&root).expect("create board root");
+    let settings_path = root.join(SETTINGS_FILE);
+    fs::write(
+        &settings_path,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "dispatch_status_filter": "umbrella"
+        }))
+        .expect("serialize settings"),
+    )
+    .expect("write settings");
+    let orchestrator = TaskBoardOrchestrator::new(root);
+
+    let settings = orchestrator.settings().expect("load settings");
+
+    assert_eq!(
+        settings.dispatch_status_filter,
+        Some(TaskBoardStatus::Backlog)
+    );
+    let contents = fs::read_to_string(settings_path).expect("read repaired settings");
+    assert!(contents.contains("\"dispatch_status_filter\": \"backlog\""));
+    assert!(!contents.contains("\"dispatch_status_filter\": \"umbrella\""));
+}
+
+#[test]
 fn settings_update_writes_current_dispatch_status_filter() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path().join("board");

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -456,8 +456,46 @@ fn apply_optional_patch<T>(target: &mut Option<T>, patch: OptionalFieldPatch<T>)
 
 pub(crate) fn read_path(path: &Path) -> Result<TaskBoardItem, CliError> {
     let text = io::read_text(path)?;
-    let parsed = io::parse_frontmatter::<TaskBoardFrontmatter>(&text, &path.display().to_string())?;
-    Ok(parsed.frontmatter.into_item(parsed.body))
+    let label = path.display().to_string();
+    let parsed = io::parse_frontmatter::<serde_json::Value>(&text, &label)?;
+    let mut document = parsed.frontmatter;
+    normalize_legacy_umbrella_statuses(&mut document);
+    let frontmatter: TaskBoardFrontmatter = serde_json::from_value(document)
+        .map_err(|error| CliErrorKind::workflow_parse(format!("{label} frontmatter: {error}")))?;
+    Ok(frontmatter.into_item(parsed.body))
+}
+
+fn normalize_legacy_umbrella_statuses(document: &mut serde_json::Value) {
+    let Some(frontmatter) = document.as_object_mut() else {
+        return;
+    };
+    if let Some(status) = frontmatter.get_mut("status") {
+        normalize_legacy_status(status);
+    }
+    let Some(external_refs) = frontmatter
+        .get_mut("external_refs")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    for external_ref in external_refs {
+        let Some(sync_state) = external_ref
+            .as_object_mut()
+            .and_then(|mapping| mapping.get_mut("sync_state"))
+            .and_then(serde_json::Value::as_object_mut)
+        else {
+            continue;
+        };
+        if let Some(status) = sync_state.get_mut("status") {
+            normalize_legacy_status(status);
+        }
+    }
+}
+
+fn normalize_legacy_status(value: &mut serde_json::Value) {
+    if value.as_str() == Some("umbrella") {
+        *value = serde_json::Value::String("backlog".to_string());
+    }
 }
 
 #[cfg(test)]

--- a/src/task_board/store/legacy_umbrella_tests.rs
+++ b/src/task_board/store/legacy_umbrella_tests.rs
@@ -1,0 +1,59 @@
+use fs_err as fs;
+use tempfile::tempdir;
+
+use crate::task_board::store::{TaskBoardItemPatch, TaskBoardStore};
+use crate::task_board::types::TaskBoardStatus;
+
+#[test]
+fn legacy_markdown_umbrella_statuses_read_and_rewrite_as_backlog() {
+    let temp = tempdir().expect("tempdir");
+    let store = TaskBoardStore::new(temp.path().join("board"));
+    let path = store.tasks_dir().join("legacy-umbrella.md");
+    fs::create_dir_all(store.tasks_dir()).expect("create tasks dir");
+    fs::write(
+        &path,
+        r#"---
+schema_version: 1
+id: legacy-umbrella
+title: Legacy lane
+status: umbrella
+priority: medium
+agent_mode: headless
+external_refs:
+- provider: github
+  external_id: '42'
+  sync_state:
+    status: umbrella
+created_at: 2026-05-14T00:00:00Z
+updated_at: 2026-05-14T00:00:00Z
+---
+
+body
+"#,
+    )
+    .expect("write legacy item");
+
+    let loaded = store.get("legacy-umbrella").expect("read legacy item");
+    assert_eq!(loaded.status, TaskBoardStatus::Backlog);
+    assert_eq!(
+        loaded.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.status),
+        Some(TaskBoardStatus::Backlog)
+    );
+
+    store
+        .update(
+            "legacy-umbrella",
+            TaskBoardItemPatch {
+                title: Some("Canonical lane".to_string()),
+                ..TaskBoardItemPatch::default()
+            },
+        )
+        .expect("rewrite legacy item");
+
+    let contents = fs::read_to_string(path).expect("read canonical item");
+    assert_eq!(contents.matches("status: backlog").count(), 2);
+    assert!(!contents.contains("status: umbrella"));
+}

--- a/src/task_board/store/tests.rs
+++ b/src/task_board/store/tests.rs
@@ -8,6 +8,9 @@ use crate::task_board::types::{
 };
 use fs_err as fs;
 
+#[path = "legacy_umbrella_tests.rs"]
+mod legacy_umbrella_tests;
+
 fn seed_item(store: &TaskBoardStore, id: &str, title: &str) {
     let item = TaskBoardItem::new(
         id.into(),
@@ -243,7 +246,7 @@ fn list_keeps_filter_and_sort_across_parallel_parse() {
         item.status = if index % 2 == 0 {
             TaskBoardStatus::InProgress
         } else {
-            TaskBoardStatus::Umbrella
+            TaskBoardStatus::Backlog
         };
         item.priority = TaskBoardPriority::High;
         store

--- a/src/task_board/summary.rs
+++ b/src/task_board/summary.rs
@@ -238,7 +238,7 @@ fn is_github_repo(project_id: &str) -> bool {
 
 fn status_counts(items: &[TaskBoardItem]) -> Vec<TaskBoardStatusCount> {
     let statuses = [
-        TaskBoardStatus::Umbrella,
+        TaskBoardStatus::Backlog,
         TaskBoardStatus::Todo,
         TaskBoardStatus::Planning,
         TaskBoardStatus::InProgress,

--- a/src/task_board/types.rs
+++ b/src/task_board/types.rs
@@ -148,7 +148,7 @@ pub enum TaskBoardWorkflowStatus {
 #[value(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum TaskBoardStatus {
-    Umbrella,
+    Backlog,
     #[default]
     Todo,
     Planning,
@@ -274,4 +274,29 @@ pub struct TaskUsage {
 )]
 fn is_zero(value: &u32) -> bool {
     *value == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TaskBoardStatus;
+
+    #[test]
+    fn backlog_is_the_canonical_status_wire_value() {
+        assert_eq!(
+            serde_json::to_string(&TaskBoardStatus::Backlog).expect("serialize backlog"),
+            "\"backlog\""
+        );
+        assert_eq!(
+            serde_json::from_str::<TaskBoardStatus>("\"backlog\"").expect("deserialize backlog"),
+            TaskBoardStatus::Backlog
+        );
+    }
+
+    #[test]
+    fn public_status_wire_rejects_legacy_umbrella() {
+        assert!(
+            serde_json::from_str::<TaskBoardStatus>("\"umbrella\"").is_err(),
+            "legacy umbrella is accepted only at persisted-data migration boundaries"
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

Task Board’s Umbrella lane is ambiguous, and newly synced open items currently enter Todo even though Todo represents prioritized, ordered work. The rename also needs a safe migration for persisted data without moving existing Todo items automatically.

## Implementation

- Rename the canonical Task Board status and lane from Umbrella to Backlog across Rust, generated Swift, Monitor UI, intents, settings, mirrors, documentation, and wire surfaces.
- Add schema v37 and narrow legacy readers that rewrite persisted umbrella values to canonical backlog without moving existing Todo records.
- Route newly imported open GitHub, Todoist, inbox, and review items to Backlog while preserving explicit local workflow lanes and correct terminal mappings.
- Keep Todo prioritized and dispatch-ready, prove Backlog is non-dispatchable, and canonicalize legacy mobile dispatch statuses before validation.
- Validate code generation, focused Rust and Swift unit tests, Harness checks, Monitor lint, and Monitor build while including the scoped preexisting Rust formatting and Monitor lint cleanup.