### PR TITLE
perf(monitor): accelerate Task Board Step Mode

### DIFF
--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefresh.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefresh.swift
@@ -23,6 +23,7 @@ extension HarnessMonitorStore {
     let sessions: MeasuredOperation<[SessionSummary]>
     let taskBoardItems: TaskBoardSnapshotLoad<[TaskBoardItem]>
     let taskBoardOrchestratorStatus: TaskBoardSnapshotLoad<TaskBoardOrchestratorStatus?>
+    let stepModeConfirmationRevision: UInt64
   }
 
   private enum RefreshSnapshotPiece: Sendable {
@@ -206,7 +207,12 @@ extension HarnessMonitorStore {
     isInitialConnect: Bool = false
   ) async throws {
     let adoptsLocalManifest = !usesRemoteDaemon
-    let refreshSnapshot = try await Self.loadRefreshSnapshot(using: client)
+    let stepModeConfirmationRevision =
+      taskBoardRuntimeState.stepModeMutation.confirmationRevision
+    let refreshSnapshot = try await Self.loadRefreshSnapshot(
+      using: client,
+      stepModeConfirmationRevision: stepModeConfirmationRevision
+    )
     await applyRefreshSnapshot(
       refreshSnapshot,
       using: client,
@@ -225,7 +231,12 @@ extension HarnessMonitorStore {
     preserveSelection: Bool
   ) async throws {
     let adoptsLocalManifest = !usesRemoteDaemon
-    let refreshSnapshot = try await Self.loadRefreshSnapshot(using: client)
+    let stepModeConfirmationRevision =
+      taskBoardRuntimeState.stepModeMutation.confirmationRevision
+    let refreshSnapshot = try await Self.loadRefreshSnapshot(
+      using: client,
+      stepModeConfirmationRevision: stepModeConfirmationRevision
+    )
     await applyRefreshSnapshot(
       refreshSnapshot,
       using: client,
@@ -240,7 +251,8 @@ extension HarnessMonitorStore {
   }
 
   nonisolated private static func loadRefreshSnapshot(
-    using client: any HarnessMonitorClientProtocol
+    using client: any HarnessMonitorClientProtocol,
+    stepModeConfirmationRevision: UInt64
   ) async throws -> RefreshSnapshot {
     try await withThrowingTaskGroup(
       of: RefreshSnapshotPiece.self,
@@ -326,7 +338,8 @@ extension HarnessMonitorStore {
         projects: projects,
         sessions: sessions,
         taskBoardItems: taskBoardItems,
-        taskBoardOrchestratorStatus: taskBoardOrchestratorStatus
+        taskBoardOrchestratorStatus: taskBoardOrchestratorStatus,
+        stepModeConfirmationRevision: stepModeConfirmationRevision
       )
     }
   }

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefreshApply.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+LifecycleRefreshApply.swift
@@ -28,6 +28,7 @@ extension HarnessMonitorStore {
     let resolvedTaskBoardSnapshot = resolvedTaskBoardRefreshSnapshot(
       items: refreshSnapshot.taskBoardItems,
       orchestratorStatus: refreshSnapshot.taskBoardOrchestratorStatus,
+      stepModeConfirmationRevision: refreshSnapshot.stepModeConfirmationRevision,
       isInitialConnect: isInitialConnect
     )
     let didChangeTaskBoardSnapshot =
@@ -115,6 +116,7 @@ extension HarnessMonitorStore {
   func resolvedTaskBoardRefreshSnapshot(
     items: TaskBoardSnapshotLoad<[TaskBoardItem]>,
     orchestratorStatus: TaskBoardSnapshotLoad<TaskBoardOrchestratorStatus?>,
+    stepModeConfirmationRevision: UInt64,
     isInitialConnect: Bool
   ) -> ResolvedTaskBoardRefreshSnapshot {
     let currentItems = globalTaskBoardItems
@@ -163,9 +165,13 @@ extension HarnessMonitorStore {
         currentStatus
       }
 
+    let reconciledStatus = reconcileTaskBoardOrchestratorStatus(
+      resolvedStatus,
+      snapshotConfirmationRevision: stepModeConfirmationRevision
+    )
     return ResolvedTaskBoardRefreshSnapshot(
       items: resolvedItems,
-      orchestratorStatus: resolvedStatus,
+      orchestratorStatus: reconciledStatus,
       preservedItemIDs: preservedItemIDs,
       preservedStatus: shouldPreserveStatus
     )
@@ -217,7 +223,12 @@ extension HarnessMonitorStore {
         guard self.connectionState == .online || self.connectionState == .connecting else {
           return
         }
-        let snapshot = await Self.loadTaskBoardRefreshSnapshot(using: client)
+        let stepModeConfirmationRevision =
+          self.taskBoardRuntimeState.stepModeMutation.confirmationRevision
+        let snapshot = await Self.loadTaskBoardRefreshSnapshot(
+          using: client,
+          stepModeConfirmationRevision: stepModeConfirmationRevision
+        )
         let reachedDeadline = ContinuousClock.now >= deadline
         let tick = self.evaluateTaskBoardConfirmationTick(
           snapshot: snapshot,
@@ -300,7 +311,10 @@ extension HarnessMonitorStore {
       return
     }
     if measuredStatus.value != nil || reachedDeadline {
-      tick.resolvedStatus = measuredStatus.value
+      tick.resolvedStatus = reconcileTaskBoardOrchestratorStatus(
+        measuredStatus.value,
+        snapshotConfirmationRevision: snapshot.stepModeConfirmationRevision
+      )
       tick.shouldApply = true
     } else {
       tick.shouldKeepWaiting = true

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboard.swift
@@ -10,6 +10,7 @@ extension HarnessMonitorStore {
   struct TaskBoardRefreshSnapshot: Sendable {
     let items: TaskBoardSnapshotLoad<[TaskBoardItem]>
     let orchestratorStatus: TaskBoardSnapshotLoad<TaskBoardOrchestratorStatus?>
+    let stepModeConfirmationRevision: UInt64
   }
 
   private static let taskBoardDashboardSyncRequest = TaskBoardSyncRequest(
@@ -56,6 +57,7 @@ extension HarnessMonitorStore {
 
   nonisolated static func loadTaskBoardRefreshSnapshot(
     using client: any HarnessMonitorClientProtocol,
+    stepModeConfirmationRevision: UInt64,
     includeItems: Bool = true,
     includeOrchestratorStatus: Bool = true
   ) async -> TaskBoardRefreshSnapshot {
@@ -73,7 +75,8 @@ extension HarnessMonitorStore {
       }
     return TaskBoardRefreshSnapshot(
       items: await items,
-      orchestratorStatus: await orchestratorStatus
+      orchestratorStatus: await orchestratorStatus,
+      stepModeConfirmationRevision: stepModeConfirmationRevision
     )
   }
 

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardDashboardSupport.swift
@@ -60,12 +60,16 @@ extension HarnessMonitorStore {
     fallbackStatus: TaskBoardOrchestratorStatus? = nil
   ) {
     let resolvedItems = snapshot.items.value ?? globalTaskBoardItems
-    let resolvedStatus =
+    let snapshotStatus =
       if let measuredStatus = snapshot.orchestratorStatus.measured {
         measuredStatus.value ?? fallbackStatus
       } else {
         fallbackStatus ?? globalTaskBoardOrchestratorStatus
       }
+    let resolvedStatus = reconcileTaskBoardOrchestratorStatus(
+      snapshotStatus,
+      snapshotConfirmationRevision: snapshot.stepModeConfirmationRevision
+    )
     let didChangeTaskBoardSnapshot =
       globalTaskBoardItems != resolvedItems
       || globalTaskBoardOrchestratorStatus != resolvedStatus

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardRefreshCoalescing.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardRefreshCoalescing.swift
@@ -132,8 +132,11 @@ extension HarnessMonitorStore {
       self.cacheWriteSync.pendingTaskBoardPolicyPipelineRefresh = false
       self.cacheWriteSync.pendingTaskBoardFallbackStatus = nil
 
+      let stepModeConfirmationRevision =
+        self.taskBoardRuntimeState.stepModeMutation.confirmationRevision
       let snapshot = await Self.loadTaskBoardRefreshSnapshot(
         using: client,
+        stepModeConfirmationRevision: stepModeConfirmationRevision,
         includeItems: includeItems,
         includeOrchestratorStatus: includeOrchestratorStatus
       )

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardSettings.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardSettings.swift
@@ -15,13 +15,13 @@ struct TaskBoardConnectionState: Sendable {
 
 extension HarnessMonitorStore {
   var taskBoardDatabaseInstanceID: String? {
-    get { taskBoardConnectionState.databaseInstanceID }
-    set { taskBoardConnectionState.databaseInstanceID = newValue }
+    get { taskBoardRuntimeState.connection.databaseInstanceID }
+    set { taskBoardRuntimeState.connection.databaseInstanceID = newValue }
   }
 
   var lastTaskBoardCredentialSync: TaskBoardCredentialSyncState? {
-    get { taskBoardConnectionState.credentialSync }
-    set { taskBoardConnectionState.credentialSync = newValue }
+    get { taskBoardRuntimeState.connection.credentialSync }
+    set { taskBoardRuntimeState.connection.credentialSync = newValue }
   }
 
   public func taskBoardGitSettingsSnapshot() async throws -> TaskBoardGitSettingsSnapshot {
@@ -155,10 +155,11 @@ extension HarnessMonitorStore {
       }
 
       if let status = globalTaskBoardOrchestratorStatus {
+        confirmTaskBoardOrchestratorSettings(orchestratorSettings)
         globalTaskBoardOrchestratorStatus = TaskBoardOrchestratorStatus(
           enabled: status.enabled,
           running: status.running,
-          stepMode: status.stepMode,
+          stepMode: orchestratorSettings.stepMode,
           heldDispatches: status.heldDispatches,
           currentTick: status.currentTick,
           lastRun: status.lastRun,

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardStepMode.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardStepMode.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+extension HarnessMonitorStore {
+  @discardableResult
+  public func setTaskBoardStepMode(enabled: Bool) async -> Bool {
+    guard
+      let client,
+      let currentStatus = globalTaskBoardOrchestratorStatus
+    else {
+      return false
+    }
+
+    let generation = beginTaskBoardStepModeMutation(
+      enabled: enabled,
+      currentSettings: currentStatus.settings
+    )
+    await acquireTaskBoardStepModeRequestLock()
+    defer { releaseTaskBoardStepModeRequestLock() }
+
+    guard generation == taskBoardRuntimeState.stepModeMutation.latestGeneration else {
+      return true
+    }
+    if let settings = taskBoardRuntimeState.stepModeMutation.lastAuthoritativeSettings,
+      settings.stepMode == enabled
+    {
+      finishTaskBoardStepModeSuccess(
+        settings: settings,
+        enabled: enabled,
+        generation: generation
+      )
+      return true
+    }
+
+    do {
+      let settings = try await client.updateTaskBoardOrchestratorSettings(
+        request: TaskBoardOrchestratorSettingsUpdateRequest(stepMode: enabled)
+      )
+      taskBoardRuntimeState.stepModeMutation.lastAuthoritativeSettings = settings
+      confirmTaskBoardOrchestratorSettings(settings)
+      guard generation == taskBoardRuntimeState.stepModeMutation.latestGeneration else {
+        return true
+      }
+      finishTaskBoardStepModeSuccess(
+        settings: settings,
+        enabled: enabled,
+        generation: generation
+      )
+      return true
+    } catch {
+      guard generation == taskBoardRuntimeState.stepModeMutation.latestGeneration else {
+        return true
+      }
+      finishTaskBoardStepModeFailure(error, generation: generation)
+      return false
+    }
+  }
+
+  private func beginTaskBoardStepModeMutation(
+    enabled: Bool,
+    currentSettings: TaskBoardOrchestratorSettings
+  ) -> UInt64 {
+    if taskBoardRuntimeState.stepModeMutation.desiredValue == nil {
+      taskBoardRuntimeState.stepModeMutation.lastAuthoritativeSettings = currentSettings
+    }
+    taskBoardRuntimeState.stepModeMutation.latestGeneration &+= 1
+    taskBoardRuntimeState.stepModeMutation.desiredValue = enabled
+    isDaemonActionInFlight = true
+    return taskBoardRuntimeState.stepModeMutation.latestGeneration
+  }
+
+  private func acquireTaskBoardStepModeRequestLock() async {
+    guard taskBoardRuntimeState.stepModeMutation.isRequestLocked else {
+      taskBoardRuntimeState.stepModeMutation.isRequestLocked = true
+      return
+    }
+    await withCheckedContinuation { continuation in
+      taskBoardRuntimeState.stepModeMutation.requestWaiters.append(continuation)
+    }
+  }
+
+  private func releaseTaskBoardStepModeRequestLock() {
+    guard !taskBoardRuntimeState.stepModeMutation.requestWaiters.isEmpty else {
+      taskBoardRuntimeState.stepModeMutation.isRequestLocked = false
+      return
+    }
+    taskBoardRuntimeState.stepModeMutation.requestWaiters.removeFirst().resume()
+  }
+
+  private func finishTaskBoardStepModeSuccess(
+    settings: TaskBoardOrchestratorSettings,
+    enabled: Bool,
+    generation: UInt64
+  ) {
+    guard generation == taskBoardRuntimeState.stepModeMutation.latestGeneration else { return }
+    recordRequestSuccess()
+    presentSuccessFeedback(
+      enabled ? "Enabled task-board step mode" : "Disabled task-board step mode"
+    )
+    finishTaskBoardStepModeMutation(settings: settings)
+  }
+
+  private func finishTaskBoardStepModeFailure(
+    _ error: any Error,
+    generation: UInt64
+  ) {
+    guard generation == taskBoardRuntimeState.stepModeMutation.latestGeneration else { return }
+    presentFailureFeedback(error.localizedDescription)
+    finishTaskBoardStepModeMutation(
+      settings: taskBoardRuntimeState.stepModeMutation.lastAuthoritativeSettings
+    )
+  }
+
+  private func finishTaskBoardStepModeMutation(
+    settings: TaskBoardOrchestratorSettings?
+  ) {
+    let updatedStatus = settings.flatMap { settings in
+      globalTaskBoardOrchestratorStatus.map {
+        taskBoardOrchestratorStatus($0, applying: settings)
+      }
+    }
+    let didChangeStatus = updatedStatus != nil && updatedStatus != globalTaskBoardOrchestratorStatus
+    withUISyncBatch {
+      if let updatedStatus {
+        globalTaskBoardOrchestratorStatus = updatedStatus
+      }
+      isDaemonActionInFlight = false
+    }
+    if didChangeStatus {
+      scheduleTaskBoardSnapshotCacheWrite(
+        items: globalTaskBoardItems,
+        orchestratorStatus: updatedStatus
+      )
+    }
+    taskBoardRuntimeState.stepModeMutation.desiredValue = nil
+    taskBoardRuntimeState.stepModeMutation.lastAuthoritativeSettings = nil
+  }
+
+  func confirmTaskBoardOrchestratorSettings(
+    _ settings: TaskBoardOrchestratorSettings
+  ) {
+    taskBoardRuntimeState.stepModeMutation.confirmationRevision &+= 1
+    taskBoardRuntimeState.stepModeMutation.confirmedSettings = settings
+  }
+
+  func reconcileTaskBoardOrchestratorStatus(
+    _ status: TaskBoardOrchestratorStatus?,
+    snapshotConfirmationRevision: UInt64
+  ) -> TaskBoardOrchestratorStatus? {
+    let stepModeState = taskBoardRuntimeState.stepModeMutation
+    guard
+      snapshotConfirmationRevision < stepModeState.confirmationRevision,
+      let confirmedSettings = stepModeState.confirmedSettings,
+      let baseStatus = status ?? globalTaskBoardOrchestratorStatus
+    else {
+      return status
+    }
+    return taskBoardOrchestratorStatus(baseStatus, applying: confirmedSettings)
+  }
+
+  private func taskBoardOrchestratorStatus(
+    _ status: TaskBoardOrchestratorStatus,
+    applying settings: TaskBoardOrchestratorSettings
+  ) -> TaskBoardOrchestratorStatus {
+    TaskBoardOrchestratorStatus(
+      enabled: status.enabled,
+      running: status.running,
+      stepMode: settings.stepMode,
+      heldDispatches: status.heldDispatches,
+      currentTick: status.currentTick,
+      lastRun: status.lastRun,
+      workflowExecutionCounts: status.workflowExecutionCounts,
+      settings: settings
+    )
+  }
+}

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardSteps.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore+TaskBoardSteps.swift
@@ -91,30 +91,6 @@ extension HarnessMonitorStore {
     return delivery
   }
 
-  @discardableResult
-  public func setTaskBoardStepMode(enabled: Bool) async -> Bool {
-    guard let client else {
-      return false
-    }
-    isDaemonActionInFlight = true
-    defer { isDaemonActionInFlight = false }
-
-    do {
-      _ = try await client.updateTaskBoardOrchestratorSettings(
-        request: TaskBoardOrchestratorSettingsUpdateRequest(stepMode: enabled)
-      )
-      recordRequestSuccess()
-      await refreshTaskBoardDashboardSnapshot(using: client)
-      presentSuccessFeedback(
-        enabled ? "Enabled task-board step mode" : "Disabled task-board step mode"
-      )
-      return true
-    } catch {
-      presentFailureFeedback(error.localizedDescription)
-      return false
-    }
-  }
-
   public func policyApprovalGrants() async -> [PolicyApprovalGrant]? {
     guard let client else {
       return nil

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStore.swift
@@ -27,7 +27,7 @@ public final class HarnessMonitorStore {
   @ObservationIgnored let timelineWindowWorker = TimelineWindowWorker()
   @ObservationIgnored let sessionWindowPresentationWorker = SessionWindowPresentationWorker()
   @ObservationIgnored let taskBoardSettingsWorker: TaskBoardSettingsWorker
-  @ObservationIgnored var taskBoardConnectionState = TaskBoardConnectionState()
+  @ObservationIgnored var taskBoardRuntimeState = TaskBoardRuntimeState()
   @ObservationIgnored var sessionIndexSnapshotApplyTask: Task<Void, Never>?
   @ObservationIgnored var sessionIndexSnapshotApplyGeneration: UInt64 = 0
   @ObservationIgnored var acpTimelineSync = AcpTimelineSyncState()

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStoreState.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Stores/HarnessMonitorStoreState.swift
@@ -21,6 +21,21 @@ struct CacheWriteSyncState {
   var pendingSessionDetailCacheWrites: [String: PendingSessionDetailCacheWrite] = [:]
 }
 
+struct TaskBoardRuntimeState {
+  var connection = TaskBoardConnectionState()
+  var stepModeMutation = TaskBoardStepModeMutationState()
+}
+
+struct TaskBoardStepModeMutationState {
+  var latestGeneration: UInt64 = 0
+  var desiredValue: Bool?
+  var lastAuthoritativeSettings: TaskBoardOrchestratorSettings?
+  var confirmationRevision: UInt64 = 0
+  var confirmedSettings: TaskBoardOrchestratorSettings?
+  var isRequestLocked = false
+  var requestWaiters: [CheckedContinuation<Void, Never>] = []
+}
+
 struct SelectedTimelineLoadState {
   var pageLoadTask: Task<Void, Never>?
   var pageLoadKey: HarnessMonitorStore.SelectedTimelinePageLoadKey?

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorActionTestSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorActionTestSupport.swift
@@ -195,6 +195,7 @@ final class RecordingHarnessClient: HarnessMonitorClientProtocol, @unchecked Sen
     case approveTaskBoardPlan(id: String, approvedBy: String, approvedAt: String?)
     case revokeTaskBoardPlan(id: String, actor: String?)
     case updateTaskBoardOrchestratorSettings(
+      stepMode: Bool?,
       policyVersion: String?,
       clearProjectDir: Bool,
       clearDispatchStatusFilter: Bool
@@ -295,6 +296,9 @@ final class RecordingHarnessClient: HarnessMonitorClientProtocol, @unchecked Sen
   var taskBoardUpdateError: (any Error)?
   var taskBoardRuntimeConfigError: (any Error)?
   var taskBoardOrchestratorSettingsError: (any Error)?
+  var taskBoardOrchestratorSettingsResponse: TaskBoardOrchestratorSettings?
+  let orchestratorSettingsMutationGate =
+    RecordingTaskBoardOrchestratorSettingsMutationGate()
   var taskBoardGitHubTokensSyncError: (any Error)?
   var taskBoardTodoistTokenSyncError: (any Error)?
   var taskBoardGitIdentityDefaultsValue = TaskBoardGitIdentityDefaults()

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardSettingsTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardSettingsTests.swift
@@ -165,7 +165,7 @@ struct HarnessMonitorStoreTaskBoardSettingsTests {
       keychainBundle: keychainBundle
     )
     let baselineCallCount = client.recordedCalls().count
-    let snapshot = makeSettingsSnapshot()
+    let snapshot = makeSettingsSnapshot(stepMode: true)
 
     let success = await store.updateTaskBoardGitSettings(
       snapshot: snapshot,
@@ -181,6 +181,10 @@ struct HarnessMonitorStoreTaskBoardSettingsTests {
       } == false
     )
     #expect(store.currentSuccessFeedbackMessage == "Saved task board settings")
+    #expect(store.globalTaskBoardOrchestratorStatus?.stepMode == true)
+    #expect(store.globalTaskBoardOrchestratorStatus?.settings.stepMode == true)
+    #expect(store.contentUI.dashboard.taskBoardOrchestratorStatus?.stepMode == true)
+    #expect(store.contentUI.dashboard.taskBoardOrchestratorStatus?.settings.stepMode == true)
     #expect(credentialPersistence.github.savedSnapshots == [snapshot.githubCredentials])
     #expect(keychainBundle.ssh.recorded.isEmpty)
   }
@@ -314,9 +318,10 @@ struct HarnessMonitorStoreTaskBoardSettingsTests {
     #expect(reloaded.isEmpty)
   }
 
-  private func makeSettingsSnapshot() -> TaskBoardGitSettingsSnapshot {
+  private func makeSettingsSnapshot(stepMode: Bool = false) -> TaskBoardGitSettingsSnapshot {
     TaskBoardGitSettingsSnapshot(
       orchestratorSettings: TaskBoardOrchestratorSettings(
+        stepMode: stepMode,
         enabledWorkflows: [.defaultTask],
         dryRunDefault: true,
         dispatchStatusFilter: .todo,

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardStepModeTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/HarnessMonitorStoreTaskBoardStepModeTests.swift
@@ -1,0 +1,199 @@
+import Testing
+
+@testable import HarnessMonitorKit
+
+@MainActor
+@Suite("Harness Monitor task-board Step Mode")
+struct HarnessMonitorStoreTaskBoardStepModeTests {
+  @Test("Applies authoritative settings without a dashboard refresh")
+  func appliesAuthoritativeSettingsWithoutDashboardRefresh() async throws {
+    let client = RecordingHarnessClient()
+    let authoritativeSettings = client.sampleTaskBoardOrchestratorSettings(
+      stepMode: true,
+      policyVersion: "task-board-policy-authoritative"
+    )
+    client.configureTaskBoardOrchestratorSettingsResponse(authoritativeSettings)
+    let store = await makeBootstrappedStore(client: client)
+    let baselineReads = taskBoardReadCounts(client)
+
+    let success = await store.setTaskBoardStepMode(enabled: true)
+
+    #expect(success)
+    try expectPresentedSettings(store, equal: authoritativeSettings)
+    #expect(taskBoardReadCounts(client) == baselineReads)
+    #expect(recordedStepModeMutations(client) == [true])
+    #expect(!store.isDaemonActionInFlight)
+  }
+
+  @Test("Failure rolls back to the last authoritative settings")
+  func failureRollsBackToLastAuthoritativeSettings() async throws {
+    let client = RecordingHarnessClient()
+    let store = await makeBootstrappedStore(client: client)
+    let baselineReads = taskBoardReadCounts(client)
+
+    #expect(await store.setTaskBoardStepMode(enabled: true))
+    let lastAuthoritativeSettings = try #require(
+      store.globalTaskBoardOrchestratorStatus?.settings
+    )
+    client.configureTaskBoardOrchestratorSettingsError(
+      HarnessMonitorAPIError.server(code: 503, message: "Step Mode unavailable.")
+    )
+
+    let success = await store.setTaskBoardStepMode(enabled: false)
+
+    #expect(!success)
+    try expectPresentedSettings(store, equal: lastAuthoritativeSettings)
+    #expect(store.globalTaskBoardOrchestratorStatus?.stepMode == true)
+    #expect(taskBoardReadCounts(client) == baselineReads)
+    #expect(recordedStepModeMutations(client) == [true, false])
+    #expect(store.currentFailureFeedbackMessage?.contains("Step Mode unavailable") == true)
+    #expect(!store.isDaemonActionInFlight)
+  }
+
+  @Test("A stale dashboard refresh cannot overwrite confirmed Step Mode")
+  func staleDashboardRefreshCannotOverwriteConfirmedStepMode() async throws {
+    let client = RecordingHarnessClient()
+    let store = await makeBootstrappedStore(client: client)
+    let staleStatus = client.sampleTaskBoardOrchestratorStatus(stepMode: false)
+    let staleSnapshot = taskBoardSnapshot(
+      status: staleStatus,
+      confirmationRevision: store.taskBoardRuntimeState.stepModeMutation.confirmationRevision
+    )
+
+    #expect(await store.setTaskBoardStepMode(enabled: true))
+    store.applyTaskBoardDashboardSnapshot(staleSnapshot)
+
+    let confirmedSettings = try #require(
+      store.globalTaskBoardOrchestratorStatus?.settings
+    )
+    #expect(confirmedSettings.stepMode)
+    try expectPresentedSettings(store, equal: confirmedSettings)
+
+    let freshSnapshot = taskBoardSnapshot(
+      status: staleStatus,
+      confirmationRevision: store.taskBoardRuntimeState.stepModeMutation.confirmationRevision
+    )
+    store.applyTaskBoardDashboardSnapshot(freshSnapshot)
+    #expect(store.globalTaskBoardOrchestratorStatus?.stepMode == false)
+  }
+
+  @Test("Rapid enable then disable ignores the stale enable completion")
+  func rapidEnableThenDisableIgnoresStaleEnableCompletion() async throws {
+    let client = RecordingHarnessClient()
+    let store = await makeBootstrappedStore(client: client)
+    let baselineReads = taskBoardReadCounts(client)
+    await client.blockNextTaskBoardOrchestratorSettingsMutations()
+
+    let enableTask = Task { @MainActor in
+      await store.setTaskBoardStepMode(enabled: true)
+    }
+    await client.waitForBlockedTaskBoardOrchestratorSettingsMutations()
+    let disableTask = Task { @MainActor in
+      await store.setTaskBoardStepMode(enabled: false)
+    }
+    #expect(await waitForMutationGeneration(2, store: store))
+
+    await client.releaseNextTaskBoardOrchestratorSettingsMutation()
+    #expect(await enableTask.value)
+    #expect(await disableTask.value)
+
+    let settings = try #require(store.globalTaskBoardOrchestratorStatus?.settings)
+    #expect(!settings.stepMode)
+    try expectPresentedSettings(store, equal: settings)
+    #expect(recordedStepModeMutations(client) == [true, false])
+    #expect(taskBoardReadCounts(client) == baselineReads)
+    #expect(!store.isDaemonActionInFlight)
+  }
+
+  @Test("Rapid enable disable enable coalesces stale intermediate intent")
+  func rapidEnableDisableEnableCoalescesStaleIntermediateIntent() async throws {
+    let client = RecordingHarnessClient()
+    let store = await makeBootstrappedStore(client: client)
+    let baselineReads = taskBoardReadCounts(client)
+    await client.blockNextTaskBoardOrchestratorSettingsMutations()
+
+    let firstEnableTask = Task { @MainActor in
+      await store.setTaskBoardStepMode(enabled: true)
+    }
+    await client.waitForBlockedTaskBoardOrchestratorSettingsMutations()
+    let disableTask = Task { @MainActor in
+      await store.setTaskBoardStepMode(enabled: false)
+    }
+    #expect(await waitForMutationGeneration(2, store: store))
+    let finalEnableTask = Task { @MainActor in
+      await store.setTaskBoardStepMode(enabled: true)
+    }
+    #expect(await waitForMutationGeneration(3, store: store))
+
+    await client.releaseNextTaskBoardOrchestratorSettingsMutation()
+    #expect(await firstEnableTask.value)
+    #expect(await disableTask.value)
+    #expect(await finalEnableTask.value)
+
+    let settings = try #require(store.globalTaskBoardOrchestratorStatus?.settings)
+    #expect(settings.stepMode)
+    try expectPresentedSettings(store, equal: settings)
+    #expect(recordedStepModeMutations(client) == [true])
+    #expect(taskBoardReadCounts(client) == baselineReads)
+    #expect(!store.isDaemonActionInFlight)
+  }
+
+  private func taskBoardReadCounts(_ client: RecordingHarnessClient) -> [Int] {
+    [
+      client.readCallCount(.taskBoardItems(nil)),
+      client.readCallCount(.taskBoardOrchestratorStatus),
+    ]
+  }
+
+  private func recordedStepModeMutations(_ client: RecordingHarnessClient) -> [Bool] {
+    client.recordedCalls().compactMap { call in
+      guard case .updateTaskBoardOrchestratorSettings(let stepMode, _, _, _) = call else {
+        return nil
+      }
+      return stepMode
+    }
+  }
+
+  private func taskBoardSnapshot(
+    status: TaskBoardOrchestratorStatus,
+    confirmationRevision: UInt64
+  ) -> HarnessMonitorStore.TaskBoardRefreshSnapshot {
+    HarnessMonitorStore.TaskBoardRefreshSnapshot(
+      items: HarnessMonitorStore.TaskBoardSnapshotLoad<[TaskBoardItem]>(measured: nil),
+      orchestratorStatus: HarnessMonitorStore.TaskBoardSnapshotLoad(
+        measured: HarnessMonitorStore.MeasuredOperation(
+          value: Optional(status),
+          latencyMs: 0
+        )
+      ),
+      stepModeConfirmationRevision: confirmationRevision
+    )
+  }
+
+  private func expectPresentedSettings(
+    _ store: HarnessMonitorStore,
+    equal expected: TaskBoardOrchestratorSettings
+  ) throws {
+    let globalStatus = try #require(store.globalTaskBoardOrchestratorStatus)
+    let presentedStatus = try #require(
+      store.contentUI.dashboard.taskBoardOrchestratorStatus
+    )
+    #expect(globalStatus.stepMode == expected.stepMode)
+    #expect(globalStatus.settings == expected)
+    #expect(presentedStatus.stepMode == expected.stepMode)
+    #expect(presentedStatus.settings == expected)
+  }
+
+  private func waitForMutationGeneration(
+    _ generation: UInt64,
+    store: HarnessMonitorStore
+  ) async -> Bool {
+    for _ in 0..<10_000 {
+      if store.taskBoardRuntimeState.stepModeMutation.latestGeneration >= generation {
+        return true
+      }
+      await Task.yield()
+    }
+    return false
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+TaskBoardOrchestratorSupport.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingHarnessClient+TaskBoardOrchestratorSupport.swift
@@ -21,17 +21,25 @@ extension RecordingHarnessClient {
   func updateTaskBoardOrchestratorSettings(
     request: TaskBoardOrchestratorSettingsUpdateRequest
   ) async throws -> TaskBoardOrchestratorSettings {
-    calls.append(
-      .updateTaskBoardOrchestratorSettings(
-        policyVersion: request.policyVersion,
-        clearProjectDir: request.clearProjectDir,
-        clearDispatchStatusFilter: request.clearDispatchStatusFilter
+    lock.withLock {
+      callsStorage.append(
+        .updateTaskBoardOrchestratorSettings(
+          stepMode: request.stepMode,
+          policyVersion: request.policyVersion,
+          clearProjectDir: request.clearProjectDir,
+          clearDispatchStatusFilter: request.clearDispatchStatusFilter
+        )
       )
-    )
+    }
+    await orchestratorSettingsMutationGate.suspendIfConfigured()
     if let error = lock.withLock({ taskBoardOrchestratorSettingsError }) {
       throw error
     }
+    if let response = lock.withLock({ taskBoardOrchestratorSettingsResponse }) {
+      return response
+    }
     return TaskBoardOrchestratorSettings(
+      stepMode: request.stepMode ?? false,
       enabledWorkflows: request.enabledWorkflows ?? [.defaultTask],
       dryRunDefault: request.dryRunDefault ?? true,
       dispatchStatusFilter: request.dispatchStatusFilter,
@@ -150,11 +158,13 @@ extension RecordingHarnessClient {
 
   func sampleTaskBoardOrchestratorStatus(
     enabled: Bool = true,
-    running: Bool = false
+    running: Bool = false,
+    stepMode: Bool = false
   ) -> TaskBoardOrchestratorStatus {
     TaskBoardOrchestratorStatus(
       enabled: enabled,
       running: running,
+      stepMode: stepMode,
       currentTick: TaskBoardOrchestratorTickInfo(
         runId: "run-active",
         phase: .evaluation,
@@ -176,12 +186,16 @@ extension RecordingHarnessClient {
       workflowExecutionCounts: [
         TaskBoardWorkflowExecutionCount(status: .completed, count: 1)
       ],
-      settings: sampleTaskBoardOrchestratorSettings()
+      settings: sampleTaskBoardOrchestratorSettings(stepMode: stepMode)
     )
   }
 
-  func sampleTaskBoardOrchestratorSettings() -> TaskBoardOrchestratorSettings {
+  func sampleTaskBoardOrchestratorSettings(
+    stepMode: Bool = false,
+    policyVersion: String = "task-board-policy-v1"
+  ) -> TaskBoardOrchestratorSettings {
     TaskBoardOrchestratorSettings(
+      stepMode: stepMode,
       enabledWorkflows: [.defaultTask, .prFix],
       dryRunDefault: false,
       dispatchStatusFilter: .todo,
@@ -194,7 +208,7 @@ extension RecordingHarnessClient {
         enabledAutomations: TaskBoardGitHubAutomationToggles(enabled: [.syncTaskBoard, .autoMerge])
       ),
       githubInbox: TaskBoardGitHubInboxConfig(repositories: ["example/harness", "example/aff"]),
-      policyVersion: "task-board-policy-v1"
+      policyVersion: policyVersion
     )
   }
 

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingTaskBoardOrchestratorSettingsMutationGate.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/RecordingTaskBoardOrchestratorSettingsMutationGate.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+@testable import HarnessMonitorKit
+
+actor RecordingTaskBoardOrchestratorSettingsMutationGate {
+  private struct ArrivalWaiter {
+    let count: Int
+    let continuation: CheckedContinuation<Void, Never>
+  }
+
+  private var remainingBlocks = 0
+  private var blockedArrivalCount = 0
+  private var blockedContinuations: [CheckedContinuation<Void, Never>] = []
+  private var arrivalWaiters: [ArrivalWaiter] = []
+
+  func blockNext(_ count: Int) {
+    precondition(count >= 0)
+    precondition(blockedContinuations.isEmpty)
+    remainingBlocks = count
+    blockedArrivalCount = 0
+  }
+
+  func suspendIfConfigured() async {
+    guard remainingBlocks > 0 else { return }
+    remainingBlocks -= 1
+    blockedArrivalCount += 1
+    resumeSatisfiedArrivalWaiters()
+    await withCheckedContinuation { continuation in
+      blockedContinuations.append(continuation)
+    }
+  }
+
+  func waitForBlockedArrivalCount(_ count: Int) async {
+    guard blockedArrivalCount < count else { return }
+    await withCheckedContinuation { continuation in
+      arrivalWaiters.append(ArrivalWaiter(count: count, continuation: continuation))
+    }
+  }
+
+  func releaseNext() {
+    precondition(!blockedContinuations.isEmpty)
+    blockedContinuations.removeFirst().resume()
+  }
+
+  private func resumeSatisfiedArrivalWaiters() {
+    var pending: [ArrivalWaiter] = []
+    for waiter in arrivalWaiters {
+      if blockedArrivalCount >= waiter.count {
+        waiter.continuation.resume()
+      } else {
+        pending.append(waiter)
+      }
+    }
+    arrivalWaiters = pending
+  }
+}
+
+extension RecordingHarnessClient {
+  func configureTaskBoardOrchestratorSettingsResponse(
+    _ settings: TaskBoardOrchestratorSettings?
+  ) {
+    lock.withLock {
+      taskBoardOrchestratorSettingsResponse = settings
+    }
+  }
+
+  func blockNextTaskBoardOrchestratorSettingsMutations(_ count: Int = 1) async {
+    await orchestratorSettingsMutationGate.blockNext(count)
+  }
+
+  func waitForBlockedTaskBoardOrchestratorSettingsMutations(_ count: Int = 1) async {
+    await orchestratorSettingsMutationGate.waitForBlockedArrivalCount(count)
+  }
+
+  func releaseNextTaskBoardOrchestratorSettingsMutation() async {
+    await orchestratorSettingsMutationGate.releaseNext()
+  }
+}

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientHTTPContractTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientHTTPContractTests.swift
@@ -83,6 +83,7 @@ extension TaskBoardAPIClientTests {
     _ = try await client.taskBoardOrchestratorSettings()
     let updatedSettings = try await client.updateTaskBoardOrchestratorSettings(
       request: TaskBoardOrchestratorSettingsUpdateRequest(
+        stepMode: true,
         enabledWorkflows: [.defaultTask, .prFix],
         dryRunDefault: false,
         dispatchStatusFilter: .agenticReview,
@@ -269,6 +270,7 @@ extension TaskBoardAPIClientTests {
     #expect(records[7].body?["dry_run"] as? Bool == false)
     #expect(records[8].query == "status=failed")
     #expect(records[12].body?.isEmpty == true)
+    #expect(records[14].body?["step_mode"] as? Bool == true)
     #expect(records[14].body?["enabled_workflows"] as? [String] == ["default_task", "pr_fix"])
     #expect(records[14].body?["dry_run_default"] as? Bool == false)
     #expect(records[14].body?["dispatch_status_filter"] as? String == "agentic_review")

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientTests+Contracts.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientTests+Contracts.swift
@@ -60,6 +60,7 @@ extension TaskBoardAPIClientTests {
     )
     let settings = try await client.updateTaskBoardOrchestratorSettings(
       request: TaskBoardOrchestratorSettingsUpdateRequest(
+        stepMode: true,
         clearDispatchStatusFilter: true,
         clearProjectDir: true,
         githubInbox: TaskBoardGitHubInboxConfig(repositories: ["example/harness", "example/aff"]),
@@ -90,6 +91,7 @@ extension TaskBoardAPIClientTests {
     #expect(runtimeConfig.global.authorName == "Harness Bot")
     #expect(runOnce.lastRun?.sync.total == 1)
     #expect(runOnce.lastRun?.policyTraceIds == ["trace-1"])
+    #expect(settings.stepMode)
     #expect(settings.githubInbox.repositories == ["example/harness", "example/aff"])
     #expect(settings.policyVersion == "task-board-policy-v3")
     #expect(updatedRuntimeConfig.repositoryOverrides.first?.repository == "example/harness")
@@ -107,6 +109,7 @@ extension TaskBoardAPIClientTests {
           projectDir: "/tmp/harness"
         ),
         .updateTaskBoardOrchestratorSettings(
+          stepMode: true,
           policyVersion: "task-board-policy-v3",
           clearProjectDir: true,
           clearDispatchStatusFilter: true

--- a/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientWebSocketContractTests.swift
+++ b/apps/harness-monitor/Tests/HarnessMonitorKitTests/TaskBoardAPIClientWebSocketContractTests.swift
@@ -106,6 +106,7 @@ extension TaskBoardAPIClientTests {
     _ = try await transport.taskBoardOrchestratorSettings()
     _ = try await transport.updateTaskBoardOrchestratorSettings(
       request: TaskBoardOrchestratorSettingsUpdateRequest(
+        stepMode: true,
         enabledWorkflows: [.defaultTask, .prFix],
         dryRunDefault: false,
         dispatchStatusFilter: .agenticReview,
@@ -251,6 +252,7 @@ extension TaskBoardAPIClientTests {
     #expect(calls[11].params == nil)
     #expect(calls[12].params == .object([:]))
     #expect(calls[13].params == nil)
+    #expect(objectValue(calls[14].params, key: "step_mode") == .bool(true))
     #expect(
       objectValue(calls[14].params, key: "enabled_workflows")
         == .array([


### PR DESCRIPTION
## Motivation

Step Mode waited for a full Task Board dashboard refresh after the daemon had already committed the setting. On the warmed regular Debug app against `smyk.la`, the baseline click-to-enabled interval was 626.7 ms p50 and 634.9 ms p95/worst across two enables. The stable baseline board had 225 active items: 168 Done and 57 Todo, with 57 items rendered.

## Implementation

Apply the committed settings response directly to both orchestrator status representations, finish the action without blocking on dashboard rematerialization, serialize and coalesce rapid toggle intent, roll back failures, and reject dashboard, lifecycle, and confirmation snapshots older than the latest settings confirmation. Focused tests cover the response path, zero blocking dashboard reads, rollback, rapid toggles, stale snapshots, settings consistency, and HTTP/WebSocket contracts.

The measured interval started when the Toggle setter received the action and ended when daemon-backed `stepMode` was true, the switch and rail/manual controls had rendered, and the in-flight action had cleared. The final regular Debug build used lane `task-board-step-mode-latency` and a stable remote board with 225 active items: 169 Done and 56 Todo, with 56 items rendered. After one relaunch warm-up (359.8 ms with a 214 ms remote RPC), three measured enables were 213.1, 202.3, and 170.8 ms: nearest-rank p50 202.3 ms, p95 213.1 ms, and worst 213.1 ms.
