### PR TITLE
perf(monitor): eliminate daemon freshness latency

### DIFF
--- a/apps/harness-monitor/Scripts/build-daemon-agent.sh
+++ b/apps/harness-monitor/Scripts/build-daemon-agent.sh
@@ -30,8 +30,10 @@ source "$SCRIPT_DIR/lib/daemon-cargo-build.sh"
 repo_root="$(resolve_repo_root)"
 staged_daemon_binary="$(daemon_staged_binary_path "$repo_root")"
 if daemon_staged_binary_is_fresh "$staged_daemon_binary" "$repo_root"; then
+  daemon_mark_staged_binary_ready "$staged_daemon_binary"
   exit 0
 fi
 
 daemon_binary="$(build_daemon_binary | /usr/bin/tail -n 1)"
-stage_daemon_binary "$daemon_binary" "$repo_root" >/dev/null
+staged_daemon_binary="$(stage_daemon_binary "$daemon_binary" "$repo_root")"
+daemon_mark_staged_binary_ready "$staged_daemon_binary"

--- a/apps/harness-monitor/Scripts/lib/daemon-cargo-build.sh
+++ b/apps/harness-monitor/Scripts/lib/daemon-cargo-build.sh
@@ -6,6 +6,9 @@
 # shellcheck source=apps/harness-monitor/Scripts/lib/swift-tool-env.sh
 source "$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/swift-tool-env.sh"
 sanitize_xcode_only_swift_environment
+DAEMON_INPUT_STATE_HELPER="$(
+  CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd
+)/daemon-input-state.py"
 
 # Hard-fail when a standalone rust install (Homebrew, MacPorts) is present at
 # one of the listed paths. The rustc-cache-wrapper at
@@ -237,6 +240,14 @@ daemon_build_profile_dir() {
   fi
 }
 
+daemon_build_features() {
+  printf '%s\n' "harness-daemon/tokio-console"
+}
+
+daemon_rustflags_contract() {
+  printf '%s\n' "config-plus-daemon-info-linker-args"
+}
+
 daemon_binary_output_path() {
   local target_dir profile_dir
   target_dir="$(resolve_cargo_target_dir)"
@@ -277,81 +288,10 @@ daemon_binary_dep_info_path() {
   printf '%s.d\n' "$source_binary"
 }
 
-# Print the first Makefile rule from Cargo's binary dep-info as one logical
-# line. Cargo's top-level `harness-daemon.d` already contains the exact union
-# of source inputs for the binary and every locally compiled dependency.
-daemon_dep_info_rule() {
-  local dep_info_path="$1"
-  /usr/bin/awk '
-    NR == 1 { sub(/^[^:]*:[[:space:]]*/, "") }
-    {
-      continued = sub(/\\$/, "")
-      printf "%s%s", $0, continued ? " " : "\n"
-      if (!continued) exit
-    }
-  ' "$dep_info_path"
-}
-
-daemon_compiler_input_files() {
-  local dep_info_path="$1"
-  local repo_root="${2:-${repo_root:-$(resolve_repo_root)}}"
-  local path
-
-  if [ ! -r "$dep_info_path" ]; then
-    printf 'daemon-cargo-build: compiler dep-info missing at %s\n' "$dep_info_path" >&2
-    return 1
-  fi
-
-  while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    case "$path" in
-      "$repo_root"/*)
-        [ -e "$path" ] || [ -L "$path" ] || continue
-        printf '%s\n' "$path"
-        ;;
-      /*)
-        # Registry and toolchain sources are represented by Cargo.lock and the
-        # pinned toolchain, not copied into the worktree input manifest.
-        ;;
-      *)
-        path="$repo_root/$path"
-        [ -e "$path" ] || [ -L "$path" ] || continue
-        printf '%s\n' "$path"
-        ;;
-    esac
-  done < <(daemon_dep_info_rule "$dep_info_path" | /usr/bin/xargs -n 1 printf '%s\n')
-}
-
-daemon_source_manifests() {
-  local repo_root="$1"
-  local source_manifest="$2"
-  local path parent
-
-  [ -f "$repo_root/Cargo.toml" ] && printf '%s\n' "$repo_root/Cargo.toml"
-  while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    parent="$(dirname "$path")"
-    while [ "$parent" != "$repo_root" ] && [ "$parent" != "/" ]; do
-      [ -f "$parent/Cargo.toml" ] && printf '%s\n' "$parent/Cargo.toml"
-      parent="$(dirname "$parent")"
-    done
-  done <"$source_manifest"
-}
-
-daemon_input_files() {
+daemon_current_input_state() {
   local repo_root="${1:-${repo_root:-$(resolve_repo_root)}}"
   local source_manifest="${2:-$(daemon_staged_binary_sources_path "$repo_root")}"
-  local path
-  local -a global_inputs=(
-    "$repo_root/Cargo.toml"
-    "$repo_root/Cargo.lock"
-    "$repo_root/rust-toolchain.toml"
-    "$repo_root/.cargo"
-    "$repo_root/scripts/rustc-cache-wrapper.sh"
-    "$PROJECT_DIR/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist"
-    "${BASH_SOURCE[0]}"
-    "$(dirname -- "${BASH_SOURCE[0]}")/daemon-bundle-env.sh"
-  )
+  local pinned_channel
 
   if [ ! -r "$source_manifest" ]; then
     printf 'daemon-cargo-build: staged compiler input manifest missing at %s\n' \
@@ -359,38 +299,72 @@ daemon_input_files() {
     return 1
   fi
 
-  for path in "${global_inputs[@]}"; do
-    [ -e "$path" ] || continue
-    if [ -d "$path" ]; then
-      /usr/bin/find "$path" \( -type f -o -type l \) -print
-    else
-      printf '%s\n' "$path"
-    fi
-  done
-
-  daemon_source_manifests "$repo_root" "$source_manifest"
-  /bin/cat "$source_manifest"
+  pinned_channel="$(resolve_pinned_toolchain_channel "$repo_root")"
+  /usr/bin/python3 "$DAEMON_INPUT_STATE_HELPER" state \
+    --repo-root "$repo_root" \
+    --source-manifest "$source_manifest" \
+    --global-input "$repo_root/Cargo.toml" \
+    --global-input "$repo_root/Cargo.lock" \
+    --global-input "$repo_root/rust-toolchain.toml" \
+    --global-input "$repo_root/.cargo" \
+    --global-input "$repo_root/scripts/rustc-cache-wrapper.sh" \
+    --global-input "$PROJECT_DIR/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist" \
+    --global-input "${BASH_SOURCE[0]}" \
+    --global-input "$(dirname -- "${BASH_SOURCE[0]}")/daemon-bundle-env.sh" \
+    --metadata "profile=$(daemon_build_profile_dir)" \
+    --metadata "features=$(daemon_build_features)" \
+    --metadata "marketing_version=${MARKETING_VERSION:-}" \
+    --metadata "toolchain=$pinned_channel" \
+    --metadata "rustflags=$(daemon_rustflags_contract)" \
+    --metadata "rustc_wrapper=${RUSTC_WRAPPER:-}" \
+    --metadata "cargo_bin=${CARGO_BIN:-$HOME/.cargo/bin/cargo}" \
+    --metadata "macosx_deployment_target=${MACOSX_DEPLOYMENT_TARGET:-}" \
+    --metadata "cc=${CC:-}" \
+    --metadata "cc_aarch64_apple_darwin=${CC_aarch64_apple_darwin:-}" \
+    --metadata "cc_x86_64_apple_darwin=${CC_x86_64_apple_darwin:-}" \
+    --metadata "developer_dir=${DEVELOPER_DIR:-}" \
+    --metadata "sdkroot=${SDKROOT:-}"
 }
 
-daemon_current_input_state() {
-  local repo_root="${1:-${repo_root:-$(resolve_repo_root)}}"
-  local source_manifest="${2:-$(daemon_staged_binary_sources_path "$repo_root")}"
-  local input_files path relative digest
+daemon_build_invocation_token_path() {
+  [ -n "${PROJECT_TEMP_DIR:-}" ] || return 1
+  printf '%s/HarnessMonitor-daemon-build-invocation.id\n' "$PROJECT_TEMP_DIR"
+}
 
-  input_files="$(daemon_input_files "$repo_root" "$source_manifest")" || return 1
-  printf '@profile\t%s\n' "$(daemon_build_profile_dir)"
-  printf '@features\tharness-daemon/tokio-console\n'
-  printf '@marketing-version\t%s\n' "${MARKETING_VERSION:-}"
-  printf '@rustflags\tconfig-plus-daemon-info-linker-args\n'
-  while IFS= read -r path; do
-    relative="${path#"$repo_root"/}"
-    if [ -L "$path" ]; then
-      digest="link:$(/usr/bin/readlink "$path")"
-    else
-      digest="$(/usr/bin/shasum -a 256 "$path" | /usr/bin/awk '{print $1}')"
-    fi
-    printf '%s\t%s\n' "$relative" "$digest"
-  done < <(printf '%s\n' "$input_files" | LC_ALL=C /usr/bin/sort -u)
+daemon_staged_binary_ready_path() {
+  [ -n "${PROJECT_TEMP_DIR:-}" ] || return 1
+  printf '%s/HarnessMonitor-daemon-staged-ready.id\n' "$PROJECT_TEMP_DIR"
+}
+
+daemon_mark_staged_binary_ready() {
+  local staged_binary="$1"
+  local invocation_token_path ready_path ready_tmp
+
+  [ -x "$staged_binary" ] || return 1
+  invocation_token_path="$(daemon_build_invocation_token_path)" || return 0
+  ready_path="$(daemon_staged_binary_ready_path)" || return 0
+  [ -s "$invocation_token_path" ] || return 0
+  ready_tmp="$ready_path.staging"
+  (
+    set -e
+    trap '/bin/rm -f "$ready_tmp"' EXIT
+    /bin/cp "$invocation_token_path" "$ready_tmp"
+    /bin/mv -f "$ready_tmp" "$ready_path"
+  )
+}
+
+daemon_staged_binary_is_ready_for_current_invocation() {
+  local staged_binary="$1"
+  local invocation_token_path ready_path
+
+  [ -x "$staged_binary" ] || return 1
+  [ -f "$staged_binary.inputs" ] || return 1
+  [ -f "$staged_binary.sources" ] || return 1
+  invocation_token_path="$(daemon_build_invocation_token_path)" || return 1
+  ready_path="$(daemon_staged_binary_ready_path)" || return 1
+  [ -s "$invocation_token_path" ] || return 1
+  [ -s "$ready_path" ] || return 1
+  /usr/bin/cmp -s "$invocation_token_path" "$ready_path"
 }
 
 daemon_staged_binary_is_fresh() {
@@ -412,7 +386,7 @@ stage_daemon_binary() {
   local source_binary="$1"
   local repo_root="${2:-${repo_root:-$(resolve_repo_root)}}"
   local staged_binary staged_dir staged_binary_tmp state_path state_tmp
-  local source_manifest source_manifest_tmp dep_info_path current_state compiler_inputs
+  local source_manifest source_manifest_tmp dep_info_path current_state
 
   staged_binary="$(daemon_staged_binary_path "$repo_root")"
   staged_dir="$(dirname "$staged_binary")"
@@ -424,11 +398,17 @@ stage_daemon_binary() {
   dep_info_path="${HARNESS_MONITOR_DAEMON_DEP_INFO_PATH:-$(daemon_binary_dep_info_path "$source_binary")}"
 
   /bin/mkdir -p "$staged_dir"
-  compiler_inputs="$(daemon_compiler_input_files "$dep_info_path" "$repo_root")" || {
+  if [ ! -r "$dep_info_path" ]; then
+    printf 'daemon-cargo-build: compiler dep-info missing at %s\n' "$dep_info_path" >&2
+    return 1
+  fi
+  /usr/bin/python3 "$DAEMON_INPUT_STATE_HELPER" manifest \
+    --dep-info "$dep_info_path" \
+    --repo-root "$repo_root" \
+    --output "$source_manifest_tmp" || {
     /bin/rm -f "$source_manifest_tmp"
     return 1
   }
-  printf '%s\n' "$compiler_inputs" | LC_ALL=C /usr/bin/sort -u >"$source_manifest_tmp"
   if [ ! -s "$source_manifest_tmp" ]; then
     printf 'daemon-cargo-build: compiler dep-info contained no worktree inputs: %s\n' \
       "$dep_info_path" >&2
@@ -440,6 +420,7 @@ stage_daemon_binary() {
     return 1
   }
   (
+    set -e
     trap '/bin/rm -f "$staged_binary_tmp" "$state_tmp" "$source_manifest_tmp"' EXIT
     /bin/cp -p "$source_binary" "$staged_binary_tmp"
     /bin/chmod 755 "$staged_binary_tmp"
@@ -447,7 +428,7 @@ stage_daemon_binary() {
     /bin/mv -f "$staged_binary_tmp" "$staged_binary"
     /bin/mv -f "$source_manifest_tmp" "$source_manifest"
     /bin/mv -f "$state_tmp" "$state_path"
-  )
+  ) || return 1
 
   printf '%s\n' "$staged_binary"
 }
@@ -457,6 +438,10 @@ resolve_daemon_binary_for_bundle() {
   local staged_binary built_binary
 
   staged_binary="$(daemon_staged_binary_path "$repo_root")"
+  if daemon_staged_binary_is_ready_for_current_invocation "$staged_binary"; then
+    printf '%s\n' "$staged_binary"
+    return 0
+  fi
   if daemon_staged_binary_is_fresh "$staged_binary" "$repo_root"; then
     printf '%s\n' "$staged_binary"
     return 0
@@ -464,7 +449,9 @@ resolve_daemon_binary_for_bundle() {
 
   built_binary="$(build_daemon_binary | /usr/bin/tail -n 1)"
   stage_daemon_binary "$built_binary" "$repo_root" >/dev/null
-  printf '%s\n' "$(daemon_staged_binary_path "$repo_root")"
+  staged_binary="$(daemon_staged_binary_path "$repo_root")"
+  daemon_mark_staged_binary_ready "$staged_binary"
+  printf '%s\n' "$staged_binary"
 }
 
 build_daemon_binary() {
@@ -476,11 +463,13 @@ build_daemon_binary() {
 
   local profile_dir
   profile_dir="$(daemon_build_profile_dir)"
+  local features
+  features="$(daemon_build_features)"
   local cargo_args=(
     rustc
     --package harness-daemon
     --bin harness-daemon
-    --features harness-daemon/tokio-console
+    --features "$features"
   )
   if [ "$profile_dir" = "release" ]; then
     cargo_args+=(--release)

--- a/apps/harness-monitor/Scripts/lib/daemon-input-state.py
+++ b/apps/harness-monitor/Scripts/lib/daemon-input-state.py
@@ -1,0 +1,297 @@
+#!/usr/bin/python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import struct
+from pathlib import Path
+from typing import Any, Iterable
+
+
+STATE_VERSION = 2
+
+
+def _first_logical_rule(data: bytes) -> bytes:
+    rule = bytearray()
+    for raw_line in data.splitlines(keepends=True):
+        line = raw_line.rstrip(b"\r\n")
+        trailing_backslashes = len(line) - len(line.rstrip(b"\\"))
+        if trailing_backslashes % 2 == 1:
+            rule.extend(line[:-1])
+            rule.extend(b" ")
+            continue
+        rule.extend(line)
+        break
+    return bytes(rule)
+
+
+def _rule_dependencies(rule: bytes) -> bytes:
+    escaped = False
+    for index, value in enumerate(rule):
+        if escaped:
+            escaped = False
+        elif value == ord("\\"):
+            escaped = True
+        elif value == ord(":"):
+            return rule[index + 1 :]
+    raise ValueError("compiler dep-info has no target separator")
+
+
+def _makefile_tokens(value: bytes) -> list[bytes]:
+    tokens: list[bytes] = []
+    token = bytearray()
+    escaped = False
+    for byte in value:
+        if escaped:
+            token.append(byte)
+            escaped = False
+        elif byte == ord("\\"):
+            escaped = True
+        elif byte in (ord(" "), ord("\t")):
+            if token:
+                tokens.append(bytes(token))
+                token.clear()
+        else:
+            token.append(byte)
+    if escaped:
+        token.append(ord("\\"))
+    if token:
+        tokens.append(bytes(token))
+    return tokens
+
+
+def _normalize_path(path: str, repo_root: str) -> str:
+    if not os.path.isabs(path):
+        path = os.path.join(repo_root, path)
+    return os.path.abspath(os.path.normpath(path))
+
+
+def _is_within(path: str, root: str) -> bool:
+    try:
+        return os.path.commonpath((path, root)) == root
+    except ValueError:
+        return False
+
+
+def _sorted_paths(paths: Iterable[str]) -> list[str]:
+    return sorted(set(paths), key=os.fsencode)
+
+
+def _compiler_inputs(dep_info_path: str, repo_root: str) -> list[str]:
+    repo_root = os.path.abspath(repo_root)
+    rule = _first_logical_rule(Path(dep_info_path).read_bytes())
+    dependencies = _makefile_tokens(_rule_dependencies(rule))
+    inputs: list[str] = []
+    for raw_path in dependencies:
+        path = _normalize_path(os.fsdecode(raw_path), repo_root)
+        if not _is_within(path, repo_root):
+            continue
+        if os.path.lexists(path):
+            inputs.append(path)
+    return _sorted_paths(inputs)
+
+
+def _write_manifest(args: argparse.Namespace) -> None:
+    inputs = _compiler_inputs(args.dep_info, args.repo_root)
+    if not inputs:
+        raise ValueError(
+            f"compiler dep-info contained no worktree inputs: {args.dep_info}"
+        )
+    payload = b"".join(os.fsencode(path) + b"\0" for path in inputs)
+    Path(args.output).write_bytes(payload)
+
+
+def _read_manifest(path: str) -> list[str]:
+    payload = Path(path).read_bytes()
+    if b"\0" in payload:
+        entries = payload.split(b"\0")
+    else:
+        # Upgrade old line-delimited manifests in place on the next rebuild.
+        entries = payload.splitlines()
+    return [os.fsdecode(entry) for entry in entries if entry]
+
+
+def _directory_inputs(path: str) -> list[str]:
+    inputs = [path]
+    for current_root, directory_names, file_names in os.walk(
+        path, followlinks=False
+    ):
+        directory_names.sort(key=os.fsencode)
+        file_names.sort(key=os.fsencode)
+
+        traversable_directories: list[str] = []
+        for name in directory_names:
+            child = os.path.join(current_root, name)
+            if os.path.islink(child):
+                inputs.append(child)
+            else:
+                inputs.append(child)
+                traversable_directories.append(name)
+        directory_names[:] = traversable_directories
+
+        for name in file_names:
+            child = os.path.join(current_root, name)
+            try:
+                child_mode = os.lstat(child).st_mode
+            except FileNotFoundError:
+                inputs.append(child)
+                continue
+            if stat.S_ISREG(child_mode) or stat.S_ISLNK(child_mode):
+                inputs.append(child)
+    return inputs
+
+
+def _expanded_inputs(paths: Iterable[str], repo_root: str) -> list[str]:
+    expanded: list[str] = []
+    for raw_path in paths:
+        path = _normalize_path(raw_path, repo_root)
+        try:
+            mode = os.lstat(path).st_mode
+        except FileNotFoundError:
+            expanded.append(path)
+            continue
+        if stat.S_ISDIR(mode):
+            expanded.extend(_directory_inputs(path))
+        else:
+            expanded.append(path)
+    return _sorted_paths(expanded)
+
+
+def _source_manifests(source_inputs: Iterable[str], repo_root: str) -> list[str]:
+    manifests = [os.path.join(repo_root, "Cargo.toml")]
+    for path in source_inputs:
+        current = path if os.path.isdir(path) else os.path.dirname(path)
+        while _is_within(current, repo_root) and current != repo_root:
+            manifest = os.path.join(current, "Cargo.toml")
+            if os.path.isfile(manifest):
+                manifests.append(manifest)
+            current = os.path.dirname(current)
+    return _sorted_paths(manifests)
+
+
+def _metadata(values: Iterable[str]) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for value in values:
+        key, separator, metadata_value = value.partition("=")
+        if not separator or not key:
+            raise ValueError(f"invalid metadata entry: {value!r}")
+        metadata[key] = metadata_value
+    return metadata
+
+
+def _update_bytes(digest: Any, value: bytes) -> None:
+    digest.update(struct.pack(">Q", len(value)))
+    digest.update(value)
+
+
+def _path_label(path: str, repo_root: str) -> bytes:
+    if _is_within(path, repo_root):
+        return os.fsencode(os.path.relpath(path, repo_root))
+    return os.fsencode(path)
+
+
+def _hash_input(digest: Any, path: str, repo_root: str) -> None:
+    _update_bytes(digest, b"input")
+    _update_bytes(digest, _path_label(path, repo_root))
+    try:
+        path_stat = os.lstat(path)
+    except FileNotFoundError:
+        _update_bytes(digest, b"missing")
+        return
+
+    mode = path_stat.st_mode
+    _update_bytes(digest, str(stat.S_IMODE(mode)).encode())
+    if stat.S_ISLNK(mode):
+        _update_bytes(digest, b"symlink")
+        _update_bytes(digest, os.fsencode(os.readlink(path)))
+    elif stat.S_ISDIR(mode):
+        _update_bytes(digest, b"directory")
+    elif stat.S_ISREG(mode):
+        _update_bytes(digest, b"file")
+        _update_bytes(digest, str(path_stat.st_size).encode())
+        with open(path, "rb") as input_file:
+            while chunk := input_file.read(1024 * 1024):
+                digest.update(chunk)
+    else:
+        _update_bytes(digest, b"other")
+
+
+def _record_trace() -> None:
+    trace_path = os.environ.get(
+        "HARNESS_MONITOR_DAEMON_INPUT_STATE_TRACE_PATH", ""
+    )
+    if trace_path:
+        with open(trace_path, "ab") as trace:
+            trace.write(b"state\n")
+
+
+def _write_state(args: argparse.Namespace) -> None:
+    _record_trace()
+    repo_root = os.path.abspath(args.repo_root)
+    source_inputs = [
+        _normalize_path(path, repo_root)
+        for path in _read_manifest(args.source_manifest)
+    ]
+    all_inputs = list(args.global_input)
+    all_inputs.extend(source_inputs)
+    all_inputs.extend(_source_manifests(source_inputs, repo_root))
+    all_inputs.append(os.path.abspath(__file__))
+    inputs = _expanded_inputs(all_inputs, repo_root)
+    metadata = _metadata(args.metadata)
+
+    digest = hashlib.sha256()
+    _update_bytes(
+        digest,
+        json.dumps(
+            metadata, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        ).encode(),
+    )
+    for path in inputs:
+        _hash_input(digest, path, repo_root)
+
+    state = {
+        "digest": digest.hexdigest(),
+        "input_count": len(inputs),
+        "metadata": metadata,
+        "version": STATE_VERSION,
+    }
+    print(
+        json.dumps(
+            state, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        )
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    manifest = subparsers.add_parser("manifest")
+    manifest.add_argument("--dep-info", required=True)
+    manifest.add_argument("--repo-root", required=True)
+    manifest.add_argument("--output", required=True)
+    manifest.set_defaults(handler=_write_manifest)
+
+    state = subparsers.add_parser("state")
+    state.add_argument("--repo-root", required=True)
+    state.add_argument("--source-manifest", required=True)
+    state.add_argument("--global-input", action="append", default=[])
+    state.add_argument("--metadata", action="append", default=[])
+    state.set_defaults(handler=_write_state)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    try:
+        args.handler(args)
+    except (OSError, ValueError) as error:
+        raise SystemExit(f"daemon-input-state: {error}") from error
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/harness-monitor/Scripts/prepare-app-entitlements.sh
+++ b/apps/harness-monitor/Scripts/prepare-app-entitlements.sh
@@ -6,6 +6,8 @@ APP_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
 
 project_temp_dir="${PROJECT_TEMP_DIR:?missing PROJECT_TEMP_DIR}"
 output_dir="$project_temp_dir/GeneratedAppEntitlements"
+build_invocation_path="$project_temp_dir/HarnessMonitor-daemon-build-invocation.id"
+build_invocation_tmp="$build_invocation_path.staging"
 
 copy_entitlements() {
   local target_name="$1"
@@ -23,6 +25,8 @@ copy_entitlements() {
 }
 
 /bin/mkdir -p "$output_dir"
+/usr/bin/uuidgen >"$build_invocation_tmp"
+/bin/mv -f "$build_invocation_tmp" "$build_invocation_path"
 copy_entitlements "HarnessMonitor" "HarnessMonitor.entitlements"
 copy_entitlements "HarnessMonitorExternalDaemon" "HarnessMonitorExternalDaemon.entitlements"
 copy_entitlements "HarnessMonitorUITestHost" "HarnessMonitorUITestHost.entitlements"

--- a/apps/harness-monitor/Scripts/tests/test_bundle_daemon_agent_env.py
+++ b/apps/harness-monitor/Scripts/tests/test_bundle_daemon_agent_env.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 import plistlib
 import subprocess
 import tempfile
@@ -12,6 +14,13 @@ HELPER_PATH = (
 )
 CARGO_HELPER_PATH = (
     Path(__file__).resolve().parents[1] / "lib" / "daemon-cargo-build.sh"
+)
+INPUT_STATE_HELPER_PATH = (
+    Path(__file__).resolve().parents[1] / "lib" / "daemon-input-state.py"
+)
+BUILD_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "build-daemon-agent.sh"
+PREPARE_ENTITLEMENTS_PATH = (
+    Path(__file__).resolve().parents[1] / "prepare-app-entitlements.sh"
 )
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "bundle-daemon-agent.sh"
 DAEMON_INFO_PLIST_PATH = (
@@ -35,8 +44,6 @@ def _isolated_subprocess_env() -> dict:
     real repo where mise's hook-env re-affirms the pinned toolchain instead
     of stripping it; the test repo lacks `.mise.toml`, so unsetting BASH_ENV
     is the equivalent isolation."""
-    import os
-
     isolated = dict(os.environ)
     isolated.pop("BASH_ENV", None)
     return isolated
@@ -73,6 +80,34 @@ def run_build_helper(script: str) -> str:
     return completed.stdout.strip()
 
 
+def _read_source_manifest(path: Path) -> list[Path]:
+    return [
+        Path(os.fsdecode(entry))
+        for entry in path.read_bytes().split(b"\0")
+        if entry
+    ]
+
+
+def _bundle_stamp_lines(daemon_source: Path) -> list[str]:
+    daemon_stat = daemon_source.stat()
+    return [
+        f"daemon_source={daemon_source}",
+        f"daemon_source_stat={int(daemon_stat.st_mtime)}:{daemon_stat.st_size}",
+        "codesign_identity=fake-identity",
+        "timestamp_flag=--timestamp=none",
+        "launch_agent_label=Q498EB36N4.io.harnessmonitor.daemon",
+        "app_group_id=test.group",
+        "marketing_version=1.2.3",
+        "daemon_data_home=/tmp/test-daemon-home",
+        "codex_ws_port=4242",
+        "runtime_lane=test-lane",
+        "daemon_plist_sha=missing",
+        "legacy_managed_plist_sha=missing",
+        "legacy_plist_sha=missing",
+        "entitlements_sha=missing",
+    ]
+
+
 class BundleDaemonAgentScriptTests(unittest.TestCase):
     def test_main_app_test_actions_do_not_skip_bundling(self) -> None:
         script = SCRIPT_PATH.read_text(encoding="utf-8")
@@ -82,6 +117,51 @@ class BundleDaemonAgentScriptTests(unittest.TestCase):
             script,
         )
         self.assertIn("if is_test_bundle_target; then", script)
+
+
+class DaemonInputStateScriptTests(unittest.TestCase):
+    def test_freshness_uses_one_batched_input_state_process(self) -> None:
+        source = CARGO_HELPER_PATH.read_text()
+
+        self.assertTrue(INPUT_STATE_HELPER_PATH.is_file())
+        self.assertIn(
+            '/usr/bin/python3 "$DAEMON_INPUT_STATE_HELPER" state',
+            source,
+        )
+        self.assertNotIn(
+            'shasum -a 256 "$path"',
+            source,
+        )
+
+    def test_prepare_entitlements_rotates_build_invocation_token(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            project_temp_dir = Path(tmp_dir) / "HarnessMonitor.build"
+            env = _isolated_subprocess_env()
+            env["PROJECT_TEMP_DIR"] = str(project_temp_dir)
+
+            subprocess.run(
+                ["bash", str(PREPARE_ENTITLEMENTS_PATH)],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            token_path = (
+                project_temp_dir / "HarnessMonitor-daemon-build-invocation.id"
+            )
+            first_token = token_path.read_text()
+
+            subprocess.run(
+                ["bash", str(PREPARE_ENTITLEMENTS_PATH)],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            second_token = token_path.read_text()
+
+            self.assertNotEqual(first_token, second_token)
+            self.assertEqual(len(second_token.strip()), 36)
 
 
 class DaemonInfoPlistTests(unittest.TestCase):
@@ -434,7 +514,10 @@ class DaemonStagedBinaryTests(unittest.TestCase):
             self.assertTrue(staged_path.is_file())
             self.assertEqual(staged_path.read_text(), "binary\n")
             self.assertTrue(staged_path.stat().st_mode & 0o111)
-            self.assertTrue(Path(f"{staged_binary}.inputs").is_file())
+            state = json.loads(Path(f"{staged_binary}.inputs").read_text())
+            self.assertEqual(state["version"], 2)
+            self.assertGreater(state["input_count"], 0)
+            self.assertTrue(Path(f"{staged_binary}.sources").is_file())
 
     def test_bundle_resolution_reuses_fresh_staged_binary_without_cargo(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -447,20 +530,24 @@ class DaemonStagedBinaryTests(unittest.TestCase):
             source_binary.chmod(0o755)
             staged_binary = run_build_helper(
                 f'export PROJECT_DIR="{project_dir}"; '
+                f'export CARGO_BIN="{fake_cargo}"; '
                 f'export CARGO_TARGET_DIR="{target_dir}"; '
                 f'stage_daemon_binary "{source_binary}"'
             )
+            trace_path = Path(tmp_dir) / "input-state-trace.txt"
 
             resolved_binary = run_build_helper(
                 f'export PROJECT_DIR="{project_dir}"; '
                 f'export CARGO_BIN="{fake_cargo}"; '
                 f'export CARGO_TARGET_DIR="{target_dir}"; '
                 f'export CAPTURED_ENV_PATH="{captured_env_path}"; '
+                f'export HARNESS_MONITOR_DAEMON_INPUT_STATE_TRACE_PATH="{trace_path}"; '
                 "resolve_daemon_binary_for_bundle"
             )
 
             self.assertEqual(resolved_binary, staged_binary)
             self.assertFalse(captured_env_path.exists(), "cargo must not run when staged binary is fresh")
+            self.assertEqual(trace_path.read_text().splitlines(), ["state"])
 
     def test_bundle_resolution_builds_and_stages_when_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -488,19 +575,24 @@ class DaemonStagedBinaryTests(unittest.TestCase):
                 layout["env"]
                 + f'stage_daemon_binary "{layout["source_binary"]}"'
             )
-            source_manifest = Path(f"{staged_binary}.sources").read_text()
-            state = Path(f"{staged_binary}.inputs").read_text()
+            source_manifest = _read_source_manifest(
+                Path(f"{staged_binary}.sources")
+            )
+            state = json.loads(Path(f"{staged_binary}.inputs").read_text())
 
-            self.assertIn(str(layout["daemon_source"]), source_manifest)
-            self.assertIn(str(layout["protocol_source"]), source_manifest)
-            self.assertNotIn(str(layout["workflow_source"]), source_manifest)
-            self.assertIn("crates/harness-daemon/Cargo.toml", state)
-            self.assertIn("crates/harness-protocol/Cargo.toml", state)
-            self.assertIn("Cargo.lock", state)
-            self.assertIn("rust-toolchain.toml", state)
-            self.assertIn(".cargo/config.toml", state)
-            self.assertIn("scripts/rustc-cache-wrapper.sh", state)
-            self.assertIn("io.harnessmonitor.daemon.Info.plist", state)
+            self.assertIn(layout["daemon_source"], source_manifest)
+            self.assertIn(layout["protocol_source"], source_manifest)
+            self.assertNotIn(layout["workflow_source"], source_manifest)
+            self.assertEqual(state["metadata"]["profile"], "debug")
+            self.assertEqual(
+                state["metadata"]["features"],
+                "harness-daemon/tokio-console",
+            )
+            self.assertEqual(
+                state["metadata"]["rustflags"],
+                "config-plus-daemon-info-linker-args",
+            )
+            self.assertEqual(state["metadata"]["toolchain"], "stable")
 
             layout["daemon_source"].write_text("pub fn daemon_changed() {}\n")
             freshness = run_build_helper(
@@ -568,8 +660,8 @@ class DaemonStagedBinaryTests(unittest.TestCase):
                 + f'stage_daemon_binary "{layout["source_binary"]}" >/dev/null'
             )
             self.assertIn(
-                new_module.as_posix(),
-                Path(f"{staged_binary}.sources").read_text(),
+                new_module,
+                _read_source_manifest(Path(f"{staged_binary}.sources")),
             )
 
             new_module.write_text("pub fn new_module_changed() {}\n")
@@ -577,6 +669,118 @@ class DaemonStagedBinaryTests(unittest.TestCase):
                 layout["env"]
                 + f'daemon_staged_binary_is_fresh "{staged_binary}" '
                 "&& printf yes || printf no"
+            )
+            self.assertEqual(freshness, "no")
+
+    def test_directory_dep_info_tracks_regular_files_and_new_untracked_inputs(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            layout = _setup_dep_info_freshness_layout(
+                Path(tmp_dir) / "layout with spaces"
+            )
+            daemon_source = layout["daemon_source"]
+            daemon_source_dir = daemon_source.parent
+            nested_source = daemon_source_dir / "nested" / "existing.rs"
+            nested_source.parent.mkdir()
+            nested_source.write_text("pub fn existing() {}\n")
+            _write_dep_info(
+                layout["source_binary"],
+                [daemon_source_dir, layout["protocol_source"]],
+            )
+
+            staged_binary = run_build_helper(
+                layout["env"]
+                + f'stage_daemon_binary "{layout["source_binary"]}"'
+            )
+            manifest_path = Path(f"{staged_binary}.sources")
+            manifest = _read_source_manifest(manifest_path)
+            self.assertIn(daemon_source_dir, manifest)
+            self.assertIn(b"\0", manifest_path.read_bytes())
+
+            nested_source.write_text("pub fn existing_changed() {}\n")
+            freshness = run_build_helper(
+                layout["env"]
+                + f'daemon_staged_binary_is_fresh "{staged_binary}" '
+                "&& printf yes || printf no"
+            )
+            self.assertEqual(freshness, "no")
+
+            nested_source.write_text("pub fn existing() {}\n")
+            run_build_helper(
+                layout["env"]
+                + f'stage_daemon_binary "{layout["source_binary"]}" >/dev/null'
+            )
+            untracked_source = daemon_source_dir / "new_untracked.rs"
+            untracked_source.write_text("pub fn untracked() {}\n")
+            freshness = run_build_helper(
+                layout["env"]
+                + f'daemon_staged_binary_is_fresh "{staged_binary}" '
+                "&& printf yes || printf no"
+            )
+            self.assertEqual(freshness, "no")
+
+    def test_build_metadata_and_global_inputs_invalidate_staged_binary(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            layout = _setup_dep_info_freshness_layout(Path(tmp_dir))
+            base_env = (
+                layout["env"]
+                + 'export MARKETING_VERSION="1.2.3"; '
+                + 'export RUSTC_WRAPPER="/tmp/wrapper-a"; '
+                + 'export MACOSX_DEPLOYMENT_TARGET="26.0"; '
+            )
+            staged_binary = run_build_helper(
+                base_env
+                + f'stage_daemon_binary "{layout["source_binary"]}"'
+            )
+            state = json.loads(Path(f"{staged_binary}.inputs").read_text())
+            self.assertEqual(state["metadata"]["marketing_version"], "1.2.3")
+            self.assertEqual(
+                state["metadata"]["rustc_wrapper"],
+                "/tmp/wrapper-a",
+            )
+            self.assertEqual(
+                state["metadata"]["macosx_deployment_target"],
+                "26.0",
+            )
+
+            for changed_environment in (
+                'export MARKETING_VERSION="1.2.4"; ',
+                'export RUSTC_WRAPPER="/tmp/wrapper-b"; ',
+                'export MACOSX_DEPLOYMENT_TARGET="27.0"; ',
+            ):
+                with self.subTest(changed_environment=changed_environment):
+                    freshness = run_build_helper(
+                        base_env
+                        + changed_environment
+                        + f'daemon_staged_binary_is_fresh "{staged_binary}" '
+                        + "&& printf yes || printf no"
+                    )
+                    self.assertEqual(freshness, "no")
+
+            repo_root = layout["repo_root"]
+            toolchain_path = repo_root / "rust-toolchain.toml"
+            toolchain_path.write_text(
+                '[toolchain]\nchannel = "nightly-2026-05-19"\n'
+            )
+            freshness = run_build_helper(
+                base_env
+                + f'daemon_staged_binary_is_fresh "{staged_binary}" '
+                + "&& printf yes || printf no"
+            )
+            self.assertEqual(freshness, "no")
+            toolchain_path.write_text('[toolchain]\nchannel = "stable"\n')
+
+            cargo_config = repo_root / ".cargo" / "config.toml"
+            cargo_config.write_text(
+                '[build]\nrustflags = ["--cfg", "changed"]\n'
+            )
+            freshness = run_build_helper(
+                base_env
+                + f'daemon_staged_binary_is_fresh "{staged_binary}" '
+                + "&& printf yes || printf no"
             )
             self.assertEqual(freshness, "no")
 
@@ -834,24 +1038,9 @@ class BundleStampShortcutTests(unittest.TestCase):
             daemon_target.chmod(0o755)
             plist_target.write_text("plist\n")
 
-            daemon_stat = daemon_source.stat()
-            stamp_lines = [
-                f"daemon_source={daemon_source}",
-                f"daemon_source_stat={int(daemon_stat.st_mtime)}:{daemon_stat.st_size}",
-                "codesign_identity=fake-identity",
-                "timestamp_flag=--timestamp=none",
-                "launch_agent_label=Q498EB36N4.io.harnessmonitor.daemon",
-                "app_group_id=test.group",
-                "marketing_version=1.2.3",
-                "daemon_data_home=/tmp/test-daemon-home",
-                "codex_ws_port=4242",
-                "runtime_lane=test-lane",
-                "daemon_plist_sha=missing",
-                "legacy_managed_plist_sha=missing",
-                "legacy_plist_sha=missing",
-                "entitlements_sha=missing",
-            ]
-            bundle_stamp_path.write_text("\n".join(stamp_lines) + "\n")
+            bundle_stamp_path.write_text(
+                "\n".join(_bundle_stamp_lines(daemon_source)) + "\n"
+            )
 
             env = {
                 "HOME": tempfile.gettempdir(),
@@ -878,6 +1067,133 @@ class BundleStampShortcutTests(unittest.TestCase):
             )
 
             self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+
+    def test_pre_action_ready_stamp_avoids_bundle_state_recompute(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            project_dir, target_dir, captured_env_path, fake_cargo = (
+                _setup_fake_daemon_layout(root)
+            )
+            source_binary = target_dir / "debug" / "harness-daemon"
+            source_binary.write_text("staged\n")
+            source_binary.chmod(0o755)
+            env = _isolated_subprocess_env()
+            env.update(
+                {
+                    "CAPTURED_ENV_PATH": str(captured_env_path),
+                    "CARGO_BIN": str(fake_cargo),
+                    "CARGO_TARGET_DIR": str(target_dir),
+                    "MARKETING_VERSION": "1.2.3",
+                    "PROJECT_DIR": str(project_dir),
+                }
+            )
+            stage = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    (
+                        f'unset BASH_ENV; source "{HELPER_PATH}"; '
+                        f'source "{CARGO_HELPER_PATH}"; '
+                        f'stage_daemon_binary "{source_binary}"'
+                    ),
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(stage.returncode, 0, msg=stage.stderr)
+            staged_binary = Path(stage.stdout.strip())
+
+            project_temp_dir = root / "HarnessMonitor.build"
+            project_temp_dir.mkdir()
+            invocation_token = (
+                project_temp_dir
+                / "HarnessMonitor-daemon-build-invocation.id"
+            )
+            invocation_token.write_text("current-build-token\n")
+            trace_path = root / "input-state-trace.txt"
+            env.update(
+                {
+                    "HARNESS_MONITOR_DAEMON_INPUT_STATE_TRACE_PATH": str(
+                        trace_path
+                    ),
+                    "PROJECT_TEMP_DIR": str(project_temp_dir),
+                }
+            )
+
+            pre_action = subprocess.run(
+                ["bash", str(BUILD_SCRIPT_PATH)],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(
+                pre_action.returncode,
+                0,
+                msg=pre_action.stderr,
+            )
+            ready_path = (
+                project_temp_dir / "HarnessMonitor-daemon-staged-ready.id"
+            )
+            self.assertEqual(
+                ready_path.read_text(),
+                invocation_token.read_text(),
+            )
+
+            target_build_dir = root / "build"
+            derived_dir = root / "derived"
+            daemon_target = (
+                target_build_dir / "Contents" / "Helpers" / "harness-daemon"
+            )
+            plist_target = (
+                target_build_dir
+                / "Contents"
+                / "Library"
+                / "LaunchAgents"
+                / "Q498EB36N4.io.harnessmonitor.daemon.plist"
+            )
+            daemon_target.parent.mkdir(parents=True)
+            plist_target.parent.mkdir(parents=True)
+            derived_dir.mkdir()
+            daemon_target.write_text("bundled\n")
+            daemon_target.chmod(0o755)
+            plist_target.write_text("plist\n")
+            bundle_stamp_path = (
+                derived_dir / "HarnessMonitor-bundle-daemon-agent.stamp"
+            )
+            bundle_stamp_path.write_text(
+                "\n".join(_bundle_stamp_lines(staged_binary)) + "\n"
+            )
+            env.update(
+                {
+                    "CONTENTS_FOLDER_PATH": "Contents",
+                    "DERIVED_FILE_DIR": str(derived_dir),
+                    "EXPANDED_CODE_SIGN_IDENTITY": "fake-identity",
+                    "HARNESS_APP_GROUP_ID": "test.group",
+                    "HARNESS_CODEX_WS_PORT": "4242",
+                    "HARNESS_DAEMON_DATA_HOME": "/tmp/test-daemon-home",
+                    "HARNESS_MONITOR_RUNTIME_LANE": "test-lane",
+                    "TARGET_BUILD_DIR": str(target_build_dir),
+                    "TARGET_NAME": "HarnessMonitor",
+                }
+            )
+
+            bundle_phase = subprocess.run(
+                ["bash", str(self.BUNDLE_SCRIPT)],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(
+                bundle_phase.returncode,
+                0,
+                msg=bundle_phase.stderr,
+            )
+            self.assertEqual(trace_path.read_text().splitlines(), ["state"])
+            self.assertFalse(
+                captured_env_path.exists(),
+                "cargo must not run across the warm pre-action and bundle",
+            )
 
 
 def _setup_fake_daemon_layout(tmp_dir: Path):

--- a/apps/harness-monitor/Scripts/tests/test_xcode_build_phase_entry.py
+++ b/apps/harness-monitor/Scripts/tests/test_xcode_build_phase_entry.py
@@ -52,6 +52,7 @@ class XcodeBuildPhaseEntryTests(unittest.TestCase):
         source = BUILD_PHASES_SOURCE.read_text()
 
         required_inputs = (
+            '"$(PROJECT_DIR)/Scripts/lib/daemon-input-state.py"',
             '"$(PROJECT_DIR)/Resources/LaunchAgents/Q498EB36N4.io.harnessmonitor.daemon.plist"',
             '"$(PROJECT_DIR)/Resources/LaunchAgents/io.harnessmonitor.daemon.managed.plist"',
             '"$(PROJECT_DIR)/Resources/LaunchAgents/io.harnessmonitor.daemon.plist"',
@@ -65,8 +66,8 @@ class XcodeBuildPhaseEntryTests(unittest.TestCase):
             with self.subTest(required_input=required_input):
                 self.assertIn(required_input, source)
 
-        # bundleDaemonAgent opts out because cargo sources can't be enumerated
-        # in inputPaths; all other sandboxed phases must use dependency analysis.
+        # bundleDaemonAgent opts out because Cargo discovers Rust inputs
+        # dynamically; all other sandboxed phases use dependency analysis.
         self.assertEqual(source.count("basedOnDependencyAnalysis: false"), 1)
 
     def test_entry_script_unsets_swift_debug_environment_before_bash_starts(

--- a/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildPhases.swift
+++ b/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildPhases.swift
@@ -51,6 +51,7 @@ public enum BuildPhases {
                 "$(PROJECT_DIR)/Scripts/bundle-daemon-agent.sh",
                 "$(PROJECT_DIR)/Scripts/lib/daemon-bundle-env.sh",
                 "$(PROJECT_DIR)/Scripts/lib/daemon-cargo-build.sh",
+                "$(PROJECT_DIR)/Scripts/lib/daemon-input-state.py",
                 "$(PROJECT_DIR)/Scripts/lib/monitor-lanes.sh",
                 "$(PROJECT_DIR)/Scripts/lib/swift-tool-env.sh",
                 "$(PROJECT_DIR)/Resources/LaunchAgents/Q498EB36N4.io.harnessmonitor.daemon.plist",
@@ -70,11 +71,10 @@ public enum BuildPhases {
                 "$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Library/LaunchAgents/io.harnessmonitor.daemon.plist",
                 "$(DERIVED_FILE_DIR)/$(TARGET_NAME)-bundle-daemon-agent.stamp"
             ],
-            // The bundle phase's inputPaths can't enumerate every Rust source file,
-            // so dependency analysis was skipping the phase whenever scripts and
-            // plists were untouched even after cargo produced a fresh helper. Run
-            // unconditionally - bundle-daemon-agent.sh delegates freshness to
-            // cargo, which no-ops when the binary is already up to date.
+            // Rust compiler inputs are discovered dynamically from Cargo dep-info,
+            // so Xcode cannot model the complete input set here. Keep this phase
+            // unconditional; the pre-action publishes a same-invocation ready
+            // stamp, while fallback builds use one batched content digest.
             basedOnDependencyAnalysis: false
         )
     }

--- a/scripts/check-scripts.sh
+++ b/scripts/check-scripts.sh
@@ -106,6 +106,10 @@ monitor_shell_scripts=(
   "$ROOT"/apps/harness-monitor/Scripts/*.sh
   "$ROOT"/apps/harness-monitor/Scripts/lib/*.sh
 )
+monitor_python_scripts=(
+  "$ROOT"/apps/harness-monitor/Scripts/*.py
+  "$ROOT"/apps/harness-monitor/Scripts/lib/*.py
+)
 monitor_python_tests_dir="$ROOT/apps/harness-monitor/Scripts/tests"
 monitor_python_tests=("$ROOT"/apps/harness-monitor/Scripts/tests/*.py)
 monitor_python_fast_tests=()
@@ -137,6 +141,9 @@ if [[ "$mode" != "--tests" ]]; then
 
   if (( ${#python_scripts[@]} > 0 )); then
     python3 -m py_compile "${python_scripts[@]}"
+  fi
+  if (( ${#monitor_python_scripts[@]} > 0 )); then
+    python3 -m py_compile "${monitor_python_scripts[@]}"
   fi
   if (( ${#monitor_python_tests[@]} > 0 )); then
     python3 -m py_compile "${monitor_python_tests[@]}"


### PR DESCRIPTION
## Motivation
Warm Harness Monitor builds spent minutes recomputing daemon freshness twice, once in the scheme pre-action and again in the bundle phase. Per-file `shasum` and `awk` launches also mishandled directory dep-info inputs and made unchanged builds unusably slow.

## Implementation
- Replace per-file subprocess hashing with one NUL-safe batched content digest over normalized Cargo dep-info inputs and build metadata.
- Expand directory inputs deterministically while preserving invalidation for tracked, dirty, and untracked Rust sources.
- Add a same-invocation ready stamp so the bundle phase reuses the pre-action result without a second digest.
- Keep Xcode dependency analysis disabled because dynamic Rust inputs cannot be declared statically without risking stale daemon bundles.
- Validate 182 script tests, script lint, project generation, and two full Monitor builds, with warm pre-action latency reduced from 143.294s to 1.229s and bundle latency from 135.865s to 0.446s.
