### PR TITLE
perf(test): run Rust suites in parallel

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,13 @@
 nextest-version = "0.9.140"
 
+[profile.default]
+test-threads = "num-cpus"
+fail-fast = false
+status-level = "fail"
+final-status-level = "fail"
+
 [profile.rust-timing]
-test-threads = 1
+test-threads = "num-cpus"
 retries = 0
 fail-fast = false
 status-level = "slow"

--- a/.mise.toml
+++ b/.mise.toml
@@ -154,63 +154,68 @@ run = "./scripts/tests/test-release-install.sh"
 [tasks."test:unit"]
 description = "Run unit tests"
 run = [
-  "./scripts/cargo-local.sh test --quiet --lib --features full-runtime -- --test-threads=1 --format terse",
-  "./scripts/cargo-local.sh test --quiet -p harness-command -p harness-daemon-client -p harness-protocol -p harness-telemetry -p harness-testkit",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --lib --features full-runtime",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness-command -p harness-daemon-client -p harness-protocol -p harness-telemetry -p harness-testkit",
 ]
 
 [tasks."test:integration"]
-description = "Run integration tests (fast only, single-threaded for env safety)"
+description = "Run fast integration tests in parallel with process isolation"
 run = [
   "./scripts/cargo-local.sh build -p harness-daemon -p harness-bridge -p harness-mcp",
-  "./scripts/cargo-local.sh test --quiet --test integration --features full-runtime -- --test-threads=1 --format terse",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --test integration --features full-runtime",
 ]
 
 [tasks."test:workers"]
 description = "Run standalone worker integration and parity tests"
 run = [
-  "./scripts/cargo-local.sh test --quiet -p harness-daemon -p harness-bridge --test standalone_parity -- --format terse",
-  "./scripts/cargo-local.sh test --quiet -p harness-hook --test standalone -- --format terse",
-  "./scripts/cargo-local.sh test --quiet -p harness-mcp --test cli --test dependency_guard -- --format terse",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness-daemon -p harness-bridge --test standalone_parity",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness-hook --test standalone",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness-mcp --test cli --test dependency_guard",
 ]
 
 [tasks."test:slow"]
-description = "Run ignored slow tests (fake toolchain, ENV_LOCK)"
+description = "Run self-contained ignored tests; use test:perf for timing budgets and e2e:swarm:full for the real-runtime swarm lane"
 run = [
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --lib --features full-runtime --run-ignored only -E 'test(=agents::acp::throughput_bench::tests::throughput_meets_threshold)'",
   "./scripts/cargo-local.sh build -p harness-daemon -p harness-bridge -p harness-mcp",
-  "./scripts/cargo-local.sh test --quiet --test integration --features full-runtime -- --ignored --test-threads=1 --format terse",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --test integration --features full-runtime --run-ignored only -E 'not test(~integration::daemon_perf::) and not test(=integration::commands::session::swarm_full_flow::swarm_full_flow_mise_lane_passes)'",
 ]
+
+[tasks."test:perf"]
+description = "Run ignored Rust performance budgets in their own parallel process-isolated lane"
+run = "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --test integration --features full-runtime --run-ignored only -E 'test(~integration::daemon_perf::)'"
 
 [tasks."test:profile:compile"]
 description = "Profile reproducible Rust test compilation and capture Cargo/sccache artifacts"
 run = "./scripts/profile-rust-tests.sh compile"
 
 [tasks."test:profile:unit"]
-description = "Profile root Rust unit tests serially with nextest timing artifacts"
+description = "Profile root Rust unit tests in parallel with nextest timing artifacts"
 run = "./scripts/profile-rust-tests.sh unit"
 
 [tasks."test:profile:integration"]
-description = "Profile root Rust integration tests serially with nextest timing artifacts"
+description = "Profile root Rust integration tests in parallel with nextest timing artifacts"
 run = "./scripts/profile-rust-tests.sh integration"
 
 [tasks."remote-daemon:e2e"]
 description = "Run the real remote daemon ACME, HTTPS, WSS, pairing, and revocation proof"
 run = [
   "./scripts/cargo-local.sh build -p harness-daemon",
-  "./scripts/cargo-local.sh test --quiet --test remote_daemon_e2e --features full-runtime -- --ignored --test-threads=1 --format terse",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --test remote_daemon_e2e --features full-runtime --run-ignored only",
 ]
 
 [tasks."remote-daemon:public-acme-e2e"]
 description = "Run the Linux Let's Encrypt staging proof for TLS-ALPN-01, HTTP-01, and DNS-01"
 run = [
   "./scripts/cargo-local.sh build -p harness-daemon",
-  "./scripts/cargo-local.sh test --quiet --test remote_daemon_public_acme_e2e --features full-runtime remote_daemon_public_acme_staging_proves_all_challenges -- --ignored --nocapture --test-threads=1",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --test remote_daemon_public_acme_e2e --features full-runtime --run-ignored only --success-output immediate --failure-output immediate -E 'test(=remote_daemon_public_acme_staging_proves_all_challenges)'",
 ]
 
 [tasks."remote-daemon:systemd-e2e"]
 description = "Run the real Linux systemd lifecycle and effective security proof"
 run = [
   "./scripts/cargo-local.sh build -p harness-daemon",
-  "./scripts/cargo-local.sh test --quiet --test remote_systemd_e2e --features full-runtime -- --ignored --nocapture --test-threads=1",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --test remote_systemd_e2e --features full-runtime --run-ignored only --success-output immediate --failure-output immediate -E 'test(=remote_systemd_e2e_proves_lifecycle_and_effective_security)'",
 ]
 
 [tasks.codegen]
@@ -626,8 +631,8 @@ run = "./scripts/host-metrics.sh build-darwin-exporter"
 [tasks."mcp:test"]
 description = "Run harness MCP server unit and integration tests"
 run = [
-  "./scripts/cargo-local.sh test -p harness-mcp --all-targets -- --test-threads=1",
-  "./scripts/cargo-local.sh test --test integration mcp:: -- --test-threads=1",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness-mcp --all-targets",
+  "./scripts/cargo-local.sh nextest run --config-file .config/nextest.toml --user-config-file none -p harness --test integration --features full-runtime -E 'test(~mcp::)'",
 ]
 
 [tasks."mcp:test:registry"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,13 @@ cargo fmt --check
 cargo clippy --lib
 ```
 
-Unit tests are in-crate `#[test]` blocks. Integration tests live in `tests/integration/` and run single-threaded for environment safety. Tests that read XDG paths must isolate state with `temp_env::with_vars`, setting both `XDG_DATA_HOME` and `CLAUDE_SESSION_ID`. Tests use real filesystem state.
+Unit tests are in-crate `#[test]` blocks. Integration tests live in
+`tests/integration/`. Canonical Rust test tasks use nextest process isolation
+and parallel scheduling. Tests must not require runner-wide serialization;
+isolate their environment, filesystem paths, ports, and external resource
+names instead. Tests that read XDG paths must isolate state with
+`temp_env::with_vars`, setting both `XDG_DATA_HOME` and `CLAUDE_SESSION_ID`.
+Tests use real filesystem state.
 
 Pre-commit gate: `mise run check`. Add `mise run aff:check` when the task touches `aff` or aff-owned runtime hooks.
 

--- a/docs/agent-guides/root-reference.md
+++ b/docs/agent-guides/root-reference.md
@@ -71,10 +71,12 @@ hooks.
 ## Testing details
 
 Integration tests live in `tests/integration/` and cover hooks, commands, and
-workflows end to end. They run with `--test-threads=1` for environment safety.
-Tests that read XDG paths must isolate state with `temp_env::with_vars`, setting
-both `XDG_DATA_HOME` and `CLAUDE_SESSION_ID`. Avoid mocks; tests use real
-filesystem state.
+workflows end to end. Canonical Rust test tasks use nextest process isolation
+and parallel scheduling. A test must isolate its environment, filesystem
+paths, ports, and external resource names instead of requiring runner-wide
+serialization. Tests that read XDG paths must isolate state with
+`temp_env::with_vars`, setting both `XDG_DATA_HOME` and `CLAUDE_SESSION_ID`.
+Avoid mocks; tests use real filesystem state.
 
 ## Build lane and fsmonitor cleanup
 

--- a/scripts/cargo-local.sh
+++ b/scripts/cargo-local.sh
@@ -205,6 +205,49 @@ tmpdir_is_usable() {
   rm -f "$probe"
 }
 
+prepare_private_tmpdir() {
+  local path="$1"
+
+  if [[ -L "$path" ]]; then
+    return 1
+  fi
+  if [[ -e "$path" ]]; then
+    [[ -d "$path" && -O "$path" ]] || return 1
+  else
+    (umask 077 && mkdir "$path") 2>/dev/null || true
+    [[ ! -L "$path" && -d "$path" && -O "$path" ]] || return 1
+  fi
+
+  chmod 700 "$path" || return 1
+  tmpdir_is_usable "$path"
+}
+
+configure_tmpdir() {
+  local external_fallback repo_fallback tmpdir_id
+
+  if tmpdir_is_usable "${TMPDIR:-}"; then
+    return 0
+  fi
+
+  tmpdir_id="$(short_hash "${UID:-${USER:-user}}:$COMMON_REPO_ROOT:$ROOT:$target_segment")"
+  external_fallback="/tmp/harness-cargo-$tmpdir_id"
+  if tmpdir_is_usable "/tmp"; then
+    if ! prepare_private_tmpdir "$external_fallback"; then
+      printf 'failed to prepare writable TMPDIR at %s\n' "$external_fallback" >&2
+      return 1
+    fi
+    export TMPDIR="$external_fallback/"
+    return 0
+  fi
+
+  repo_fallback="$COMMON_REPO_ROOT/target/.cargo-local/tmp/$target_segment"
+  if ! mkdir -p "$repo_fallback" || ! tmpdir_is_usable "$repo_fallback"; then
+    printf 'failed to prepare writable TMPDIR at %s\n' "$repo_fallback" >&2
+    return 1
+  fi
+  export TMPDIR="$repo_fallback/"
+}
+
 cleanup_stale_leases() {
   local lease_file pid
 
@@ -300,6 +343,29 @@ default_jobs() {
   printf '%s\n' "$base_jobs"
 }
 
+default_test_jobs() {
+  local cpu_count max_jobs test_jobs
+  cpu_count="$(detect_cpu_count)"
+
+  if [[ -n "$session_id" ]]; then
+    max_jobs=8
+  else
+    max_jobs=12
+  fi
+  test_jobs=$cpu_count
+  if (( test_jobs > max_jobs )); then
+    test_jobs=$max_jobs
+  fi
+  if (( active_build_count > 1 )); then
+    test_jobs=$(((test_jobs + active_build_count - 1) / active_build_count))
+  fi
+  if (( test_jobs < 2 )); then
+    test_jobs=2
+  fi
+
+  printf '%s\n' "$test_jobs"
+}
+
 session_id="$(first_nonempty_env \
   CODEX_SESSION_ID \
   CODEX_THREAD_ID \
@@ -326,15 +392,7 @@ if [[ -n "$session_id" ]]; then
   target_segment="agent-$(sanitize_segment "$session_id")"
 fi
 
-if ! tmpdir_is_usable "${TMPDIR:-}"; then
-  tmpdir_fallback="$COMMON_REPO_ROOT/target/.cargo-local/tmp/$target_segment"
-  mkdir -p "$tmpdir_fallback"
-  if ! tmpdir_is_usable "$tmpdir_fallback"; then
-    printf 'failed to prepare writable TMPDIR at %s\n' "$tmpdir_fallback" >&2
-    exit 1
-  fi
-  export TMPDIR="$tmpdir_fallback/"
-fi
+configure_tmpdir
 
 resolve_sccache_bin || true
 if [[ -n "${SCCACHE_BIN:-}" ]]; then
@@ -349,10 +407,18 @@ fi
 
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${HARNESS_CARGO_TARGET_DIR:-$COMMON_REPO_ROOT/target/dev/$target_segment}}"
 export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-${HARNESS_CARGO_JOBS:-$(default_jobs)}}"
+export NEXTEST_TEST_THREADS="${NEXTEST_TEST_THREADS:-${HARNESS_NEXTEST_JOBS:-$(default_test_jobs)}}"
+if [[ "$NEXTEST_TEST_THREADS" != "num-cpus" ]] \
+  && [[ ! "$NEXTEST_TEST_THREADS" =~ ^([2-9]|[1-9][0-9]+)$ ]]; then
+  printf 'NEXTEST_TEST_THREADS must be num-cpus or an integer greater than one (got %s)\n' \
+    "$NEXTEST_TEST_THREADS" >&2
+  exit 2
+fi
 
 if [[ "${1:-}" == "--print-env" ]]; then
   printf 'CARGO_TARGET_DIR=%s\n' "$CARGO_TARGET_DIR"
   printf 'CARGO_BUILD_JOBS=%s\n' "$CARGO_BUILD_JOBS"
+  printf 'NEXTEST_TEST_THREADS=%s\n' "$NEXTEST_TEST_THREADS"
   printf 'CARGO_BUILD_BUILD_DIR=%s\n' "${CARGO_BUILD_BUILD_DIR:-}"
   printf 'ACTIVE_BUILD_COUNT=%s\n' "$active_build_count"
   if [[ -n "$session_id" ]]; then

--- a/scripts/check-parallel-rust-tests.sh
+++ b/scripts/check-parallel-rust-tests.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+SCAN_ROOT="${1:-$ROOT}"
+
+if (( $# > 1 )); then
+  printf 'usage: %s [scan-root]\n' "${0##*/}" >&2
+  exit 2
+fi
+if [[ ! -d "$SCAN_ROOT" ]]; then
+  printf 'error: parallel Rust test scan root is not a directory: %s\n' "$SCAN_ROOT" >&2
+  exit 2
+fi
+if ! command -v rg >/dev/null 2>&1; then
+  printf 'error: ripgrep is required for the parallel Rust test policy\n' >&2
+  exit 1
+fi
+
+serial_pattern='--test-threads|(RUST_TEST_THREADS|NEXTEST_TEST_THREADS)[[:space:]]*=[[:space:]]*["'\'']?0*1["'\'']?([^0-9]|$)|^[[:space:]]*(test-threads|max-threads)[[:space:]]*=[[:space:]]*["'\'']?0*1["'\'']?([[:space:]#]|$)'
+nextest_serial_pattern='nextest[^#\n]*(\\[ \t]*\r?\n[^#\n]*)*(--no-?capture|--nocapture|--jobs([= \t]+)["'\'']?0*1["'\'']?([ \t\\,)\]}]|$)|(^|[ \t])-j([= \t]*)["'\'']?0*1["'\'']?([ \t\\,)\]}]|$))'
+
+scan_args=(
+  -n
+  --hidden
+  --glob '!.git/**'
+  --glob '!target/**'
+  --glob '*.json'
+  --glob '*.py'
+  --glob '*.rs'
+  --glob '*.sh'
+  --glob '*.toml'
+  --glob '*.yaml'
+  --glob '*.yml'
+  --glob '!scripts/check-parallel-rust-tests.sh'
+)
+
+set +e
+literal_violations="$(rg "${scan_args[@]}" -- "$serial_pattern" "$SCAN_ROOT")"
+literal_status=$?
+nextest_violations="$(rg -U "${scan_args[@]}" -- "$nextest_serial_pattern" "$SCAN_ROOT")"
+nextest_status=$?
+set -e
+
+if (( literal_status > 1 || nextest_status > 1 )); then
+  printf 'error: failed to scan for serialized Rust test configuration\n' >&2
+  exit 2
+fi
+if (( literal_status == 0 || nextest_status == 0 )); then
+  violations="$literal_violations"
+  if [[ -n "$nextest_violations" ]]; then
+    if [[ -n "$violations" ]]; then
+      violations+=$'\n'
+    fi
+    violations+="$nextest_violations"
+  fi
+  printf 'error: Rust tests must use parallel scheduling and process/resource isolation:\n%s\n' \
+    "$violations" >&2
+  exit 1
+fi

--- a/scripts/check-scripts.sh
+++ b/scripts/check-scripts.sh
@@ -2,6 +2,15 @@
 set -euo pipefail
 
 ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+host_os="$(uname -s)"
+case "$host_os" in
+  Darwin|Linux)
+    ;;
+  *)
+    printf 'error: unsupported script-test host OS: %s\n' "$host_os" >&2
+    exit 1
+    ;;
+esac
 
 if (( $# > 1 )); then
   printf 'usage: %s [--all|--lint|--tests]\n' "${0##*/}" >&2
@@ -100,7 +109,13 @@ python_scripts=(
   "$ROOT"/scripts/lib/*.py
   "$ROOT"/scripts/tests/test_*.py
 )
-root_python_tests=("$ROOT"/scripts/tests/test_*.py)
+portable_root_python_tests=(
+  "$ROOT"/scripts/tests/test_disable_fsmonitor_dormant.py
+)
+macos_root_python_tests=(
+  "$ROOT"/scripts/tests/test_clean_stale_fsmonitor.py
+  "$ROOT"/scripts/tests/test_launchd_fsmonitor.py
+)
 monitor_shell_scripts=(
   "$ROOT"/apps/harness-monitor/ci_scripts/*.sh
   "$ROOT"/apps/harness-monitor/Scripts/*.sh
@@ -111,7 +126,7 @@ monitor_python_scripts=(
   "$ROOT"/apps/harness-monitor/Scripts/lib/*.py
 )
 monitor_python_tests_dir="$ROOT/apps/harness-monitor/Scripts/tests"
-monitor_python_tests=("$ROOT"/apps/harness-monitor/Scripts/tests/*.py)
+monitor_python_tests=("$ROOT"/apps/harness-monitor/Scripts/tests/test_*.py)
 monitor_python_fast_tests=()
 
 if ! command -v python3 >/dev/null 2>&1; then
@@ -124,6 +139,12 @@ if [[ "$mode" != "--tests" ]]; then
     printf "error: shellcheck is required. Install tools with \`mise install\`.\n" >&2
     exit 1
   fi
+  if ! command -v rg >/dev/null 2>&1; then
+    printf "error: ripgrep is required. Install tools with \`mise install\`.\n" >&2
+    exit 1
+  fi
+
+  "$ROOT/scripts/check-parallel-rust-tests.sh"
 
   for script_path in "${shell_scripts[@]}"; do
     bash -n "$script_path"
@@ -150,27 +171,38 @@ if [[ "$mode" != "--tests" ]]; then
   fi
 fi
 
-if [[ "$mode" != "--lint" ]] && (( ${#root_python_tests[@]} > 0 )); then
-  run_quiet_step \
-    "root python script tests" \
-    env PYTHONDONTWRITEBYTECODE=1 \
-    python3 -m unittest discover -s "$ROOT/scripts/tests" -p 'test_*.py'
-fi
-if [[ "$mode" != "--lint" ]] && (( ${#monitor_python_tests[@]} > 0 )); then
-  for test_path in "${monitor_python_tests[@]}"; do
-    case "$(basename -- "$test_path")" in
-      test_xcodebuild_with_lock.py|test_test_swift.py)
-        ;;
-      *)
-        monitor_python_fast_tests+=("$test_path")
-        ;;
-    esac
-  done
-  if (( ${#monitor_python_fast_tests[@]} > 0 )); then
+if [[ "$mode" != "--lint" ]]; then
+  if (( ${#portable_root_python_tests[@]} > 0 )); then
     run_quiet_step \
-      "monitor python script tests (fast subset)" \
-      env "PYTHONPATH=$monitor_python_tests_dir${PYTHONPATH:+:$PYTHONPATH}" \
-      python3 -m unittest "${monitor_python_fast_tests[@]}"
+      "portable root python script tests" \
+      env PYTHONDONTWRITEBYTECODE=1 \
+      python3 -m unittest "${portable_root_python_tests[@]}"
+  fi
+  if [[ "$host_os" == "Darwin" ]]; then
+    if (( ${#macos_root_python_tests[@]} > 0 )); then
+      run_quiet_step \
+        "root macOS python script tests" \
+        env PYTHONDONTWRITEBYTECODE=1 \
+        python3 -m unittest "${macos_root_python_tests[@]}"
+    fi
+    for test_path in "${monitor_python_tests[@]}"; do
+      case "$(basename -- "$test_path")" in
+        test_test_swift.py)
+          ;;
+        *)
+          monitor_python_fast_tests+=("$test_path")
+          ;;
+      esac
+    done
+    if (( ${#monitor_python_fast_tests[@]} > 0 )); then
+      run_quiet_step \
+        "monitor macOS python script tests (fast subset)" \
+        env "PYTHONPATH=$monitor_python_tests_dir${PYTHONPATH:+:$PYTHONPATH}" \
+        python3 -m unittest "${monitor_python_fast_tests[@]}"
+    fi
+  else
+    printf 'ok: root macOS python script tests (skipped on %s)\n' "$host_os"
+    printf 'ok: monitor macOS python script tests (skipped on %s)\n' "$host_os"
   fi
 fi
 

--- a/scripts/disable-fsmonitor-dormant.sh
+++ b/scripts/disable-fsmonitor-dormant.sh
@@ -124,6 +124,24 @@ is_excluded() {
   return 1
 }
 
+# Print a file's modification time as Unix seconds. BSD stat uses -f while
+# GNU stat uses -c; validate the BSD-shaped result before accepting it because
+# GNU stat -f can emit filesystem details even though that invocation fails.
+file_mtime() {
+  local path="$1"
+  local m
+
+  m="$(/usr/bin/stat -f '%m' "$path" 2>/dev/null || true)"
+  if [[ "$m" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$m"
+    return 0
+  fi
+
+  m="$(/usr/bin/stat -c '%Y' "$path" 2>/dev/null || true)"
+  [[ "$m" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$m"
+}
+
 # Returns days-since-most-recent of HEAD/FETCH_HEAD. Empty if neither
 # exists.
 days_since_activity() {
@@ -131,8 +149,7 @@ days_since_activity() {
   local mtime=0 f m now days
   for f in "$gitdir/HEAD" "$gitdir/FETCH_HEAD"; do
     if [[ -e "$f" ]]; then
-      m="$(/usr/bin/stat -f '%m' "$f" 2>/dev/null || echo 0)"
-      if [[ "$m" =~ ^[0-9]+$ ]] && (( m > mtime )); then
+      if m="$(file_mtime "$f")" && (( m > mtime )); then
         mtime=$m
       fi
     fi

--- a/scripts/e2e/recording-triage/tests/lib-test.sh
+++ b/scripts/e2e/recording-triage/tests/lib-test.sh
@@ -20,6 +20,10 @@ recording_triage_test_skip_unless_binary() {
   local repo_root="$1"
   local debug_path="$repo_root/apps/harness-monitor/Tools/HarnessMonitorE2E/.build/debug/harness-monitor-e2e"
   local release_path="$repo_root/apps/harness-monitor/Tools/HarnessMonitorE2E/.build/release/harness-monitor-e2e"
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    printf 'skipping: harness-monitor-e2e tests require macOS\n'
+    exit 0
+  fi
   # Prefer the freshly-compiled debug binary so tests always exercise the
   # current source instead of a stale release artefact left over from a prior
   # mise run monitor:macos:tools:build:e2e invocation.
@@ -38,6 +42,31 @@ recording_triage_test_skip_unless_binary() {
 recording_triage_test_make_run_dir() {
   local prefix="$1"
   mktemp -d -t "recording-triage-${prefix}.XXXXXX"
+}
+
+recording_triage_test_set_mtime() {
+  local path="$1"
+  local timestamp="$2"
+  python3 - "$path" "$timestamp" <<'PY'
+import datetime
+import os
+import sys
+
+path, timestamp = sys.argv[1:]
+parsed = datetime.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+nanoseconds = int(parsed.timestamp() * 1_000_000_000)
+open(path, "a", encoding="utf-8").close()
+os.utime(path, ns=(nanoseconds, nanoseconds))
+PY
+}
+
+recording_triage_test_mtime_seconds() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+print(int(os.stat(sys.argv[1]).st_mtime))
+PY
 }
 
 recording_triage_test_seed_run() {

--- a/scripts/e2e/recording-triage/tests/run-all.sh
+++ b/scripts/e2e/recording-triage/tests/run-all.sh
@@ -1,25 +1,55 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Discover and run every test_*.sh under scripts/e2e/recording-triage/tests/.
-# Run serially; fail fast on first failure.
+# Run the recording-triage test matrix for this host.
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-shopt -s nullglob
+host_os="$(uname -s)"
+portable_tests=(
+  test_assert_launch_args.sh
+  test_assert_recording.sh
+  test_build_fixture.sh
+  test_e2e_copy_preserves_mtime.sh
+  test_extract_keyframes.sh
+)
+macos_tests=(
+  test_act_timing.sh
+  test_assert_act_identifiers.sh
+  test_auto_keyframes.sh
+  test_compare_keyframes.sh
+  test_compare_layout.sh
+  test_emit_checklist.sh
+  test_frame_gaps.sh
+  test_run_all.sh
+)
+selected_tests=("${portable_tests[@]}")
+case "$host_os" in
+  Darwin)
+    selected_tests+=("${macos_tests[@]}")
+    ;;
+  Linux)
+    printf 'skipping %d macOS recording-triage tests on Linux\n' "${#macos_tests[@]}"
+    ;;
+  *)
+    printf 'unsupported recording-triage test host OS: %s\n' "$host_os" >&2
+    exit 1
+    ;;
+esac
 
 failures=0
 ran=0
-for test_path in "$SCRIPT_DIR"/test_*.sh; do
+for test_name in "${selected_tests[@]}"; do
+  test_path="$SCRIPT_DIR/$test_name"
   ran=$((ran + 1))
-  printf '== running %s\n' "$(basename -- "$test_path")"
+  printf '== running %s\n' "$test_name"
   if ! "$test_path"; then
     failures=$((failures + 1))
-    printf '!! failed: %s\n' "$(basename -- "$test_path")" >&2
+    printf '!! failed: %s\n' "$test_name" >&2
   fi
 done
 
 if (( ran == 0 )); then
-  printf 'no recording-triage tests discovered under %s\n' "$SCRIPT_DIR" >&2
+  printf 'no recording-triage tests selected for %s\n' "$host_os" >&2
   exit 1
 fi
 

--- a/scripts/e2e/recording-triage/tests/test_act_timing.sh
+++ b/scripts/e2e/recording-triage/tests/test_act_timing.sh
@@ -32,10 +32,10 @@ cat >"$LOGS_DIR/daemon.log" <<'EOM'
 EOM
 
 # Two markers: act1.ready 10s after recording-started, act2.ready 5s later.
-touch -d '2026-04-25T10:00:15Z' "$MARKER_DIR/act1.ready"
-touch -d '2026-04-25T10:00:20Z' "$MARKER_DIR/act2.ready"
-touch -d '2026-04-25T10:00:15.500000Z' "$MARKER_DIR/act1.ack"
-touch -d '2026-04-25T10:00:20.200000Z' "$MARKER_DIR/act2.ack"
+recording_triage_test_set_mtime "$MARKER_DIR/act1.ready" '2026-04-25T10:00:15Z'
+recording_triage_test_set_mtime "$MARKER_DIR/act2.ready" '2026-04-25T10:00:20Z'
+recording_triage_test_set_mtime "$MARKER_DIR/act1.ack" '2026-04-25T10:00:15.500000Z'
+recording_triage_test_set_mtime "$MARKER_DIR/act2.ack" '2026-04-25T10:00:20.200000Z'
 
 "$WRAPPER" --run "$RUN_DIR" >/dev/null
 REPORT="$RUN_DIR/recording-triage/act-timing.json"

--- a/scripts/e2e/recording-triage/tests/test_auto_keyframes.sh
+++ b/scripts/e2e/recording-triage/tests/test_auto_keyframes.sh
@@ -35,8 +35,8 @@ cat >"$LOGS_DIR/daemon.log" <<'EOM'
 EOM
 
 # tiny.mov is 0.2s long; pick mtimes inside the window.
-touch -d '2026-04-25T10:00:00.040Z' "$MARKER_DIR/act1.ready"
-touch -d '2026-04-25T10:00:00.140Z' "$MARKER_DIR/act2.ready"
+recording_triage_test_set_mtime "$MARKER_DIR/act1.ready" '2026-04-25T10:00:00.040Z'
+recording_triage_test_set_mtime "$MARKER_DIR/act2.ready" '2026-04-25T10:00:00.140Z'
 
 # Ground-truth snapshots reuse a frame from the same recording so distance is
 # small/zero.

--- a/scripts/e2e/recording-triage/tests/test_e2e_copy_preserves_mtime.sh
+++ b/scripts/e2e/recording-triage/tests/test_e2e_copy_preserves_mtime.sh
@@ -23,7 +23,7 @@ printf 'ready\n' >"$SRC_FILE"
 # copy that drops the timestamp immediately fails the assertion.
 TARGET_TS='200001020304.05'
 touch -t "$TARGET_TS" "$SRC_FILE"
-EXPECTED_MTIME="$(/usr/bin/stat -f '%m' "$SRC_FILE")"
+EXPECTED_MTIME="$(recording_triage_test_mtime_seconds "$SRC_FILE")"
 
 if ! command -v e2e_copy_path_if_exists >/dev/null 2>&1; then
   printf 'expected e2e_copy_path_if_exists to be defined in scripts/e2e/lib.sh\n' >&2
@@ -37,7 +37,7 @@ if [[ ! -f "$DEST_DIR/act1.ready" ]]; then
   exit 1
 fi
 
-ACTUAL_MTIME="$(/usr/bin/stat -f '%m' "$DEST_DIR/act1.ready")"
+ACTUAL_MTIME="$(recording_triage_test_mtime_seconds "$DEST_DIR/act1.ready")"
 if [[ "$ACTUAL_MTIME" != "$EXPECTED_MTIME" ]]; then
   printf 'mtime not preserved: expected=%s actual=%s\n' \
     "$EXPECTED_MTIME" "$ACTUAL_MTIME" >&2
@@ -47,7 +47,7 @@ fi
 # Also exercise the single-file branch.
 SINGLE_DEST="$WORKDIR/single.ready"
 e2e_copy_path_if_exists "$SRC_FILE" "$SINGLE_DEST"
-ACTUAL_SINGLE_MTIME="$(/usr/bin/stat -f '%m' "$SINGLE_DEST")"
+ACTUAL_SINGLE_MTIME="$(recording_triage_test_mtime_seconds "$SINGLE_DEST")"
 if [[ "$ACTUAL_SINGLE_MTIME" != "$EXPECTED_MTIME" ]]; then
   printf 'single-file mtime not preserved: expected=%s actual=%s\n' \
     "$EXPECTED_MTIME" "$ACTUAL_SINGLE_MTIME" >&2

--- a/scripts/tests/test-cargo-local.sh
+++ b/scripts/tests/test-cargo-local.sh
@@ -66,6 +66,189 @@ print_cargo_env() {
   )
 }
 
+print_tmpdir_env() {
+  local session_id="$1" configured_tmpdir="${2:-}"
+  (
+    unset SCCACHE_SERVER_UDS SCCACHE_SERVER_PORT SCCACHE_NO_DAEMON
+    unset SCCACHE_BASEDIRS SCCACHE_IDLE_TIMEOUT SCCACHE_CACHE_SIZE SCCACHE_VERSION
+    unset HARNESS_SCCACHE_TMPDIR
+    unset CODEX_SESSION_ID CODEX_THREAD_ID CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID
+    unset GEMINI_SESSION_ID COPILOT_SESSION_ID OPENCODE_SESSION_ID
+    if [[ -n "$configured_tmpdir" ]]; then
+      export TMPDIR="$configured_tmpdir"
+    else
+      unset TMPDIR
+    fi
+    SCCACHE_BIN="$SANDBOX/missing-sccache" \
+      RUSTC_WRAPPER='' \
+      CODEX_SESSION_ID="$session_id" \
+      HARNESS_CARGO_SKIP_LEASE=1 \
+      HARNESS_CARGO_ACTIVE_BUILD_COUNT=1 \
+      "$ROOT/scripts/cargo-local.sh" --print-env
+  )
+}
+
+scenario_missing_tmpdir_uses_short_external_fallback() {
+  local first second other fallback other_fallback test_threads
+
+  first="$(print_tmpdir_env "cargo-local-tmp-a-$$")"
+  second="$(print_tmpdir_env "cargo-local-tmp-a-$$")"
+  other="$(print_tmpdir_env "cargo-local-tmp-b-$$")"
+  fallback="$(awk -F= '$1 == "TMPDIR" { print substr($0, index($0, "=") + 1) }' <<<"$first")"
+  other_fallback="$(
+    awk -F= '$1 == "TMPDIR" { print substr($0, index($0, "=") + 1) }' <<<"$other"
+  )"
+  test_threads="$(
+    awk -F= '$1 == "NEXTEST_TEST_THREADS" { print substr($0, index($0, "=") + 1) }' <<<"$first"
+  )"
+
+  if [[ "$fallback" == /tmp/harness-cargo-*/ ]] \
+    && (( ${#fallback} < 64 )) \
+    && [[ ! -L "${fallback%/}" ]] \
+    && [[ -O "${fallback%/}" ]] \
+    && assert_line "TMPDIR=$fallback" "$second" \
+    && [[ "$fallback" != "$other_fallback" ]] \
+    && [[ -d "${fallback%/}" ]] \
+    && [[ "$fallback" != "$ROOT/"* ]] \
+    && [[ "$fallback" != "$COMMON_REPO_ROOT/"* ]] \
+    && [[ "$test_threads" =~ ^[0-9]+$ ]] \
+    && (( test_threads >= 2 )); then
+    pass "missing TMPDIR uses a stable short external repo/session fallback"
+  else
+    fail "missing TMPDIR fallback was not short, external, and session-scoped: $first"
+  fi
+
+  rm -rf "${fallback%/}" "${other_fallback%/}"
+}
+
+scenario_concurrent_tmpdir_creation_is_idempotent() {
+  local barrier="$SANDBOX/mkdir-barrier"
+  local fake_bin="$SANDBOX/mkdir-bin"
+  local first="$SANDBOX/concurrent-first.out"
+  local second="$SANDBOX/concurrent-second.out"
+  local real_mkdir session_id first_pid second_pid first_status second_status fallback
+  real_mkdir="$(command -v mkdir)"
+  session_id="cargo-local-concurrent-tmp-$$"
+  mkdir -p "$barrier" "$fake_bin"
+  cat >"$fake_bin/mkdir" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+target="${!#}"
+if [[ "$target" == /tmp/harness-cargo-* ]]; then
+  : >"$HARNESS_TEST_MKDIR_BARRIER/$$"
+  for _ in {1..200}; do
+    count=0
+    for marker in "$HARNESS_TEST_MKDIR_BARRIER"/*; do
+      [[ -e "$marker" ]] && count=$((count + 1))
+    done
+    (( count >= 2 )) && break
+    sleep 0.01
+  done
+fi
+exec "$HARNESS_TEST_REAL_MKDIR" "$@"
+EOF
+  chmod +x "$fake_bin/mkdir"
+
+  PATH="$fake_bin:$PATH" HARNESS_TEST_MKDIR_BARRIER="$barrier" \
+    HARNESS_TEST_REAL_MKDIR="$real_mkdir" print_tmpdir_env "$session_id" >"$first" 2>&1 &
+  first_pid=$!
+  PATH="$fake_bin:$PATH" HARNESS_TEST_MKDIR_BARRIER="$barrier" \
+    HARNESS_TEST_REAL_MKDIR="$real_mkdir" print_tmpdir_env "$session_id" >"$second" 2>&1 &
+  second_pid=$!
+
+  set +e
+  wait "$first_pid"
+  first_status=$?
+  wait "$second_pid"
+  second_status=$?
+  set -e
+
+  fallback="$(
+    awk -F= '$1 == "TMPDIR" { print substr($0, index($0, "=") + 1) }' "$first"
+  )"
+  if (( first_status == 0 && second_status == 0 )) \
+    && [[ -n "$fallback" ]] \
+    && grep -Fxq -- "TMPDIR=$fallback" "$second"; then
+    pass "concurrent same-session TMPDIR creation is idempotent"
+  else
+    fail "concurrent TMPDIR creation failed: first=$(<"$first") second=$(<"$second")"
+  fi
+  rm -rf "${fallback%/}"
+}
+
+scenario_unusable_tmpdir_uses_short_external_fallback() {
+  local unusable="$SANDBOX/not-a-directory" output fallback
+  : >"$unusable"
+
+  output="$(print_tmpdir_env "cargo-local-unusable-tmp-$$" "$unusable")"
+  fallback="$(
+    awk -F= '$1 == "TMPDIR" { print substr($0, index($0, "=") + 1) }' <<<"$output"
+  )"
+
+  if [[ "$fallback" == /tmp/harness-cargo-*/ ]] \
+    && (( ${#fallback} < 64 )) \
+    && [[ -d "${fallback%/}" ]]; then
+    pass "unusable TMPDIR uses a short external fallback"
+  else
+    fail "unusable TMPDIR did not use the short external fallback: $output"
+  fi
+
+  rm -rf "${fallback%/}"
+}
+
+scenario_usable_tmpdir_is_preserved() {
+  local explicit="$SANDBOX/explicit-tmp" output
+  mkdir -p "$explicit"
+
+  output="$(print_tmpdir_env "cargo-local-explicit-tmp-$$" "$explicit/")"
+  if assert_line "TMPDIR=$explicit/" "$output"; then
+    pass "usable explicit TMPDIR is preserved"
+  else
+    fail "usable explicit TMPDIR was replaced: $output"
+  fi
+}
+
+scenario_single_thread_nextest_override_is_rejected() {
+  local output single_thread status
+  single_thread="$((2 - 1))"
+
+  set +e
+  output="$(
+    NEXTEST_TEST_THREADS="$single_thread" \
+      print_tmpdir_env "cargo-local-serial-nextest-$$" 2>&1
+  )"
+  status=$?
+  set -e
+
+  if (( status == 2 )) \
+    && assert_contains "NEXTEST_TEST_THREADS must be num-cpus or an integer greater than one" \
+      "$output"; then
+    pass "single-thread nextest override is rejected"
+  else
+    fail "single-thread nextest override should fail with status 2: $output"
+  fi
+}
+
+scenario_noncanonical_nextest_override_is_rejected() {
+  local invalid_threads="08" output status
+
+  set +e
+  output="$(
+    NEXTEST_TEST_THREADS="$invalid_threads" \
+      print_tmpdir_env "cargo-local-noncanonical-nextest-$$" 2>&1
+  )"
+  status=$?
+  set -e
+
+  if (( status == 2 )) \
+    && assert_contains "NEXTEST_TEST_THREADS must be num-cpus or an integer greater than one" \
+      "$output"; then
+    pass "noncanonical nextest override is rejected cleanly"
+  else
+    fail "noncanonical nextest override should fail with status 2: $output"
+  fi
+}
+
 scenario_supported_sccache_is_resolved_once() {
   local fake_bin="$SANDBOX/supported-bin"
   local tmpdir="$SANDBOX/supported-tmp"
@@ -151,6 +334,12 @@ EOF
   fi
 }
 
+scenario_missing_tmpdir_uses_short_external_fallback
+scenario_concurrent_tmpdir_creation_is_idempotent
+scenario_unusable_tmpdir_uses_short_external_fallback
+scenario_usable_tmpdir_is_preserved
+scenario_single_thread_nextest_override_is_rejected
+scenario_noncanonical_nextest_override_is_rejected
 scenario_supported_sccache_is_resolved_once
 scenario_old_explicit_sccache_is_disabled
 scenario_failed_lsof_preserves_unknown_sockets

--- a/scripts/tests/test-check-scripts.sh
+++ b/scripts/tests/test-check-scripts.sh
@@ -38,15 +38,125 @@ require_absent "scripts/validate-reviews-rename.sh"
 require_text "scripts/check-scripts.sh" '"$ROOT"/scripts/lib/*.py'
 # shellcheck disable=SC2016
 require_text "scripts/check-scripts.sh" '"$ROOT"/scripts/tests/test_*.py'
-require_text "scripts/check-scripts.sh" 'root python script tests'
+# shellcheck disable=SC2016
+require_text "scripts/check-scripts.sh" 'host_os="$(uname -s)"'
+# shellcheck disable=SC2016
+require_text "scripts/check-scripts.sh" 'case "$host_os" in'
+require_text "scripts/check-scripts.sh" 'portable root python script tests'
+require_text "scripts/check-scripts.sh" 'root macOS python script tests'
+require_text "scripts/check-scripts.sh" 'monitor macOS python script tests'
+require_text "scripts/check-scripts.sh" 'Scripts/tests/test_*.py'
+# shellcheck disable=SC2016
+require_text "scripts/check-scripts.sh" '[[ "$host_os" == "Darwin" ]]'
+require_text "scripts/check-scripts.sh" '(skipped on %s)'
 require_text "scripts/check-scripts.sh" 'check-scripts shell tests'
 require_text "scripts/check-scripts.sh" 'clean-stale-lanes shell tests'
+require_text "scripts/check-scripts.sh" 'swarm e2e contract shell tests'
 require_text "scripts/check-scripts.sh" 'e2e triage-run shell tests'
 require_text "scripts/check-scripts.sh" 'HARNESS_CHECK_SCRIPTS_FULL_TIMEOUT_SECONDS'
+require_text "scripts/check-scripts.sh" 'check-parallel-rust-tests.sh'
 require_no_text "scripts/check-scripts.sh" 'HARNESS_CHECK_SCRIPTS_STEP_TIMEOUT_SECONDS=180'
+require_text \
+  "scripts/e2e/recording-triage/tests/lib-test.sh" \
+  'harness-monitor-e2e tests require macOS'
+require_no_text "scripts/e2e/recording-triage/tests/test_act_timing.sh" 'touch -d'
+require_no_text "scripts/e2e/recording-triage/tests/test_auto_keyframes.sh" 'touch -d'
+require_no_text \
+  "scripts/e2e/recording-triage/tests/test_e2e_copy_preserves_mtime.sh" \
+  "/usr/bin/stat -f"
 
 set +e
 "$ROOT/scripts/check-scripts.sh" --lint extra >/dev/null 2>&1
 status=$?
 set -e
 [[ "$status" -eq 2 ]] || fail "extra arguments should return usage status 2 (got $status)"
+
+policy_sandbox="$(mktemp -d "${TMPDIR:-/tmp}/parallel-rust-test-policy.XXXXXX")"
+policy_probe="$policy_sandbox/probe.toml"
+python_policy_probe="$policy_sandbox/probe.py"
+cleanup() {
+  rm -rf "$policy_sandbox"
+}
+trap cleanup EXIT
+
+# shellcheck source=scripts/e2e/recording-triage/tests/lib-test.sh
+. "$ROOT/scripts/e2e/recording-triage/tests/lib-test.sh"
+mtime_probe="$policy_sandbox/portable-mtime.ready"
+recording_triage_test_set_mtime "$mtime_probe" "2000-01-02T03:04:05Z"
+[[ -f "$mtime_probe" ]] || fail "portable mtime helper should create a missing marker"
+[[ "$(recording_triage_test_mtime_seconds "$mtime_probe")" == "946782245" ]] \
+  || fail "portable mtime helper should preserve the requested timestamp"
+
+assert_parallel_policy_rejects() {
+  local label="$1" probe="$2" output status
+  shift 2
+  "$@" >"$probe"
+
+  set +e
+  output="$("$ROOT/scripts/check-parallel-rust-tests.sh" "$policy_sandbox" 2>&1)"
+  status=$?
+  set -e
+
+  [[ "$status" -eq 1 ]] || fail "$label should fail parallel Rust test policy (got $status)"
+  grep -Fq "Rust tests must use parallel scheduling" <<<"$output" \
+    || fail "$label should report the parallel Rust test policy"
+}
+
+assert_parallel_policy_accepts() {
+  local label="$1" probe="$2" output status
+  shift 2
+  "$@" >"$probe"
+
+  set +e
+  output="$("$ROOT/scripts/check-parallel-rust-tests.sh" "$policy_sandbox" 2>&1)"
+  status=$?
+  set -e
+
+  [[ "$status" -eq 0 ]] || fail "$label should pass parallel Rust test policy: $output"
+}
+
+assert_parallel_policy_rejects \
+  "single-thread libtest" \
+  "$policy_probe" \
+  printf '%s%s%s\n' '--test-' 'threads=' '1'
+assert_parallel_policy_rejects \
+  "single-thread nextest profile" \
+  "$policy_probe" \
+  printf '%s%s\n' 'test-threads = 0' '1'
+assert_parallel_policy_rejects \
+  "single-thread Rust environment" \
+  "$policy_probe" \
+  printf '%s%s%s\n' 'RUST_TEST_THREADS=' "'" "1'"
+assert_parallel_policy_rejects \
+  "uncaptured same-line nextest" \
+  "$policy_probe" \
+  printf '%s%s\n' 'nextest run --no' '-capture'
+assert_parallel_policy_rejects \
+  "single-thread nextest long jobs alias" \
+  "$policy_probe" \
+  printf '%s%s%s\n' 'nextest run --jobs=' "'" "01'"
+assert_parallel_policy_rejects \
+  "single-thread nextest short jobs alias" \
+  "$policy_probe" \
+  printf '%s%s\n' 'nextest run -j 0' '1'
+assert_parallel_policy_rejects \
+  "single-thread nextest attached jobs alias" \
+  "$policy_probe" \
+  printf '%s%s\n' 'nextest run -j0' '1'
+assert_parallel_policy_rejects \
+  "uncaptured multiline nextest" \
+  "$policy_probe" \
+  printf '%s %s\n%s %s\n%s%s\n' \
+  'nextest run' "\\" \
+  '  --config-file .config/nextest.toml' "\\" \
+  '  --no-' 'capture'
+assert_parallel_policy_rejects \
+  "single-thread Python nextest command" \
+  "$python_policy_probe" \
+  printf '%s%s\n' 'command = "cargo nextest run --jobs=0' '1"'
+
+rm -f "$policy_probe" "$python_policy_probe"
+assert_parallel_policy_accepts \
+  "unrelated no-capture command" \
+  "$policy_probe" \
+  printf '%s\n%s%s\n' 'nextest run' 'other-runner --no-' 'capture'

--- a/scripts/tests/test_clean_stale_fsmonitor.py
+++ b/scripts/tests/test_clean_stale_fsmonitor.py
@@ -392,22 +392,23 @@ git     X      u    16u  unix 0x123  0t0           fsmonitor--daemon.ipc
             self.assertEqual(completed.returncode, 0, completed.stderr)
             self.assertIn("live=1 orphan=1 redundant=1", completed.stdout)
 
-    def test_canonicalization_collapses_tmp_vs_private_tmp(self) -> None:
-        # macOS lsof prints `/tmp/foo` for some daemons and `/private/tmp/foo`
-        # for others against the same physical directory (the system /tmp is
-        # a symlink to /private/tmp). Without path canonicalization the
-        # duplicate is missed. With canonicalization, both daemons collapse
-        # to the same gitdir key and the older one is marked redundant.
-        with tempfile.TemporaryDirectory(dir="/private/tmp") as repo_str:
-            repo_dir = Path(repo_str)
+    def test_canonicalization_collapses_symlink_alias(self) -> None:
+        # lsof can report two lexical paths to the same physical directory.
+        # Without path canonicalization the duplicate is missed. With
+        # canonicalization, both daemons collapse to the same gitdir key and
+        # the older one is marked redundant.
+        with tempfile.TemporaryDirectory() as tmp_str:
+            tmp_dir = Path(tmp_str)
+            repo_dir = tmp_dir / "real"
             (repo_dir / ".git" / "worktrees" / "active").mkdir(parents=True)
-            alias_dir = Path("/tmp") / repo_dir.relative_to("/private/tmp")
-            self.assertTrue(alias_dir.exists(), "tmp/private/tmp alias must hold")
-            lsof_via_private = self._linked_worktree_lsof(repo_dir, "active")
+            alias_dir = tmp_dir / "alias"
+            alias_dir.symlink_to(repo_dir, target_is_directory=True)
+            self.assertTrue(alias_dir.exists(), "symlink alias must resolve")
+            lsof_via_real = self._linked_worktree_lsof(repo_dir, "active")
             lsof_via_alias = self._linked_worktree_lsof(alias_dir, "active")
             completed, _ = self.run_script(
                 fake_lsof_outputs={
-                    "1300": lsof_via_private,
+                    "1300": lsof_via_real,
                     "1301": lsof_via_alias,
                 },
                 fake_pgrep_pids=["1300", "1301"],

--- a/scripts/tests/test_disable_fsmonitor_dormant.py
+++ b/scripts/tests/test_disable_fsmonitor_dormant.py
@@ -48,6 +48,7 @@ class DisableFsmonitorDormantTests(unittest.TestCase):
             completed = run_script("--root", str(root), "--days", "30")
             self.assertEqual(completed.returncode, 0, completed.stderr)
             self.assertIn(f"dormant   gitdir={git_dir}", completed.stdout)
+            self.assertIn("no_signal=0", completed.stdout)
             self.assertIn("dormant=1", completed.stdout)
             self.assertIn("Dry-run", completed.stdout)
             # config must not have been modified by dry-run

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -237,12 +237,18 @@ set_build_settings_current_version() {
 
 set_daemon_plist_version() {
   local version="$1"
-  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $version" "$MONITOR_DAEMON_INFO_PLIST"
+  PLIST_KEY="CFBundleShortVersionString" NEW_VERSION="$version" perl -0pi -e '
+    my $count = s{(<key>\Q$ENV{PLIST_KEY}\E</key>\s*<string>)[^<]+(</string>)}{$1.$ENV{NEW_VERSION}.$2}e;
+    die "failed to update $ENV{PLIST_KEY} in $ARGV\n" unless $count;
+  ' "$MONITOR_DAEMON_INFO_PLIST"
 }
 
 set_daemon_plist_build_version() {
   local version="$1"
-  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $version" "$MONITOR_DAEMON_INFO_PLIST"
+  PLIST_KEY="CFBundleVersion" NEW_VERSION="$version" perl -0pi -e '
+    my $count = s{(<key>\Q$ENV{PLIST_KEY}\E</key>\s*<string>)[^<]+(</string>)}{$1.$ENV{NEW_VERSION}.$2}e;
+    die "failed to update $ENV{PLIST_KEY} in $ARGV\n" unless $count;
+  ' "$MONITOR_DAEMON_INFO_PLIST"
 }
 
 sync_generated_monitor_project() {

--- a/src/daemon/client/discovery_tests.rs
+++ b/src/daemon/client/discovery_tests.rs
@@ -8,6 +8,7 @@ use super::DaemonClient;
 use super::connection::try_build_client;
 use super::test_support::{fake_running_xdg_daemon, read_http_request, write_http_response};
 use crate::daemon::state::{self, DaemonManifest, HostBridgeManifest};
+#[cfg(target_os = "macos")]
 use crate::daemon::transport::HARNESS_MONITOR_APP_GROUP_ID;
 
 #[test]
@@ -20,36 +21,7 @@ fn try_build_client_requires_authenticated_api_readiness() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
 
-    let server = thread::spawn(move || {
-        for request_index in 0..3 {
-            let (mut stream, _) = listener.accept().expect("accept");
-            let request = read_http_request(&mut stream);
-            let request_lower = request.to_ascii_lowercase();
-            assert!(
-                request_lower.contains("authorization: bearer test-token"),
-                "missing bearer auth: {request}"
-            );
-            if request.starts_with("GET /v1/health ") {
-                write_http_response(&mut stream, "200 OK", "text/plain", "ok");
-                continue;
-            }
-            assert!(
-                request.starts_with("GET /v1/ready "),
-                "unexpected probe request: {request}"
-            );
-            let status = if request_index == 1 {
-                "503 Service Unavailable"
-            } else {
-                "200 OK"
-            };
-            let body = if request_index == 1 {
-                "{\"error\":\"warming up\"}"
-            } else {
-                "{\"ready\":true,\"daemon_epoch\":\"test\"}"
-            };
-            write_http_response(&mut stream, status, "application/json", body);
-        }
-    });
+    let server = spawn_warming_readiness_server(listener);
 
     temp_env::with_vars(
         [
@@ -102,6 +74,7 @@ fn try_build_client_requires_authenticated_api_readiness() {
     server.join().expect("server");
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn try_build_client_discovers_running_app_group_daemon_when_default_root_is_empty() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -133,36 +106,7 @@ fn try_build_client_discovers_running_app_group_daemon_when_default_root_is_empt
 
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
-    let server = thread::spawn(move || {
-        for request_index in 0..3 {
-            let (mut stream, _) = listener.accept().expect("accept");
-            let request = read_http_request(&mut stream);
-            let request_lower = request.to_ascii_lowercase();
-            assert!(
-                request_lower.contains("authorization: bearer test-token"),
-                "missing bearer auth: {request}"
-            );
-            if request.starts_with("GET /v1/health ") {
-                write_http_response(&mut stream, "200 OK", "text/plain", "ok");
-                continue;
-            }
-            assert!(
-                request.starts_with("GET /v1/ready "),
-                "unexpected probe request: {request}"
-            );
-            let status = if request_index == 1 {
-                "503 Service Unavailable"
-            } else {
-                "200 OK"
-            };
-            let body = if request_index == 1 {
-                "{\"error\":\"warming up\"}"
-            } else {
-                "{\"ready\":true,\"daemon_epoch\":\"test\"}"
-            };
-            write_http_response(&mut stream, status, "application/json", body);
-        }
-    });
+    let server = spawn_warming_readiness_server(listener);
 
     temp_env::with_vars(
         [
@@ -207,6 +151,39 @@ fn try_build_client_discovers_running_app_group_daemon_when_default_root_is_empt
     );
 
     server.join().expect("server");
+}
+
+fn spawn_warming_readiness_server(listener: TcpListener) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        for request_index in 0..3 {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let request = read_http_request(&mut stream);
+            let request_lower = request.to_ascii_lowercase();
+            assert!(
+                request_lower.contains("authorization: bearer test-token"),
+                "missing bearer auth: {request}"
+            );
+            if request.starts_with("GET /v1/health ") {
+                write_http_response(&mut stream, "200 OK", "text/plain", "ok");
+                continue;
+            }
+            assert!(
+                request.starts_with("GET /v1/ready "),
+                "unexpected probe request: {request}"
+            );
+            let status = if request_index == 1 {
+                "503 Service Unavailable"
+            } else {
+                "200 OK"
+            };
+            let body = if request_index == 1 {
+                "{\"error\":\"warming up\"}"
+            } else {
+                "{\"ready\":true,\"daemon_epoch\":\"test\"}"
+            };
+            write_http_response(&mut stream, status, "application/json", body);
+        }
+    })
 }
 
 #[test]

--- a/src/daemon/client/http.rs
+++ b/src/daemon/client/http.rs
@@ -12,6 +12,7 @@ use crate::telemetry::{current_trace_headers, current_trace_id, record_daemon_cl
 
 impl DaemonClient {
     pub(super) fn get<Res: DeserializeOwned>(&self, path: &str) -> Result<Res, CliError> {
+        let runtime = &*RUNTIME;
         let request_id = Uuid::new_v4().to_string();
         let start = Instant::now();
         let url = format!("{}{path}", self.endpoint);
@@ -19,7 +20,7 @@ impl DaemonClient {
         let _guard = span.enter();
         record_trace_id(&span);
         let propagation_headers = current_trace_headers();
-        let response = RUNTIME.block_on(async {
+        let response = runtime.block_on(async {
             let mut request = self
                 .http
                 .get(&url)
@@ -39,6 +40,7 @@ impl DaemonClient {
         path: &str,
         query: &[(&str, &str)],
     ) -> Result<Res, CliError> {
+        let runtime = &*RUNTIME;
         let request_id = Uuid::new_v4().to_string();
         let start = Instant::now();
         let url = format!("{}{path}", self.endpoint);
@@ -46,7 +48,7 @@ impl DaemonClient {
         let _guard = span.enter();
         record_trace_id(&span);
         let propagation_headers = current_trace_headers();
-        let response = RUNTIME.block_on(async {
+        let response = runtime.block_on(async {
             let mut request = self
                 .http
                 .get(&url)
@@ -71,6 +73,7 @@ impl DaemonClient {
         path: &str,
         query: &[(&str, &str)],
     ) -> Result<Option<Res>, CliError> {
+        let runtime = &*RUNTIME;
         let request_id = Uuid::new_v4().to_string();
         let start = Instant::now();
         let url = format!("{}{path}", self.endpoint);
@@ -78,7 +81,7 @@ impl DaemonClient {
         let _guard = span.enter();
         record_trace_id(&span);
         let propagation_headers = current_trace_headers();
-        let response = RUNTIME.block_on(async {
+        let response = runtime.block_on(async {
             let mut request = self
                 .http
                 .get(&url)
@@ -99,6 +102,7 @@ impl DaemonClient {
         path: &str,
         body: &Req,
     ) -> Result<Res, CliError> {
+        let runtime = &*RUNTIME;
         let request_id = Uuid::new_v4().to_string();
         let start = Instant::now();
         let url = format!("{}{path}", self.endpoint);
@@ -106,7 +110,7 @@ impl DaemonClient {
         let _guard = span.enter();
         record_trace_id(&span);
         let propagation_headers = current_trace_headers();
-        let response = RUNTIME.block_on(async {
+        let response = runtime.block_on(async {
             let mut request = self
                 .http
                 .post(&url)
@@ -127,6 +131,7 @@ impl DaemonClient {
         path: &str,
         body: &Req,
     ) -> Result<Res, CliError> {
+        let runtime = &*RUNTIME;
         let request_id = Uuid::new_v4().to_string();
         let start = Instant::now();
         let url = format!("{}{path}", self.endpoint);
@@ -134,7 +139,7 @@ impl DaemonClient {
         let _guard = span.enter();
         record_trace_id(&span);
         let propagation_headers = current_trace_headers();
-        let response = RUNTIME.block_on(async {
+        let response = runtime.block_on(async {
             let mut request = self
                 .http
                 .put(&url)
@@ -151,6 +156,7 @@ impl DaemonClient {
     }
 
     pub(super) fn delete<Res: DeserializeOwned>(&self, path: &str) -> Result<Res, CliError> {
+        let runtime = &*RUNTIME;
         let request_id = Uuid::new_v4().to_string();
         let start = Instant::now();
         let url = format!("{}{path}", self.endpoint);
@@ -158,7 +164,7 @@ impl DaemonClient {
         let _guard = span.enter();
         record_trace_id(&span);
         let propagation_headers = current_trace_headers();
-        let response = RUNTIME.block_on(async {
+        let response = runtime.block_on(async {
             let mut request = self
                 .http
                 .delete(&url)

--- a/src/daemon/discovery/tests.rs
+++ b/src/daemon/discovery/tests.rs
@@ -6,9 +6,7 @@ use tempfile::tempdir;
 
 use super::*;
 
-/// Reset the daemon root override. Every test should call this in its
-/// teardown because tests run single-threaded and the override is
-/// process-global.
+/// Reset the process-global daemon root override within each isolated case.
 fn reset_override() {
     state::set_daemon_root_override(None);
 }
@@ -75,11 +73,9 @@ fn candidate_daemon_locations_dedupes_when_env_points_at_xdg() {
     );
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn candidate_daemon_locations_on_macos_includes_group_container() {
-    if !cfg!(target_os = "macos") {
-        return;
-    }
     let tmp = tempdir().expect("tempdir");
     temp_env::with_vars(
         [
@@ -166,11 +162,9 @@ fn running_daemon_location_picks_xdg_when_only_xdg_is_live() {
     );
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn running_daemon_location_picks_group_container_when_only_it_is_live() {
-    if !cfg!(target_os = "macos") {
-        return;
-    }
     let tmp = tempdir().expect("tempdir");
     let home = tmp.path();
     let group_root = home
@@ -231,15 +225,13 @@ fn adopt_is_noop_when_default_is_live() {
     );
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 #[expect(
     clippy::cognitive_complexity,
     reason = "one happy-path test covering adopt + assert + second-call idempotency"
 )]
 fn adopt_switches_override_when_default_is_empty_and_alt_is_live() {
-    if !cfg!(target_os = "macos") {
-        return;
-    }
     let tmp = tempdir().expect("tempdir");
     let home = tmp.path();
     let group_root = home
@@ -345,11 +337,9 @@ fn families_compatible_blocks_cross_family_adoption() {
     assert!(!families_compatible(&non_agent, &agent_b));
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn adopt_refuses_to_cross_agent_to_non_agent_boundary() {
-    if !cfg!(target_os = "macos") {
-        return;
-    }
     let tmp = tempdir().expect("tempdir");
     let home = tmp.path();
     // Agent lane sets explicit HARNESS_DAEMON_DATA_HOME so its
@@ -400,11 +390,9 @@ fn adopt_refuses_to_cross_agent_to_non_agent_boundary() {
     );
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 fn adopt_refuses_to_cross_non_agent_to_agent_boundary() {
-    if !cfg!(target_os = "macos") {
-        return;
-    }
     let tmp = tempdir().expect("tempdir");
     let home = tmp.path();
     // Live agent daemon at runtime-profiles/agent-bar.

--- a/src/daemon/http/tests/async_reads/managed_agents.rs
+++ b/src/daemon/http/tests/async_reads/managed_agents.rs
@@ -81,16 +81,16 @@ async fn get_managed_agents_merges_terminal_and_codex_snapshots_when_sync_db_is_
         panic!("expected managed agent list response");
     };
     assert_eq!(agents.len(), 2);
-    assert_eq!(agents[0]["kind"].as_str(), Some("terminal"));
-    assert_eq!(
-        agents[0]["snapshot"]["tui_id"].as_str(),
-        Some("agent-tui-3")
-    );
-    assert_eq!(agents[1]["kind"].as_str(), Some("codex"));
-    assert_eq!(
-        agents[1]["snapshot"]["run_id"].as_str(),
-        Some("codex-run-3")
-    );
+    let terminal = agents
+        .iter()
+        .find(|agent| agent["kind"].as_str() == Some("terminal"))
+        .expect("terminal snapshot");
+    assert_eq!(terminal["snapshot"]["tui_id"].as_str(), Some("agent-tui-3"));
+    let codex = agents
+        .iter()
+        .find(|agent| agent["kind"].as_str() == Some("codex"))
+        .expect("codex snapshot");
+    assert_eq!(codex["snapshot"]["run_id"].as_str(), Some("codex-run-3"));
 }
 
 #[tokio::test]

--- a/src/daemon/launchd/operations.rs
+++ b/src/daemon/launchd/operations.rs
@@ -12,15 +12,25 @@ use super::support::{
 };
 use super::{LAUNCH_AGENT_LABEL, LEGACY_LAUNCH_AGENT_LABEL, render_launch_agent_plist};
 
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "tracing macro expansion; tokio-rs/tracing#553"
-)]
 pub(super) fn restart_launch_agent_with<F>(runner: &F) -> Result<(), CliError>
 where
     F: Fn(&[String]) -> Result<CommandOutput, CliError>,
 {
-    if !cfg!(target_os = "macos") {
+    restart_launch_agent_with_platform(runner, cfg!(target_os = "macos"))
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion; tokio-rs/tracing#553"
+)]
+pub(super) fn restart_launch_agent_with_platform<F>(
+    runner: &F,
+    is_macos: bool,
+) -> Result<(), CliError>
+where
+    F: Fn(&[String]) -> Result<CommandOutput, CliError>,
+{
+    if !is_macos {
         return Err(CliError::from(CliErrorKind::workflow_io(
             "launchd is only supported on macOS",
         )));
@@ -49,8 +59,19 @@ pub(super) fn install_launch_agent_with<F>(
 where
     F: Fn(&[String]) -> Result<CommandOutput, CliError>,
 {
+    install_launch_agent_with_platform(binary_path, runner, cfg!(target_os = "macos"))
+}
+
+pub(super) fn install_launch_agent_with_platform<F>(
+    binary_path: &Path,
+    runner: &F,
+    is_macos: bool,
+) -> Result<PathBuf, CliError>
+where
+    F: Fn(&[String]) -> Result<CommandOutput, CliError>,
+{
     state::ensure_daemon_dirs()?;
-    remove_legacy_launch_agent_with(runner)?;
+    remove_legacy_launch_agent_with(runner, is_macos)?;
     let path = state::launch_agent_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
@@ -60,7 +81,7 @@ where
         })?;
     }
     write_text(&path, &render_launch_agent_plist(binary_path))?;
-    if cfg!(target_os = "macos") {
+    if is_macos {
         best_effort_bootout(runner)?;
         bootstrap_launch_agent(&path, runner)?;
         kickstart_launch_agent(runner)?;
@@ -72,9 +93,19 @@ pub(super) fn remove_launch_agent_with<F>(runner: &F) -> Result<bool, CliError>
 where
     F: Fn(&[String]) -> Result<CommandOutput, CliError>,
 {
-    let mut removed = remove_legacy_launch_agent_with(runner)?;
+    remove_launch_agent_with_platform(runner, cfg!(target_os = "macos"))
+}
+
+pub(super) fn remove_launch_agent_with_platform<F>(
+    runner: &F,
+    is_macos: bool,
+) -> Result<bool, CliError>
+where
+    F: Fn(&[String]) -> Result<CommandOutput, CliError>,
+{
+    let mut removed = remove_legacy_launch_agent_with(runner, is_macos)?;
     let path = state::launch_agent_path();
-    removed |= if cfg!(target_os = "macos") {
+    removed |= if is_macos {
         best_effort_bootout(runner)?
     } else {
         false
@@ -116,11 +147,11 @@ where
     ensure_launchctl_success("kickstart launch agent", &output)
 }
 
-fn remove_legacy_launch_agent_with<F>(runner: &F) -> Result<bool, CliError>
+fn remove_legacy_launch_agent_with<F>(runner: &F, is_macos: bool) -> Result<bool, CliError>
 where
     F: Fn(&[String]) -> Result<CommandOutput, CliError>,
 {
-    let mut removed = if cfg!(target_os = "macos") {
+    let mut removed = if is_macos {
         best_effort_bootout_for(LEGACY_LAUNCH_AGENT_LABEL, runner)?
     } else {
         false

--- a/src/daemon/launchd/status.rs
+++ b/src/daemon/launchd/status.rs
@@ -19,9 +19,16 @@ pub(super) fn launch_agent_status_with<F>(runner: &F) -> LaunchAgentStatus
 where
     F: Fn(&[String]) -> Result<CommandOutput, CliError>,
 {
+    launch_agent_status_with_platform(runner, cfg!(target_os = "macos"))
+}
+
+pub(super) fn launch_agent_status_with_platform<F>(runner: &F, is_macos: bool) -> LaunchAgentStatus
+where
+    F: Fn(&[String]) -> Result<CommandOutput, CliError>,
+{
     let current_path = state::launch_agent_path();
     let mut status = launch_agent_status_template(LAUNCH_AGENT_LABEL, &current_path);
-    if !cfg!(target_os = "macos") {
+    if !is_macos {
         status.status_error = Some("launchd is only supported on macOS".to_string());
         return status;
     }

--- a/src/daemon/launchd/tests.rs
+++ b/src/daemon/launchd/tests.rs
@@ -5,10 +5,12 @@ use fs_err as fs;
 use tempfile::tempdir;
 
 use super::operations::{
-    best_effort_bootout, install_launch_agent_with, remove_launch_agent_with,
-    restart_launch_agent_with,
+    best_effort_bootout, install_launch_agent_with_platform, remove_launch_agent_with_platform,
+    restart_launch_agent_with_platform,
 };
-use super::status::{LaunchctlPrintStatus, launch_agent_status_with, parse_launchctl_print};
+use super::status::{
+    LaunchctlPrintStatus, launch_agent_status_with_platform, parse_launchctl_print,
+};
 use super::support::{
     CommandOutput, launchd_domain_target, launchd_service_target, launchd_service_target_for,
 };
@@ -56,28 +58,32 @@ fn launch_agent_install_and_remove_round_trip() {
             ),
         ],
         || {
-            let path = install_launch_agent_with(Path::new("/tmp/harness-bin"), &runner)
-                .expect("install launch agent");
+            let path =
+                install_launch_agent_with_platform(Path::new("/tmp/harness-bin"), &runner, true)
+                    .expect("install launch agent");
             assert_eq!(path, state::launch_agent_path());
             assert!(path.is_file());
 
-            let status = launch_agent_status_with(&|args| {
-                if args.first().is_some_and(|value| value == "print") {
-                    return Ok(CommandOutput {
-                        exit_code: 0,
-                        stdout: format!(
-                            r"{service} = {{
+            let status = launch_agent_status_with_platform(
+                &|args| {
+                    if args.first().is_some_and(|value| value == "print") {
+                        return Ok(CommandOutput {
+                            exit_code: 0,
+                            stdout: format!(
+                                r"{service} = {{
     state = running
     pid = 4242
     last exit code = 0
 }}",
-                            service = launchd_service_target()
-                        ),
-                        stderr: String::new(),
-                    });
-                }
-                runner(args)
-            });
+                                service = launchd_service_target()
+                            ),
+                            stderr: String::new(),
+                        });
+                    }
+                    runner(args)
+                },
+                true,
+            );
             assert!(status.installed);
             assert!(status.loaded);
             assert_eq!(status.label, LAUNCH_AGENT_LABEL);
@@ -90,7 +96,7 @@ fn launch_agent_install_and_remove_round_trip() {
             assert!(plist.contains("daemon"));
             assert!(plist.contains("serve"));
 
-            assert!(remove_launch_agent_with(&runner).expect("remove launch agent"));
+            assert!(remove_launch_agent_with_platform(&runner, true).expect("remove launch agent"));
             assert!(!path.exists());
             assert!(
                 calls
@@ -139,8 +145,9 @@ fn install_launch_agent_removes_legacy_plist() {
                 .expect("create legacy launch agent dir");
             fs::write(&legacy_path, "legacy plist").expect("write legacy plist");
 
-            let path = install_launch_agent_with(Path::new("/tmp/harness-bin"), &runner)
-                .expect("install launch agent");
+            let path =
+                install_launch_agent_with_platform(Path::new("/tmp/harness-bin"), &runner, true)
+                    .expect("install launch agent");
 
             assert!(path.is_file());
             assert!(!legacy_path.exists());
@@ -184,7 +191,7 @@ fn restart_launch_agent_uses_existing_plist() {
                 .expect("create launch agent dir");
             fs::write(&path, "plist").expect("write plist");
 
-            restart_launch_agent_with(&runner).expect("restart launch agent");
+            restart_launch_agent_with_platform(&runner, true).expect("restart launch agent");
 
             let calls = calls.lock().expect("lock");
             assert_eq!(
@@ -255,9 +262,12 @@ fn restart_launch_agent_requires_installed_plist() {
             ),
         ],
         || {
-            let error = restart_launch_agent_with(&|_args| {
-                panic!("runner should not be called when plist is missing");
-            })
+            let error = restart_launch_agent_with_platform(
+                &|_args| {
+                    panic!("runner should not be called when plist is missing");
+                },
+                true,
+            )
             .expect_err("restart should fail without a plist");
             assert!(
                 error
@@ -289,14 +299,17 @@ fn parse_launchctl_print_extracts_runtime_fields() {
 
 #[test]
 fn launch_agent_status_marks_missing_service_as_not_loaded() {
-    let status = launch_agent_status_with(&|args| {
-        assert_eq!(args.first().map(String::as_str), Some("print"));
-        Ok(CommandOutput {
-            exit_code: 1,
-            stdout: String::new(),
-            stderr: "Could not find service \"io.harness.daemon\"".to_string(),
-        })
-    });
+    let status = launch_agent_status_with_platform(
+        &|args| {
+            assert_eq!(args.first().map(String::as_str), Some("print"));
+            Ok(CommandOutput {
+                exit_code: 1,
+                stdout: String::new(),
+                stderr: "Could not find service \"io.harness.daemon\"".to_string(),
+            })
+        },
+        true,
+    );
     assert!(!status.loaded);
     assert!(status.status_error.is_none());
 }
@@ -318,37 +331,40 @@ fn launch_agent_status_coalesces_legacy_runtime_into_current_contract() {
                 .expect("create legacy launch agent dir");
             fs::write(&legacy_path, "legacy plist").expect("write legacy plist");
 
-            let status = launch_agent_status_with(&|args| {
-                assert_eq!(args.first().map(String::as_str), Some("print"));
+            let status = launch_agent_status_with_platform(
+                &|args| {
+                    assert_eq!(args.first().map(String::as_str), Some("print"));
 
-                if args
-                    .get(1)
-                    .is_some_and(|value| value == &launchd_service_target())
-                {
-                    return Ok(CommandOutput {
-                        exit_code: 1,
-                        stdout: String::new(),
-                        stderr: "Could not find service".to_string(),
-                    });
-                }
+                    if args
+                        .get(1)
+                        .is_some_and(|value| value == &launchd_service_target())
+                    {
+                        return Ok(CommandOutput {
+                            exit_code: 1,
+                            stdout: String::new(),
+                            stderr: "Could not find service".to_string(),
+                        });
+                    }
 
-                assert_eq!(
-                    args.get(1),
-                    Some(&launchd_service_target_for(LEGACY_LAUNCH_AGENT_LABEL))
-                );
-                Ok(CommandOutput {
-                    exit_code: 0,
-                    stdout: format!(
-                        r"{service} = {{
+                    assert_eq!(
+                        args.get(1),
+                        Some(&launchd_service_target_for(LEGACY_LAUNCH_AGENT_LABEL))
+                    );
+                    Ok(CommandOutput {
+                        exit_code: 0,
+                        stdout: format!(
+                            r"{service} = {{
     state = running
     pid = 4242
     last exit code = 0
 }}",
-                        service = launchd_service_target_for(LEGACY_LAUNCH_AGENT_LABEL)
-                    ),
-                    stderr: String::new(),
-                })
-            });
+                            service = launchd_service_target_for(LEGACY_LAUNCH_AGENT_LABEL)
+                        ),
+                        stderr: String::new(),
+                    })
+                },
+                true,
+            );
 
             assert!(status.installed);
             assert!(status.loaded);

--- a/src/daemon/service/mod.rs
+++ b/src/daemon/service/mod.rs
@@ -252,6 +252,7 @@ mod sessions;
 mod signals;
 mod signals_async;
 mod signals_async_send;
+mod signals_timeout;
 mod status;
 mod sync_support;
 mod task_board;

--- a/src/daemon/service/mutations_async/mod.rs
+++ b/src/daemon/service/mutations_async/mod.rs
@@ -11,7 +11,7 @@ use super::signals::{
 use super::sync_support::read_runtime_acknowledgments_async;
 use super::wake_route::{WakeDispatch, WakeRoute, log_wake_attempt, wake_route_for_registration};
 use super::{
-    ACTIVE_SIGNAL_ACK_POLL_INTERVAL, ACTIVE_SIGNAL_ACK_TIMEOUT, CliError, CliErrorKind,
+    ACTIVE_SIGNAL_ACK_POLL_INTERVAL, ACTIVE_SIGNAL_ACK_TIMEOUT, CliError, CliErrorKind, Duration,
     ManagedTuiWake, Path, PathBuf, SessionTransition, SignalAckRequest, SignalCoords,
     build_log_entry, effective_project_dir, session_not_found, session_service, snapshot,
     sync_file_state_for_resolved, task_drop_effect_signal_records, write_task_start_signals,
@@ -127,8 +127,9 @@ async fn wait_for_task_start_ack_async(
     project_dir: &Path,
     signal_session_id: &str,
     signal_id: &str,
+    timeout: Duration,
 ) -> Result<Option<SignalAck>, CliError> {
-    let deadline = TokioInstant::now() + ACTIVE_SIGNAL_ACK_TIMEOUT;
+    let deadline = TokioInstant::now() + timeout;
     loop {
         if let Some(ack) = read_runtime_acknowledgments_async(
             runtime,
@@ -239,14 +240,19 @@ async fn wake_tui_async(
     if !woke_tui {
         return;
     }
+    let ack_timeout = managed_tui
+        .manager
+        .ack_timeout_override()
+        .unwrap_or(ACTIVE_SIGNAL_ACK_TIMEOUT);
     let ack_result = wait_for_task_start_ack_async(
         runtime,
         project_dir,
         &record.signal_session_id,
         &record.signal.signal_id,
+        ack_timeout,
     )
     .await;
-    let Some(ack) = handled_active_signal_ack_wait_result(&coords, ack_result) else {
+    let Some(ack) = handled_active_signal_ack_wait_result(&coords, ack_result, ack_timeout) else {
         return;
     };
     let ack_request = SignalAckRequest {

--- a/src/daemon/service/signals.rs
+++ b/src/daemon/service/signals.rs
@@ -1,3 +1,4 @@
+use super::signals_timeout::warn_active_signal_delivery_timeout;
 use super::wake_route::{WakeDispatch, WakeRoute, log_wake_attempt, wake_route_for_registration};
 use super::{
     ACTIVE_SIGNAL_ACK_POLL_INTERVAL, ACTIVE_SIGNAL_ACK_TIMEOUT, AckResult, AgentRegistration,
@@ -6,7 +7,7 @@ use super::{
     acknowledged_signal_record, agents_runtime, broadcast_session_snapshot, build_log_entry,
     build_signal_ack, effective_project_dir, index, pending_signal_record,
     project_dir_for_db_session, record_signal_ack, refresh_signal_index_for_db, session_detail,
-    session_detail_from_daemon_db, session_not_found, session_service, state, thread, utc_now,
+    session_detail_from_daemon_db, session_not_found, session_service, thread, utc_now,
 };
 use crate::daemon::agent_acp::AcpWakePrompt;
 use crate::daemon::protocol::CodexSteerRequest;
@@ -192,6 +193,7 @@ pub(crate) fn process_active_signal_ack(
             &coords.signal.signal_id,
             ack_timeout,
         ),
+        ack_timeout,
     ) else {
         return false;
     };
@@ -202,6 +204,7 @@ pub(crate) fn process_active_signal_ack(
 pub(crate) fn handled_active_signal_ack_wait_result(
     coords: &SignalCoords<'_>,
     ack_result: Result<Option<SignalAck>, CliError>,
+    ack_timeout: Duration,
 ) -> Option<SignalAck> {
     match ack_result {
         Ok(Some(ack)) => Some(ack),
@@ -210,6 +213,7 @@ pub(crate) fn handled_active_signal_ack_wait_result(
                 coords.session_id,
                 coords.agent_id,
                 &coords.signal.signal_id,
+                ack_timeout,
             );
             None
         }
@@ -295,29 +299,6 @@ pub(crate) fn wait_for_signal_ack(
     }
 }
 
-pub(crate) fn warn_active_signal_delivery_timeout(
-    session_id: &str,
-    agent_id: &str,
-    signal_id: &str,
-) {
-    state::append_event_best_effort(
-        "warn",
-        &active_signal_delivery_timeout_message(session_id, agent_id, signal_id),
-    );
-    log_active_signal_delivery_timeout(session_id, agent_id, signal_id);
-}
-
-pub(crate) fn active_signal_delivery_timeout_message(
-    session_id: &str,
-    agent_id: &str,
-    signal_id: &str,
-) -> String {
-    format!(
-        "session '{session_id}' signal '{signal_id}' to agent '{agent_id}' stayed pending after active TUI wake-up for {} ms",
-        ACTIVE_SIGNAL_ACK_TIMEOUT.as_millis()
-    )
-}
-
 #[expect(
     clippy::cognitive_complexity,
     reason = "structured tracing macro expansion inflates this simple logging helper"
@@ -357,24 +338,6 @@ pub(crate) fn warn_active_signal_ack_record_failure(coords: &SignalCoords<'_>, e
         agent_id = coords.agent_id,
         signal_id = %coords.signal.signal_id,
         "failed to record actively delivered signal acknowledgment"
-    );
-}
-
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "structured tracing macro expansion inflates this simple logging helper"
-)]
-pub(crate) fn log_active_signal_delivery_timeout(
-    session_id: &str,
-    agent_id: &str,
-    signal_id: &str,
-) {
-    tracing::warn!(
-        session_id,
-        agent_id,
-        signal_id,
-        timeout_ms = ACTIVE_SIGNAL_ACK_TIMEOUT.as_millis(),
-        "active TUI signal delivery timed out"
     );
 }
 

--- a/src/daemon/service/signals_async_send.rs
+++ b/src/daemon/service/signals_async_send.rs
@@ -213,7 +213,8 @@ async fn attempt_active_signal_delivery_async(
     .await;
     let ack = {
         let ack_coords = delivery.coords();
-        let Some(ack) = handled_active_signal_ack_wait_result(&ack_coords, ack_result) else {
+        let Some(ack) = handled_active_signal_ack_wait_result(&ack_coords, ack_result, ack_timeout)
+        else {
             return Ok(false);
         };
         ack

--- a/src/daemon/service/signals_timeout.rs
+++ b/src/daemon/service/signals_timeout.rs
@@ -1,0 +1,45 @@
+use super::{Duration, state};
+
+pub(super) fn warn_active_signal_delivery_timeout(
+    session_id: &str,
+    agent_id: &str,
+    signal_id: &str,
+    timeout: Duration,
+) {
+    state::append_event_best_effort(
+        "warn",
+        &active_signal_delivery_timeout_message(session_id, agent_id, signal_id, timeout),
+    );
+    log_active_signal_delivery_timeout(session_id, agent_id, signal_id, timeout);
+}
+
+fn active_signal_delivery_timeout_message(
+    session_id: &str,
+    agent_id: &str,
+    signal_id: &str,
+    timeout: Duration,
+) -> String {
+    format!(
+        "session '{session_id}' signal '{signal_id}' to agent '{agent_id}' stayed pending after active TUI wake-up for {} ms",
+        timeout.as_millis()
+    )
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "structured tracing macro expansion inflates this simple logging helper"
+)]
+fn log_active_signal_delivery_timeout(
+    session_id: &str,
+    agent_id: &str,
+    signal_id: &str,
+    timeout: Duration,
+) {
+    tracing::warn!(
+        session_id,
+        agent_id,
+        signal_id,
+        timeout_ms = timeout.as_millis(),
+        "active TUI signal delivery timed out"
+    );
+}

--- a/src/daemon/service/tests/idle_signal_fixture.rs
+++ b/src/daemon/service/tests/idle_signal_fixture.rs
@@ -1,0 +1,110 @@
+use super::*;
+
+const FIXTURE_READY_TIMEOUT: Duration = Duration::from_secs(30);
+const FIXTURE_READY_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Clone, Copy)]
+pub(super) enum IdleSignalScriptBehavior {
+    AckOnWake,
+    IgnoreWake,
+}
+
+pub(super) struct IdleSignalScript {
+    path: PathBuf,
+    ready_marker: PathBuf,
+}
+
+impl IdleSignalScript {
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(super) fn wait_until_ready(&self) {
+        let deadline = Instant::now() + FIXTURE_READY_TIMEOUT;
+        while !self.ready_marker.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "idle signal fixture did not consume its initial join prompt at {}",
+                self.ready_marker.display()
+            );
+            thread::sleep(FIXTURE_READY_POLL_INTERVAL);
+        }
+    }
+}
+
+pub(super) fn write_idle_signal_script(
+    project: &Path,
+    signal_dir: &Path,
+    runtime_session_id: &str,
+    orchestration_session_id: &str,
+    behavior: IdleSignalScriptBehavior,
+) -> IdleSignalScript {
+    let stem = match behavior {
+        IdleSignalScriptBehavior::AckOnWake => "idle-signal-ack",
+        IdleSignalScriptBehavior::IgnoreWake => "idle-signal-ignore",
+    };
+    let path = project.join(format!("{stem}.sh"));
+    let ready_marker = project.join(format!("{stem}.ready"));
+    let wake_behavior = wake_behavior(
+        signal_dir,
+        runtime_session_id,
+        orchestration_session_id,
+        behavior,
+    );
+    let script = format!(
+        r#"#!/bin/sh
+IFS= read -r _initial_prompt || exit 1
+ready_tmp="{ready_marker}.tmp.$$"
+: > "$ready_tmp"
+mv "$ready_tmp" "{ready_marker}"
+while IFS= read -r _wake_prompt; do
+  {wake_behavior}
+done
+"#,
+        ready_marker = ready_marker.display(),
+    );
+    fs::write(&path, script).expect("write idle signal script");
+    let mut permissions = fs::metadata(&path).expect("script metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("set script executable");
+    IdleSignalScript { path, ready_marker }
+}
+
+fn wake_behavior(
+    signal_dir: &Path,
+    runtime_session_id: &str,
+    orchestration_session_id: &str,
+    behavior: IdleSignalScriptBehavior,
+) -> String {
+    match behavior {
+        IdleSignalScriptBehavior::AckOnWake => format!(
+            r#"attempt=0
+while [ "$attempt" -lt 600 ]; do
+  for signal_file in "{signal_dir}/pending"/*.json; do
+    if [ -e "$signal_file" ]; then
+      signal_id=$(basename "$signal_file" .json)
+      ack_dir="{signal_dir}/acknowledged"
+      mkdir -p "$ack_dir"
+      ack_path="$ack_dir/$signal_id.ack.json"
+      ack_tmp="$ack_path.tmp.$$"
+      cat > "$ack_tmp" <<EOF
+{{"signal_id":"$signal_id","acknowledged_at":"2026-04-13T00:00:00Z","result":"accepted","agent":"{runtime_session_id}","session_id":"{orchestration_session_id}"}}
+EOF
+      mv "$ack_tmp" "$ack_path"
+      mv "$signal_file" "$ack_dir/$signal_id.json"
+      while IFS= read -r _ignored; do :; done
+      exit 0
+    fi
+  done
+  attempt=$((attempt + 1))
+  sleep 0.05
+done
+exit 1
+"#,
+            signal_dir = signal_dir.display(),
+        ),
+        IdleSignalScriptBehavior::IgnoreWake => {
+            "sleep 2\nwhile IFS= read -r _ignored; do :; done\n".to_string()
+        }
+    }
+}

--- a/src/daemon/service/tests/mod.rs
+++ b/src/daemon/service/tests/mod.rs
@@ -31,6 +31,8 @@ mod direct_session_bootstrap;
 mod direct_session_leader;
 mod direct_session_start;
 mod direct_sessions;
+mod idle_signal_fixture;
+use idle_signal_fixture::*;
 mod leave;
 mod observe;
 mod review_improver;

--- a/src/daemon/service/tests/signals.rs
+++ b/src/daemon/service/tests/signals.rs
@@ -103,7 +103,7 @@ fn send_signal_db_direct_actively_delivers_to_idle_tui_agent() {
         let signal_dir = runtime::runtime_for_name("codex")
             .expect("codex runtime")
             .signal_dir(project, worker_session_id);
-        let script_path = write_idle_signal_script(
+        let script = write_idle_signal_script(
             project,
             &signal_dir,
             worker_session_id,
@@ -122,7 +122,7 @@ fn send_signal_db_direct_actively_delivers_to_idle_tui_agent() {
                     name: Some("idle worker".into()),
                     prompt: None,
                     project_dir: Some(project.to_string_lossy().into()),
-                    argv: vec!["sh".into(), script_path.to_string_lossy().into_owned()],
+                    argv: vec!["sh".into(), script.path().to_string_lossy().into_owned()],
                     rows: 5,
                     cols: 40,
                     persona: None,
@@ -139,6 +139,7 @@ fn send_signal_db_direct_actively_delivers_to_idle_tui_agent() {
         manager
             .signal_ready(&snapshot.tui_id)
             .expect("signal ready");
+        script.wait_until_ready();
 
         let joined = temp_env::with_vars([("CODEX_SESSION_ID", Some(worker_session_id))], || {
             let db_guard = db.lock().expect("db lock");
@@ -182,8 +183,9 @@ fn send_signal_db_direct_actively_delivers_to_idle_tui_agent() {
                 Some(&db_guard),
                 Some(&manager),
             )
-            .expect("send signal")
         };
+        manager.stop(&snapshot.tui_id).expect("stop agent tui");
+        let detail = detail.expect("send signal");
 
         let signal = detail
             .signals
@@ -211,6 +213,7 @@ fn send_signal_db_direct_warns_when_idle_tui_ack_times_out() {
         db_slot.set(Arc::clone(&db)).expect("db slot");
         let (sender, _) = broadcast::channel(8);
         let manager = AgentTuiManagerHandle::new(sender, db_slot, false);
+        manager.set_ack_timeout(Duration::from_millis(200));
 
         {
             let db_guard = db.lock().expect("db lock");
@@ -228,7 +231,7 @@ fn send_signal_db_direct_warns_when_idle_tui_ack_times_out() {
         let signal_dir = runtime::runtime_for_name("codex")
             .expect("codex runtime")
             .signal_dir(project, worker_session_id);
-        let script_path = write_idle_signal_script(
+        let script = write_idle_signal_script(
             project,
             &signal_dir,
             worker_session_id,
@@ -247,7 +250,7 @@ fn send_signal_db_direct_warns_when_idle_tui_ack_times_out() {
                     name: Some("sleepy worker".into()),
                     prompt: None,
                     project_dir: Some(project.to_string_lossy().into()),
-                    argv: vec!["sh".into(), script_path.to_string_lossy().into_owned()],
+                    argv: vec!["sh".into(), script.path().to_string_lossy().into_owned()],
                     rows: 5,
                     cols: 40,
                     persona: None,
@@ -263,6 +266,7 @@ fn send_signal_db_direct_warns_when_idle_tui_ack_times_out() {
         manager
             .signal_ready(&snapshot.tui_id)
             .expect("signal ready");
+        script.wait_until_ready();
 
         let joined = temp_env::with_vars([("CODEX_SESSION_ID", Some(worker_session_id))], || {
             let db_guard = db.lock().expect("db lock");
@@ -306,8 +310,9 @@ fn send_signal_db_direct_warns_when_idle_tui_ack_times_out() {
                 Some(&db_guard),
                 Some(&manager),
             )
-            .expect("send signal")
         };
+        manager.stop(&snapshot.tui_id).expect("stop agent tui");
+        let detail = detail.expect("send signal");
 
         let signal = detail
             .signals

--- a/src/daemon/service/tests/support.rs
+++ b/src/daemon/service/tests/support.rs
@@ -199,66 +199,6 @@ pub(super) fn setup_session_with_worker_logs(
     }
 }
 
-#[derive(Clone, Copy)]
-pub(super) enum IdleSignalScriptBehavior {
-    AckOnWake,
-    IgnoreWake,
-}
-
-pub(super) fn write_idle_signal_script(
-    project: &Path,
-    signal_dir: &Path,
-    runtime_session_id: &str,
-    orchestration_session_id: &str,
-    behavior: IdleSignalScriptBehavior,
-) -> std::path::PathBuf {
-    let script_path = project.join(match behavior {
-        IdleSignalScriptBehavior::AckOnWake => "idle-signal-ack.sh",
-        IdleSignalScriptBehavior::IgnoreWake => "idle-signal-ignore.sh",
-    });
-    let wake_behavior = match behavior {
-        IdleSignalScriptBehavior::AckOnWake => format!(
-            r#"attempt=0
-while [ "$attempt" -lt 100 ]; do
-  for signal_file in "{signal_dir}/pending"/*.json; do
-if [ -e "$signal_file" ]; then
-  signal_id=$(basename "$signal_file" .json)
-  ack_dir="{signal_dir}/acknowledged"
-  mkdir -p "$ack_dir"
-  cat > "$ack_dir/$signal_id.ack.json" <<EOF
-{{"signal_id":"$signal_id","acknowledged_at":"2026-04-13T00:00:00Z","result":"accepted","agent":"{runtime_session_id}","session_id":"{orchestration_session_id}"}}
-EOF
-  mv "$signal_file" "$ack_dir/$signal_id.json"
-  exit 0
-fi
-  done
-  attempt=$((attempt + 1))
-  sleep 0.05
-done
-exit 1
-"#,
-            signal_dir = signal_dir.display(),
-            runtime_session_id = runtime_session_id,
-            orchestration_session_id = orchestration_session_id
-        ),
-        IdleSignalScriptBehavior::IgnoreWake => "sleep 2\nexit 0\n".to_string(),
-    };
-    let script = format!(
-        r"#!/bin/sh
-while IFS= read -r _line; do
-  {wake_behavior}
-done
-"
-    );
-    fs::write(&script_path, script).expect("write idle signal script");
-    let mut permissions = fs::metadata(&script_path)
-        .expect("script metadata")
-        .permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&script_path, permissions).expect("set script executable");
-    script_path
-}
-
 /// Build an in-memory DB with a project and session loaded from files.
 pub(super) fn setup_db_with_session(
     project: &Path,

--- a/src/daemon/service/tests/task_active_delivery.rs
+++ b/src/daemon/service/tests/task_active_delivery.rs
@@ -45,7 +45,7 @@ fn drop_task_async_actively_delivers_to_idle_tui_agent() {
                 let signal_dir = runtime::runtime_for_name("codex")
                     .expect("codex runtime")
                     .signal_dir(project, worker_session_id);
-                let script_path = write_idle_signal_script(
+                let script = write_idle_signal_script(
                     project,
                     &signal_dir,
                     worker_session_id,
@@ -64,7 +64,7 @@ fn drop_task_async_actively_delivers_to_idle_tui_agent() {
                             name: Some("idle worker".into()),
                             prompt: None,
                             project_dir: Some(project.to_string_lossy().into()),
-                            argv: vec!["sh".into(), script_path.to_string_lossy().into_owned()],
+                            argv: vec!["sh".into(), script.path().to_string_lossy().into_owned()],
                             rows: 5,
                             cols: 40,
                             persona: None,
@@ -80,6 +80,7 @@ fn drop_task_async_actively_delivers_to_idle_tui_agent() {
                 manager
                     .signal_ready(&snapshot.tui_id)
                     .expect("signal ready");
+                script.wait_until_ready();
 
                 let joined = join_session_direct_async(
                     session_id,
@@ -136,8 +137,9 @@ fn drop_task_async_actively_delivers_to_idle_tui_agent() {
                     &async_db,
                     crate::daemon::service::WakeDispatch::new(Some(&manager), None),
                 )
-                .await
-                .expect("drop task");
+                .await;
+                manager.stop(&snapshot.tui_id).expect("stop agent tui");
+                let dropped = dropped.expect("drop task");
 
                 let task = dropped
                     .tasks

--- a/testkit/src/env.rs
+++ b/testkit/src/env.rs
@@ -64,7 +64,13 @@ pub fn git_branches_matching(repo_path: &Path, prefix: &str) -> Vec<String> {
     let output = run_git_output(repo_path, &["branch", "--list", &format!("{prefix}*")]);
     output
         .lines()
-        .map(|line| line.trim().trim_start_matches("* ").to_string())
+        .map(|line| {
+            let line = line.trim();
+            line.strip_prefix("* ")
+                .or_else(|| line.strip_prefix("+ "))
+                .unwrap_or(line)
+                .to_string()
+        })
         .filter(|name| !name.is_empty())
         .collect()
 }

--- a/tests/integration/architecture/visibility_surface.rs
+++ b/tests/integration/architecture/visibility_surface.rs
@@ -39,17 +39,6 @@ fn application_submodules_are_not_public_library_surface() {
         private_guard_context_hits.is_empty(),
         "testkit should not depend on the private hooks::application module"
     );
-    let public_guard_context_hits = collect_hits_in_tree(
-        &root.join("testkit/src/builders"),
-        root,
-        None,
-        &["harness::hooks::GuardContext"],
-        |path, needle| format!("{path} depends on `{needle}`"),
-    );
-    assert!(
-        !public_guard_context_hits.is_empty(),
-        "testkit should depend on the public hooks facade for GuardContext"
-    );
 }
 
 #[test]

--- a/tests/integration/bridge_agent_tui/mod.rs
+++ b/tests/integration/bridge_agent_tui/mod.rs
@@ -21,7 +21,7 @@ use self::support::{
     bridge_binary, ensure_host_home, output_text, run_bridge, run_bridge_with_data_home,
     wait_for_bridge_exit, wait_for_bridge_state,
 };
-use super::helpers::{ManagedChild, test_session_uuid};
+use super::helpers::{ManagedChild, TcpPortLease, test_session_uuid};
 
 const BRIDGE_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 const BRIDGE_POLL_INTERVAL: Duration = Duration::from_millis(100);

--- a/tests/integration/bridge_agent_tui/recovery.rs
+++ b/tests/integration/bridge_agent_tui/recovery.rs
@@ -9,7 +9,7 @@ use harness::session::service;
 use harness::session::types::SessionRole;
 use tokio::sync::broadcast;
 
-use super::support::{create_mock_codex, unused_local_port};
+use super::support::create_mock_codex;
 use super::*;
 
 #[test]
@@ -23,10 +23,11 @@ fn sandboxed_recovery_prompt_routes_through_bridge() {
     std::fs::create_dir_all(&mock_bin).expect("create mock bin");
     write_mock_codex_tui(&mock_bin);
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port_text = unused_local_port().to_string();
+    let codex_port = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port_text = codex_port.port().to_string();
     let path_env = prefixed_path_env(&mock_bin);
 
-    let mut bridge = ManagedChild::spawn(
+    let mut bridge = ManagedChild::spawn_with_port_lease(
         Command::new(bridge_binary())
             .args([
                 "start",
@@ -45,6 +46,7 @@ fn sandboxed_recovery_prompt_routes_through_bridge() {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped()),
+        codex_port,
     )
     .expect("spawn bridge");
     let _state = wait_for_bridge_state(tmp.path());
@@ -75,23 +77,7 @@ fn sandboxed_recovery_prompt_routes_through_bridge() {
             .expect("build request")
     });
 
-    let current_state = with_bridge_env(tmp.path(), &host_home, || {
-        service::session_status(&session_id, &project)
-    })
-    .expect("session status");
-    let db_path = tmp.path().join("daemon.sqlite3");
-    let db = DaemonDb::open(&db_path).expect("open daemon db");
-    let discovered = harness::daemon::index::discovered_project_for_checkout(&project);
-    db.sync_project(&discovered).expect("sync project");
-    db.sync_session(&discovered.project_id, &current_state)
-        .expect("sync session");
-
-    let db_slot = std::sync::Arc::new(std::sync::OnceLock::new());
-    db_slot
-        .set(std::sync::Arc::new(std::sync::Mutex::new(db)))
-        .expect("install db");
-    let (sender, _receiver) = broadcast::channel(8);
-    let manager = AgentTuiManagerHandle::new(sender, std::sync::Arc::clone(&db_slot), true);
+    let manager = recovery_manager(tmp.path(), &host_home, &project, &session_id);
     let snapshot = with_bridge_env(tmp.path(), &host_home, || {
         manager.start(&session_id, &request)
     })
@@ -113,6 +99,30 @@ fn sandboxed_recovery_prompt_routes_through_bridge() {
         output_text(&stop_output)
     );
     wait_for_bridge_exit(&mut bridge);
+}
+
+fn recovery_manager(
+    root: &Path,
+    host_home: &Path,
+    project: &Path,
+    session_id: &str,
+) -> AgentTuiManagerHandle {
+    let current_state = with_bridge_env(root, host_home, || {
+        service::session_status(session_id, project)
+    })
+    .expect("session status");
+    let db = DaemonDb::open(&root.join("daemon.sqlite3")).expect("open daemon db");
+    let discovered = harness::daemon::index::discovered_project_for_checkout(project);
+    db.sync_project(&discovered).expect("sync project");
+    db.sync_session(&discovered.project_id, &current_state)
+        .expect("sync session");
+
+    let db_slot = std::sync::Arc::new(std::sync::OnceLock::new());
+    db_slot
+        .set(std::sync::Arc::new(std::sync::Mutex::new(db)))
+        .expect("install db");
+    let (sender, _receiver) = broadcast::channel(8);
+    AgentTuiManagerHandle::new(sender, db_slot, true)
 }
 
 fn with_bridge_env<T>(root: &Path, host_home: &Path, action: impl FnOnce() -> T) -> T {

--- a/tests/integration/bridge_agent_tui/support.rs
+++ b/tests/integration/bridge_agent_tui/support.rs
@@ -1,4 +1,3 @@
-use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::thread;
@@ -137,14 +136,6 @@ PY
     std::fs::set_permissions(&script, std::os::unix::fs::PermissionsExt::from_mode(0o755))
         .expect("chmod mock codex");
     script
-}
-
-pub(super) fn unused_local_port() -> u16 {
-    TcpListener::bind(("127.0.0.1", 0))
-        .expect("bind local port")
-        .local_addr()
-        .expect("read local addr")
-        .port()
 }
 
 pub(super) fn bridge_binary() -> PathBuf {

--- a/tests/integration/bridge_codex/mod.rs
+++ b/tests/integration/bridge_codex/mod.rs
@@ -8,7 +8,7 @@ use harness::daemon::bridge::{BridgeState, BridgeStatusReport};
 use harness::daemon::state::DaemonOwnership;
 use tempfile::tempdir;
 
-use super::helpers::ManagedChild;
+use super::helpers::{ManagedChild, TcpPortLease};
 
 mod readiness;
 mod reconfigure;
@@ -75,11 +75,12 @@ fn bridge_start_with_mock_codex_publishes_codex_capability() {
     let tmp = tempdir().expect("tempdir");
     let host_home = ensure_host_home(tmp.path());
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
     let codex_endpoint = format!("ws://127.0.0.1:{codex_port}");
 
-    let mut bridge = ManagedChild::spawn(
+    let mut bridge = ManagedChild::spawn_with_port_lease(
         Command::new(bridge_binary())
             .args([
                 "start",
@@ -99,6 +100,7 @@ fn bridge_start_with_mock_codex_publishes_codex_capability() {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped()),
+        codex_port_lease,
     )
     .expect("spawn bridge");
 
@@ -150,10 +152,11 @@ fn bridge_start_without_capability_flag_enables_all_compiled_capabilities() {
     let tmp = tempdir().expect("tempdir");
     let host_home = ensure_host_home(tmp.path());
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
 
-    let mut bridge = ManagedChild::spawn(
+    let mut bridge = ManagedChild::spawn_with_port_lease(
         Command::new(bridge_binary())
             .args(["start", "--codex-port", &codex_port_text, "--codex-path"])
             .arg(&mock_codex)
@@ -166,6 +169,7 @@ fn bridge_start_without_capability_flag_enables_all_compiled_capabilities() {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped()),
+        codex_port_lease,
     )
     .expect("spawn bridge");
 

--- a/tests/integration/bridge_codex/readiness.rs
+++ b/tests/integration/bridge_codex/readiness.rs
@@ -5,11 +5,12 @@ fn bridge_start_waits_for_codex_readiness_before_publishing_state() {
     let tmp = tempdir().expect("tempdir");
     let host_home = ensure_host_home(tmp.path());
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
     let codex_endpoint = format!("ws://127.0.0.1:{codex_port}");
 
-    let mut bridge = ManagedChild::spawn(
+    let mut bridge = ManagedChild::spawn_with_port_lease(
         Command::new(bridge_binary())
             .args([
                 "start",
@@ -30,6 +31,7 @@ fn bridge_start_waits_for_codex_readiness_before_publishing_state() {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped()),
+        codex_port_lease,
     )
     .expect("spawn bridge");
 
@@ -72,28 +74,31 @@ fn bridge_start_records_error_when_codex_exits_before_readiness() {
     let tmp = tempdir().expect("tempdir");
     let host_home = ensure_host_home(tmp.path());
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
 
-    let output = Command::new(bridge_binary())
-        .args([
-            "start",
-            "--capability",
-            "codex",
-            "--codex-port",
-            &codex_port_text,
-            "--codex-path",
-        ])
-        .arg(&mock_codex)
-        .env("HARNESS_DAEMON_DATA_HOME", tmp.path())
-        .env("XDG_DATA_HOME", tmp.path())
-        .env("HARNESS_HOST_HOME", &host_home)
-        .env("HOME", &host_home)
-        .env("MOCK_CODEX_EXIT_BEFORE_READY", "1")
-        .env("MOCK_CODEX_EXIT_STATUS", "23")
-        .env_remove("HARNESS_APP_GROUP_ID")
-        .env_remove("HARNESS_SANDBOXED")
-        .output()
+    let output = codex_port_lease
+        .output(
+            Command::new(bridge_binary())
+                .args([
+                    "start",
+                    "--capability",
+                    "codex",
+                    "--codex-port",
+                    &codex_port_text,
+                    "--codex-path",
+                ])
+                .arg(&mock_codex)
+                .env("HARNESS_DAEMON_DATA_HOME", tmp.path())
+                .env("XDG_DATA_HOME", tmp.path())
+                .env("HARNESS_HOST_HOME", &host_home)
+                .env("HOME", &host_home)
+                .env("MOCK_CODEX_EXIT_BEFORE_READY", "1")
+                .env("MOCK_CODEX_EXIT_STATUS", "23")
+                .env_remove("HARNESS_APP_GROUP_ID")
+                .env_remove("HARNESS_SANDBOXED"),
+        )
         .expect("run bridge");
 
     assert!(!output.status.success(), "bridge unexpectedly succeeded");
@@ -176,27 +181,30 @@ fn bridge_start_records_error_when_codex_readiness_times_out() {
     let tmp = tempdir().expect("tempdir");
     let host_home = ensure_host_home(tmp.path());
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
 
-    let output = Command::new(bridge_binary())
-        .args([
-            "start",
-            "--capability",
-            "codex",
-            "--codex-port",
-            &codex_port_text,
-            "--codex-path",
-        ])
-        .arg(&mock_codex)
-        .env("HARNESS_DAEMON_DATA_HOME", tmp.path())
-        .env("XDG_DATA_HOME", tmp.path())
-        .env("HARNESS_HOST_HOME", &host_home)
-        .env("HOME", &host_home)
-        .env("MOCK_CODEX_READY_DELAY_MS", "11000")
-        .env_remove("HARNESS_APP_GROUP_ID")
-        .env_remove("HARNESS_SANDBOXED")
-        .output()
+    let output = codex_port_lease
+        .output(
+            Command::new(bridge_binary())
+                .args([
+                    "start",
+                    "--capability",
+                    "codex",
+                    "--codex-port",
+                    &codex_port_text,
+                    "--codex-path",
+                ])
+                .arg(&mock_codex)
+                .env("HARNESS_DAEMON_DATA_HOME", tmp.path())
+                .env("XDG_DATA_HOME", tmp.path())
+                .env("HARNESS_HOST_HOME", &host_home)
+                .env("HOME", &host_home)
+                .env("MOCK_CODEX_READY_DELAY_MS", "11000")
+                .env_remove("HARNESS_APP_GROUP_ID")
+                .env_remove("HARNESS_SANDBOXED"),
+        )
         .expect("run bridge");
 
     assert!(!output.status.success(), "bridge unexpectedly succeeded");

--- a/tests/integration/bridge_codex/reconfigure.rs
+++ b/tests/integration/bridge_codex/reconfigure.rs
@@ -5,11 +5,12 @@ fn bridge_reconfigure_enables_codex_without_restarting_bridge() {
     let tmp = tempdir().expect("tempdir");
     let host_home = ensure_host_home(tmp.path());
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
     let codex_endpoint = format!("ws://127.0.0.1:{codex_port}");
 
-    let mut bridge = ManagedChild::spawn(
+    let mut bridge = ManagedChild::spawn_with_port_lease(
         Command::new(bridge_binary())
             .args([
                 "start",
@@ -29,6 +30,7 @@ fn bridge_reconfigure_enables_codex_without_restarting_bridge() {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped()),
+        codex_port_lease,
     )
     .expect("spawn bridge");
 
@@ -64,10 +66,11 @@ fn bridge_reconfigure_persists_capabilities_across_restart() {
     let tmp = tempdir().expect("tempdir");
     let host_home = ensure_host_home(tmp.path());
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
 
-    let mut bridge = ManagedChild::spawn(
+    let mut bridge = ManagedChild::spawn_with_port_lease(
         Command::new(bridge_binary())
             .args(["start", "--codex-port", &codex_port_text, "--codex-path"])
             .arg(&mock_codex)
@@ -80,6 +83,7 @@ fn bridge_reconfigure_persists_capabilities_across_restart() {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped()),
+        codex_port_lease,
     )
     .expect("spawn bridge");
 

--- a/tests/integration/bridge_codex/support.rs
+++ b/tests/integration/bridge_codex/support.rs
@@ -173,14 +173,6 @@ pub(super) fn ensure_host_home(data_home: &Path) -> PathBuf {
     host_home
 }
 
-pub(super) fn unused_local_port() -> u16 {
-    TcpListener::bind(("127.0.0.1", 0))
-        .expect("bind local port")
-        .local_addr()
-        .expect("read local addr")
-        .port()
-}
-
 pub(super) fn bridge_binary() -> PathBuf {
     assert_cmd::cargo::cargo_bin("harness-bridge")
 }

--- a/tests/integration/bridge_discovery.rs
+++ b/tests/integration/bridge_discovery.rs
@@ -15,7 +15,6 @@
 
 #![cfg(target_os = "macos")]
 
-use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::thread;
@@ -25,7 +24,7 @@ use fs2::FileExt;
 use harness::daemon::bridge::BridgeState;
 use tempfile::tempdir;
 
-use super::helpers::ManagedChild;
+use super::helpers::{ManagedChild, TcpPortLease};
 
 const BRIDGE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 const BRIDGE_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -46,10 +45,10 @@ fn bridge_start_adopts_group_container_when_xdg_is_empty() {
     let lock_file = hold_running_daemon_lock(&group_daemon_root);
 
     let mock_codex = create_mock_codex(home);
-    let codex_port = unused_local_port();
-    let codex_port_text = codex_port.to_string();
+    let codex_port = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port_text = codex_port.port().to_string();
 
-    let mut bridge = ManagedChild::spawn(
+    let mut bridge = ManagedChild::spawn_with_port_lease(
         Command::new(bridge_binary())
             .args([
                 "start",
@@ -70,6 +69,7 @@ fn bridge_start_adopts_group_container_when_xdg_is_empty() {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped()),
+        codex_port,
     )
     .expect("spawn bridge");
 
@@ -128,8 +128,8 @@ fn bridge_start_personal_profile_adopts_group_container_when_profile_root_is_emp
     let lock_file = hold_running_daemon_lock(&group_daemon_root);
 
     let mock_codex = create_mock_codex(home);
-    let codex_port = unused_local_port();
-    let codex_port_text = codex_port.to_string();
+    let codex_port = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port_text = codex_port.port().to_string();
 
     let mut command = Command::new(bridge_binary());
     command
@@ -153,7 +153,8 @@ fn bridge_start_personal_profile_adopts_group_container_when_profile_root_is_emp
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let mut bridge = ManagedChild::spawn(&mut command).expect("spawn bridge");
+    let mut bridge =
+        ManagedChild::spawn_with_port_lease(&mut command, codex_port).expect("spawn bridge");
 
     let adopted_state_path = group_daemon_root.join("bridge.json");
     let profile_state_path = profile_data_home
@@ -192,8 +193,8 @@ fn bridge_start_personal_profile_keeps_profile_root_when_no_running_daemon_exist
     std::fs::create_dir_all(&profile_data_home).expect("create profile data home");
 
     let mock_codex = create_mock_codex(home);
-    let codex_port = unused_local_port();
-    let codex_port_text = codex_port.to_string();
+    let codex_port = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port_text = codex_port.port().to_string();
 
     let mut command = Command::new(bridge_binary());
     command
@@ -217,7 +218,8 @@ fn bridge_start_personal_profile_keeps_profile_root_when_no_running_daemon_exist
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let mut bridge = ManagedChild::spawn(&mut command).expect("spawn bridge");
+    let mut bridge =
+        ManagedChild::spawn_with_port_lease(&mut command, codex_port).expect("spawn bridge");
 
     let profile_state_path = profile_data_home
         .join("harness")
@@ -257,8 +259,8 @@ fn bridge_start_agent_profile_keeps_profile_root_when_group_daemon_is_running() 
     let lock_file = hold_running_daemon_lock(&group_daemon_root);
 
     let mock_codex = create_mock_codex(home);
-    let codex_port = unused_local_port();
-    let codex_port_text = codex_port.to_string();
+    let codex_port = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port_text = codex_port.port().to_string();
 
     let mut command = Command::new(bridge_binary());
     command
@@ -282,7 +284,8 @@ fn bridge_start_agent_profile_keeps_profile_root_when_group_daemon_is_running() 
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let mut bridge = ManagedChild::spawn(&mut command).expect("spawn bridge");
+    let mut bridge =
+        ManagedChild::spawn_with_port_lease(&mut command, codex_port).expect("spawn bridge");
 
     let profile_state_path = profile_data_home
         .join("harness")
@@ -465,14 +468,6 @@ fn run_bridge_with_profile(
 
 fn bridge_binary() -> PathBuf {
     assert_cmd::cargo::cargo_bin("harness-bridge")
-}
-
-fn unused_local_port() -> u16 {
-    TcpListener::bind(("127.0.0.1", 0))
-        .expect("bind local port")
-        .local_addr()
-        .expect("read local addr")
-        .port()
 }
 
 fn wait_for_bridge_exit(bridge: &mut ManagedChild) -> Result<(), String> {

--- a/tests/integration/commands/record/env_tests.rs
+++ b/tests/integration/commands/record/env_tests.rs
@@ -1,23 +1,77 @@
-use std::sync::PoisonError;
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn run_records_kubectl_with_active_run_kubeconfig() {
+    super::env_kubectl_tests::check_run_records_kubectl_with_active_run_kubeconfig();
+}
 
 #[test]
 #[ignore = "slow: spawns fake toolchain processes"]
-fn env_dependent_tests() {
-    let _lock = super::super::super::helpers::ENV_LOCK
-        .lock()
-        .unwrap_or_else(PoisonError::into_inner);
-
-    super::env_kubectl_tests::check_run_records_kubectl_with_active_run_kubeconfig();
+fn record_rewrites_kubectl_to_tracked_kubeconfig() {
     super::env_kubectl_tests::check_record_rewrites_kubectl_to_tracked_kubeconfig();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn record_rejects_kubectl_target_override() {
     super::env_kubectl_tests::check_record_rejects_kubectl_target_override();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn record_rejects_kubectl_without_tracked_cluster() {
     super::env_kubectl_tests::check_record_rejects_kubectl_without_tracked_cluster();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn record_kubectl_without_tracked_kubeconfig_fails_closed() {
     super::env_kubectl_tests::check_record_kubectl_without_tracked_kubeconfig_fails_closed();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn kumactl_build_runs_make_and_prints_binary() {
     super::env_kubectl_tests::check_kumactl_build_runs_make_and_prints_binary();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn bootstrap_command_runs_gateway_api_crd_install() {
     super::env_kubectl_tests::check_bootstrap_command_runs_gateway_api_crd_install();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn capture_uses_current_run_context() {
     super::env_kubectl_tests::check_capture_uses_current_run_context();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn record_isolates_run_context_by_session_id() {
     super::env_create_tests::check_record_isolates_run_context_by_session_id();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn create_begin_persists_suite_default_repo_root() {
     super::env_create_tests::check_create_begin_persists_suite_default_repo_root();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn create_save_accepts_inline_payload() {
     super::env_create_tests::check_create_save_accepts_inline_payload();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn create_save_accepts_stdin() {
     super::env_create_tests::check_create_save_accepts_stdin();
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn create_save_rejects_schema_missing_fields() {
     super::env_create_tests::check_create_save_rejects_schema_missing_fields();
 }

--- a/tests/integration/compact/lifecycle_tests.rs
+++ b/tests/integration/compact/lifecycle_tests.rs
@@ -1,0 +1,137 @@
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn build_compact_worktree_project() {
+    super::with_compact_env(
+        "compact-worktree-project",
+        super::check_build_compact_worktree_project,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn build_compact_includes_create() {
+    super::with_compact_env(
+        "compact-includes-create",
+        super::check_build_compact_includes_create,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn build_compact_create_fallback() {
+    super::with_compact_env(
+        "compact-create-fallback",
+        super::check_build_compact_create_fallback,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn save_consume_compact_handoff() {
+    super::with_compact_env(
+        "compact-save-consume",
+        super::check_save_consume_compact_handoff,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn pre_compact_persists() {
+    super::with_compact_env("compact-pre-compact", super::check_pre_compact_persists);
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_compact_hydrates() {
+    super::with_compact_env(
+        "compact-start-hydrates",
+        super::check_session_start_compact_hydrates,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_compact_worktree() {
+    super::with_compact_env(
+        "compact-start-worktree",
+        super::check_session_start_compact_worktree,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_compact_aborted_resume() {
+    super::with_compact_env(
+        "compact-aborted-resume",
+        super::check_session_start_compact_aborted_resume,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_compact_restores_create() {
+    super::with_compact_env(
+        "compact-restores-create",
+        super::check_session_start_compact_restores_create,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_compact_divergence_warning() {
+    super::with_compact_env(
+        "compact-divergence-warning",
+        super::check_session_start_compact_divergence_warning,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_restores_project() {
+    super::with_compact_env(
+        "compact-restores-project",
+        super::check_session_start_restores_project,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_restores_worktree() {
+    super::with_compact_env(
+        "compact-restores-worktree",
+        super::check_session_start_restores_worktree,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_cross_project() {
+    super::with_compact_env(
+        "compact-cross-project",
+        super::check_session_start_cross_project,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_without_pending_handoff() {
+    super::with_compact_env(
+        "compact-without-pending",
+        super::check_session_start_without_pending_handoff,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_stop_without_pointer() {
+    super::with_compact_env(
+        "compact-stop-without-pointer",
+        super::check_session_stop_without_pointer,
+    );
+}
+
+#[test]
+#[ignore = "slow: spawns fake toolchain processes"]
+fn session_start_no_replay() {
+    super::with_compact_env("compact-no-replay", super::check_session_start_no_replay);
+}

--- a/tests/integration/compact/mod.rs
+++ b/tests/integration/compact/mod.rs
@@ -1,14 +1,12 @@
 // Compact/fingerprint integration tests.
 // Tests compact handoff lifecycle (build, save, consume, session start/stop).
 //
-// All env-dependent tests are combined into one #[test] to avoid races
-// from parallel test execution mutating the same env vars (XDG_DATA_HOME,
-// CLAUDE_SESSION_ID, HOME). See workspace tests for the same pattern.
+// Environment-dependent checks run as separate nextest processes so they can
+// execute concurrently without sharing XDG, session, HOME, or PATH state.
 
 use std::env;
 use std::fs;
 use std::path::Path;
-use std::sync::PoisonError;
 
 use harness::setup::{PreCompactArgs, SessionStartArgs, SessionStopArgs};
 use harness::workspace::compact::{
@@ -18,6 +16,7 @@ use harness::workspace::compact::{
 use super::helpers::*;
 
 mod fingerprints;
+mod lifecycle_tests;
 
 // Build a runner handoff for testing.
 fn test_runner() -> RunnerHandoff<'static> {
@@ -70,7 +69,6 @@ fn setup_env() -> (tempfile::TempDir, tempfile::TempDir) {
 }
 
 fn with_compact_env(session_id: &str, test: impl FnOnce(&Path)) {
-    let _lock = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
     let (xdg, project) = setup_env();
     let orig_path = env::var("PATH").unwrap_or_default();
     let path_with_bin = format!("{}:{orig_path}", xdg.path().join("bin").display());
@@ -90,9 +88,7 @@ fn with_compact_env(session_id: &str, test: impl FnOnce(&Path)) {
 // ============================================================================
 // Compact handoff tests
 //
-// All env-dependent tests live in one function to prevent env var races.
-// Each logical test is a standalone helper called sequentially inside a
-// single with_env_vars scope.
+// Each logical lifecycle check gets its own isolated nextest process.
 // ============================================================================
 
 // build_compact_handoff returns runner: None by default.
@@ -458,28 +454,4 @@ fn compact_runner_handoff_roundtrip_smoke() {
         "compact-runner-roundtrip",
         check_build_compact_includes_runner,
     );
-}
-
-#[test]
-#[ignore = "slow: spawns fake toolchain processes"]
-fn compact_handoff_lifecycle() {
-    with_compact_env("compact-lifecycle", |project| {
-        check_build_compact_includes_runner(project);
-        check_build_compact_worktree_project(project);
-        check_build_compact_includes_create(project);
-        check_build_compact_create_fallback(project);
-        check_save_consume_compact_handoff(project);
-        check_pre_compact_persists(project);
-        check_session_start_compact_hydrates(project);
-        check_session_start_compact_worktree(project);
-        check_session_start_compact_aborted_resume(project);
-        check_session_start_compact_restores_create(project);
-        check_session_start_compact_divergence_warning(project);
-        check_session_start_restores_project(project);
-        check_session_start_restores_worktree(project);
-        check_session_start_cross_project(project);
-        check_session_start_without_pending_handoff(project);
-        check_session_stop_without_pointer(project);
-        check_session_start_no_replay(project);
-    });
 }

--- a/tests/integration/daemon_comparison.rs
+++ b/tests/integration/daemon_comparison.rs
@@ -8,6 +8,9 @@ use harness::session::types::{SessionRole, TaskSeverity};
 use harness::workspace::utc_now;
 use harness_testkit::{init_git_repo_with_seed, with_isolated_harness_env};
 
+const SESSION_A: &str = "50000000-0000-4000-8000-000000000001";
+const SESSION_B: &str = "50000000-0000-4000-8000-000000000002";
+
 /// Seed two projects with sessions, agents, tasks, and a daemon manifest.
 fn seed_workspace(tmp: &std::path::Path) {
     state::ensure_daemon_dirs().expect("dirs");
@@ -34,10 +37,20 @@ fn seed_workspace(tmp: &std::path::Path) {
         init_git_repo_with_seed(project);
     }
 
-    let state_a = session_service::start_session("", "comparison-a", &project_a, Some("cmp1"))
-        .expect("start cmp1");
+    session_service::start_session("", "comparison-a", &project_a, Some(SESSION_A))
+        .expect("start comparison session A");
+    let state_a = session_service::join_session(
+        SESSION_A,
+        SessionRole::Leader,
+        "claude",
+        &[],
+        None,
+        &project_a,
+        None,
+    )
+    .expect("join comparison leader A");
     session_service::join_session(
-        "cmp1",
+        SESSION_A,
         SessionRole::Worker,
         "codex",
         &[],
@@ -45,20 +58,26 @@ fn seed_workspace(tmp: &std::path::Path) {
         &project_a,
         None,
     )
-    .expect("join cmp1");
+    .expect("join comparison session A");
 
-    let state_b = session_service::start_session("", "comparison-b", &project_b, Some("cmp2"))
-        .expect("start cmp2");
+    session_service::start_session("", "comparison-b", &project_b, Some(SESSION_B))
+        .expect("start comparison session B");
+    let state_b = session_service::join_session(
+        SESSION_B,
+        SessionRole::Leader,
+        "claude",
+        &[],
+        None,
+        &project_b,
+        None,
+    )
+    .expect("join comparison leader B");
 
     for (session_id, project_dir, session_state) in [
-        ("cmp1", project_a.as_path(), &state_a),
-        ("cmp2", project_b.as_path(), &state_b),
+        (SESSION_A, project_a.as_path(), &state_a),
+        (SESSION_B, project_b.as_path(), &state_b),
     ] {
-        let leader = session_state
-            .agents
-            .keys()
-            .find(|id| id.starts_with("claude"))
-            .expect("leader agent");
+        let leader = session_state.leader_id.as_deref().expect("leader agent");
         for i in 0..2 {
             session_service::create_task(
                 session_id,
@@ -155,8 +174,8 @@ fn file_and_db_reads_produce_identical_output() {
         );
 
         // --- session_detail ---
-        let file_detail = service::session_detail("cmp1", None).expect("file detail");
-        let db_detail = service::session_detail("cmp1", Some(&db)).expect("db detail");
+        let file_detail = service::session_detail(SESSION_A, None).expect("file detail");
+        let db_detail = service::session_detail(SESSION_A, Some(&db)).expect("db detail");
         let file_json = to_normalized_json(&file_detail);
         let db_json = to_normalized_json(&db_detail);
         // Compare key fields (full JSON may differ in ordering of
@@ -175,8 +194,8 @@ fn file_and_db_reads_produce_identical_output() {
         );
 
         // --- session_timeline ---
-        let file_timeline = service::session_timeline("cmp1", None).expect("file timeline");
-        let db_timeline = service::session_timeline("cmp1", Some(&db)).expect("db timeline");
+        let file_timeline = service::session_timeline(SESSION_A, None).expect("file timeline");
+        let db_timeline = service::session_timeline(SESSION_A, Some(&db)).expect("db timeline");
         assert_eq!(
             file_timeline.len(),
             db_timeline.len(),

--- a/tests/integration/daemon_control.rs
+++ b/tests/integration/daemon_control.rs
@@ -1,4 +1,3 @@
-use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::thread;
@@ -16,7 +15,7 @@ use serde_json::{Value, json};
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
 
-use super::helpers::{ManagedChild, test_session_uuid};
+use super::helpers::{ManagedChild, TcpPortLease, test_session_uuid};
 
 mod bridge;
 mod daemon_api;

--- a/tests/integration/daemon_control/bridge.rs
+++ b/tests/integration/daemon_control/bridge.rs
@@ -63,11 +63,12 @@ fn sandboxed_codex_run_succeeds_immediately_after_bridge_start_with_codex() {
     init_git_repo(&project);
 
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
     let mut daemon = spawn_daemon_serve_with_args(&home, &xdg, &["--sandboxed"]);
     let _initial_status = wait_for_daemon_ready(&home, &xdg);
-    let mut bridge = spawn_bridge(
+    let mut bridge = spawn_bridge_with_port_lease(
         &home,
         &xdg,
         &[
@@ -78,6 +79,7 @@ fn sandboxed_codex_run_succeeds_immediately_after_bridge_start_with_codex() {
             "--codex-path",
             mock_codex.to_str().expect("utf8 codex path"),
         ],
+        codex_port_lease,
     );
     let _bridge_status = wait_for_bridge_capabilities(&home, &xdg, &["codex"]);
     let _daemon_ready = wait_for_daemon_ready(&home, &xdg);
@@ -139,11 +141,12 @@ fn sandboxed_agent_tui_start_returns_501_when_bridge_excludes_agent_tui() {
     init_git_repo(&project);
 
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
     let mut daemon = spawn_daemon_serve_with_args(&home, &xdg, &["--sandboxed"]);
     let _initial_status = wait_for_daemon_ready(&home, &xdg);
-    let mut bridge = spawn_bridge(
+    let mut bridge = spawn_bridge_with_port_lease(
         &home,
         &xdg,
         &[
@@ -154,6 +157,7 @@ fn sandboxed_agent_tui_start_returns_501_when_bridge_excludes_agent_tui() {
             "--codex-path",
             mock_codex.to_str().expect("utf8 codex path"),
         ],
+        codex_port_lease,
     );
     let _bridge_status = wait_for_bridge_capabilities(&home, &xdg, &["codex"]);
     let _daemon_ready = wait_for_daemon_ready(&home, &xdg);
@@ -212,11 +216,12 @@ fn sandboxed_agent_tui_start_succeeds_after_http_bridge_reconfigure_enable() {
     init_git_repo(&project);
 
     let mock_codex = create_mock_codex(tmp.path());
-    let codex_port = unused_local_port();
+    let codex_port_lease = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port = codex_port_lease.port();
     let codex_port_text = codex_port.to_string();
     let mut daemon = spawn_daemon_serve_with_args(&home, &xdg, &["--sandboxed"]);
     let _initial_status = wait_for_daemon_ready(&home, &xdg);
-    let mut bridge = spawn_bridge(
+    let mut bridge = spawn_bridge_with_port_lease(
         &home,
         &xdg,
         &[
@@ -227,6 +232,7 @@ fn sandboxed_agent_tui_start_succeeds_after_http_bridge_reconfigure_enable() {
             "--codex-path",
             mock_codex.to_str().expect("utf8 codex path"),
         ],
+        codex_port_lease,
     );
     let _bridge_status = wait_for_bridge_capabilities(&home, &xdg, &["codex"]);
     let _daemon_ready = wait_for_daemon_ready(&home, &xdg);
@@ -336,47 +342,61 @@ fn sandboxed_bridge_reconfigure_disable_agent_tui_requires_force_over_http() {
     );
     assert_eq!(start_status, 200, "unexpected body: {start_body}");
 
-    let (reconfigure_status, reconfigure_body) = post_json(
-        &endpoint,
-        &token,
-        "/v1/bridge/reconfigure",
-        json!({
-            "disable": ["agent-tui"],
-        }),
-    );
-    assert_eq!(
-        reconfigure_status, 409,
-        "unexpected body: {reconfigure_body}"
-    );
-    assert_eq!(reconfigure_body["error"]["code"], "KSRCLI092");
+    assert_disable_without_force_conflicts(&endpoint, &token);
+    force_disable_agent_tui(&endpoint, &token);
+    let _bridge_status = wait_for_bridge_capabilities(&home, &xdg, &[]);
+    let _daemon_ready = wait_for_daemon_ready(&home, &xdg);
+
+    assert_agent_tui_restart_disabled(&endpoint, &token, &session.session_id);
+
+    let bridge_stop_output = run_harness(&home, &xdg, &["bridge", "stop"]);
     assert!(
-        reconfigure_body["error"]["message"]
+        bridge_stop_output.status.success(),
+        "bridge stop failed: {}",
+        output_text(&bridge_stop_output)
+    );
+    wait_for_child_exit(&mut bridge);
+
+    daemon.kill().expect("kill daemon");
+    wait_for_child_exit(&mut daemon);
+}
+
+fn assert_disable_without_force_conflicts(endpoint: &str, token: &str) {
+    let (status, body) = post_json(
+        endpoint,
+        token,
+        "/v1/bridge/reconfigure",
+        json!({ "disable": ["agent-tui"] }),
+    );
+    assert_eq!(status, 409, "unexpected body: {body}");
+    assert_eq!(body["error"]["code"], "KSRCLI092");
+    assert!(
+        body["error"]["message"]
             .as_str()
             .is_some_and(|message| message.contains("--force")),
-        "unexpected body: {reconfigure_body}"
+        "unexpected body: {body}"
     );
+}
 
-    let (forced_status, forced_body) = post_json(
-        &endpoint,
-        &token,
+fn force_disable_agent_tui(endpoint: &str, token: &str) {
+    let (status, body) = post_json(
+        endpoint,
+        token,
         "/v1/bridge/reconfigure",
         json!({
             "disable": ["agent-tui"],
             "force": true,
         }),
     );
-    assert_eq!(forced_status, 200, "unexpected body: {forced_body}");
-    assert!(forced_body["capabilities"]["agent-tui"].is_null());
-    let _bridge_status = wait_for_bridge_capabilities(&home, &xdg, &[]);
-    let _daemon_ready = wait_for_daemon_ready(&home, &xdg);
+    assert_eq!(status, 200, "unexpected body: {body}");
+    assert!(body["capabilities"]["agent-tui"].is_null());
+}
 
+fn assert_agent_tui_restart_disabled(endpoint: &str, token: &str, session_id: &str) {
     let (restart_status, restart_body) = post_json(
-        &endpoint,
-        &token,
-        &format!(
-            "/v1/sessions/{}/managed-agents/terminal",
-            session.session_id
-        ),
+        endpoint,
+        token,
+        &format!("/v1/sessions/{session_id}/managed-agents/terminal"),
         json!({
             "runtime": "codex",
             "name": "Excluded again",
@@ -389,15 +409,4 @@ fn sandboxed_bridge_reconfigure_disable_agent_tui_requires_force_over_http() {
     assert_eq!(restart_status, 501, "unexpected body: {restart_body}");
     assert_eq!(restart_body["error"], "sandbox-disabled");
     assert_eq!(restart_body["feature"], "agent-tui.host-bridge");
-
-    let bridge_stop_output = run_harness(&home, &xdg, &["bridge", "stop"]);
-    assert!(
-        bridge_stop_output.status.success(),
-        "bridge stop failed: {}",
-        output_text(&bridge_stop_output)
-    );
-    wait_for_child_exit(&mut bridge);
-
-    daemon.kill().expect("kill daemon");
-    wait_for_child_exit(&mut daemon);
 }

--- a/tests/integration/daemon_control/daemon_api.rs
+++ b/tests/integration/daemon_control/daemon_api.rs
@@ -1,19 +1,21 @@
 use super::*;
 
 pub(super) fn wait_for_daemon_ready(home: &Path, xdg: &Path) -> DaemonStatusReport {
+    let manifest_path = isolated_daemon_manifest_path(xdg);
     let deadline = Instant::now() + DAEMON_WAIT_TIMEOUT;
     loop {
-        let retry_reason = match try_daemon_status(home, xdg) {
-            Ok(status) => {
-                if let Some(manifest) = status.manifest.as_ref() {
-                    match readiness_issue(&manifest.endpoint, &manifest.token_path) {
-                        None => return status,
-                        Some(issue) => issue,
-                    }
-                } else {
-                    "daemon status did not report a manifest yet".to_string()
-                }
-            }
+        let retry_reason = match read_manifest_value(&manifest_path) {
+            Ok(manifest) => match manifest_endpoint_and_token_path(&manifest) {
+                Ok((endpoint, token_path)) => match readiness_issue(endpoint, token_path) {
+                    None => match try_daemon_status(home, xdg) {
+                        Ok(status) if status.manifest.is_some() => return status,
+                        Ok(_) => "daemon status did not report a manifest".to_string(),
+                        Err(error) => error,
+                    },
+                    Some(issue) => issue,
+                },
+                Err(error) => error,
+            },
             Err(error) => error,
         };
         assert!(
@@ -29,10 +31,8 @@ pub(super) fn wait_for_app_group_daemon_ready(home: &Path) -> Value {
     let manifest_path = root.join("manifest.json");
     let deadline = Instant::now() + DAEMON_WAIT_TIMEOUT;
     loop {
-        if let Ok(data) = std::fs::read_to_string(&manifest_path)
-            && let Ok(manifest) = serde_json::from_str::<Value>(&data)
-            && let Some(endpoint) = manifest.get("endpoint").and_then(Value::as_str)
-            && let Some(token_path) = manifest.get("token_path").and_then(Value::as_str)
+        if let Ok(manifest) = read_manifest_value(&manifest_path)
+            && let Ok((endpoint, token_path)) = manifest_endpoint_and_token_path(&manifest)
             && endpoint_is_healthy(endpoint, token_path)
         {
             return manifest;
@@ -46,21 +46,17 @@ pub(super) fn wait_for_app_group_daemon_ready(home: &Path) -> Value {
     }
 }
 
-pub(super) fn wait_for_daemon_stopped(home: &Path, xdg: &Path) {
+pub(super) fn wait_for_daemon_stopped(_home: &Path, xdg: &Path) {
+    let manifest_path = isolated_daemon_manifest_path(xdg);
     let deadline = Instant::now() + DAEMON_WAIT_TIMEOUT;
     loop {
-        let retry_reason = match try_daemon_status(home, xdg) {
-            Ok(status) => {
-                if status.manifest.is_none() {
-                    return;
-                }
-                "daemon status still reports a manifest".to_string()
-            }
-            Err(error) => error,
-        };
+        if !manifest_path.exists() {
+            return;
+        }
         assert!(
             Instant::now() < deadline,
-            "daemon did not stop before timeout: {retry_reason}"
+            "daemon did not remove its manifest before timeout at {}",
+            manifest_path.display()
         );
         thread::sleep(DAEMON_WAIT_INTERVAL);
     }
@@ -71,9 +67,31 @@ pub(super) fn wait_for_bridge_capabilities(
     xdg: &Path,
     required_capabilities: &[&str],
 ) -> BridgeStatusReport {
+    wait_for_bridge_capabilities_at_root(home, xdg, required_capabilities, None)
+}
+
+pub(super) fn wait_for_app_group_bridge_capabilities(
+    home: &Path,
+    xdg: &Path,
+    required_capabilities: &[&str],
+    app_group_id: &str,
+) -> BridgeStatusReport {
+    wait_for_bridge_capabilities_at_root(home, xdg, required_capabilities, Some(app_group_id))
+}
+
+fn wait_for_bridge_capabilities_at_root(
+    home: &Path,
+    xdg: &Path,
+    required_capabilities: &[&str],
+    app_group_id: Option<&str>,
+) -> BridgeStatusReport {
     let deadline = Instant::now() + DAEMON_WAIT_TIMEOUT;
     loop {
-        let output = run_harness(home, xdg, &["bridge", "status"]);
+        let output = if let Some(app_group_id) = app_group_id {
+            run_harness_in_app_group(home, xdg, &["bridge", "status"], app_group_id)
+        } else {
+            run_harness(home, xdg, &["bridge", "status"])
+        };
         if output.status.success() {
             let report: BridgeStatusReport =
                 serde_json::from_slice(&output.stdout).expect("parse bridge status");
@@ -334,16 +352,14 @@ pub(super) fn join_session_leader_via_http(
         .state
 }
 
-pub(super) fn current_daemon_endpoint_and_token(home: &Path, xdg: &Path) -> (String, String) {
+pub(super) fn current_daemon_endpoint_and_token(_home: &Path, xdg: &Path) -> (String, String) {
+    let manifest_path = isolated_daemon_manifest_path(xdg);
     let deadline = Instant::now() + DAEMON_WAIT_TIMEOUT;
     loop {
-        if let Ok(status) = try_daemon_status(home, xdg)
-            && let Some(manifest) = status.manifest.as_ref()
+        if let Ok(manifest) = read_manifest_value(&manifest_path)
+            && let Ok((endpoint, token_path)) = manifest_endpoint_and_token_path(&manifest)
         {
-            return (
-                manifest.endpoint.clone(),
-                read_daemon_token(&manifest.token_path),
-            );
+            return (endpoint.to_string(), read_daemon_token(token_path));
         }
 
         assert!(
@@ -352,6 +368,32 @@ pub(super) fn current_daemon_endpoint_and_token(home: &Path, xdg: &Path) -> (Str
         );
         thread::sleep(DAEMON_WAIT_INTERVAL);
     }
+}
+
+fn isolated_daemon_manifest_path(xdg: &Path) -> PathBuf {
+    xdg.join("harness")
+        .join("daemon")
+        .join("managed")
+        .join("manifest.json")
+}
+
+fn read_manifest_value(path: &Path) -> Result<Value, String> {
+    let data = std::fs::read_to_string(path)
+        .map_err(|error| format!("read daemon manifest {}: {error}", path.display()))?;
+    serde_json::from_str(&data)
+        .map_err(|error| format!("parse daemon manifest {}: {error}", path.display()))
+}
+
+fn manifest_endpoint_and_token_path(manifest: &Value) -> Result<(&str, &str), String> {
+    let endpoint = manifest
+        .get("endpoint")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "daemon manifest has no endpoint".to_string())?;
+    let token_path = manifest
+        .get("token_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "daemon manifest has no token path".to_string())?;
+    Ok((endpoint, token_path))
 }
 
 fn read_session_status(

--- a/tests/integration/daemon_control/lifecycle.rs
+++ b/tests/integration/daemon_control/lifecycle.rs
@@ -24,6 +24,63 @@ fn daemon_stop_stops_running_manual_daemon() {
 }
 
 #[test]
+fn parallel_manual_daemons_keep_migration_databases_isolated() {
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path().join("home");
+    let xdg_a = tmp.path().join("xdg-a");
+    let xdg_b = tmp.path().join("xdg-b");
+    let poisoned_shared_root = tmp.path().join("shared-daemon-root");
+    for path in [&home, &xdg_a, &xdg_b, &poisoned_shared_root] {
+        std::fs::create_dir_all(path).expect("create test directory");
+    }
+
+    let mut command_a = Command::new(daemon_binary());
+    command_a
+        .env("HARNESS_DAEMON_DATA_HOME", &poisoned_shared_root)
+        .env("HARNESS_APP_GROUP_ID", "test.shared");
+    configure_daemon_serve_command(&mut command_a, &home, &xdg_a, &[]);
+    let mut command_b = Command::new(daemon_binary());
+    command_b
+        .env("HARNESS_DAEMON_DATA_HOME", &poisoned_shared_root)
+        .env("HARNESS_APP_GROUP_ID", "test.shared");
+    configure_daemon_serve_command(&mut command_b, &home, &xdg_b, &[]);
+
+    let mut daemon_a = ManagedChild::spawn(&mut command_a).expect("spawn daemon A");
+    let mut daemon_b = ManagedChild::spawn(&mut command_b).expect("spawn daemon B");
+    let status_a = wait_for_daemon_ready(&home, &xdg_a);
+    let status_b = wait_for_daemon_ready(&home, &xdg_b);
+    assert_eq!(
+        status_a.manifest.expect("daemon A manifest").pid,
+        daemon_a.id()
+    );
+    assert_eq!(
+        status_b.manifest.expect("daemon B manifest").pid,
+        daemon_b.id()
+    );
+
+    let db_a = xdg_a.join("harness/daemon/managed/harness.db");
+    let db_b = xdg_b.join("harness/daemon/managed/harness.db");
+    assert!(db_a.is_file(), "daemon A database missing");
+    assert!(db_b.is_file(), "daemon B database missing");
+    assert!(
+        !poisoned_shared_root
+            .join("harness/daemon/managed/harness.db")
+            .exists()
+    );
+
+    for xdg in [&xdg_a, &xdg_b] {
+        let output = run_harness(&home, xdg, &["daemon", "stop"]);
+        assert!(
+            output.status.success(),
+            "daemon stop failed: {}",
+            output_text(&output)
+        );
+    }
+    wait_for_child_exit(&mut daemon_a);
+    wait_for_child_exit(&mut daemon_b);
+}
+
+#[test]
 fn daemon_restart_starts_manual_daemon_when_offline() {
     let tmp = tempdir().expect("tempdir");
     let home = tmp.path().join("home");

--- a/tests/integration/daemon_control/process.rs
+++ b/tests/integration/daemon_control/process.rs
@@ -12,43 +12,101 @@ pub(super) fn spawn_daemon_serve(home: &Path, xdg: &Path) -> ManagedChild {
     spawn_daemon_serve_with_args(home, xdg, &[])
 }
 
+pub(super) fn configure_daemon_serve_command(
+    command: &mut Command,
+    home: &Path,
+    xdg: &Path,
+    extra_args: &[&str],
+) {
+    let mut args = vec!["serve", "--host", "127.0.0.1", "--port", "0"];
+    args.extend(extra_args);
+    command
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(diagnostic_child_stdio())
+        .stderr(diagnostic_child_stdio());
+    configure_isolated_daemon_env(command, home, xdg);
+}
+
 pub(super) fn spawn_daemon_serve_with_args(
     home: &Path,
     xdg: &Path,
     extra_args: &[&str],
 ) -> ManagedChild {
-    let mut args = vec!["serve", "--host", "127.0.0.1", "--port", "0"];
-    args.extend(extra_args);
-    ManagedChild::spawn(
-        Command::new(daemon_binary())
-            .args(&args)
-            .env("HARNESS_HOST_HOME", home)
-            .env("HOME", home)
-            .env("HARNESS_HOST_HOME", home)
-            .env("XDG_DATA_HOME", xdg)
-            .stdin(Stdio::null())
-            .stdout(diagnostic_child_stdio())
-            .stderr(diagnostic_child_stdio()),
-    )
-    .expect("spawn daemon serve")
+    let mut command = Command::new(daemon_binary());
+    configure_daemon_serve_command(&mut command, home, xdg, extra_args);
+    ManagedChild::spawn(&mut command).expect("spawn daemon serve")
+}
+
+pub(super) fn configure_isolated_daemon_env(command: &mut Command, home: &Path, xdg: &Path) {
+    configure_common_daemon_env(command, home, xdg);
+    command
+        .env("HARNESS_DAEMON_DATA_HOME", xdg)
+        .env_remove("HARNESS_APP_GROUP_ID");
+}
+
+pub(super) fn configure_app_group_daemon_env(
+    command: &mut Command,
+    home: &Path,
+    xdg: &Path,
+    app_group_id: &str,
+) {
+    configure_common_daemon_env(command, home, xdg);
+    command
+        .env_remove("HARNESS_DAEMON_DATA_HOME")
+        .env("HARNESS_APP_GROUP_ID", app_group_id);
+}
+
+fn configure_common_daemon_env(command: &mut Command, home: &Path, xdg: &Path) {
+    command
+        .env("HARNESS_HOST_HOME", home)
+        .env("HOME", home)
+        .env("XDG_DATA_HOME", xdg)
+        .env_remove("HARNESS_DAEMON_OWNERSHIP")
+        .env_remove("HARNESS_SANDBOXED")
+        .env_remove("CLAUDE_SESSION_ID");
 }
 
 pub(super) fn spawn_bridge(home: &Path, xdg: &Path, extra_args: &[&str]) -> ManagedChild {
+    spawn_bridge_inner(home, xdg, extra_args, None, None)
+}
+
+pub(super) fn spawn_bridge_with_port_lease(
+    home: &Path,
+    xdg: &Path,
+    extra_args: &[&str],
+    port_lease: TcpPortLease,
+) -> ManagedChild {
+    spawn_bridge_inner(home, xdg, extra_args, Some(&port_lease), None)
+}
+
+fn spawn_bridge_inner(
+    home: &Path,
+    xdg: &Path,
+    extra_args: &[&str],
+    port_lease: Option<&TcpPortLease>,
+    app_group_id: Option<&str>,
+) -> ManagedChild {
     let deadline = Instant::now() + DAEMON_WAIT_TIMEOUT;
     loop {
         let mut args = vec!["start"];
         args.extend(extra_args);
-        let mut child = ManagedChild::spawn(
-            Command::new(bridge_binary())
-                .args(&args)
-                .env("HARNESS_HOST_HOME", home)
-                .env("HOME", home)
-                .env("HARNESS_HOST_HOME", home)
-                .env("XDG_DATA_HOME", xdg)
-                .stdin(Stdio::null())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped()),
-        )
+        let mut command = Command::new(bridge_binary());
+        command
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(app_group_id) = app_group_id {
+            configure_app_group_daemon_env(&mut command, home, xdg, app_group_id);
+        } else {
+            configure_isolated_daemon_env(&mut command, home, xdg);
+        }
+        let mut child = if let Some(port_lease) = port_lease {
+            ManagedChild::spawn_with_port_lease(&mut command, port_lease.clone())
+        } else {
+            ManagedChild::spawn(&mut command)
+        }
         .expect("spawn agent tui bridge");
 
         let startup_deadline = Instant::now() + Duration::from_secs(1);
@@ -78,8 +136,38 @@ pub(super) fn spawn_bridge_with_mock_codex(
     capability: &str,
     extra_args: &[&str],
 ) -> ManagedChild {
+    spawn_bridge_with_mock_codex_at_root(home, xdg, base, capability, extra_args, None)
+}
+
+pub(super) fn spawn_app_group_bridge_with_mock_codex(
+    home: &Path,
+    xdg: &Path,
+    base: &Path,
+    capability: &str,
+    extra_args: &[&str],
+    app_group_id: &str,
+) -> ManagedChild {
+    spawn_bridge_with_mock_codex_at_root(
+        home,
+        xdg,
+        base,
+        capability,
+        extra_args,
+        Some(app_group_id),
+    )
+}
+
+fn spawn_bridge_with_mock_codex_at_root(
+    home: &Path,
+    xdg: &Path,
+    base: &Path,
+    capability: &str,
+    extra_args: &[&str],
+    app_group_id: Option<&str>,
+) -> ManagedChild {
     let mock_codex = create_mock_codex(base);
-    let codex_port_text = unused_local_port().to_string();
+    let codex_port = TcpPortLease::acquire().expect("reserve codex port");
+    let codex_port_text = codex_port.port().to_string();
     let codex_path = mock_codex.to_str().expect("utf8 codex path");
     let mut args = vec![
         "--capability",
@@ -90,16 +178,22 @@ pub(super) fn spawn_bridge_with_mock_codex(
         codex_path,
     ];
     args.extend(extra_args.iter().copied());
-    spawn_bridge(home, xdg, &args)
+    spawn_bridge_inner(home, xdg, &args, Some(&codex_port), app_group_id)
 }
 
 pub(super) fn run_harness(home: &Path, xdg: &Path, args: &[&str]) -> Output {
-    Command::new(harness_binary())
-        .args(args)
-        .env("HARNESS_HOST_HOME", home)
-        .env("HOME", home)
-        .env("HARNESS_HOST_HOME", home)
-        .env("XDG_DATA_HOME", xdg)
+    harness_command(home, xdg, args, None)
+        .output()
+        .expect("run harness")
+}
+
+pub(super) fn run_harness_in_app_group(
+    home: &Path,
+    xdg: &Path,
+    args: &[&str],
+    app_group_id: &str,
+) -> Output {
+    harness_command(home, xdg, args, Some(app_group_id))
         .output()
         .expect("run harness")
 }
@@ -110,12 +204,27 @@ pub(super) fn run_harness_with_timeout(
     args: &[&str],
     timeout: Duration,
 ) -> Output {
-    let mut child = Command::new(harness_binary())
-        .args(args)
-        .env("HARNESS_HOST_HOME", home)
-        .env("HOME", home)
-        .env("HARNESS_HOST_HOME", home)
-        .env("XDG_DATA_HOME", xdg)
+    run_harness_with_timeout_at_root(home, xdg, args, timeout, None)
+}
+
+pub(super) fn run_harness_in_app_group_with_timeout(
+    home: &Path,
+    xdg: &Path,
+    args: &[&str],
+    timeout: Duration,
+    app_group_id: &str,
+) -> Output {
+    run_harness_with_timeout_at_root(home, xdg, args, timeout, Some(app_group_id))
+}
+
+fn run_harness_with_timeout_at_root(
+    home: &Path,
+    xdg: &Path,
+    args: &[&str],
+    timeout: Duration,
+    app_group_id: Option<&str>,
+) -> Output {
+    let mut child = harness_command(home, xdg, args, app_group_id)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -139,6 +248,17 @@ pub(super) fn run_harness_with_timeout(
     }
 }
 
+fn harness_command(home: &Path, xdg: &Path, args: &[&str], app_group_id: Option<&str>) -> Command {
+    let mut command = Command::new(harness_binary());
+    command.args(args);
+    if let Some(app_group_id) = app_group_id {
+        configure_app_group_daemon_env(&mut command, home, xdg, app_group_id);
+    } else {
+        configure_isolated_daemon_env(&mut command, home, xdg);
+    }
+    command
+}
+
 pub(crate) fn init_git_repo(path: &Path) {
     harness_testkit::init_git_repo_with_seed(path);
 }
@@ -155,14 +275,6 @@ pub(super) fn wait_for_child_exit(child: &mut ManagedChild) {
         );
         thread::sleep(DAEMON_WAIT_INTERVAL);
     }
-}
-
-pub(super) fn unused_local_port() -> u16 {
-    TcpListener::bind(("127.0.0.1", 0))
-        .expect("bind local port")
-        .local_addr()
-        .expect("read local addr")
-        .port()
 }
 
 pub(super) fn harness_binary() -> PathBuf {

--- a/tests/integration/daemon_control/tui.rs
+++ b/tests/integration/daemon_control/tui.rs
@@ -129,22 +129,28 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
     std::fs::create_dir_all(&xdg).expect("create xdg");
     init_git_repo(&project);
 
-    let mut daemon = ManagedChild::spawn(
-        Command::new(daemon_binary())
-            .args(["serve", "--host", "127.0.0.1", "--port", "0", "--sandboxed"])
-            .env("HARNESS_HOST_HOME", &home)
-            .env("HOME", &home)
-            .env("XDG_DATA_HOME", &xdg)
-            .env("HARNESS_APP_GROUP_ID", HARNESS_MONITOR_APP_GROUP_ID)
-            .env("HARNESS_SANDBOXED", "1")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null()),
-    )
-    .expect("spawn app-group daemon");
+    let mut daemon_command = Command::new(daemon_binary());
+    daemon_command
+        .args(["serve", "--host", "127.0.0.1", "--port", "0", "--sandboxed"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    configure_app_group_daemon_env(
+        &mut daemon_command,
+        &home,
+        &xdg,
+        HARNESS_MONITOR_APP_GROUP_ID,
+    );
+    daemon_command.env("HARNESS_SANDBOXED", "1");
+    let mut daemon = ManagedChild::spawn(&mut daemon_command).expect("spawn app-group daemon");
 
     let _manifest = wait_for_app_group_daemon_ready(&home);
-    let status_output = run_harness(&home, &xdg, &["daemon", "status"]);
+    let status_output = run_harness_in_app_group(
+        &home,
+        &xdg,
+        &["daemon", "status"],
+        HARNESS_MONITOR_APP_GROUP_ID,
+    );
     assert!(
         status_output.status.success(),
         "daemon status failed: {}",
@@ -157,8 +163,20 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
         "daemon status should discover the running app-group daemon"
     );
 
-    let mut bridge = spawn_bridge_with_mock_codex(&home, &xdg, tmp.path(), "agent-tui", &[]);
-    let _bridge_status = wait_for_bridge_capabilities(&home, &xdg, &["agent-tui"]);
+    let mut bridge = spawn_app_group_bridge_with_mock_codex(
+        &home,
+        &xdg,
+        tmp.path(),
+        "agent-tui",
+        &[],
+        HARNESS_MONITOR_APP_GROUP_ID,
+    );
+    let _bridge_status = wait_for_app_group_bridge_capabilities(
+        &home,
+        &xdg,
+        &["agent-tui"],
+        HARNESS_MONITOR_APP_GROUP_ID,
+    );
 
     let project_arg = project.to_str().expect("utf8 project");
     let session_id = session_uuid("app-group-cli-tui");
@@ -180,7 +198,7 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
         "unexpected session status: {session_body}"
     );
 
-    let start_output = run_harness_with_timeout(
+    let start_output = run_harness_in_app_group_with_timeout(
         &home,
         &xdg,
         &[
@@ -200,6 +218,7 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
             "--arg=cat",
         ],
         COMMAND_WAIT_TIMEOUT,
+        HARNESS_MONITOR_APP_GROUP_ID,
     );
     assert!(
         start_output.status.success(),
@@ -209,7 +228,7 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
     let started = parse_terminal_agent_output(&start_output.stdout);
     assert_eq!(started.status, AgentTuiStatus::Running);
 
-    let text_output = run_harness(
+    let text_output = run_harness_in_app_group(
         &home,
         &xdg,
         &[
@@ -220,6 +239,7 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
             "--text",
             "bridge ok",
         ],
+        HARNESS_MONITOR_APP_GROUP_ID,
     );
     assert!(
         text_output.status.success(),
@@ -227,7 +247,7 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
         output_text(&text_output)
     );
 
-    let enter_output = run_harness(
+    let enter_output = run_harness_in_app_group(
         &home,
         &xdg,
         &[
@@ -238,6 +258,7 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
             "--key",
             "enter",
         ],
+        HARNESS_MONITOR_APP_GROUP_ID,
     );
     assert!(
         enter_output.status.success(),
@@ -247,10 +268,11 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
     let echoed = parse_terminal_agent_output(&enter_output.stdout);
     assert!(echoed.screen.text.contains("bridge ok"));
 
-    let stop_output = run_harness(
+    let stop_output = run_harness_in_app_group(
         &home,
         &xdg,
         &["session", "agents", "stop", started.tui_id.as_str()],
+        HARNESS_MONITOR_APP_GROUP_ID,
     );
     assert!(
         stop_output.status.success(),
@@ -260,7 +282,12 @@ fn cli_tui_commands_follow_running_app_group_daemon_root() {
     let stopped = parse_terminal_agent_output(&stop_output.stdout);
     assert_eq!(stopped.status, AgentTuiStatus::Stopped);
 
-    let bridge_stop_output = run_harness(&home, &xdg, &["bridge", "stop"]);
+    let bridge_stop_output = run_harness_in_app_group(
+        &home,
+        &xdg,
+        &["bridge", "stop"],
+        HARNESS_MONITOR_APP_GROUP_ID,
+    );
     assert!(
         bridge_stop_output.status.success(),
         "bridge stop failed: {}",
@@ -287,18 +314,15 @@ fn recover_leader_starts_managed_tui_with_policy_preset_prompt() {
     write_mock_codex_tui(&mock_bin);
     let path_env = prefixed_path_env(&mock_bin);
 
-    let mut daemon = ManagedChild::spawn(
-        Command::new(daemon_binary())
-            .args(["serve", "--host", "127.0.0.1", "--port", "0"])
-            .env("HARNESS_HOST_HOME", &home)
-            .env("HOME", &home)
-            .env("XDG_DATA_HOME", &xdg)
-            .env("PATH", &path_env)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null()),
-    )
-    .expect("spawn daemon serve");
+    let mut daemon_command = Command::new(daemon_binary());
+    daemon_command
+        .args(["serve", "--host", "127.0.0.1", "--port", "0"])
+        .env("PATH", &path_env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    configure_isolated_daemon_env(&mut daemon_command, &home, &xdg);
+    let mut daemon = ManagedChild::spawn(&mut daemon_command).expect("spawn daemon serve");
 
     let _daemon_ready = wait_for_daemon_ready(&home, &xdg);
     let project_arg = project.to_str().expect("utf8 project");

--- a/tests/integration/daemon_control/tui_attach.rs
+++ b/tests/integration/daemon_control/tui_attach.rs
@@ -233,6 +233,11 @@ impl AttachedTuiSession {
         command.env("HARNESS_HOST_HOME", home);
         command.env("HOME", home);
         command.env("XDG_DATA_HOME", xdg);
+        command.env("HARNESS_DAEMON_DATA_HOME", xdg);
+        command.env_remove("HARNESS_APP_GROUP_ID");
+        command.env_remove("HARNESS_DAEMON_OWNERSHIP");
+        command.env_remove("HARNESS_SANDBOXED");
+        command.env_remove("CLAUDE_SESSION_ID");
         let child = pair
             .slave
             .spawn_command(command)

--- a/tests/integration/daemon_perf.rs
+++ b/tests/integration/daemon_perf.rs
@@ -22,6 +22,9 @@ use harness::session::types::{SessionRole, TaskSeverity};
 use harness_testkit::{init_git_repo_with_seed, with_isolated_harness_env};
 
 const SAMPLE_COUNT: usize = 10;
+const SESSION_A: &str = "60000000-0000-4000-8000-000000000001";
+const SESSION_B: &str = "60000000-0000-4000-8000-000000000002";
+const STATUS_SESSION: &str = "60000000-0000-4000-8000-000000000003";
 
 fn with_perf_test_env<T>(
     base: &std::path::Path,
@@ -168,10 +171,20 @@ fn seed_workspace(tmp: &std::path::Path) {
         init_git_repo_with_seed(project);
     }
 
-    let state_a =
-        session_service::start_session("", "perf-test", &project_a, Some("s1")).expect("start s1");
+    session_service::start_session("", "perf-test", &project_a, Some(SESSION_A))
+        .expect("start performance session A");
+    let state_a = session_service::join_session(
+        SESSION_A,
+        SessionRole::Leader,
+        "claude",
+        &[],
+        None,
+        &project_a,
+        None,
+    )
+    .expect("join performance leader A");
     session_service::join_session(
-        "s1",
+        SESSION_A,
         SessionRole::Worker,
         "codex",
         &[],
@@ -179,22 +192,28 @@ fn seed_workspace(tmp: &std::path::Path) {
         &project_a,
         None,
     )
-    .expect("join s1");
+    .expect("join performance session A");
 
-    let state_b = session_service::start_session("", "perf-test-2", &project_b, Some("s2"))
-        .expect("start s2");
+    session_service::start_session("", "perf-test-2", &project_b, Some(SESSION_B))
+        .expect("start performance session B");
+    let state_b = session_service::join_session(
+        SESSION_B,
+        SessionRole::Leader,
+        "claude",
+        &[],
+        None,
+        &project_b,
+        None,
+    )
+    .expect("join performance leader B");
 
     let sessions = [
-        ("s1", project_a.as_path(), &state_a),
-        ("s2", project_b.as_path(), &state_b),
+        (SESSION_A, project_a.as_path(), &state_a),
+        (SESSION_B, project_b.as_path(), &state_b),
     ];
 
     for (session_id, project_dir, session_state) in &sessions {
-        let leader = session_state
-            .agents
-            .keys()
-            .find(|id| id.starts_with("claude"))
-            .expect("leader agent");
+        let leader = session_state.leader_id.as_deref().expect("leader agent");
         for i in 0..3 {
             session_service::create_task(
                 session_id,
@@ -225,13 +244,15 @@ async fn daemon_http_endpoint_performance_budgets() {
     let daemon = start_test_daemon(Some(db)).await;
     let client = Client::new();
 
-    let endpoints: Vec<(&str, &str, f64)> = vec![
+    let session_detail_path = format!("/v1/sessions/{SESSION_A}");
+    let timeline_path = format!("/v1/sessions/{SESSION_A}/timeline");
+    let endpoints = [
         ("health", "/v1/health", 5.0),
         ("projects", "/v1/projects", 10.0),
         ("sessions", "/v1/sessions", 10.0),
         ("diagnostics", "/v1/diagnostics", 10.0),
-        ("session_detail", "/v1/sessions/s1", 30.0),
-        ("timeline", "/v1/sessions/s1/timeline", 50.0),
+        ("session_detail", session_detail_path.as_str(), 30.0),
+        ("timeline", timeline_path.as_str(), 50.0),
     ];
 
     let mut results = Vec::new();
@@ -257,7 +278,9 @@ async fn daemon_http_endpoint_performance_budgets() {
     let perf_dir = std::path::Path::new("tmp/perf");
     let _ = fs_err::create_dir_all(perf_dir);
     let json = serde_json::to_string_pretty(&results).expect("serialize results");
-    let _ = fs_err::write(perf_dir.join("daemon-http-perf.json"), &json);
+    let result_path = perf_dir.join(format!("daemon-http-perf-{}.json", std::process::id()));
+    let _ = fs_err::write(&result_path, &json);
+    println!("performance artifact: {}", result_path.display());
 
     for result in &results {
         let status = if result.passed { "PASS" } else { "FAIL" };
@@ -284,7 +307,7 @@ fn daemon_status_report_within_budget() {
         state::ensure_daemon_dirs().expect("dirs");
         let project = tmp.path().join("project");
         init_git_repo_with_seed(&project);
-        session_service::start_session("", "status-perf", &project, Some("sp1"))
+        session_service::start_session("", "status-perf", &project, Some(STATUS_SESSION))
             .expect("start session");
     });
 

--- a/tests/integration/helpers.rs
+++ b/tests/integration/helpers.rs
@@ -22,12 +22,14 @@ use harness::setup::{
 use sha2::{Digest, Sha256};
 
 mod hook;
+mod port_lease;
 mod run;
 
 // Keep lightweight fixtures in testkit and root-coupled fixtures local so
 // integration tests can continue importing everything through `helpers::*`.
 pub use harness_testkit::*;
 pub use hook::*;
+pub use port_lease::*;
 pub use run::*;
 
 /// Deterministically derive a valid UUID from a readable test label.
@@ -40,25 +42,38 @@ pub fn test_session_uuid(label: &str) -> String {
     uuid::Uuid::from_bytes(bytes).to_string()
 }
 
-/// Global lock for tests that modify the process environment via `with_env_vars`.
+/// Safety net for ad hoc libtest runs that share one process.
 ///
-/// All integration test modules that set PATH (or other env vars) must acquire
-/// this lock so that concurrent tests never observe a partially-modified
-/// environment. Per-module locks are insufficient because Rust runs tests from
-/// different modules on the same thread pool.
+/// Canonical tasks use nextest process isolation, so this lock does not
+/// serialize integration cases in the supported parallel test workflow.
 pub static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 pub struct ManagedChild {
     child: Option<Child>,
+    _retained_port_leases: Vec<TcpPortLease>,
 }
 
 impl ManagedChild {
     pub fn new(child: Child) -> Self {
-        Self { child: Some(child) }
+        Self {
+            child: Some(child),
+            _retained_port_leases: Vec::new(),
+        }
     }
 
     pub fn spawn(command: &mut ProcessCommand) -> std::io::Result<Self> {
         command.spawn().map(Self::new)
+    }
+
+    pub fn spawn_with_port_lease(
+        command: &mut ProcessCommand,
+        port_lease: TcpPortLease,
+    ) -> std::io::Result<Self> {
+        port_lease.release_listener()?;
+        command.spawn().map(|child| Self {
+            child: Some(child),
+            _retained_port_leases: vec![port_lease],
+        })
     }
 
     pub fn id(&self) -> u32 {

--- a/tests/integration/helpers/port_lease.rs
+++ b/tests/integration/helpers/port_lease.rs
@@ -1,0 +1,101 @@
+use std::fs::{self, DirBuilder, File, OpenOptions};
+use std::io;
+use std::net::TcpListener;
+use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, PermissionsExt as _};
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::{Arc, Mutex};
+
+use fs2::FileExt as _;
+
+const PORT_LEASE_ATTEMPTS: usize = 64;
+
+#[derive(Clone)]
+pub struct TcpPortLease {
+    inner: Arc<TcpPortLeaseInner>,
+}
+
+struct TcpPortLeaseInner {
+    port: u16,
+    listener: Mutex<Option<TcpListener>>,
+    _lock_file: File,
+}
+
+impl TcpPortLease {
+    pub fn acquire() -> io::Result<Self> {
+        let lock_root = user_global_lock_root()?;
+        for _ in 0..PORT_LEASE_ATTEMPTS {
+            let listener = TcpListener::bind(("127.0.0.1", 0))?;
+            let port = listener.local_addr()?.port();
+            let lock_path = lock_root.join(format!("tcp-{port}.lock"));
+            let lock_file = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)?;
+
+            match lock_file.try_lock_exclusive() {
+                Ok(()) => {
+                    return Ok(Self {
+                        inner: Arc::new(TcpPortLeaseInner {
+                            port,
+                            listener: Mutex::new(Some(listener)),
+                            _lock_file: lock_file,
+                        }),
+                    });
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            format!(
+                "could not reserve a globally unique local port after {PORT_LEASE_ATTEMPTS} attempts"
+            ),
+        ))
+    }
+
+    #[must_use]
+    pub fn port(&self) -> u16 {
+        self.inner.port
+    }
+
+    pub fn output(&self, command: &mut Command) -> io::Result<Output> {
+        self.release_listener()?;
+        command.output()
+    }
+
+    pub(super) fn release_listener(&self) -> io::Result<()> {
+        self.inner
+            .listener
+            .lock()
+            .map_err(|_| io::Error::other("TCP port lease listener lock poisoned"))?
+            .take();
+        Ok(())
+    }
+}
+
+fn user_global_lock_root() -> io::Result<PathBuf> {
+    let uid = uzers::get_current_uid();
+    let lock_root = PathBuf::from("/tmp").join(format!("harness-test-port-leases-{uid}"));
+    match DirBuilder::new().mode(0o700).create(&lock_root) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error),
+    }
+
+    let metadata = fs::symlink_metadata(&lock_root)?;
+    if !metadata.file_type().is_dir() || metadata.uid() != uid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "integration port lease root is not a private user-owned directory: {}",
+                lock_root.display()
+            ),
+        ));
+    }
+    fs::set_permissions(&lock_root, fs::Permissions::from_mode(0o700))?;
+    Ok(lock_root)
+}

--- a/tests/integration/install_workflow/cargo_local.rs
+++ b/tests/integration/install_workflow/cargo_local.rs
@@ -6,17 +6,20 @@ use tempfile::tempdir;
 use super::support::{parse_env_output, write_fake_shell_tool};
 
 #[test]
-fn cargo_local_script_falls_back_to_repo_local_tmpdir_when_tmpdir_is_missing() {
+fn cargo_local_script_uses_short_external_tmpdir_when_tmpdir_is_missing() {
     let tmp = tempdir().expect("tempdir");
     let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let missing_sccache = tmp.path().join("missing-sccache");
+    let session_id = format!("cargo-local-missing-tmpdir-{}", std::process::id());
 
     let output = Command::new("/bin/bash")
         .arg(repo.join("scripts/cargo-local.sh"))
         .arg("--print-env")
         .current_dir(&repo)
         .env("HOME", tmp.path().join("home"))
+        .env("SCCACHE_BIN", &missing_sccache)
         .env_remove("TMPDIR")
-        .env_remove("CODEX_SESSION_ID")
+        .env("CODEX_SESSION_ID", session_id)
         .env_remove("CODEX_THREAD_ID")
         .env_remove("CLAUDE_SESSION_ID")
         .env_remove("GEMINI_SESSION_ID")
@@ -35,17 +38,25 @@ fn cargo_local_script_falls_back_to_repo_local_tmpdir_when_tmpdir_is_missing() {
     let env = parse_env_output(&output.stdout);
     let tmpdir = env.get("TMPDIR").expect("TMPDIR line");
     let common_repo_root = resolve_common_repo_root(&repo);
-    assert_eq!(
-        tmpdir,
-        &format!(
-            "{}/target/.cargo-local/tmp/local/",
-            common_repo_root.display()
-        )
+    let fallback = Path::new(tmpdir.trim_end_matches('/'));
+    assert!(
+        tmpdir.starts_with("/tmp/harness-cargo-") && tmpdir.ends_with('/'),
+        "expected short external TMPDIR, got {tmpdir}"
     );
     assert!(
-        Path::new(tmpdir).is_dir(),
-        "expected repo-local tmpdir to exist: {tmpdir}"
+        tmpdir.len() < 64,
+        "external TMPDIR should remain short: {tmpdir}"
     );
+    assert!(
+        !fallback.starts_with(&repo) && !fallback.starts_with(&common_repo_root),
+        "fallback must stay outside checkout and common repo: {tmpdir}"
+    );
+    assert!(
+        fallback.is_dir(),
+        "expected external tmpdir to exist: {tmpdir}"
+    );
+
+    std::fs::remove_dir(fallback).expect("remove external tmpdir");
 }
 
 fn resolve_common_repo_root(repo: &Path) -> PathBuf {
@@ -105,6 +116,57 @@ fn cargo_local_script_preserves_explicit_writable_tmpdir() {
         env.get("TMPDIR").expect("TMPDIR line"),
         &explicit_tmpdir.display().to_string()
     );
+}
+
+#[test]
+fn cargo_local_script_uses_short_external_tmpdir_when_tmpdir_is_unusable() {
+    let tmp = tempdir().expect("tempdir");
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let unusable_tmpdir = tmp.path().join("not-a-directory");
+    let missing_sccache = tmp.path().join("missing-sccache");
+    let session_id = format!("cargo-local-unusable-tmpdir-{}", std::process::id());
+    std::fs::write(&unusable_tmpdir, "not a directory").expect("write unusable TMPDIR");
+
+    let output = Command::new("/bin/bash")
+        .arg(repo.join("scripts/cargo-local.sh"))
+        .arg("--print-env")
+        .current_dir(&repo)
+        .env("HOME", tmp.path().join("home"))
+        .env("SCCACHE_BIN", &missing_sccache)
+        .env("TMPDIR", &unusable_tmpdir)
+        .env("CODEX_SESSION_ID", session_id)
+        .env_remove("CODEX_THREAD_ID")
+        .env_remove("CLAUDE_SESSION_ID")
+        .env_remove("GEMINI_SESSION_ID")
+        .env_remove("COPILOT_SESSION_ID")
+        .env_remove("OPENCODE_SESSION_ID")
+        .output()
+        .expect("run cargo-local script");
+
+    assert!(
+        output.status.success(),
+        "script failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let env = parse_env_output(&output.stdout);
+    let tmpdir = env.get("TMPDIR").expect("TMPDIR line");
+    let fallback = Path::new(tmpdir.trim_end_matches('/'));
+    assert!(
+        tmpdir.starts_with("/tmp/harness-cargo-") && tmpdir.ends_with('/'),
+        "expected short external TMPDIR, got {tmpdir}"
+    );
+    assert!(
+        tmpdir.len() < 64,
+        "external TMPDIR should remain short: {tmpdir}"
+    );
+    assert!(
+        fallback.is_dir(),
+        "expected external tmpdir to exist: {tmpdir}"
+    );
+
+    std::fs::remove_dir(fallback).expect("remove external tmpdir");
 }
 
 #[test]

--- a/tests/integration/workspace/adopt_external.rs
+++ b/tests/integration/workspace/adopt_external.rs
@@ -13,13 +13,15 @@ use serde_json::{Value, json};
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
 
+use harness::session::types::CURRENT_VERSION;
+
 use super::support::{
     DAEMON_HTTP_TIMEOUT, DAEMON_WAIT_INTERVAL, DAEMON_WAIT_TIMEOUT,
     current_daemon_endpoint_and_token, spawn_daemon_serve, wait_for_daemon_ready,
 };
 
-// Current schema version — must match `CURRENT_VERSION` in `session::types`.
-const SCHEMA_VERSION: u32 = 9;
+const IDEMPOTENT_SESSION_ID: &str = "72026b9c-9f8f-5a76-a6cf-a05cbb5741ee";
+const EXTERNAL_SESSION_ID: &str = "72026b9c-9f8f-5a76-a6cf-a05cbb5741ef";
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
@@ -38,7 +40,7 @@ fn write_b_layout_session(project_dir: &Path, sid: &str, origin: &Path) -> PathB
 
     let origin_str = origin.to_string_lossy();
     let state = json!({
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": CURRENT_VERSION,
         "state_version": 0,
         "session_id": sid,
         "project_name": project_dir.file_name().unwrap().to_string_lossy(),
@@ -214,7 +216,7 @@ fn adopt_external_is_idempotent_with_409() {
 
         let project_dir = xdg.join("harness").join("sessions").join("kuma");
         fs::create_dir_all(&project_dir).unwrap();
-        let session_root = write_b_layout_session(&project_dir, "abcdabcd", &origin);
+        let session_root = write_b_layout_session(&project_dir, IDEMPOTENT_SESSION_ID, &origin);
 
         let mut daemon = spawn_daemon_serve(&home, &xdg);
         wait_for_daemon_ready(&home, &xdg);
@@ -238,7 +240,7 @@ fn adopt_external_is_idempotent_with_409() {
         );
         assert_eq!(
             second_body["session_id"].as_str(),
-            Some("abcdabcd"),
+            Some(IDEMPOTENT_SESSION_ID),
             "session_id must be echoed in the conflict body"
         );
 
@@ -267,7 +269,7 @@ fn adopt_external_outside_sessions_root_sets_flag() {
         // External project dir — lives completely outside `xdg/harness/sessions/`.
         let external_project = tmp.path().join("external-root").join("kuma");
         fs::create_dir_all(&external_project).unwrap();
-        let session_root = write_b_layout_session(&external_project, "ffff0000", &origin);
+        let session_root = write_b_layout_session(&external_project, EXTERNAL_SESSION_ID, &origin);
 
         let mut daemon = spawn_daemon_serve(&home, &xdg);
         wait_for_daemon_ready(&home, &xdg);

--- a/tests/integration/workspace/collision.rs
+++ b/tests/integration/workspace/collision.rs
@@ -2,6 +2,9 @@
 // distinct project names in the sessions layout.  The second resolves to
 // `project-<4hex>` so sessions never collide.
 
+use std::path::Path;
+
+use harness::session::types::SessionState;
 use harness_testkit::init_git_repo_with_seed;
 use tempfile::tempdir;
 
@@ -9,6 +12,10 @@ use super::support::{
     layout_for_state, output_text, run_harness, spawn_daemon_serve, start_session_try,
     start_session_via_http, wait_for_daemon_ready,
 };
+
+const COLLISION_SESSION_A: &str = "40000000-0000-4000-8000-000000000001";
+const COLLISION_SESSION_B: &str = "40000000-0000-4000-8000-000000000002";
+const INVALID_PROJECT_SESSION: &str = "40000000-0000-4000-8000-000000000003";
 
 /// Slow: spawns daemon.
 #[ignore = "slow integration test that spawns a real daemon"]
@@ -31,8 +38,8 @@ fn two_origins_same_basename_get_distinct_project_names() {
     wait_for_daemon_ready(&home, &xdg);
 
     // Start one session from each origin.
-    let state_a = start_session_via_http(&home, &xdg, &origin_a, "col-same-a1234567");
-    let state_b = start_session_via_http(&home, &xdg, &origin_b, "col-same-b1234567");
+    let state_a = start_session_via_http(&home, &xdg, &origin_a, COLLISION_SESSION_A);
+    let state_b = start_session_via_http(&home, &xdg, &origin_b, COLLISION_SESSION_B);
 
     // Project names must differ even though both basenames are "project".
     assert_ne!(
@@ -58,8 +65,14 @@ fn two_origins_same_basename_get_distinct_project_names() {
         "hash suffix must be 4 hex chars"
     );
 
-    // Both sessions must appear in the list.
-    let list_out = run_harness(&home, &xdg, &["session", "list", "--json"]);
+    assert_sessions_listed(&home, &xdg);
+    assert_origin_markers(&xdg, &state_a, &state_b, &origin_a, &origin_b);
+
+    daemon.kill().expect("kill daemon");
+}
+
+fn assert_sessions_listed(home: &Path, xdg: &Path) {
+    let list_out = run_harness(home, xdg, &["session", "list", "--json"]);
     assert!(
         list_out.status.success(),
         "session list failed: {}",
@@ -72,19 +85,27 @@ fn two_origins_same_basename_get_distinct_project_names() {
         .filter_map(|s| s["session_id"].as_str())
         .collect();
     assert!(
-        session_ids.contains(&"col-same-a1234567"),
+        session_ids.contains(&COLLISION_SESSION_A),
         "session A must appear in list; found: {session_ids:?}"
     );
     assert!(
-        session_ids.contains(&"col-same-b1234567"),
+        session_ids.contains(&COLLISION_SESSION_B),
         "session B must appear in list; found: {session_ids:?}"
     );
+}
 
+fn assert_origin_markers(
+    xdg: &Path,
+    state_a: &SessionState,
+    state_b: &SessionState,
+    origin_a: &Path,
+    origin_b: &Path,
+) {
     // Verify .origin marker content for both sessions.
     // Session-level marker is written by WorktreeController::create; project-level
     // marker is written by session_setup::prepare_session for collision detection.
-    let layout_a = layout_for_state(&xdg, &state_a);
-    let layout_b = layout_for_state(&xdg, &state_b);
+    let layout_a = layout_for_state(xdg, state_a);
+    let layout_b = layout_for_state(xdg, state_b);
     let origin_text_a =
         std::fs::read_to_string(layout_a.origin_marker()).expect("read .origin for session A");
     let origin_text_b =
@@ -128,8 +149,6 @@ fn two_origins_same_basename_get_distinct_project_names() {
         canonical_b,
         "project-level .origin for B must hold canonical origin path"
     );
-
-    daemon.kill().expect("kill daemon");
 }
 
 /// Slow: spawns daemon.
@@ -148,8 +167,9 @@ fn invalid_project_dir_returns_error_status() {
 
     // A path that does not exist on the filesystem cannot be canonicalized.
     let nonexistent = tmp.path().join("does-not-exist").join("project");
-    let (status, _body) = start_session_try(&home, &xdg, &nonexistent, "col-bad-a1234567", None)
-        .expect_err("start with nonexistent project_dir must fail");
+    let (status, _body) =
+        start_session_try(&home, &xdg, &nonexistent, INVALID_PROJECT_SESSION, None)
+            .expect_err("start with nonexistent project_dir must fail");
     // Daemon returns 400 for all validation/workflow errors (see src/daemon/http/response.rs).
     assert_eq!(
         status, 400,

--- a/tests/integration/workspace/parallel_sessions.rs
+++ b/tests/integration/workspace/parallel_sessions.rs
@@ -9,6 +9,13 @@ use super::support::{
     spawn_daemon_serve, start_session_via_http, wait_for_daemon_ready,
 };
 
+const PARALLEL_SESSION_A: &str = "10000000-0000-4000-8000-000000000001";
+const PARALLEL_SESSION_B: &str = "10000000-0000-4000-8000-000000000002";
+const DELETE_SESSION_A: &str = "20000000-0000-4000-8000-000000000001";
+const DELETE_SESSION_B: &str = "20000000-0000-4000-8000-000000000002";
+const ACTIVE_SESSION_A: &str = "30000000-0000-4000-8000-000000000001";
+const ACTIVE_SESSION_B: &str = "30000000-0000-4000-8000-000000000002";
+
 /// Slow: spawns daemon.
 #[ignore = "slow integration test that spawns a real daemon"]
 #[test]
@@ -24,8 +31,8 @@ fn two_sessions_same_origin_get_distinct_workspaces() {
     let mut daemon = spawn_daemon_serve(&home, &xdg);
     wait_for_daemon_ready(&home, &xdg);
 
-    let state_a = start_session_via_http(&home, &xdg, &project, "wk-par-a1234567");
-    let state_b = start_session_via_http(&home, &xdg, &project, "wk-par-b1234567");
+    let state_a = start_session_via_http(&home, &xdg, &project, PARALLEL_SESSION_A);
+    let state_b = start_session_via_http(&home, &xdg, &project, PARALLEL_SESSION_B);
 
     // Session ids must be distinct.
     assert_ne!(
@@ -58,11 +65,11 @@ fn two_sessions_same_origin_get_distinct_workspaces() {
     // Both branches must be present in the origin repo.
     let branches = git_branches_matching(&project, "harness/");
     assert!(
-        branches.contains(&"harness/wk-par-a1234567".to_string()),
+        branches.contains(&format!("harness/{PARALLEL_SESSION_A}")),
         "branch A must exist; found: {branches:?}"
     );
     assert!(
-        branches.contains(&"harness/wk-par-b1234567".to_string()),
+        branches.contains(&format!("harness/{PARALLEL_SESSION_B}")),
         "branch B must exist; found: {branches:?}"
     );
 
@@ -80,11 +87,11 @@ fn two_sessions_same_origin_get_distinct_workspaces() {
         .filter_map(|s| s["session_id"].as_str())
         .collect();
     assert!(
-        session_ids.contains(&"wk-par-a1234567"),
+        session_ids.contains(&PARALLEL_SESSION_A),
         "session A must appear in list; found: {session_ids:?}"
     );
     assert!(
-        session_ids.contains(&"wk-par-b1234567"),
+        session_ids.contains(&PARALLEL_SESSION_B),
         "session B must appear in list; found: {session_ids:?}"
     );
 
@@ -106,11 +113,11 @@ fn deleting_one_session_leaves_other_intact() {
     let mut daemon = spawn_daemon_serve(&home, &xdg);
     wait_for_daemon_ready(&home, &xdg);
 
-    let state_a = start_session_via_http(&home, &xdg, &project, "wk-del-a7654321");
-    let state_b = start_session_via_http(&home, &xdg, &project, "wk-del-b7654321");
+    let state_a = start_session_via_http(&home, &xdg, &project, DELETE_SESSION_A);
+    let state_b = start_session_via_http(&home, &xdg, &project, DELETE_SESSION_B);
 
     // Delete only session A.
-    let http_status = delete_session_via_http(&home, &xdg, "wk-del-a7654321");
+    let http_status = delete_session_via_http(&home, &xdg, DELETE_SESSION_A);
     assert_eq!(http_status, 204, "DELETE A must return 204");
 
     // Session A's worktree is gone.
@@ -130,11 +137,11 @@ fn deleting_one_session_leaves_other_intact() {
     // Branch A gone, branch B present.
     let branches = git_branches_matching(&project, "harness/");
     assert!(
-        !branches.contains(&"harness/wk-del-a7654321".to_string()),
+        !branches.contains(&format!("harness/{DELETE_SESSION_A}")),
         "branch A must be deleted; found: {branches:?}"
     );
     assert!(
-        branches.contains(&"harness/wk-del-b7654321".to_string()),
+        branches.contains(&format!("harness/{DELETE_SESSION_B}")),
         "branch B must still exist; found: {branches:?}"
     );
 
@@ -152,11 +159,11 @@ fn deleting_one_session_leaves_other_intact() {
         .filter_map(|s| s["session_id"].as_str())
         .collect();
     assert!(
-        !session_ids.contains(&"wk-del-a7654321"),
+        !session_ids.contains(&DELETE_SESSION_A),
         "session A must not appear in list after delete; found: {session_ids:?}"
     );
     assert!(
-        session_ids.contains(&"wk-del-b7654321"),
+        session_ids.contains(&DELETE_SESSION_B),
         "session B must still appear in list; found: {session_ids:?}"
     );
 
@@ -178,8 +185,8 @@ fn active_json_tracks_each_session() {
     let mut daemon = spawn_daemon_serve(&home, &xdg);
     wait_for_daemon_ready(&home, &xdg);
 
-    let state_a = start_session_via_http(&home, &xdg, &project, "wk-act-a2468ace");
-    let state_b = start_session_via_http(&home, &xdg, &project, "wk-act-b2468ace");
+    let state_a = start_session_via_http(&home, &xdg, &project, ACTIVE_SESSION_A);
+    let state_b = start_session_via_http(&home, &xdg, &project, ACTIVE_SESSION_B);
 
     let active_a = layout_for_state(&xdg, &state_a).active_registry();
     let active_b = layout_for_state(&xdg, &state_b).active_registry();
@@ -192,7 +199,7 @@ fn active_json_tracks_each_session() {
     );
     let active_text_a = std::fs::read_to_string(&active_a).expect("read .active.json A");
     assert!(
-        active_text_a.contains("wk-act-a2468ace"),
+        active_text_a.contains(ACTIVE_SESSION_A),
         ".active.json A must contain session A; content: {active_text_a}"
     );
 
@@ -204,7 +211,7 @@ fn active_json_tracks_each_session() {
     );
     let active_text_b = std::fs::read_to_string(&active_b).expect("read .active.json B");
     assert!(
-        active_text_b.contains("wk-act-b2468ace"),
+        active_text_b.contains(ACTIVE_SESSION_B),
         ".active.json B must contain session B; content: {active_text_b}"
     );
 

--- a/tests/integration/workspace/support.rs
+++ b/tests/integration/workspace/support.rs
@@ -38,25 +38,30 @@ fn daemon_binary() -> PathBuf {
 pub fn spawn_daemon_serve(home: &Path, xdg: &Path) -> super::super::helpers::ManagedChild {
     let mut cmd = Command::new(daemon_binary());
     cmd.args(["serve", "--host", "127.0.0.1", "--port", "0"])
-        .env("HARNESS_HOST_HOME", home)
-        .env("HOME", home)
-        .env("XDG_DATA_HOME", xdg)
-        .env_remove("CLAUDE_SESSION_ID")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    configure_isolated_daemon_env(&mut cmd, home, xdg);
     super::super::helpers::ManagedChild::spawn(&mut cmd).expect("spawn daemon serve")
 }
 
 pub fn run_harness(home: &Path, xdg: &Path, args: &[&str]) -> Output {
-    Command::new(harness_binary())
-        .args(args)
+    let mut command = Command::new(harness_binary());
+    command.args(args);
+    configure_isolated_daemon_env(&mut command, home, xdg);
+    command.output().expect("run harness")
+}
+
+fn configure_isolated_daemon_env(command: &mut Command, home: &Path, xdg: &Path) {
+    command
         .env("HARNESS_HOST_HOME", home)
         .env("HOME", home)
         .env("XDG_DATA_HOME", xdg)
-        .env_remove("CLAUDE_SESSION_ID")
-        .output()
-        .expect("run harness")
+        .env("HARNESS_DAEMON_DATA_HOME", xdg)
+        .env_remove("HARNESS_APP_GROUP_ID")
+        .env_remove("HARNESS_DAEMON_OWNERSHIP")
+        .env_remove("HARNESS_SANDBOXED")
+        .env_remove("CLAUDE_SESSION_ID");
 }
 
 pub fn output_text(output: &Output) -> String {
@@ -65,13 +70,12 @@ pub fn output_text(output: &Output) -> String {
     format!("stdout={stdout:?} stderr={stderr:?}")
 }
 
-pub fn wait_for_daemon_ready(home: &Path, xdg: &Path) {
+pub fn wait_for_daemon_ready(_home: &Path, xdg: &Path) {
+    let manifest_path = daemon_manifest_path(xdg);
     let deadline = Instant::now() + DAEMON_WAIT_TIMEOUT;
     loop {
-        let output = run_harness(home, xdg, &["daemon", "status"]);
-        if output.status.success()
-            && let Ok(status) = serde_json::from_slice::<serde_json::Value>(&output.stdout)
-            && status.get("manifest").is_some_and(|v| !v.is_null())
+        if let Ok((endpoint, token)) = read_daemon_endpoint_and_token(&manifest_path)
+            && daemon_endpoint_is_healthy(&endpoint, &token)
         {
             return;
         }
@@ -83,22 +87,12 @@ pub fn wait_for_daemon_ready(home: &Path, xdg: &Path) {
     }
 }
 
-pub fn current_daemon_endpoint_and_token(home: &Path, xdg: &Path) -> (String, String) {
+pub fn current_daemon_endpoint_and_token(_home: &Path, xdg: &Path) -> (String, String) {
+    let manifest_path = daemon_manifest_path(xdg);
     let deadline = Instant::now() + DAEMON_WAIT_TIMEOUT;
     loop {
-        let output = run_harness(home, xdg, &["daemon", "status"]);
-        if output.status.success()
-            && let Ok(status) = serde_json::from_slice::<serde_json::Value>(&output.stdout)
-            && let (Some(endpoint), Some(token_path)) = (
-                status["manifest"]["endpoint"].as_str(),
-                status["manifest"]["token_path"].as_str(),
-            )
-            && let Ok(token) = std::fs::read_to_string(token_path)
-        {
-            let token = token.trim().to_string();
-            if !token.is_empty() {
-                return (endpoint.to_string(), token);
-            }
+        if let Ok(endpoint_and_token) = read_daemon_endpoint_and_token(&manifest_path) {
+            return endpoint_and_token;
         }
         assert!(
             Instant::now() < deadline,
@@ -106,6 +100,46 @@ pub fn current_daemon_endpoint_and_token(home: &Path, xdg: &Path) -> (String, St
         );
         thread::sleep(DAEMON_WAIT_INTERVAL);
     }
+}
+
+fn daemon_manifest_path(xdg: &Path) -> PathBuf {
+    xdg.join("harness")
+        .join("daemon")
+        .join("managed")
+        .join("manifest.json")
+}
+
+fn read_daemon_endpoint_and_token(manifest_path: &Path) -> Result<(String, String), String> {
+    let data = std::fs::read_to_string(manifest_path)
+        .map_err(|error| format!("read {}: {error}", manifest_path.display()))?;
+    let manifest: Value = serde_json::from_str(&data)
+        .map_err(|error| format!("parse {}: {error}", manifest_path.display()))?;
+    let endpoint = manifest["endpoint"]
+        .as_str()
+        .ok_or_else(|| "daemon manifest has no endpoint".to_string())?;
+    let token_path = manifest["token_path"]
+        .as_str()
+        .ok_or_else(|| "daemon manifest has no token path".to_string())?;
+    let token = std::fs::read_to_string(token_path)
+        .map_err(|error| format!("read daemon token {token_path}: {error}"))?;
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err("daemon token is empty".to_string());
+    }
+    Ok((endpoint.to_string(), token))
+}
+
+fn daemon_endpoint_is_healthy(endpoint: &str, token: &str) -> bool {
+    let url = format!("{}/v1/health", endpoint.trim_end_matches('/'));
+    runtime().block_on(async {
+        reqwest::Client::new()
+            .get(url)
+            .bearer_auth(token)
+            .timeout(DAEMON_HTTP_TIMEOUT)
+            .send()
+            .await
+            .is_ok_and(|response| response.status().is_success())
+    })
 }
 
 /// Attempt a session start and return `Ok(state)` on 200, or `Err((status, body))` on any

--- a/tests/remote_daemon_e2e/process.rs
+++ b/tests/remote_daemon_e2e/process.rs
@@ -1,10 +1,12 @@
-use std::fs::{self, File};
+use std::fs::{self, DirBuilder, File, OpenOptions};
 use std::net::TcpListener;
-use std::os::unix::fs::PermissionsExt as _;
+use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use fs2::FileExt as _;
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -20,8 +22,8 @@ pub struct RemoteDaemonEnvironment {
     acme_ca_root: PathBuf,
     daemon_stdout: PathBuf,
     daemon_stderr: PathBuf,
-    https_port: u16,
-    http_port: u16,
+    https_port: PortLease,
+    http_port: PortLease,
 }
 
 pub struct AftermarketDnsEnvironment<'a> {
@@ -60,8 +62,8 @@ impl RemoteDaemonEnvironment {
             acme_ca_root,
             daemon_stdout: PathBuf::from("daemon.stdout.log"),
             daemon_stderr: PathBuf::from("daemon.stderr.log"),
-            https_port: unused_port()?,
-            http_port: unused_port()?,
+            https_port: PortLease::acquire()?,
+            http_port: PortLease::acquire()?,
         }
         .with_log_paths())
     }
@@ -72,12 +74,12 @@ impl RemoteDaemonEnvironment {
         self
     }
 
-    pub const fn https_port(&self) -> u16 {
-        self.https_port
+    pub fn https_port(&self) -> u16 {
+        self.https_port.port
     }
 
-    pub const fn http_port(&self) -> u16 {
-        self.http_port
+    pub fn http_port(&self) -> u16 {
+        self.http_port.port
     }
 
     pub fn dns_log(&self) -> &Path {
@@ -102,6 +104,86 @@ impl RemoteDaemonEnvironment {
             .env("HARNESS_REMOTE_ACME_DNS_LOG", &self.dns_log)
             .env("RUST_LOG", "harness=debug");
     }
+
+    fn release_port_reservations(&self) -> Result<(), String> {
+        self.https_port.release_socket()?;
+        self.http_port.release_socket()
+    }
+}
+
+struct PortLease {
+    port: u16,
+    listener: Mutex<Option<TcpListener>>,
+    _lock_file: File,
+}
+
+impl PortLease {
+    fn acquire() -> Result<Self, String> {
+        for _ in 0..32 {
+            let listener = TcpListener::bind(("127.0.0.1", 0))
+                .map_err(|error| format!("reserve local port: {error}"))?;
+            let port = listener
+                .local_addr()
+                .map_err(|error| format!("read reserved local port: {error}"))?
+                .port();
+            let lock_path = port_lock_root()?.join(format!("tcp-{port}.lock"));
+            let lock_file = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)
+                .map_err(|error| format!("open port lease {}: {error}", lock_path.display()))?;
+            match lock_file.try_lock_exclusive() {
+                Ok(()) => {
+                    return Ok(Self {
+                        port,
+                        listener: Mutex::new(Some(listener)),
+                        _lock_file: lock_file,
+                    });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(error) => {
+                    return Err(format!("lock port lease {}: {error}", lock_path.display()));
+                }
+            }
+        }
+        Err("could not reserve a unique local port after 32 attempts".to_string())
+    }
+
+    fn release_socket(&self) -> Result<(), String> {
+        self.listener
+            .lock()
+            .map_err(|_| "port reservation lock poisoned".to_string())?
+            .take();
+        Ok(())
+    }
+}
+
+fn port_lock_root() -> Result<PathBuf, String> {
+    let uid = uzers::get_current_uid();
+    let root = PathBuf::from("/tmp").join(format!("harness-test-port-leases-{uid}"));
+    match DirBuilder::new().mode(0o700).create(&root) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(format!(
+                "create port lease root {}: {error}",
+                root.display()
+            ));
+        }
+    }
+    let metadata = fs::symlink_metadata(&root)
+        .map_err(|error| format!("inspect port lease root {}: {error}", root.display()))?;
+    if !metadata.file_type().is_dir() || metadata.uid() != uid {
+        return Err(format!(
+            "port lease root must be an owned directory: {}",
+            root.display()
+        ));
+    }
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o700))
+        .map_err(|error| format!("secure port lease root {}: {error}", root.display()))?;
+    Ok(root)
 }
 
 pub struct RemoteDaemonProcess {
@@ -163,6 +245,7 @@ impl RemoteDaemonProcess {
         directory_url: &str,
         mut command: Command,
     ) -> Result<Self, String> {
+        environment.release_port_reservations()?;
         let stdout = File::create(&environment.daemon_stdout)
             .map_err(|error| format!("create daemon stdout log: {error}"))?;
         let stderr = File::create(&environment.daemon_stderr)
@@ -332,9 +415,9 @@ fn remote_daemon_command(
         "--host",
         "127.0.0.1",
         "--https-port",
-        &environment.https_port.to_string(),
+        &environment.https_port().to_string(),
         "--http-port",
-        &environment.http_port.to_string(),
+        &environment.http_port().to_string(),
         "--acme-email",
         "remote-e2e@example.com",
         "--acme-challenge",
@@ -344,13 +427,6 @@ fn remote_daemon_command(
         command.args(["--acme-dns-provider", provider]);
     }
     command
-}
-
-fn unused_port() -> Result<u16, String> {
-    TcpListener::bind(("127.0.0.1", 0))
-        .and_then(|listener| listener.local_addr())
-        .map(|address| address.port())
-        .map_err(|error| format!("select unused local port: {error}"))
 }
 
 fn write_dns_hook(path: &Path) -> Result<(), String> {

--- a/tests/remote_daemon_public_acme_e2e.rs
+++ b/tests/remote_daemon_public_acme_e2e.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 #![allow(
     clippy::absolute_paths,
     reason = "the public ACME proof keeps system-bound collaborators explicit"

--- a/tests/remote_systemd_e2e.rs
+++ b/tests/remote_systemd_e2e.rs
@@ -18,6 +18,8 @@ mod acme;
 mod client;
 #[path = "remote_systemd_e2e/host.rs"]
 mod host;
+#[path = "remote_systemd_e2e/ports.rs"]
+mod ports;
 
 use acme::{AcmeChallenge, AcmeChallengeConfig, FakeAcmeServer};
 use client::RemoteDaemonClient;

--- a/tests/remote_systemd_e2e/host.rs
+++ b/tests/remote_systemd_e2e/host.rs
@@ -1,12 +1,13 @@
 use std::ffi::OsStr;
 use std::fs;
-use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 use tempfile::TempDir;
+
+use super::ports::LowPortPairLease;
 
 pub struct RemoteSystemdHost {
     _temp: TempDir,
@@ -23,6 +24,7 @@ pub struct RemoteSystemdHost {
     dns_log: PathBuf,
     https_port: u16,
     http_port: u16,
+    _port_lease: LowPortPairLease,
 }
 
 impl RemoteSystemdHost {
@@ -36,7 +38,9 @@ impl RemoteSystemdHost {
             .map_err(|error| format!("read system clock: {error}"))?
             .as_nanos();
         let unit = format!("harness-remote-e2e-{}-{nonce}", std::process::id());
-        let (https_port, http_port) = available_low_port_pair()?;
+        let port_lease = LowPortPairLease::acquire()?;
+        let https_port = port_lease.https_port();
+        let http_port = port_lease.http_port();
         Ok(Self {
             binary_source: assert_cmd::cargo::cargo_bin("harness-daemon"),
             binary_path: PathBuf::from(format!("/usr/local/libexec/{unit}")),
@@ -51,6 +55,7 @@ impl RemoteSystemdHost {
             unit,
             https_port,
             http_port,
+            _port_lease: port_lease,
             _temp: temp,
         })
     }
@@ -371,23 +376,6 @@ fn install_file(source: &Path, destination: &Path, mode: &str) -> Result<(), Str
         &format!("install {}", destination.display()),
     )?;
     Ok(())
-}
-
-fn available_low_port_pair() -> Result<(u16, u16), String> {
-    for pair in [(944, 908), (943, 907), (942, 906), (941, 905)] {
-        if !tcp_port_accepts(pair.0) && !tcp_port_accepts(pair.1) {
-            return Ok(pair);
-        }
-    }
-    Err("no free low-port pair available for systemd e2e".to_string())
-}
-
-fn tcp_port_accepts(port: u16) -> bool {
-    TcpStream::connect_timeout(
-        &SocketAddr::from(([127, 0, 0, 1], port)),
-        Duration::from_millis(100),
-    )
-    .is_ok()
 }
 
 fn assert_non_root_uid(status: &str) -> Result<(), String> {

--- a/tests/remote_systemd_e2e/ports.rs
+++ b/tests/remote_systemd_e2e/ports.rs
@@ -1,0 +1,99 @@
+use std::fs::{self, DirBuilder, File, OpenOptions};
+use std::net::{SocketAddr, TcpStream};
+use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, PermissionsExt as _};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use fs2::FileExt as _;
+
+pub struct LowPortPairLease {
+    https_port: u16,
+    http_port: u16,
+    _https_lock: File,
+    _http_lock: File,
+}
+
+impl LowPortPairLease {
+    pub fn acquire() -> Result<Self, String> {
+        let root = port_lock_root()?;
+        for (https_port, http_port) in [(944, 908), (943, 907), (942, 906), (941, 905)] {
+            if tcp_port_accepts(https_port) || tcp_port_accepts(http_port) {
+                continue;
+            }
+            let Some(https_lock) = try_lock_port(&root, https_port)? else {
+                continue;
+            };
+            let Some(http_lock) = try_lock_port(&root, http_port)? else {
+                continue;
+            };
+            if tcp_port_accepts(https_port) || tcp_port_accepts(http_port) {
+                continue;
+            }
+            return Ok(Self {
+                https_port,
+                http_port,
+                _https_lock: https_lock,
+                _http_lock: http_lock,
+            });
+        }
+        Err("no free low-port pair available for systemd e2e".to_string())
+    }
+
+    pub const fn https_port(&self) -> u16 {
+        self.https_port
+    }
+
+    pub const fn http_port(&self) -> u16 {
+        self.http_port
+    }
+}
+
+fn try_lock_port(root: &Path, port: u16) -> Result<Option<File>, String> {
+    let path = root.join(format!("tcp-{port}.lock"));
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(|error| format!("open port lease {}: {error}", path.display()))?;
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(Some(file)),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(format!("lock port lease {}: {error}", path.display())),
+    }
+}
+
+fn port_lock_root() -> Result<PathBuf, String> {
+    let uid = uzers::get_current_uid();
+    let root = PathBuf::from("/tmp").join(format!("harness-test-port-leases-{uid}"));
+    match DirBuilder::new().mode(0o700).create(&root) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(format!(
+                "create port lease root {}: {error}",
+                root.display()
+            ));
+        }
+    }
+    let metadata = fs::symlink_metadata(&root)
+        .map_err(|error| format!("inspect port lease root {}: {error}", root.display()))?;
+    if !metadata.file_type().is_dir() || metadata.uid() != uid {
+        return Err(format!(
+            "port lease root must be an owned directory: {}",
+            root.display()
+        ));
+    }
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o700))
+        .map_err(|error| format!("secure port lease root {}: {error}", root.display()))?;
+    Ok(root)
+}
+
+fn tcp_port_accepts(port: u16) -> bool {
+    TcpStream::connect_timeout(
+        &SocketAddr::from(([127, 0, 0, 1], port)),
+        Duration::from_millis(100),
+    )
+    .is_ok()
+}


### PR DESCRIPTION
## Motivation
Rust validation was serialized by test-runner flags and hidden shared-state assumptions, making the suite slower and allowing platform-specific no-op tests to look green. The test workflow should use available cores safely while preserving deterministic filesystem, database, process, and port isolation.

## Implementation
- Move Rust unit, integration, worker, slow, performance, MCP, and remote lanes to process-isolated cargo-nextest scheduling with dynamic parallelism that rejects single-thread configurations.
- Add repository policy checks that prevent reintroducing serialized Rust tests or uncaptured nextest runs and install ripgrep through mise for deterministic enforcement.
- Remove duplicated aggregate coverage, repair stale fixtures, and isolate temporary roots, daemon databases, process environments, and TCP ports so test cases can coexist.
- Make active TUI delivery and daemon-readiness fixtures event-driven and atomic, eliminating timing races exposed by concurrent execution.
- Select macOS- and Linux-specific tests at compile/run time while keeping portable script coverage and static syntax checks shared across hosts.
- Validate with `mise run check`, `mise run test`, `mise run test:slow`, `mise run test:perf`, and `mise run test:scripts`.
