### PR TITLE
feat(task-board): make provider creates crash-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "aff"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "harness-bridge"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "harness-command"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "tempfile",
  "uzers",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "harness-daemon"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "harness-daemon-client"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "fs2",
  "reqwest",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "harness-hook"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "chrono",
  "clap",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "harness-mcp"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "clap",
  "serde",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "harness-systemd"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "harness-systemd-protocol"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "nix 0.31.3",
  "temp-env",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "harness-telemetry"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "harness-testkit"
-version = "48.1.0"
+version = "48.1.1"
 dependencies = [
  "temp-env",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 
 [package]
 name = "harness"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 autoexamples = false
@@ -38,11 +38,11 @@ include = [
 ]
 
 [dependencies]
-harness-command = { path = "crates/harness-command", version = "48.1.0" }
-harness-mcp = { path = "crates/harness-mcp", version = "48.1.0", optional = true }
-harness-protocol = { path = "crates/harness-protocol", version = "48.1.0" }
-harness-systemd-protocol = { path = "crates/harness-systemd-protocol", version = "48.1.0", optional = true }
-harness-telemetry = { path = "crates/harness-telemetry", version = "48.1.0" }
+harness-command = { path = "crates/harness-command", version = "48.1.1" }
+harness-mcp = { path = "crates/harness-mcp", version = "48.1.1", optional = true }
+harness-protocol = { path = "crates/harness-protocol", version = "48.1.1" }
+harness-systemd-protocol = { path = "crates/harness-systemd-protocol", version = "48.1.1", optional = true }
+harness-telemetry = { path = "crates/harness-telemetry", version = "48.1.1" }
 arc-swap = "1.9.1"
 bollard = "0.21.0"
 bytes = "1.10.1"

--- a/aff/Cargo.toml
+++ b/aff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aff"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 

--- a/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
+++ b/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>48.1.0</string>
+	<string>48.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>48.1.0</string>
+	<string>48.1.1</string>
 	<key>LSBackgroundOnly</key>
 	<true/>
 </dict>

--- a/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
+++ b/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
@@ -32,7 +32,7 @@ public enum BuildSettings {
         "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS": .string(
             compilationCacheDiagnosticRemarksSetting
         ),
-        "CURRENT_PROJECT_VERSION": "48.1.0", // VERSION_MARKER_CURRENT
+        "CURRENT_PROJECT_VERSION": "48.1.1", // VERSION_MARKER_CURRENT
         "DEVELOPMENT_TEAM": "Q498EB36N4",
         "DEAD_CODE_STRIPPING": "YES",
         "ENABLE_HARDENED_RUNTIME": "YES",
@@ -61,7 +61,7 @@ public enum BuildSettings {
         "HARNESS_MONITOR_BUILD_GIT_COMMIT": "local-dev",
         "HARNESS_MONITOR_BUILD_GIT_DIRTY": "false",
         "HARNESS_MONITOR_BUILD_WORKSPACE_FINGERPRINT": "local-dev",
-        "MARKETING_VERSION": "48.1.0" // VERSION_MARKER_MARKETING
+        "MARKETING_VERSION": "48.1.1" // VERSION_MARKER_MARKETING
     ]
 
     public static let previewOverrides: SettingsDictionary = [

--- a/crates/harness-bridge/Cargo.toml
+++ b/crates/harness-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-bridge"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 
@@ -21,9 +21,9 @@ clap = { version = "4.6.0", features = ["derive", "env"] }
 crossterm = "0.29.0"
 fs2 = "0.4.3"
 fs-err = "3.3.0"
-harness-hook = { path = "../harness-hook", version = "48.1.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.1.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.1.0" }
+harness-hook = { path = "../harness-hook", version = "48.1.1" }
+harness-protocol = { path = "../harness-protocol", version = "48.1.1" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.1.1" }
 hex = "0.4.3"
 nix = { version = "0.31", features = ["signal"] }
 notify = "8.2.0"

--- a/crates/harness-command/Cargo.toml
+++ b/crates/harness-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-command"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 

--- a/crates/harness-daemon-client/Cargo.toml
+++ b/crates/harness-daemon-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-daemon-client"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-daemon/Cargo.toml
+++ b/crates/harness-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-daemon"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 
@@ -28,11 +28,11 @@ fs-err = "3.3.0"
 futures-util = "0.3.31"
 gix = { version = "0.83.0", features = ["status", "worktree-mutation", "index", "blocking-http-transport-reqwest-rust-tls"] }
 gray_matter = { version = "0.3.2", default-features = false, features = ["yaml"] }
-harness-command = { path = "../harness-command", version = "48.1.0" }
-harness-hook = { path = "../harness-hook", version = "48.1.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.1.0" }
-harness-systemd-protocol = { path = "../harness-systemd-protocol", version = "48.1.0", optional = true }
-harness-telemetry = { path = "../harness-telemetry", version = "48.1.0" }
+harness-command = { path = "../harness-command", version = "48.1.1" }
+harness-hook = { path = "../harness-hook", version = "48.1.1" }
+harness-protocol = { path = "../harness-protocol", version = "48.1.1" }
+harness-systemd-protocol = { path = "../harness-systemd-protocol", version = "48.1.1", optional = true }
+harness-telemetry = { path = "../harness-telemetry", version = "48.1.1" }
 hex = "0.4.3"
 hickory-resolver = "0.26.1"
 hmac = "0.13.0"

--- a/crates/harness-hook/Cargo.toml
+++ b/crates/harness-hook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-hook"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 
@@ -14,9 +14,9 @@ test = false
 
 [dependencies]
 clap = { version = "4.6.0", features = ["derive", "env"] }
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.1.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.1.0" }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.1" }
+harness-protocol = { path = "../harness-protocol", version = "48.1.1" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.1.1" }
 chrono = { version = "0.4.44", features = ["serde"] }
 fs-err = "3.3.0"
 fs2 = "0.4.3"

--- a/crates/harness-mcp/Cargo.toml
+++ b/crates/harness-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-mcp"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 
@@ -13,9 +13,9 @@ async-trait = "0.1.83"
 base64 = "0.22.1"
 clap = { version = "4.6.0", features = ["derive", "env"] }
 futures-util = "0.3.31"
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.1.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.1.0" }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.1" }
+harness-protocol = { path = "../harness-protocol", version = "48.1.1" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.1.1" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
@@ -26,7 +26,7 @@ uuid = { version = "1.18.1", features = ["v4"] }
 
 [dev-dependencies]
 axum = { version = "0.8.7", features = ["ws"] }
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.0", features = ["test-support"] }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.1", features = ["test-support"] }
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tempfile = "3.27.0"
 

--- a/crates/harness-protocol/Cargo.toml
+++ b/crates/harness-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-protocol"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-systemd-protocol/Cargo.toml
+++ b/crates/harness-systemd-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-systemd-protocol"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-systemd/Cargo.toml
+++ b/crates/harness-systemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-systemd"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 build = "build.rs"
@@ -14,7 +14,7 @@ chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive"] }
 fs-err = "3.3.0"
 fs2 = "0.4.3"
-harness-command = { path = "../harness-command", version = "48.1.0" }
+harness-command = { path = "../harness-command", version = "48.1.1" }
 hex = "0.4.3"
 libc = "0.2"
 nix = { version = "0.31", features = ["fs", "signal", "user"] }

--- a/crates/harness-telemetry/Cargo.toml
+++ b/crates/harness-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-telemetry"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/src/daemon/db/async_bootstrap.rs
+++ b/src/daemon/db/async_bootstrap.rs
@@ -134,6 +134,7 @@ const fn migration_floor_version(migration_version: i64) -> u64 {
         29 => 35,
         30 => 36,
         31 => 37,
+        32 => 38,
         _ => u64::MAX,
     }
 }

--- a/src/daemon/db/audit.rs
+++ b/src/daemon/db/audit.rs
@@ -8,7 +8,7 @@ use crate::daemon::protocol::{
 use super::{AsyncDaemonDb, CliError, db_error};
 
 #[allow(dead_code)]
-const UPSERT_AUDIT_EVENT_SQL: &str = "
+pub(in crate::daemon::db) const UPSERT_AUDIT_EVENT_SQL: &str = "
 INSERT INTO audit_events (
     id, recorded_at, source, category, kind, severity, outcome, title, summary,
     subject, actor, correlation_id, action_key, payload_json, legacy_message, related_urls_json

--- a/src/daemon/db/migrations/0032_daemon_v38_task_board_external_create_intents.sql
+++ b/src/daemon/db/migrations/0032_daemon_v38_task_board_external_create_intents.sql
@@ -34,6 +34,16 @@ CREATE TABLE IF NOT EXISTS task_board_external_create_intents (
                                   OR attached_at GLOB '????-??-??T??:??:??Z'
                               ),
     attached_item_revision INTEGER,
+    follow_up_completed_at TEXT
+                              CHECK (
+                                  follow_up_completed_at IS NULL
+                                  OR follow_up_completed_at GLOB '????-??-??T??:??:??Z'
+                              ),
+    follow_up_audit_event_id TEXT
+                                 CHECK (
+                                     follow_up_audit_event_id IS NULL
+                                     OR length(follow_up_audit_event_id) > 0
+                                 ),
     updated_at            TEXT NOT NULL
                               CHECK (updated_at GLOB '????-??-??T??:??:??Z'),
     CHECK (
@@ -44,6 +54,8 @@ CREATE TABLE IF NOT EXISTS task_board_external_create_intents (
             AND outcome_recorded_at IS NULL
             AND attached_at IS NULL
             AND attached_item_revision IS NULL
+            AND follow_up_completed_at IS NULL
+            AND follow_up_audit_event_id IS NULL
             AND updated_at = created_at
         )
         OR
@@ -57,6 +69,8 @@ CREATE TABLE IF NOT EXISTS task_board_external_create_intents (
             AND outcome_recorded_at > created_at
             AND attached_at IS NULL
             AND attached_item_revision IS NULL
+            AND follow_up_completed_at IS NULL
+            AND follow_up_audit_event_id IS NULL
             AND updated_at = outcome_recorded_at
         )
         OR
@@ -72,6 +86,18 @@ CREATE TABLE IF NOT EXISTS task_board_external_create_intents (
             AND attached_at > outcome_recorded_at
             AND attached_item_revision IS NOT NULL
             AND attached_item_revision >= item_revision
+            AND (
+                (
+                    follow_up_completed_at IS NULL
+                    AND follow_up_audit_event_id IS NULL
+                )
+                OR
+                (
+                    follow_up_completed_at IS NOT NULL
+                    AND follow_up_audit_event_id IS NOT NULL
+                    AND follow_up_completed_at > attached_at
+                )
+            )
             AND updated_at = attached_at
         )
     )
@@ -93,6 +119,14 @@ CREATE INDEX IF NOT EXISTS idx_task_board_external_create_intents_active_scope_s
 CREATE INDEX IF NOT EXISTS idx_task_board_external_create_intents_created_recovery
     ON task_board_external_create_intents(outcome_recorded_at, intent_id)
     WHERE state = 'created';
+
+CREATE INDEX IF NOT EXISTS idx_task_board_external_create_intents_pending_follow_up
+    ON task_board_external_create_intents(
+        provider, scope_id, attached_at, intent_id
+    )
+    WHERE state = 'attached'
+      AND follow_up_completed_at IS NULL
+      AND follow_up_audit_event_id IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_task_board_external_create_intents_item_history
     ON task_board_external_create_intents(item_id, provider, updated_at DESC, intent_id);

--- a/src/daemon/db/migrations/0032_daemon_v38_task_board_external_create_intents.sql
+++ b/src/daemon/db/migrations/0032_daemon_v38_task_board_external_create_intents.sql
@@ -1,0 +1,100 @@
+CREATE TABLE IF NOT EXISTS task_board_external_create_intents (
+    intent_id             TEXT PRIMARY KEY CHECK (length(intent_id) > 0),
+    item_id               TEXT NOT NULL
+                              CHECK (length(item_id) > 0)
+                              REFERENCES task_board_items(item_id) ON DELETE RESTRICT,
+    item_revision         INTEGER NOT NULL CHECK (item_revision > 0),
+    provider              TEXT NOT NULL,
+    scope_id              TEXT NOT NULL CHECK (length(scope_id) > 0),
+    create_key            TEXT NOT NULL CHECK (length(create_key) > 0),
+    state                 TEXT NOT NULL
+                              CHECK (state IN ('in_flight', 'created', 'attached')),
+    create_snapshot_json  TEXT NOT NULL
+                               CHECK (
+                                   json_valid(create_snapshot_json)
+                                   AND json_type(create_snapshot_json) = 'object'
+                               ),
+    changed_fields_json   TEXT NOT NULL
+                               CHECK (
+                                   json_valid(changed_fields_json)
+                                   AND json_type(changed_fields_json) = 'array'
+                               ),
+    outcome_json          TEXT,
+    external_ref_json     TEXT,
+    created_at            TEXT NOT NULL
+                              CHECK (created_at GLOB '????-??-??T??:??:??Z'),
+    outcome_recorded_at   TEXT
+                              CHECK (
+                                  outcome_recorded_at IS NULL
+                                  OR outcome_recorded_at GLOB '????-??-??T??:??:??Z'
+                              ),
+    attached_at           TEXT
+                              CHECK (
+                                  attached_at IS NULL
+                                  OR attached_at GLOB '????-??-??T??:??:??Z'
+                              ),
+    attached_item_revision INTEGER,
+    updated_at            TEXT NOT NULL
+                              CHECK (updated_at GLOB '????-??-??T??:??:??Z'),
+    CHECK (
+        (
+            state = 'in_flight'
+            AND outcome_json IS NULL
+            AND external_ref_json IS NULL
+            AND outcome_recorded_at IS NULL
+            AND attached_at IS NULL
+            AND attached_item_revision IS NULL
+            AND updated_at = created_at
+        )
+        OR
+        (
+            state = 'created'
+            AND outcome_json IS NOT NULL
+            AND external_ref_json IS NOT NULL
+            AND json_valid(outcome_json)
+            AND json_valid(external_ref_json)
+            AND outcome_recorded_at IS NOT NULL
+            AND outcome_recorded_at > created_at
+            AND attached_at IS NULL
+            AND attached_item_revision IS NULL
+            AND updated_at = outcome_recorded_at
+        )
+        OR
+        (
+            state = 'attached'
+            AND outcome_json IS NOT NULL
+            AND external_ref_json IS NOT NULL
+            AND json_valid(outcome_json)
+            AND json_valid(external_ref_json)
+            AND outcome_recorded_at IS NOT NULL
+            AND outcome_recorded_at > created_at
+            AND attached_at IS NOT NULL
+            AND attached_at > outcome_recorded_at
+            AND attached_item_revision IS NOT NULL
+            AND attached_item_revision >= item_revision
+            AND updated_at = attached_at
+        )
+    )
+) WITHOUT ROWID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_task_board_external_create_intents_create_key
+    ON task_board_external_create_intents(provider, create_key);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_task_board_external_create_intents_one_active
+    ON task_board_external_create_intents(item_id, provider)
+    WHERE state IN ('in_flight', 'created');
+
+CREATE INDEX IF NOT EXISTS idx_task_board_external_create_intents_active_scope_state
+    ON task_board_external_create_intents(
+        provider, scope_id, state, updated_at, intent_id
+    )
+    WHERE state IN ('in_flight', 'created');
+
+CREATE INDEX IF NOT EXISTS idx_task_board_external_create_intents_created_recovery
+    ON task_board_external_create_intents(outcome_recorded_at, intent_id)
+    WHERE state = 'created';
+
+CREATE INDEX IF NOT EXISTS idx_task_board_external_create_intents_item_history
+    ON task_board_external_create_intents(item_id, provider, updated_at DESC, intent_id);
+
+UPDATE schema_meta SET value = '38' WHERE key = 'version';

--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -67,6 +67,7 @@ mod runtime;
 mod schema;
 mod schema_migrations;
 mod schema_repairs;
+mod schema_repairs_external_creates;
 mod schema_sql;
 mod schema_v10;
 mod schema_v11;
@@ -96,6 +97,7 @@ mod schema_v34;
 mod schema_v35;
 mod schema_v36;
 mod schema_v37;
+mod schema_v38;
 #[allow(dead_code)]
 mod task_board;
 #[allow(unused_imports)]
@@ -297,7 +299,7 @@ impl fmt::Debug for DaemonDb {
     }
 }
 
-pub(crate) const SCHEMA_VERSION: &str = "37";
+pub(crate) const SCHEMA_VERSION: &str = "38";
 
 /// Summary of what was imported from file-based storage.
 #[derive(Debug, Default)]

--- a/src/daemon/db/schema.rs
+++ b/src/daemon/db/schema.rs
@@ -211,6 +211,9 @@ impl DaemonDb {
         if version_number <= 36 {
             self.migrate_v36_to_v37()?;
         }
+        if version_number <= 37 {
+            self.migrate_v37_to_v38()?;
+        }
         Ok(())
     }
 
@@ -350,6 +353,10 @@ impl DaemonDb {
 
     fn migrate_v36_to_v37(&self) -> Result<(), CliError> {
         super::schema_v37::run(&self.conn)
+    }
+
+    fn migrate_v37_to_v38(&self) -> Result<(), CliError> {
+        super::schema_v38::run(&self.conn)
     }
 }
 

--- a/src/daemon/db/schema_repairs.rs
+++ b/src/daemon/db/schema_repairs.rs
@@ -93,6 +93,7 @@ pub(super) fn current_schema_shape_needs_repair(
         "task_board_execution_attempts",
         "task_board_admission_leases",
         "task_board_provider_scope_state",
+        "task_board_external_create_intents",
         "task_board_sync_conflicts",
         "task_board_execution_hosts",
         "task_board_remote_assignments",
@@ -112,6 +113,7 @@ pub(super) fn current_schema_shape_needs_repair(
             return Ok(true);
         }
     }
+    super::schema_repairs_external_creates::require_table_shape(conn)?;
     if !table_sql_contains(conn, "task_board_dispatch_intents", "'held'")? {
         return Ok(true);
     }
@@ -129,6 +131,9 @@ pub(super) fn current_schema_shape_needs_repair(
         if !trigger_exists(conn, trigger)? {
             return Ok(true);
         }
+    }
+    if super::schema_repairs_external_creates::indexes_need_repair(conn)? {
+        return Ok(true);
     }
     Ok(false)
 }
@@ -162,6 +167,8 @@ pub(super) fn repair_current_schema_shape(db: &DaemonDb) -> Result<(), CliError>
     super::schema_v35::run(&db.conn)?;
     super::schema_v36::run(&db.conn)?;
     super::schema_v37::run(&db.conn)?;
+    super::schema_v38::run(&db.conn)?;
+    super::schema_repairs_external_creates::require_complete_shape(&db.conn)?;
     db.conn
         .execute(
             "UPDATE schema_meta SET value = ?1 WHERE key = 'version'",

--- a/src/daemon/db/schema_repairs_external_creates.rs
+++ b/src/daemon/db/schema_repairs_external_creates.rs
@@ -84,6 +84,8 @@ const EXPECTED_COLUMNS: &[ExpectedColumn] = &[
     ExpectedColumn::optional("outcome_recorded_at", "TEXT"),
     ExpectedColumn::optional("attached_at", "TEXT"),
     ExpectedColumn::optional("attached_item_revision", "INTEGER"),
+    ExpectedColumn::optional("follow_up_completed_at", "TEXT"),
+    ExpectedColumn::optional("follow_up_audit_event_id", "TEXT"),
     ExpectedColumn::required("updated_at", "TEXT"),
 ];
 
@@ -121,6 +123,20 @@ const INDEX_SHAPES: &[IndexShape] = &[
         partial: true,
         columns: &[("outcome_recorded_at", false), ("intent_id", false)],
         predicate: Some("where state = 'created'"),
+    },
+    IndexShape {
+        name: "idx_task_board_external_create_intents_pending_follow_up",
+        unique: false,
+        partial: true,
+        columns: &[
+            ("provider", false),
+            ("scope_id", false),
+            ("attached_at", false),
+            ("intent_id", false),
+        ],
+        predicate: Some(
+            "where state = 'attached' and follow_up_completed_at is null and follow_up_audit_event_id is null",
+        ),
     },
     IndexShape {
         name: "idx_task_board_external_create_intents_item_history",

--- a/src/daemon/db/schema_repairs_external_creates.rs
+++ b/src/daemon/db/schema_repairs_external_creates.rs
@@ -1,0 +1,359 @@
+use super::{CliError, Connection, db_error};
+
+const MIGRATION_SQL: &str =
+    include_str!("migrations/0032_daemon_v38_task_board_external_create_intents.sql");
+
+#[derive(Debug, Clone, Copy)]
+struct ExpectedColumn {
+    name: &'static str,
+    declared_type: &'static str,
+    not_null: bool,
+    primary_key: i64,
+}
+
+impl ExpectedColumn {
+    const fn required(name: &'static str, declared_type: &'static str) -> Self {
+        Self {
+            name,
+            declared_type,
+            not_null: true,
+            primary_key: 0,
+        }
+    }
+
+    const fn required_primary(name: &'static str, declared_type: &'static str) -> Self {
+        Self {
+            name,
+            declared_type,
+            not_null: true,
+            primary_key: 1,
+        }
+    }
+
+    const fn optional(name: &'static str, declared_type: &'static str) -> Self {
+        Self {
+            name,
+            declared_type,
+            not_null: false,
+            primary_key: 0,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StoredColumn {
+    name: String,
+    declared_type: String,
+    not_null: bool,
+    default_value: Option<String>,
+    primary_key: i64,
+    hidden: i64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ForeignKeyShape {
+    table: String,
+    from: String,
+    to: String,
+    on_update: String,
+    on_delete: String,
+    match_kind: String,
+}
+
+struct IndexShape {
+    name: &'static str,
+    unique: bool,
+    partial: bool,
+    columns: &'static [(&'static str, bool)],
+    predicate: Option<&'static str>,
+}
+
+const EXPECTED_COLUMNS: &[ExpectedColumn] = &[
+    ExpectedColumn::required_primary("intent_id", "TEXT"),
+    ExpectedColumn::required("item_id", "TEXT"),
+    ExpectedColumn::required("item_revision", "INTEGER"),
+    ExpectedColumn::required("provider", "TEXT"),
+    ExpectedColumn::required("scope_id", "TEXT"),
+    ExpectedColumn::required("create_key", "TEXT"),
+    ExpectedColumn::required("state", "TEXT"),
+    ExpectedColumn::required("create_snapshot_json", "TEXT"),
+    ExpectedColumn::required("changed_fields_json", "TEXT"),
+    ExpectedColumn::optional("outcome_json", "TEXT"),
+    ExpectedColumn::optional("external_ref_json", "TEXT"),
+    ExpectedColumn::required("created_at", "TEXT"),
+    ExpectedColumn::optional("outcome_recorded_at", "TEXT"),
+    ExpectedColumn::optional("attached_at", "TEXT"),
+    ExpectedColumn::optional("attached_item_revision", "INTEGER"),
+    ExpectedColumn::required("updated_at", "TEXT"),
+];
+
+const INDEX_SHAPES: &[IndexShape] = &[
+    IndexShape {
+        name: "idx_task_board_external_create_intents_create_key",
+        unique: true,
+        partial: false,
+        columns: &[("provider", false), ("create_key", false)],
+        predicate: None,
+    },
+    IndexShape {
+        name: "idx_task_board_external_create_intents_one_active",
+        unique: true,
+        partial: true,
+        columns: &[("item_id", false), ("provider", false)],
+        predicate: Some("where state in ('in_flight', 'created')"),
+    },
+    IndexShape {
+        name: "idx_task_board_external_create_intents_active_scope_state",
+        unique: false,
+        partial: true,
+        columns: &[
+            ("provider", false),
+            ("scope_id", false),
+            ("state", false),
+            ("updated_at", false),
+            ("intent_id", false),
+        ],
+        predicate: Some("where state in ('in_flight', 'created')"),
+    },
+    IndexShape {
+        name: "idx_task_board_external_create_intents_created_recovery",
+        unique: false,
+        partial: true,
+        columns: &[("outcome_recorded_at", false), ("intent_id", false)],
+        predicate: Some("where state = 'created'"),
+    },
+    IndexShape {
+        name: "idx_task_board_external_create_intents_item_history",
+        unique: false,
+        partial: false,
+        columns: &[
+            ("item_id", false),
+            ("provider", false),
+            ("updated_at", true),
+            ("intent_id", false),
+        ],
+        predicate: None,
+    },
+];
+
+pub(super) fn require_table_shape(conn: &Connection) -> Result<(), CliError> {
+    let columns = table_columns(conn)?;
+    let foreign_keys = table_foreign_keys(conn)?;
+    let definition = normalized_table_sql(conn)?;
+    if columns_match(&columns)
+        && foreign_keys == [expected_foreign_key()]
+        && definition == expected_table_sql()?
+    {
+        return Ok(());
+    }
+    Err(db_error(
+        "incompatible task_board_external_create_intents schema; refusing destructive repair",
+    ))
+}
+
+pub(super) fn indexes_need_repair(conn: &Connection) -> Result<bool, CliError> {
+    let mut missing = false;
+    for shape in INDEX_SHAPES {
+        if !index_exists(conn, shape.name)? {
+            missing = true;
+            continue;
+        }
+        require_index_shape(conn, shape)?;
+    }
+    Ok(missing)
+}
+
+pub(super) fn require_complete_shape(conn: &Connection) -> Result<(), CliError> {
+    require_table_shape(conn)?;
+    if indexes_need_repair(conn)? {
+        return Err(db_error(
+            "task-board external create intent repair left required indexes missing",
+        ));
+    }
+    Ok(())
+}
+
+fn require_index_shape(conn: &Connection, shape: &IndexShape) -> Result<(), CliError> {
+    let (stored_unique, stored_partial) = index_properties(conn, shape.name)?;
+    let stored_columns = index_columns(conn, shape.name)?;
+    let sql = normalized_index_sql(conn, shape.name)?;
+    let columns_match = stored_columns.len() == shape.columns.len()
+        && stored_columns.iter().zip(shape.columns).all(
+            |((stored_name, stored_desc), (name, desc))| stored_name == name && stored_desc == desc,
+        );
+    let predicate_matches = shape.predicate.map_or_else(
+        || !sql.contains(" where "),
+        |expected| sql.ends_with(expected),
+    );
+    if stored_unique == shape.unique
+        && stored_partial == shape.partial
+        && columns_match
+        && predicate_matches
+    {
+        return Ok(());
+    }
+    Err(db_error(format!(
+        "incompatible task-board external create intent index '{}'; refusing destructive repair",
+        shape.name
+    )))
+}
+
+fn table_columns(conn: &Connection) -> Result<Vec<StoredColumn>, CliError> {
+    let mut statement = conn
+        .prepare(
+            "SELECT name, type, \"notnull\", dflt_value, pk, hidden
+             FROM pragma_table_xinfo('task_board_external_create_intents')
+             ORDER BY cid",
+        )
+        .map_err(|error| db_error(format!("prepare external create intent columns: {error}")))?;
+    statement
+        .query_map([], |row| {
+            Ok(StoredColumn {
+                name: row.get(0)?,
+                declared_type: row.get(1)?,
+                not_null: row.get::<_, i64>(2)? != 0,
+                default_value: row.get(3)?,
+                primary_key: row.get(4)?,
+                hidden: row.get(5)?,
+            })
+        })
+        .map_err(|error| db_error(format!("query external create intent columns: {error}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| db_error(format!("read external create intent columns: {error}")))
+}
+
+fn columns_match(stored: &[StoredColumn]) -> bool {
+    stored.len() == EXPECTED_COLUMNS.len()
+        && stored
+            .iter()
+            .zip(EXPECTED_COLUMNS)
+            .all(|(stored, expected)| {
+                stored.name == expected.name
+                    && stored.declared_type == expected.declared_type
+                    && stored.not_null == expected.not_null
+                    && stored.default_value.is_none()
+                    && stored.primary_key == expected.primary_key
+                    && stored.hidden == 0
+            })
+}
+
+fn table_foreign_keys(conn: &Connection) -> Result<Vec<ForeignKeyShape>, CliError> {
+    let mut statement = conn
+        .prepare(
+            "SELECT \"table\", \"from\", \"to\", on_update, on_delete, match
+             FROM pragma_foreign_key_list('task_board_external_create_intents')
+             ORDER BY id, seq",
+        )
+        .map_err(|error| {
+            db_error(format!(
+                "prepare external create intent foreign keys: {error}"
+            ))
+        })?;
+    statement
+        .query_map([], |row| {
+            Ok(ForeignKeyShape {
+                table: row.get(0)?,
+                from: row.get(1)?,
+                to: row.get(2)?,
+                on_update: row.get(3)?,
+                on_delete: row.get(4)?,
+                match_kind: row.get(5)?,
+            })
+        })
+        .map_err(|error| {
+            db_error(format!(
+                "query external create intent foreign keys: {error}"
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| db_error(format!("read external create intent foreign keys: {error}")))
+}
+
+fn expected_foreign_key() -> ForeignKeyShape {
+    ForeignKeyShape {
+        table: "task_board_items".into(),
+        from: "item_id".into(),
+        to: "item_id".into(),
+        on_update: "NO ACTION".into(),
+        on_delete: "RESTRICT".into(),
+        match_kind: "NONE".into(),
+    }
+}
+
+fn expected_table_sql() -> Result<String, CliError> {
+    let table = MIGRATION_SQL
+        .split_once("\n\nCREATE UNIQUE INDEX")
+        .map(|(table, _)| table)
+        .ok_or_else(|| db_error("external create migration has no index boundary"))?;
+    let table = table.trim_end_matches(';').replace("IF NOT EXISTS ", "");
+    Ok(normalize_sql(&table))
+}
+
+fn index_exists(conn: &Connection, index_name: &str) -> Result<bool, CliError> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1",
+        [index_name],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|count| count > 0)
+    .map_err(|error| db_error(format!("check {index_name} index existence: {error}")))
+}
+
+fn index_properties(conn: &Connection, index_name: &str) -> Result<(bool, bool), CliError> {
+    conn.query_row(
+        "SELECT \"unique\", partial
+         FROM pragma_index_list('task_board_external_create_intents')
+         WHERE name = ?1",
+        [index_name],
+        |row| Ok((row.get::<_, i64>(0)? != 0, row.get::<_, i64>(1)? != 0)),
+    )
+    .map_err(|error| db_error(format!("read {index_name} index properties: {error}")))
+}
+
+fn index_columns(conn: &Connection, index_name: &str) -> Result<Vec<(String, bool)>, CliError> {
+    let mut statement = conn
+        .prepare(
+            "SELECT name, \"desc\" FROM pragma_index_xinfo(?1)
+             WHERE key = 1 ORDER BY seqno",
+        )
+        .map_err(|error| db_error(format!("prepare {index_name} index columns: {error}")))?;
+    statement
+        .query_map([index_name], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? != 0))
+        })
+        .map_err(|error| db_error(format!("query {index_name} index columns: {error}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| db_error(format!("read {index_name} index columns: {error}")))
+}
+
+fn normalized_index_sql(conn: &Connection, index_name: &str) -> Result<String, CliError> {
+    conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+        [index_name],
+        |row| row.get::<_, String>(0),
+    )
+    .map(|sql| normalize_sql(&sql))
+    .map_err(|error| db_error(format!("read {index_name} index definition: {error}")))
+}
+
+fn normalized_table_sql(conn: &Connection) -> Result<String, CliError> {
+    conn.query_row(
+        "SELECT sql FROM sqlite_master
+         WHERE type = 'table' AND name = 'task_board_external_create_intents'",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .map(|sql| normalize_sql(&sql))
+    .map_err(|error| {
+        db_error(format!(
+            "read external create intent table definition: {error}"
+        ))
+    })
+}
+
+fn normalize_sql(sql: &str) -> String {
+    sql.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}

--- a/src/daemon/db/schema_v38.rs
+++ b/src/daemon/db/schema_v38.rs
@@ -52,6 +52,7 @@ mod tests {
             "idx_task_board_external_create_intents_one_active",
             "idx_task_board_external_create_intents_active_scope_state",
             "idx_task_board_external_create_intents_created_recovery",
+            "idx_task_board_external_create_intents_pending_follow_up",
             "idx_task_board_external_create_intents_item_history",
         ] {
             let exists: i64 = db

--- a/src/daemon/db/schema_v38.rs
+++ b/src/daemon/db/schema_v38.rs
@@ -1,0 +1,126 @@
+use rusqlite::Connection;
+
+use super::{CliError, db_error};
+
+const EXTERNAL_CREATE_INTENTS_SQL: &str =
+    include_str!("migrations/0032_daemon_v38_task_board_external_create_intents.sql");
+
+pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
+    conn.execute_batch(EXTERNAL_CREATE_INTENTS_SQL)
+        .map_err(|error| {
+            db_error(format!(
+                "migrate task-board external create intents: {error}"
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::db::{AsyncDaemonDb, DaemonDb};
+    use crate::task_board::TaskBoardItem;
+    use tempfile::tempdir;
+
+    #[test]
+    fn migration_creates_constrained_external_create_intent_storage() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+        db.connection()
+            .execute_batch(
+                "DROP TABLE task_board_external_create_intents;
+                 UPDATE schema_meta SET value = '37' WHERE key = 'version';",
+            )
+            .expect("restore v37 shape");
+
+        run(db.connection()).expect("run external create intent migration");
+        run(db.connection()).expect("repeat external create intent migration");
+
+        assert_eq!(db.schema_version().expect("schema version"), "38");
+        let table_sql: String = db
+            .connection()
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'table' AND name = 'task_board_external_create_intents'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read intent table SQL");
+        assert!(table_sql.contains("intent_id"));
+        assert!(table_sql.contains("ON DELETE RESTRICT"));
+        assert!(table_sql.contains("'in_flight', 'created', 'attached'"));
+        for index in [
+            "idx_task_board_external_create_intents_create_key",
+            "idx_task_board_external_create_intents_one_active",
+            "idx_task_board_external_create_intents_active_scope_state",
+            "idx_task_board_external_create_intents_created_recovery",
+            "idx_task_board_external_create_intents_item_history",
+        ] {
+            let exists: i64 = db
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master
+                     WHERE type = 'index' AND name = ?1",
+                    [index],
+                    |row| row.get(0),
+                )
+                .expect("read intent index");
+            assert_eq!(exists, 1, "missing index {index}");
+        }
+    }
+
+    #[tokio::test]
+    async fn created_intent_requires_exact_outcome_and_reference_json() {
+        let dir = tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+            .await
+            .expect("database");
+        db.create_task_board_item(TaskBoardItem::new(
+            "task-schema-intent".into(),
+            "Task".into(),
+            String::new(),
+            "2026-07-16T10:00:00Z".into(),
+        ))
+        .await
+        .expect("create item");
+
+        let error = sqlx::query(
+            "INSERT INTO task_board_external_create_intents (
+                intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+                create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+                created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+             ) VALUES (
+                'intent', 'task-schema-intent', 1, 'github', 'scope', 'create-key',
+                'created', '{}', '[]', NULL, NULL, '2026-07-16T10:00:00Z',
+                '2026-07-16T10:00:01Z', NULL, NULL, '2026-07-16T10:00:01Z'
+             )",
+        )
+        .execute(db.pool())
+        .await
+        .expect_err("created state without evidence must fail");
+
+        assert!(error.to_string().contains("CHECK constraint failed"));
+
+        for (intent_id, snapshot, fields) in [
+            ("snapshot-array", "[]", "[]"),
+            ("fields-object", "{}", "{}"),
+        ] {
+            let error = sqlx::query(
+                "INSERT INTO task_board_external_create_intents (
+                    intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+                    create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+                    created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+                 ) VALUES (
+                    ?1, 'task-schema-intent', 1, 'github', 'scope', ?1, 'in_flight',
+                    ?2, ?3, NULL, NULL, '2026-07-16T10:00:00Z',
+                    NULL, NULL, NULL, '2026-07-16T10:00:00Z'
+                 )",
+            )
+            .bind(intent_id)
+            .bind(snapshot)
+            .bind(fields)
+            .execute(db.pool())
+            .await
+            .expect_err("incorrect JSON shape must fail");
+            assert!(error.to_string().contains("CHECK constraint failed"));
+        }
+    }
+}

--- a/src/daemon/db/task_board/mod.rs
+++ b/src/daemon/db/task_board/mod.rs
@@ -10,14 +10,28 @@ mod items;
 mod mapper;
 mod policy_queues;
 mod policy_runs;
+mod provider_external_create_evidence;
+mod provider_external_create_finalize;
+mod provider_external_create_rows;
+mod provider_external_creates;
 mod provider_sync;
 mod provider_sync_conflicts;
 mod rows;
 
 #[cfg(test)]
+mod provider_external_create_finalize_tests;
+#[cfg(test)]
+mod provider_external_create_optional_evidence_tests;
+#[cfg(test)]
+mod provider_external_create_recovery_tests;
+#[cfg(test)]
+mod provider_external_creates_tests;
+#[cfg(test)]
 mod provider_sync_backoff_tests;
 #[cfg(test)]
 mod provider_sync_conflict_revision_tests;
+#[cfg(test)]
+mod provider_sync_conflict_supersession_tests;
 #[cfg(test)]
 mod provider_sync_fencing_tests;
 #[cfg(test)]

--- a/src/daemon/db/task_board/mod.rs
+++ b/src/daemon/db/task_board/mod.rs
@@ -11,14 +11,19 @@ mod mapper;
 mod policy_queues;
 mod policy_runs;
 mod provider_sync;
+mod provider_sync_conflicts;
 mod rows;
 
 #[cfg(test)]
 mod provider_sync_backoff_tests;
 #[cfg(test)]
+mod provider_sync_conflict_revision_tests;
+#[cfg(test)]
 mod provider_sync_fencing_tests;
 #[cfg(test)]
 mod provider_sync_publication_tests;
+#[cfg(test)]
+mod provider_sync_renewal_tests;
 #[cfg(test)]
 mod provider_sync_tests;
 

--- a/src/daemon/db/task_board/mod.rs
+++ b/src/daemon/db/task_board/mod.rs
@@ -12,6 +12,7 @@ mod policy_queues;
 mod policy_runs;
 mod provider_external_create_evidence;
 mod provider_external_create_finalize;
+mod provider_external_create_follow_up;
 mod provider_external_create_rows;
 mod provider_external_creates;
 mod provider_sync;
@@ -20,6 +21,8 @@ mod rows;
 
 #[cfg(test)]
 mod provider_external_create_finalize_tests;
+#[cfg(test)]
+mod provider_external_create_follow_up_tests;
 #[cfg(test)]
 mod provider_external_create_optional_evidence_tests;
 #[cfg(test)]

--- a/src/daemon/db/task_board/provider_external_create_evidence.rs
+++ b/src/daemon/db/task_board/provider_external_create_evidence.rs
@@ -1,0 +1,142 @@
+use chrono::DateTime;
+
+use super::provider_external_create_rows::{create_conflict, normalize_provider_target};
+use crate::daemon::db::CliError;
+use crate::task_board::{
+    ExternalCreateOutcome, ExternalProvider, ExternalRef, ExternalRefSyncState,
+    TaskBoardExternalCreateIntent, TaskBoardStatus, normalize_repository_slug,
+};
+
+pub(super) fn validate_create_evidence(
+    intent: &TaskBoardExternalCreateIntent,
+    outcome: &ExternalCreateOutcome,
+    provider_baseline: &ExternalRef,
+) -> Result<(), CliError> {
+    let reference = &outcome.reference;
+    let state = provider_baseline
+        .sync_state
+        .as_ref()
+        .ok_or_else(|| create_conflict(intent, "provider baseline has no sync state"))?;
+    let target = normalized_evidence_target(intent, outcome)?;
+    let outcome_project =
+        normalized_optional_project(intent, outcome.provider_project_id.as_deref())?;
+    let baseline_project = normalized_optional_project(intent, state.project_id.as_deref())?;
+    require_matching_revision(intent, outcome, state)?;
+    let matches = reference.provider == intent.provider
+        && provider_baseline.provider == intent.provider.into()
+        && provider_baseline.external_id == reference.external_id
+        && provider_baseline.url == reference.url
+        && outcome_project == baseline_project
+        && optional_project_matches_identity(
+            intent.provider,
+            outcome_project.as_deref(),
+            target.as_deref(),
+        )
+        && complete_provider_state(state)
+        && valid_synced_at(state);
+    if matches {
+        Ok(())
+    } else {
+        Err(create_conflict(
+            intent,
+            "create outcome and provider baseline are inconsistent",
+        ))
+    }
+}
+
+pub(super) fn normalized_evidence_target(
+    intent: &TaskBoardExternalCreateIntent,
+    outcome: &ExternalCreateOutcome,
+) -> Result<Option<String>, CliError> {
+    match intent.provider {
+        ExternalProvider::GitHub => {
+            normalized_github_repository(intent, &outcome.reference.external_id).map(Some)
+        }
+        ExternalProvider::Todoist => {
+            if outcome.reference.external_id.trim().is_empty() {
+                return Err(create_conflict(
+                    intent,
+                    "Todoist create outcome has no external identity",
+                ));
+            }
+            normalized_optional_project(intent, outcome.provider_project_id.as_deref())
+        }
+    }
+}
+
+fn normalized_optional_project(
+    intent: &TaskBoardExternalCreateIntent,
+    project: Option<&str>,
+) -> Result<Option<String>, CliError> {
+    project
+        .map(|target| normalize_provider_target(intent.provider, target))
+        .transpose()
+}
+
+fn require_matching_revision(
+    intent: &TaskBoardExternalCreateIntent,
+    outcome: &ExternalCreateOutcome,
+    state: &ExternalRefSyncState,
+) -> Result<(), CliError> {
+    match (
+        outcome.provider_revision.as_deref(),
+        state.updated_at.as_deref(),
+    ) {
+        (None, None) => Ok(()),
+        (Some(outcome), Some(baseline)) if !outcome.trim().is_empty() && outcome == baseline => {
+            Ok(())
+        }
+        _ => Err(create_conflict(
+            intent,
+            "provider baseline revision differs from the outcome",
+        )),
+    }
+}
+
+fn complete_provider_state(state: &ExternalRefSyncState) -> bool {
+    state.title.is_some()
+        && state.body.is_some()
+        && matches!(
+            state.status,
+            Some(TaskBoardStatus::Backlog | TaskBoardStatus::Done)
+        )
+}
+
+fn valid_synced_at(state: &ExternalRefSyncState) -> bool {
+    state
+        .synced_at
+        .as_deref()
+        .is_some_and(|synced_at| DateTime::parse_from_rfc3339(synced_at).is_ok())
+}
+
+fn normalized_github_repository(
+    intent: &TaskBoardExternalCreateIntent,
+    external_id: &str,
+) -> Result<String, CliError> {
+    let Some((repository, issue)) = external_id.rsplit_once('#') else {
+        return Err(create_conflict(
+            intent,
+            "GitHub create outcome has an invalid external identity",
+        ));
+    };
+    if issue.is_empty() {
+        return Err(create_conflict(
+            intent,
+            "GitHub create outcome has an invalid external identity",
+        ));
+    }
+    normalize_repository_slug(Some(repository)).ok_or_else(|| {
+        create_conflict(
+            intent,
+            "GitHub create outcome has an invalid external identity",
+        )
+    })
+}
+
+fn optional_project_matches_identity(
+    provider: ExternalProvider,
+    project: Option<&str>,
+    target: Option<&str>,
+) -> bool {
+    provider != ExternalProvider::GitHub || project.is_none_or(|project| Some(project) == target)
+}

--- a/src/daemon/db/task_board/provider_external_create_finalize.rs
+++ b/src/daemon/db/task_board/provider_external_create_finalize.rs
@@ -1,4 +1,4 @@
-use sqlx::{Sqlite, Transaction, query_as};
+use sqlx::{Sqlite, SqliteConnection, Transaction, query_as};
 
 use super::items::{bump_change_in_tx, load_item_in_tx, replace_item_in_tx};
 use super::provider_external_create_evidence::{
@@ -8,14 +8,16 @@ use super::provider_external_create_rows::{
     create_conflict, load_intent_by_id, next_timestamp, provider_label, require_same_intent,
     update_attached_receipt,
 };
+use super::provider_sync_conflicts::supersede_open_sync_conflicts_in_connection;
 use super::{ITEMS_CHANGE_SCOPE, ORCHESTRATOR_CHANGE_SCOPE};
 use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
 use crate::task_board::{
-    ExternalProvider, ExternalRef, TaskBoardExternalCreateEvidence,
+    ExternalProvider, ExternalRef, ExternalSyncField, TaskBoardExternalCreateEvidence,
     TaskBoardExternalCreateFinalizeDisposition, TaskBoardExternalCreateFinalizeResult,
     TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState,
-    TaskBoardExternalCreateReceipt, TaskBoardItem, normalize_repository_slug,
+    TaskBoardExternalCreateReceipt, TaskBoardItem, TaskBoardStatus, normalize_repository_slug,
 };
+use crate::workspace::utc_now;
 
 impl AsyncDaemonDb {
     #[expect(
@@ -60,7 +62,7 @@ impl AsyncDaemonDb {
         ) {
             return Err(create_conflict(&stored, "intent is not ready to finalize"));
         }
-        let Some((mut item, item_revision)) =
+        let Some((item, item_revision)) =
             load_item_in_tx(&mut transaction, &stored.item_id).await?
         else {
             commit(transaction, "missing-item task-board external create").await?;
@@ -88,33 +90,66 @@ impl AsyncDaemonDb {
                 item_revision,
                 &attached_at,
                 provider_target.as_deref(),
+                &expected.provider_baseline,
             )
             .await;
         }
-        apply_provider_identity(&mut item, &stored, provider_target.as_deref())?;
-        item.external_refs.push(expected.provider_baseline.clone());
-        if item.updated_at.as_str() < attached_at.as_str() {
-            item.updated_at.clone_from(&attached_at);
-        }
-        let attached_item_revision = item_revision + 1;
-        replace_item_in_tx(&mut transaction, &item, attached_item_revision).await?;
-        update_attached_receipt(
-            &mut transaction,
-            &stored,
+        finalize_new_link(
+            transaction,
+            stored,
+            item,
+            item_revision,
             &attached_at,
-            attached_item_revision,
+            provider_target.as_deref(),
+            &expected.provider_baseline,
         )
-        .await?;
-        bump_change_in_tx(&mut transaction, ITEMS_CHANGE_SCOPE).await?;
-        commit(transaction, "task-board external create finalize").await?;
-        let attached = attached_intent(stored, &attached_at, attached_item_revision)?;
-        Ok(finalize_result(
-            attached,
-            Some(item),
-            Some(attached_item_revision),
-            TaskBoardExternalCreateFinalizeDisposition::Attached,
-        ))
+        .await
     }
+}
+
+async fn finalize_new_link(
+    mut transaction: Transaction<'_, Sqlite>,
+    stored: TaskBoardExternalCreateIntent,
+    mut item: TaskBoardItem,
+    item_revision: i64,
+    attached_at: &str,
+    provider_target: Option<&str>,
+    provider_baseline: &ExternalRef,
+) -> Result<TaskBoardExternalCreateFinalizeResult, CliError> {
+    apply_provider_identity(&mut item, &stored, provider_target)?;
+    item.external_refs.push(provider_baseline.clone());
+    if item.updated_at.as_str() < attached_at {
+        attached_at.clone_into(&mut item.updated_at);
+    }
+    let attached_item_revision = item_revision + 1;
+    replace_item_in_tx(&mut transaction, &item, attached_item_revision).await?;
+    update_attached_receipt(
+        &mut transaction,
+        &stored,
+        attached_at,
+        attached_item_revision,
+    )
+    .await?;
+    let conflicts_changed = supersede_create_conflicts(
+        transaction.as_mut(),
+        &stored,
+        &item,
+        attached_item_revision,
+        provider_baseline,
+    )
+    .await?;
+    bump_change_in_tx(&mut transaction, ITEMS_CHANGE_SCOPE).await?;
+    if conflicts_changed {
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+    }
+    commit(transaction, "task-board external create finalize").await?;
+    let attached = attached_intent(stored, attached_at, attached_item_revision)?;
+    Ok(finalize_result(
+        attached,
+        Some(item),
+        Some(attached_item_revision),
+        TaskBoardExternalCreateFinalizeDisposition::Attached,
+    ))
 }
 
 async fn finalize_existing_link(
@@ -124,6 +159,7 @@ async fn finalize_existing_link(
     item_revision: i64,
     attached_at: &str,
     provider_target: Option<&str>,
+    provider_baseline: &ExternalRef,
 ) -> Result<TaskBoardExternalCreateFinalizeResult, CliError> {
     let identity_changed = apply_provider_identity(&mut item, &stored, provider_target)?;
     let attached_item_revision = if identity_changed {
@@ -143,6 +179,14 @@ async fn finalize_existing_link(
         attached_item_revision,
     )
     .await?;
+    let conflicts_changed = supersede_create_conflicts(
+        transaction.as_mut(),
+        &stored,
+        &item,
+        attached_item_revision,
+        provider_baseline,
+    )
+    .await?;
     bump_change_in_tx(
         &mut transaction,
         if identity_changed {
@@ -152,6 +196,9 @@ async fn finalize_existing_link(
         },
     )
     .await?;
+    if identity_changed && conflicts_changed {
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+    }
     commit(transaction, "task-board external create linked receipt").await?;
     let attached = attached_intent(stored, attached_at, attached_item_revision)?;
     Ok(finalize_result(
@@ -160,6 +207,59 @@ async fn finalize_existing_link(
         Some(attached_item_revision),
         TaskBoardExternalCreateFinalizeDisposition::AlreadyLinked,
     ))
+}
+
+async fn supersede_create_conflicts(
+    connection: &mut SqliteConnection,
+    intent: &TaskBoardExternalCreateIntent,
+    item: &TaskBoardItem,
+    item_revision: i64,
+    baseline: &ExternalRef,
+) -> Result<bool, CliError> {
+    let fields = proven_create_fields(intent, item, baseline);
+    supersede_open_sync_conflicts_in_connection(
+        connection,
+        &intent.item_id,
+        intent.provider,
+        &baseline.external_id,
+        item_revision,
+        &fields,
+        &utc_now(),
+    )
+    .await
+}
+
+fn proven_create_fields(
+    intent: &TaskBoardExternalCreateIntent,
+    item: &TaskBoardItem,
+    baseline: &ExternalRef,
+) -> Vec<ExternalSyncField> {
+    let Some(state) = baseline.sync_state.as_ref() else {
+        return Vec::new();
+    };
+    intent
+        .changed_fields
+        .iter()
+        .copied()
+        .filter(|field| match field {
+            ExternalSyncField::Title => state.title.as_deref() == Some(&item.title),
+            ExternalSyncField::Body => state.body.as_deref() == Some(&item.body),
+            ExternalSyncField::Status => {
+                state.status.map(canonical_provider_status)
+                    == Some(canonical_provider_status(item.status))
+            }
+            ExternalSyncField::Project => state.project_id == item.project_id,
+            ExternalSyncField::Url => false,
+        })
+        .collect()
+}
+
+fn canonical_provider_status(status: TaskBoardStatus) -> TaskBoardStatus {
+    if status.canonical_persisted_status() == TaskBoardStatus::Done {
+        TaskBoardStatus::Done
+    } else {
+        TaskBoardStatus::Backlog
+    }
 }
 
 async fn require_identity_not_linked_elsewhere(

--- a/src/daemon/db/task_board/provider_external_create_finalize.rs
+++ b/src/daemon/db/task_board/provider_external_create_finalize.rs
@@ -1,0 +1,321 @@
+use sqlx::{Sqlite, Transaction, query_as};
+
+use super::items::{bump_change_in_tx, load_item_in_tx, replace_item_in_tx};
+use super::provider_external_create_evidence::{
+    normalized_evidence_target, validate_create_evidence,
+};
+use super::provider_external_create_rows::{
+    create_conflict, load_intent_by_id, next_timestamp, provider_label, require_same_intent,
+    update_attached_receipt,
+};
+use super::{ITEMS_CHANGE_SCOPE, ORCHESTRATOR_CHANGE_SCOPE};
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
+use crate::task_board::{
+    ExternalProvider, ExternalRef, TaskBoardExternalCreateEvidence,
+    TaskBoardExternalCreateFinalizeDisposition, TaskBoardExternalCreateFinalizeResult,
+    TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState,
+    TaskBoardExternalCreateReceipt, TaskBoardItem, normalize_repository_slug,
+};
+
+impl AsyncDaemonDb {
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "finalization keeps evidence, identity, item CAS, and receipt persistence atomic"
+    )]
+    pub(crate) async fn finalize_task_board_external_create_intent(
+        &self,
+        intent: &TaskBoardExternalCreateIntent,
+    ) -> Result<TaskBoardExternalCreateFinalizeResult, CliError> {
+        let expected = intent
+            .created_evidence()
+            .ok_or_else(|| create_conflict(intent, "outcome is absent"))?;
+        validate_create_evidence(intent, &expected.outcome, &expected.provider_baseline)?;
+        let provider_target = normalized_evidence_target(intent, &expected.outcome)?;
+        let mut transaction = self
+            .begin_immediate_transaction("task board external create finalize")
+            .await?;
+        let stored = load_intent_by_id(&mut transaction, &intent.intent_id)
+            .await?
+            .ok_or_else(|| create_conflict(intent, "create intent is missing"))?;
+        require_same_intent(&stored, intent)?;
+        let stored_evidence = stored
+            .created_evidence()
+            .ok_or_else(|| create_conflict(&stored, "outcome is absent"))?;
+        require_same_evidence(&stored, stored_evidence, expected)?;
+        if matches!(
+            &stored.state,
+            TaskBoardExternalCreateIntentState::Attached(_)
+        ) {
+            commit(transaction, "already attached task-board external create").await?;
+            return Ok(finalize_result(
+                stored,
+                None,
+                None,
+                TaskBoardExternalCreateFinalizeDisposition::AlreadyAttached,
+            ));
+        }
+        if !matches!(
+            &stored.state,
+            TaskBoardExternalCreateIntentState::Created(_)
+        ) {
+            return Err(create_conflict(&stored, "intent is not ready to finalize"));
+        }
+        let Some((mut item, item_revision)) =
+            load_item_in_tx(&mut transaction, &stored.item_id).await?
+        else {
+            commit(transaction, "missing-item task-board external create").await?;
+            return Ok(finalize_result(
+                stored,
+                None,
+                None,
+                TaskBoardExternalCreateFinalizeDisposition::RetainedMissingItem,
+            ));
+        };
+        require_identity_not_linked_elsewhere(
+            &mut transaction,
+            &stored,
+            &expected.provider_baseline,
+        )
+        .await?;
+        let already_linked =
+            require_compatible_provider_refs(&item, &stored, &expected.provider_baseline)?;
+        let attached_at = next_timestamp(&stored.updated_at)?;
+        if already_linked {
+            return finalize_existing_link(
+                transaction,
+                stored,
+                item,
+                item_revision,
+                &attached_at,
+                provider_target.as_deref(),
+            )
+            .await;
+        }
+        apply_provider_identity(&mut item, &stored, provider_target.as_deref())?;
+        item.external_refs.push(expected.provider_baseline.clone());
+        if item.updated_at.as_str() < attached_at.as_str() {
+            item.updated_at.clone_from(&attached_at);
+        }
+        let attached_item_revision = item_revision + 1;
+        replace_item_in_tx(&mut transaction, &item, attached_item_revision).await?;
+        update_attached_receipt(
+            &mut transaction,
+            &stored,
+            &attached_at,
+            attached_item_revision,
+        )
+        .await?;
+        bump_change_in_tx(&mut transaction, ITEMS_CHANGE_SCOPE).await?;
+        commit(transaction, "task-board external create finalize").await?;
+        let attached = attached_intent(stored, &attached_at, attached_item_revision)?;
+        Ok(finalize_result(
+            attached,
+            Some(item),
+            Some(attached_item_revision),
+            TaskBoardExternalCreateFinalizeDisposition::Attached,
+        ))
+    }
+}
+
+async fn finalize_existing_link(
+    mut transaction: Transaction<'_, Sqlite>,
+    stored: TaskBoardExternalCreateIntent,
+    mut item: TaskBoardItem,
+    item_revision: i64,
+    attached_at: &str,
+    provider_target: Option<&str>,
+) -> Result<TaskBoardExternalCreateFinalizeResult, CliError> {
+    let identity_changed = apply_provider_identity(&mut item, &stored, provider_target)?;
+    let attached_item_revision = if identity_changed {
+        if item.updated_at.as_str() < attached_at {
+            attached_at.clone_into(&mut item.updated_at);
+        }
+        let revision = item_revision + 1;
+        replace_item_in_tx(&mut transaction, &item, revision).await?;
+        revision
+    } else {
+        item_revision
+    };
+    update_attached_receipt(
+        &mut transaction,
+        &stored,
+        attached_at,
+        attached_item_revision,
+    )
+    .await?;
+    bump_change_in_tx(
+        &mut transaction,
+        if identity_changed {
+            ITEMS_CHANGE_SCOPE
+        } else {
+            ORCHESTRATOR_CHANGE_SCOPE
+        },
+    )
+    .await?;
+    commit(transaction, "task-board external create linked receipt").await?;
+    let attached = attached_intent(stored, attached_at, attached_item_revision)?;
+    Ok(finalize_result(
+        attached,
+        Some(item),
+        Some(attached_item_revision),
+        TaskBoardExternalCreateFinalizeDisposition::AlreadyLinked,
+    ))
+}
+
+async fn require_identity_not_linked_elsewhere(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent: &TaskBoardExternalCreateIntent,
+    expected: &ExternalRef,
+) -> Result<(), CliError> {
+    let owners = query_as::<_, (String,)>(
+        "SELECT item_id FROM task_board_external_refs
+         WHERE provider = ?1 AND external_id = ?2
+         UNION ALL
+         SELECT item_id FROM task_board_external_create_intents
+         WHERE provider = ?1 AND state IN ('created', 'attached')
+           AND json_extract(external_ref_json, '$.external_id') = ?2
+         ORDER BY item_id",
+    )
+    .bind(provider_label(intent.provider))
+    .bind(&expected.external_id)
+    .fetch_all(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("read external create reference owners: {error}")))?;
+    if owners.iter().all(|owner| owner.0 == intent.item_id) {
+        Ok(())
+    } else {
+        Err(create_conflict(
+            intent,
+            "provider identity is already linked to another item",
+        ))
+    }
+}
+
+fn require_compatible_provider_refs(
+    item: &TaskBoardItem,
+    intent: &TaskBoardExternalCreateIntent,
+    expected: &ExternalRef,
+) -> Result<bool, CliError> {
+    let refs = item
+        .external_refs
+        .iter()
+        .filter(|reference| ExternalProvider::from(reference.provider) == intent.provider)
+        .collect::<Vec<_>>();
+    if refs.is_empty() {
+        return Ok(false);
+    }
+    if refs.len() == 1 && refs[0].external_id == expected.external_id {
+        return Ok(true);
+    }
+    Err(create_conflict(
+        intent,
+        "item has a different or ambiguous same-provider reference",
+    ))
+}
+
+fn apply_provider_identity(
+    item: &mut TaskBoardItem,
+    intent: &TaskBoardExternalCreateIntent,
+    provider_target: Option<&str>,
+) -> Result<bool, CliError> {
+    match intent.provider {
+        ExternalProvider::GitHub => {
+            let provider_target = provider_target.ok_or_else(|| {
+                create_conflict(intent, "GitHub create evidence has no repository identity")
+            })?;
+            apply_github_identity(item, intent, provider_target)
+        }
+        ExternalProvider::Todoist => {
+            let recovered_project = provider_target.map(ToOwned::to_owned);
+            if item.project_id == intent.snapshot.project_id && item.project_id != recovered_project
+            {
+                item.project_id = recovered_project;
+                return Ok(true);
+            }
+            Ok(false)
+        }
+    }
+}
+
+fn apply_github_identity(
+    item: &mut TaskBoardItem,
+    intent: &TaskBoardExternalCreateIntent,
+    provider_target: &str,
+) -> Result<bool, CliError> {
+    let current = item
+        .execution_repository
+        .as_deref()
+        .map(|repository| {
+            normalize_repository_slug(Some(repository)).ok_or_else(|| {
+                create_conflict(intent, "current GitHub execution target is invalid")
+            })
+        })
+        .transpose()?;
+    if current != intent.snapshot.execution_repository
+        && current.as_deref() != Some(&intent.snapshot.provider_target)
+        && current.as_deref() != Some(provider_target)
+    {
+        return Err(create_conflict(
+            intent,
+            "GitHub execution target changed after provider creation",
+        ));
+    }
+    if current.as_deref() != Some(provider_target) {
+        item.execution_repository = Some(provider_target.to_owned());
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn require_same_evidence(
+    intent: &TaskBoardExternalCreateIntent,
+    stored: &TaskBoardExternalCreateEvidence,
+    expected: &TaskBoardExternalCreateEvidence,
+) -> Result<(), CliError> {
+    if stored.outcome == expected.outcome && stored.provider_baseline == expected.provider_baseline
+    {
+        Ok(())
+    } else {
+        Err(create_conflict(intent, "stored create evidence differs"))
+    }
+}
+
+fn attached_intent(
+    mut intent: TaskBoardExternalCreateIntent,
+    attached_at: &str,
+    attached_item_revision: i64,
+) -> Result<TaskBoardExternalCreateIntent, CliError> {
+    let evidence = intent
+        .created_evidence()
+        .cloned()
+        .ok_or_else(|| create_conflict(&intent, "outcome is absent"))?;
+    intent.state =
+        TaskBoardExternalCreateIntentState::Attached(Box::new(TaskBoardExternalCreateReceipt {
+            evidence,
+            attached_at: attached_at.to_owned(),
+            attached_item_revision,
+        }));
+    attached_at.clone_into(&mut intent.updated_at);
+    Ok(intent)
+}
+
+fn finalize_result(
+    intent: TaskBoardExternalCreateIntent,
+    item: Option<TaskBoardItem>,
+    item_revision: Option<i64>,
+    disposition: TaskBoardExternalCreateFinalizeDisposition,
+) -> TaskBoardExternalCreateFinalizeResult {
+    TaskBoardExternalCreateFinalizeResult {
+        intent,
+        item,
+        item_revision,
+        disposition,
+    }
+}
+
+async fn commit(transaction: Transaction<'_, Sqlite>, context: &str) -> Result<(), CliError> {
+    transaction
+        .commit()
+        .await
+        .map_err(|error| db_error(format!("commit {context}: {error}")))
+}

--- a/src/daemon/db/task_board/provider_external_create_finalize_tests.rs
+++ b/src/daemon/db/task_board/provider_external_create_finalize_tests.rs
@@ -1,0 +1,411 @@
+use tempfile::tempdir;
+
+use super::ITEMS_CHANGE_SCOPE;
+use super::provider_external_creates_tests::{
+    assert_published, begin, connect, create_item, item, record, sequence,
+};
+use crate::task_board::{
+    ExternalProvider, ExternalRefSyncState, ExternalTaskRef, TaskBoardExternalCreateBegin,
+    TaskBoardExternalCreateExisting, TaskBoardExternalCreateFinalizeDisposition,
+    TaskBoardExternalCreateIntentState, TaskBoardStatus,
+};
+
+#[tokio::test]
+async fn finalize_attaches_latest_item_and_retains_receipt() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-latest")).await;
+    let intent = begin(&db, "task-finalize-latest", ExternalProvider::GitHub).await;
+    let created = record(&db, &intent, "example/repository#51").await;
+    let baseline = created
+        .created_evidence()
+        .expect("created evidence")
+        .provider_baseline
+        .clone();
+    db.update_task_board_item("task-finalize-latest", |current| {
+        current.title = "Concurrent title".into();
+        current.body = "Concurrent body".into();
+        current.status = TaskBoardStatus::InProgress;
+        current.project_id = Some("board-project".into());
+        Ok(true)
+    })
+    .await
+    .expect("concurrent edit");
+    sqlx::query(
+        "UPDATE task_board_items SET updated_at = '2999-01-01T00:00:00Z'
+         WHERE item_id = 'task-finalize-latest'",
+    )
+    .execute(db.pool())
+    .await
+    .expect("seed newer item timestamp");
+    let before = sequence(&db).await;
+
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize create");
+
+    assert_eq!(
+        finalized.disposition,
+        TaskBoardExternalCreateFinalizeDisposition::Attached
+    );
+    assert_eq!(finalized.item_revision, Some(3));
+    let linked = finalized.item.expect("linked item");
+    assert_eq!(linked.title, "Concurrent title");
+    assert_eq!(linked.body, "Concurrent body");
+    assert_eq!(linked.status, TaskBoardStatus::InProgress);
+    assert_eq!(linked.project_id.as_deref(), Some("board-project"));
+    assert_eq!(
+        linked.execution_repository.as_deref(),
+        Some("example/repository")
+    );
+    assert_eq!(linked.external_refs, vec![baseline]);
+    assert_eq!(linked.updated_at, "2999-01-01T00:00:00Z");
+    assert_published(&db, before, ITEMS_CHANGE_SCOPE).await;
+    assert!(
+        db.task_board_external_create_intent("task-finalize-latest", ExternalProvider::GitHub,)
+            .await
+            .expect("active intent")
+            .is_none()
+    );
+    let TaskBoardExternalCreateIntentState::Attached(receipt) = &finalized.intent.state else {
+        panic!("finalization must retain an attached receipt");
+    };
+    assert!(receipt.attached_at > receipt.evidence.recorded_at);
+}
+
+#[tokio::test]
+async fn attached_receipt_blocks_stale_finalize_and_new_create_after_unlink() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-stale")).await;
+    let intent = begin(&db, "task-finalize-stale", ExternalProvider::GitHub).await;
+    let created = record(&db, &intent, "example/repository#57").await;
+    db.finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize create");
+    db.update_task_board_item("task-finalize-stale", |current| {
+        current.external_refs.clear();
+        Ok(true)
+    })
+    .await
+    .expect("unlink item");
+    let before_stale = sequence(&db).await;
+    let stale = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("stale finalize");
+    assert_eq!(
+        stale.disposition,
+        TaskBoardExternalCreateFinalizeDisposition::AlreadyAttached
+    );
+    assert!(stale.item.is_none());
+    assert_eq!(sequence(&db).await, before_stale);
+    let begin_after_unlink = db
+        .begin_task_board_external_create_intent(
+            "task-finalize-stale",
+            ExternalProvider::GitHub,
+            "new-scope",
+            "example/repository",
+        )
+        .await
+        .expect("begin after unlink");
+    assert!(matches!(
+        begin_after_unlink,
+        TaskBoardExternalCreateBegin::Existing(TaskBoardExternalCreateExisting::Attached(_))
+    ));
+    assert_eq!(sequence(&db).await, before_stale);
+
+    let delete_error =
+        sqlx::query("DELETE FROM task_board_items WHERE item_id = 'task-finalize-stale'")
+            .execute(db.pool())
+            .await
+            .expect_err("attached receipt must restrict hard delete");
+    assert!(delete_error.to_string().contains("FOREIGN KEY"));
+}
+
+#[tokio::test]
+async fn finalize_same_identity_preserves_newer_local_reference() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-existing")).await;
+    let intent = begin(&db, "task-finalize-existing", ExternalProvider::GitHub).await;
+    let created = record(&db, &intent, "example/repository#52").await;
+    let mut newer = ExternalTaskRef::new(ExternalProvider::GitHub, "example/repository#52")
+        .with_url("https://example.invalid/newer")
+        .into_core_ref();
+    newer.sync_state = Some(ExternalRefSyncState {
+        title: Some("Newer remote title".into()),
+        body: Some("Newer remote body".into()),
+        status: Some(TaskBoardStatus::Done),
+        project_id: Some("example/repository".into()),
+        updated_at: Some("revision-newer".into()),
+        synced_at: Some("2026-07-16T11:00:00Z".into()),
+    });
+    db.update_task_board_item("task-finalize-existing", |current| {
+        current.external_refs.push(newer.clone());
+        Ok(true)
+    })
+    .await
+    .expect("link newer reference");
+    let before = sequence(&db).await;
+
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize existing identity");
+
+    assert_eq!(
+        finalized.disposition,
+        TaskBoardExternalCreateFinalizeDisposition::AlreadyLinked
+    );
+    assert_eq!(finalized.item_revision, Some(3));
+    let linked = finalized.item.expect("linked item");
+    assert_eq!(linked.external_refs, vec![newer]);
+    assert_eq!(
+        linked.execution_repository.as_deref(),
+        Some("example/repository")
+    );
+    assert_published(&db, before, ITEMS_CHANGE_SCOPE).await;
+}
+
+#[tokio::test]
+async fn finalize_existing_todoist_identity_normalizes_provider_project() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-todoist-existing")).await;
+    let intent = begin(
+        &db,
+        "task-finalize-todoist-existing",
+        ExternalProvider::Todoist,
+    )
+    .await;
+    let created = record(&db, &intent, "todoist-task-52").await;
+    let baseline = created
+        .created_evidence()
+        .expect("created evidence")
+        .provider_baseline
+        .clone();
+    db.update_task_board_item("task-finalize-todoist-existing", |current| {
+        current.external_refs.push(baseline.clone());
+        Ok(true)
+    })
+    .await
+    .expect("link Todoist reference");
+    let before = sequence(&db).await;
+
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize existing Todoist identity");
+
+    assert_eq!(finalized.item_revision, Some(3));
+    assert_eq!(
+        finalized.item.expect("linked item").project_id.as_deref(),
+        Some("todoist-project")
+    );
+    assert_published(&db, before, ITEMS_CHANGE_SCOPE).await;
+}
+
+#[tokio::test]
+async fn finalize_rejects_cross_item_or_different_same_provider_identity() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-owner")).await;
+    create_item(&db, item("task-finalize-other")).await;
+    let intent = begin(&db, "task-finalize-owner", ExternalProvider::GitHub).await;
+    let created = record(&db, &intent, "example/repository#53").await;
+    db.update_task_board_item("task-finalize-other", |current| {
+        current.external_refs.push(
+            ExternalTaskRef::new(ExternalProvider::GitHub, "example/repository#53").into_core_ref(),
+        );
+        Ok(true)
+    })
+    .await
+    .expect("link identity elsewhere");
+    db.delete_task_board_item("task-finalize-other")
+        .await
+        .expect("tombstone identity owner");
+    let before = sequence(&db).await;
+
+    let cross_item = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect_err("cross-item identity must fail");
+    assert_eq!(cross_item.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(sequence(&db).await, before);
+
+    create_item(&db, item("task-finalize-different")).await;
+    let intent = begin(&db, "task-finalize-different", ExternalProvider::GitHub).await;
+    let created = record(&db, &intent, "example/repository#54").await;
+    db.update_task_board_item("task-finalize-different", |current| {
+        current.external_refs.push(
+            ExternalTaskRef::new(ExternalProvider::GitHub, "example/repository#99").into_core_ref(),
+        );
+        Ok(true)
+    })
+    .await
+    .expect("link different provider identity");
+    let before_different = sequence(&db).await;
+    let different = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect_err("different provider identity must fail");
+    assert_eq!(different.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(sequence(&db).await, before_different);
+    assert_eq!(
+        db.task_board_external_create_intent("task-finalize-different", ExternalProvider::GitHub,)
+            .await
+            .expect("retained created intent"),
+        Some(created)
+    );
+}
+
+#[tokio::test]
+async fn attached_receipt_reserves_provider_identity_after_unlink() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-receipt-owner")).await;
+    let owner = begin(&db, "task-finalize-receipt-owner", ExternalProvider::GitHub).await;
+    let owner = record(&db, &owner, "example/repository#58").await;
+    db.finalize_task_board_external_create_intent(&owner)
+        .await
+        .expect("attach owner");
+    db.update_task_board_item("task-finalize-receipt-owner", |current| {
+        current.external_refs.clear();
+        Ok(true)
+    })
+    .await
+    .expect("unlink owner");
+
+    create_item(&db, item("task-finalize-receipt-other")).await;
+    let other = begin(&db, "task-finalize-receipt-other", ExternalProvider::GitHub).await;
+    let other = record(&db, &other, "example/repository#58").await;
+    let before = sequence(&db).await;
+    let error = db
+        .finalize_task_board_external_create_intent(&other)
+        .await
+        .expect_err("attached receipt must reserve provider identity");
+
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(sequence(&db).await, before);
+    assert_eq!(
+        db.task_board_external_create_intent(
+            "task-finalize-receipt-other",
+            ExternalProvider::GitHub,
+        )
+        .await
+        .expect("retained created evidence"),
+        Some(other)
+    );
+}
+
+#[tokio::test]
+async fn finalize_accepts_concurrent_github_target_normalization() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-github-normalized")).await;
+    let intent = begin(
+        &db,
+        "task-finalize-github-normalized",
+        ExternalProvider::GitHub,
+    )
+    .await;
+    let created = record(&db, &intent, "example/repository#59").await;
+    db.update_task_board_item("task-finalize-github-normalized", |current| {
+        current.execution_repository = Some("example/repository".into());
+        Ok(true)
+    })
+    .await
+    .expect("normalize GitHub target");
+
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize normalized GitHub target");
+
+    assert_eq!(
+        finalized.disposition,
+        TaskBoardExternalCreateFinalizeDisposition::Attached
+    );
+    assert_eq!(
+        finalized
+            .item
+            .expect("linked item")
+            .execution_repository
+            .as_deref(),
+        Some("example/repository")
+    );
+}
+
+#[tokio::test]
+async fn finalize_fails_on_github_target_divergence_but_preserves_todoist_project_edit() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-github-target")).await;
+    let github = begin(&db, "task-finalize-github-target", ExternalProvider::GitHub).await;
+    let github = record(&db, &github, "example/repository#55").await;
+    db.update_task_board_item("task-finalize-github-target", |current| {
+        current.execution_repository = Some("other/repository".into());
+        Ok(true)
+    })
+    .await
+    .expect("change GitHub target");
+    let before_github = sequence(&db).await;
+    let github_error = db
+        .finalize_task_board_external_create_intent(&github)
+        .await
+        .expect_err("GitHub target divergence must fail");
+    assert_eq!(github_error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(sequence(&db).await, before_github);
+
+    let mut todoist_item = item("task-finalize-todoist-target");
+    todoist_item.project_id = Some("todoist-project".into());
+    create_item(&db, todoist_item).await;
+    let todoist = begin(
+        &db,
+        "task-finalize-todoist-target",
+        ExternalProvider::Todoist,
+    )
+    .await;
+    let todoist = record(&db, &todoist, "todoist-task-55").await;
+    db.update_task_board_item("task-finalize-todoist-target", |current| {
+        current.project_id = Some("todoist-project-concurrent".into());
+        Ok(true)
+    })
+    .await
+    .expect("change Todoist project");
+    let finalized = db
+        .finalize_task_board_external_create_intent(&todoist)
+        .await
+        .expect("finalize Todoist target");
+    assert_eq!(
+        finalized.item.expect("Todoist item").project_id.as_deref(),
+        Some("todoist-project-concurrent")
+    );
+}
+
+#[tokio::test]
+async fn tombstone_after_create_keeps_ref_attached_for_remote_cleanup() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-finalize-tombstone")).await;
+    let intent = begin(&db, "task-finalize-tombstone", ExternalProvider::GitHub).await;
+    db.delete_task_board_item("task-finalize-tombstone")
+        .await
+        .expect("tombstone item");
+    let created = record(&db, &intent, "example/repository#56").await;
+
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize tombstone");
+    let item = finalized.item.expect("tombstoned linked item");
+
+    assert!(item.deleted_at.is_some());
+    assert_eq!(item.external_refs.len(), 1);
+    assert_eq!(
+        finalized.disposition,
+        TaskBoardExternalCreateFinalizeDisposition::Attached
+    );
+}

--- a/src/daemon/db/task_board/provider_external_create_follow_up.rs
+++ b/src/daemon/db/task_board/provider_external_create_follow_up.rs
@@ -1,0 +1,260 @@
+use chrono::{DateTime, Duration, Utc};
+use serde_json::{Value, json};
+use sqlx::{Sqlite, Transaction, query, query_as};
+
+use super::provider_external_create_rows::{create_conflict, load_intent_by_id};
+use crate::daemon::db::audit::UPSERT_AUDIT_EVENT_SQL;
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
+use crate::daemon::protocol::HarnessMonitorAuditEvent;
+use crate::task_board::{
+    ExternalProvider, TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState,
+    TaskBoardExternalCreateReceipt,
+};
+
+const CREATE_FOLLOW_UP_TITLE: &str = "Record provider create receipt";
+
+impl AsyncDaemonDb {
+    pub(crate) async fn complete_task_board_external_create_follow_ups(
+        &self,
+        intents: &[TaskBoardExternalCreateIntent],
+    ) -> Result<Vec<HarnessMonitorAuditEvent>, CliError> {
+        let mut ordered = intents.to_vec();
+        ordered.sort_by(compare_intents);
+        ordered.dedup_by(|left, right| left.intent_id == right.intent_id);
+        if ordered.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut transaction = self
+            .begin_immediate_transaction("task board external create follow-ups")
+            .await?;
+        let mut events = Vec::new();
+        for intent in &ordered {
+            if let Some(event) = complete_one(&mut transaction, intent).await? {
+                events.push(event);
+            }
+        }
+        commit(transaction).await?;
+        Ok(events)
+    }
+}
+
+async fn complete_one(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent: &TaskBoardExternalCreateIntent,
+) -> Result<Option<HarnessMonitorAuditEvent>, CliError> {
+    let stored = load_intent_by_id(transaction, &intent.intent_id)
+        .await?
+        .ok_or_else(|| create_conflict(intent, "create intent is missing"))?;
+    if stored != *intent {
+        return Err(create_conflict(
+            intent,
+            "attached create receipt changed before follow-up",
+        ));
+    }
+    let receipt = attached_receipt(&stored)?;
+    let completed_at = deterministic_completion_timestamp(&receipt.attached_at)?;
+    let event = follow_up_event(&stored, &completed_at);
+    if let Some(existing_event_id) = load_follow_up_event_id(transaction, &stored.intent_id).await?
+    {
+        if existing_event_id == event.id {
+            return Ok(None);
+        }
+        return Err(create_conflict(
+            &stored,
+            "attached create follow-up has different audit evidence",
+        ));
+    }
+    upsert_audit_event(transaction, &event).await?;
+    acknowledge_follow_up(transaction, &stored, receipt, &event.id, &completed_at).await?;
+    Ok(Some(event))
+}
+
+fn attached_receipt(
+    intent: &TaskBoardExternalCreateIntent,
+) -> Result<&TaskBoardExternalCreateReceipt, CliError> {
+    let TaskBoardExternalCreateIntentState::Attached(receipt) = &intent.state else {
+        return Err(create_conflict(
+            intent,
+            "create intent has no attached receipt",
+        ));
+    };
+    Ok(receipt)
+}
+
+async fn acknowledge_follow_up(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent: &TaskBoardExternalCreateIntent,
+    receipt: &TaskBoardExternalCreateReceipt,
+    event_id: &str,
+    completed_at: &str,
+) -> Result<(), CliError> {
+    let updated = query(
+        "UPDATE task_board_external_create_intents
+         SET follow_up_completed_at = ?4, follow_up_audit_event_id = ?5
+         WHERE intent_id = ?1 AND state = 'attached'
+           AND attached_at = ?2 AND attached_item_revision = ?3
+           AND follow_up_completed_at IS NULL
+           AND follow_up_audit_event_id IS NULL",
+    )
+    .bind(&intent.intent_id)
+    .bind(&receipt.attached_at)
+    .bind(receipt.attached_item_revision)
+    .bind(completed_at)
+    .bind(event_id)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("acknowledge external create follow-up: {error}")))?
+    .rows_affected();
+    if updated == 1 {
+        Ok(())
+    } else {
+        Err(create_conflict(
+            intent,
+            "attached create follow-up changed before acknowledgement",
+        ))
+    }
+}
+
+async fn load_follow_up_event_id(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<Option<String>, CliError> {
+    query_as::<_, (Option<String>, Option<String>)>(
+        "SELECT follow_up_completed_at, follow_up_audit_event_id
+         FROM task_board_external_create_intents WHERE intent_id = ?1",
+    )
+    .bind(intent_id)
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("read external create follow-up: {error}")))
+    .and_then(|(completed_at, event_id)| match (completed_at, event_id) {
+        (None, None) => Ok(None),
+        (Some(_), Some(event_id)) => Ok(Some(event_id)),
+        _ => Err(db_error(
+            "external create follow-up completion evidence is incomplete",
+        )),
+    })
+}
+
+async fn upsert_audit_event(
+    transaction: &mut Transaction<'_, Sqlite>,
+    event: &HarnessMonitorAuditEvent,
+) -> Result<(), CliError> {
+    let payload_json = event.payload_json.as_ref().map(Value::to_string);
+    let related_urls_json = serde_json::to_string(&event.related_urls)
+        .map_err(|error| db_error(format!("serialize audit related urls: {error}")))?;
+    query(UPSERT_AUDIT_EVENT_SQL)
+        .bind(&event.id)
+        .bind(&event.recorded_at)
+        .bind(&event.source)
+        .bind(&event.category)
+        .bind(&event.kind)
+        .bind(&event.severity)
+        .bind(&event.outcome)
+        .bind(&event.title)
+        .bind(&event.summary)
+        .bind(event.subject.as_deref())
+        .bind(event.actor.as_deref())
+        .bind(event.correlation_id.as_deref())
+        .bind(event.action_key.as_deref())
+        .bind(payload_json.as_deref())
+        .bind(event.legacy_message.as_deref())
+        .bind(&related_urls_json)
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("upsert audit event {}: {error}", event.id)))?;
+    Ok(())
+}
+
+fn follow_up_event(
+    intent: &TaskBoardExternalCreateIntent,
+    completed_at: &str,
+) -> HarnessMonitorAuditEvent {
+    let receipt = attached_receipt(intent).expect("validated attached receipt");
+    let reference = &receipt.evidence.outcome.reference;
+    HarnessMonitorAuditEvent {
+        id: format!("audit-task-board-create-{}", intent.intent_id),
+        recorded_at: completed_at.to_owned(),
+        source: "taskBoard".to_owned(),
+        category: "taskBoardMutation".to_owned(),
+        kind: "task_board.external_create_follow_up".to_owned(),
+        severity: "info".to_owned(),
+        outcome: "success".to_owned(),
+        title: CREATE_FOLLOW_UP_TITLE.to_owned(),
+        summary: format!(
+            "{CREATE_FOLLOW_UP_TITLE} completed for task-board item '{}'",
+            intent.item_id
+        ),
+        subject: Some(intent.item_id.clone()),
+        actor: Some("Harness daemon".to_owned()),
+        correlation_id: Some(intent.create_key.clone()),
+        action_key: Some("task_board.external_create_follow_up".to_owned()),
+        payload_json: Some(json!({
+            "provider": intent.provider,
+            "scope_id": intent.scope_id,
+            "item_id": intent.item_id,
+            "external_id": reference.external_id,
+            "url": reference.url,
+            "changed_fields": intent.changed_fields,
+            "create_applied": true,
+            "operation_count": 0,
+            "applied_operation_count": 0,
+        })),
+        legacy_message: None,
+        related_urls: reference.url.iter().cloned().collect(),
+    }
+}
+
+fn deterministic_completion_timestamp(attached_at: &str) -> Result<String, CliError> {
+    let attached = DateTime::parse_from_rfc3339(attached_at)
+        .map_err(|error| db_error(format!("parse attached receipt timestamp: {error}")))?
+        .with_timezone(&Utc);
+    let completed = attached
+        .checked_add_signed(Duration::seconds(1))
+        .ok_or_else(|| db_error("attached receipt timestamp cannot advance for follow-up"))?;
+    let completed = completed.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    if completed.len() == 20 {
+        Ok(completed)
+    } else {
+        Err(db_error(
+            "attached receipt timestamp advances beyond the persisted timestamp range",
+        ))
+    }
+}
+
+fn compare_intents(
+    left: &TaskBoardExternalCreateIntent,
+    right: &TaskBoardExternalCreateIntent,
+) -> std::cmp::Ordering {
+    provider_label(left.provider)
+        .cmp(provider_label(right.provider))
+        .then_with(|| left.scope_id.cmp(&right.scope_id))
+        .then_with(|| left.updated_at.cmp(&right.updated_at))
+        .then_with(|| left.intent_id.cmp(&right.intent_id))
+}
+
+const fn provider_label(provider: ExternalProvider) -> &'static str {
+    match provider {
+        ExternalProvider::GitHub => "github",
+        ExternalProvider::Todoist => "todoist",
+    }
+}
+
+async fn commit(transaction: Transaction<'_, Sqlite>) -> Result<(), CliError> {
+    transaction.commit().await.map_err(|error| {
+        db_error(format!(
+            "commit task-board external create follow-ups: {error}"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deterministic_completion_timestamp;
+
+    #[test]
+    fn follow_up_timestamp_overflow_fails_closed() {
+        deterministic_completion_timestamp("9999-12-31T23:59:59Z")
+            .expect_err("maximum timestamp cannot advance");
+    }
+}

--- a/src/daemon/db/task_board/provider_external_create_follow_up_tests.rs
+++ b/src/daemon/db/task_board/provider_external_create_follow_up_tests.rs
@@ -1,0 +1,358 @@
+use tempfile::tempdir;
+
+use super::provider_external_creates_tests::{begin, connect, create_item, item, record};
+use crate::task_board::{
+    ExternalProvider, ExternalRefProvider, ExternalSyncField, TaskBoardConflictState,
+    TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState, TaskBoardSyncConflict,
+};
+
+#[tokio::test]
+async fn pending_follow_up_query_is_provider_filtered_and_deterministic() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-follow-up-github")).await;
+    create_item(&db, item("task-follow-up-todoist")).await;
+    let github = attach(
+        &db,
+        "task-follow-up-github",
+        ExternalProvider::GitHub,
+        "example/repository#81",
+    )
+    .await;
+    let todoist = attach(
+        &db,
+        "task-follow-up-todoist",
+        ExternalProvider::Todoist,
+        "todoist-task-81",
+    )
+    .await;
+
+    assert_eq!(
+        db.list_pending_task_board_external_create_follow_ups(None)
+            .await
+            .expect("list all pending follow-ups"),
+        vec![github.clone(), todoist.clone()]
+    );
+    assert_eq!(
+        db.list_pending_task_board_external_create_follow_ups(Some(ExternalProvider::Todoist))
+            .await
+            .expect("list Todoist follow-ups"),
+        vec![todoist]
+    );
+    assert_eq!(
+        db.list_pending_task_board_external_create_follow_ups(Some(ExternalProvider::GitHub))
+            .await
+            .expect("list GitHub follow-ups"),
+        vec![github]
+    );
+}
+
+#[tokio::test]
+async fn audit_and_follow_up_ack_are_atomic_and_idempotent() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-follow-up-atomic")).await;
+    let attached = attach(
+        &db,
+        "task-follow-up-atomic",
+        ExternalProvider::GitHub,
+        "example/repository#82",
+    )
+    .await;
+    let incomplete = sqlx::query(
+        "UPDATE task_board_external_create_intents
+         SET follow_up_completed_at = '2026-07-16T18:00:00Z'
+         WHERE intent_id = ?1",
+    )
+    .bind(&attached.intent_id)
+    .execute(db.pool())
+    .await
+    .expect_err("follow-up timestamp without audit identity must fail");
+    assert!(incomplete.to_string().contains("CHECK constraint failed"));
+    sqlx::query(
+        "CREATE TRIGGER fail_create_follow_up_audit
+         BEFORE INSERT ON audit_events
+         BEGIN SELECT RAISE(FAIL, 'simulated follow-up audit failure'); END",
+    )
+    .execute(db.pool())
+    .await
+    .expect("install audit failure");
+
+    db.complete_task_board_external_create_follow_ups(std::slice::from_ref(&attached))
+        .await
+        .expect_err("audit failure must keep the receipt pending");
+    assert_eq!(
+        db.list_pending_task_board_external_create_follow_ups(None)
+            .await
+            .expect("pending after failed audit"),
+        vec![attached.clone()]
+    );
+    sqlx::query("DROP TRIGGER fail_create_follow_up_audit")
+        .execute(db.pool())
+        .await
+        .expect("remove audit failure");
+
+    let events = db
+        .complete_task_board_external_create_follow_ups(std::slice::from_ref(&attached))
+        .await
+        .expect("complete follow-up");
+    assert_eq!(events.len(), 1);
+    let event = &events[0];
+    assert!(
+        db.list_pending_task_board_external_create_follow_ups(None)
+            .await
+            .expect("pending after completion")
+            .is_empty()
+    );
+    assert!(
+        db.complete_task_board_external_create_follow_ups(std::slice::from_ref(&attached))
+            .await
+            .expect("repeat exact completion")
+            .is_empty()
+    );
+    let stored = sqlx::query_as::<_, (Option<String>, Option<String>, i64)>(
+        "SELECT follow_up_completed_at, follow_up_audit_event_id,
+                (SELECT COUNT(*) FROM audit_events WHERE id = ?2)
+         FROM task_board_external_create_intents WHERE intent_id = ?1",
+    )
+    .bind(&attached.intent_id)
+    .bind(&event.id)
+    .fetch_one(db.pool())
+    .await
+    .expect("read completion");
+    assert!(stored.0.is_some());
+    assert_eq!(stored.1.as_deref(), Some(event.id.as_str()));
+    assert_eq!(stored.2, 1);
+    assert_eq!(event.recorded_at, stored.0.expect("completion timestamp"));
+    assert_eq!(
+        event.payload_json.as_ref().expect("payload")["create_applied"].as_bool(),
+        Some(true)
+    );
+}
+
+#[tokio::test]
+async fn follow_up_batch_failure_rolls_back_earlier_audit_and_ack_writes() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-follow-up-batch-first")).await;
+    create_item(&db, item("task-follow-up-batch-second")).await;
+    let first = attach(
+        &db,
+        "task-follow-up-batch-first",
+        ExternalProvider::GitHub,
+        "example/repository#85",
+    )
+    .await;
+    let second = attach(
+        &db,
+        "task-follow-up-batch-second",
+        ExternalProvider::GitHub,
+        "example/repository#86",
+    )
+    .await;
+    sqlx::query(
+        "CREATE TRIGGER fail_second_create_follow_up_audit
+         BEFORE INSERT ON audit_events
+         WHEN NEW.subject = 'task-follow-up-batch-second'
+         BEGIN SELECT RAISE(FAIL, 'simulated second follow-up failure'); END",
+    )
+    .execute(db.pool())
+    .await
+    .expect("install second audit failure");
+
+    db.complete_task_board_external_create_follow_ups(&[first, second])
+        .await
+        .expect_err("batch failure must roll back every follow-up");
+
+    assert_eq!(
+        db.list_pending_task_board_external_create_follow_ups(None)
+            .await
+            .expect("pending follow-ups")
+            .len(),
+        2
+    );
+    let event_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_events
+         WHERE action_key = 'task_board.external_create_follow_up'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("follow-up event count");
+    assert_eq!(event_count, 0);
+}
+
+#[tokio::test]
+async fn pending_follow_up_query_uses_the_partial_index() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+
+    let plan = sqlx::query_as::<_, (i64, i64, i64, String)>(
+        "EXPLAIN QUERY PLAN
+         SELECT intent_id FROM task_board_external_create_intents
+         WHERE provider = 'github' AND state = 'attached'
+           AND follow_up_completed_at IS NULL
+           AND follow_up_audit_event_id IS NULL
+         ORDER BY scope_id, attached_at, intent_id",
+    )
+    .fetch_all(db.pool())
+    .await
+    .expect("query plan");
+
+    assert!(plan.iter().any(|row| {
+        row.3
+            .contains("idx_task_board_external_create_intents_pending_follow_up")
+    }));
+}
+
+#[tokio::test]
+async fn finalization_supersedes_only_fields_matching_the_final_item() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-follow-up-conflicts")).await;
+    let intent = begin(&db, "task-follow-up-conflicts", ExternalProvider::GitHub).await;
+    let created = record(&db, &intent, "example/repository#83").await;
+    db.replace_open_task_board_sync_conflicts(
+        "task-follow-up-conflicts",
+        ExternalProvider::GitHub,
+        "example/repository#83",
+        1,
+        &[
+            conflict(
+                "conflict-title",
+                "task-follow-up-conflicts",
+                "example/repository#83",
+                ExternalSyncField::Title,
+            ),
+            conflict(
+                "conflict-body",
+                "task-follow-up-conflicts",
+                "example/repository#83",
+                ExternalSyncField::Body,
+            ),
+        ],
+    )
+    .await
+    .expect("record create conflicts");
+    db.update_task_board_item("task-follow-up-conflicts", |item| {
+        item.title = "Concurrent local title".into();
+        Ok(true)
+    })
+    .await
+    .expect("edit title before finalization");
+
+    db.finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize with conflict cleanup");
+
+    let open = db
+        .open_task_board_sync_conflicts()
+        .await
+        .expect("open conflicts");
+    assert_eq!(open.len(), 1);
+    assert_eq!(open[0].field, "title");
+    assert_eq!(open[0].item_revision, 1);
+}
+
+#[tokio::test]
+async fn conflict_cleanup_failure_rolls_back_attachment_and_receipt() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-follow-up-conflict-failure")).await;
+    let intent = begin(
+        &db,
+        "task-follow-up-conflict-failure",
+        ExternalProvider::GitHub,
+    )
+    .await;
+    let created = record(&db, &intent, "example/repository#84").await;
+    db.replace_open_task_board_sync_conflicts(
+        "task-follow-up-conflict-failure",
+        ExternalProvider::GitHub,
+        "example/repository#84",
+        1,
+        &[conflict(
+            "conflict-failure",
+            "task-follow-up-conflict-failure",
+            "example/repository#84",
+            ExternalSyncField::Title,
+        )],
+    )
+    .await
+    .expect("record create conflict");
+    sqlx::query(
+        "CREATE TRIGGER fail_create_conflict_cleanup
+         BEFORE UPDATE ON task_board_sync_conflicts
+         BEGIN SELECT RAISE(FAIL, 'simulated conflict cleanup failure'); END",
+    )
+    .execute(db.pool())
+    .await
+    .expect("install conflict failure");
+
+    db.finalize_task_board_external_create_intent(&created)
+        .await
+        .expect_err("conflict cleanup must roll back finalization");
+
+    let item = db
+        .task_board_item("task-follow-up-conflict-failure")
+        .await
+        .expect("reload item");
+    assert!(item.external_refs.is_empty());
+    let stored = db
+        .task_board_external_create_intent(
+            "task-follow-up-conflict-failure",
+            ExternalProvider::GitHub,
+        )
+        .await
+        .expect("reload intent")
+        .expect("created intent");
+    assert!(matches!(
+        stored.state,
+        TaskBoardExternalCreateIntentState::Created(_)
+    ));
+    assert_eq!(
+        db.list_pending_task_board_external_create_follow_ups(None)
+            .await
+            .expect("pending follow-ups"),
+        Vec::new()
+    );
+}
+
+async fn attach(
+    db: &crate::daemon::db::AsyncDaemonDb,
+    item_id: &str,
+    provider: ExternalProvider,
+    external_id: &str,
+) -> TaskBoardExternalCreateIntent {
+    let intent = begin(db, item_id, provider).await;
+    let created = record(db, &intent, external_id).await;
+    db.finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize create")
+        .intent
+}
+
+fn conflict(
+    conflict_id: &str,
+    item_id: &str,
+    external_ref: &str,
+    field: ExternalSyncField,
+) -> TaskBoardSyncConflict {
+    TaskBoardSyncConflict {
+        conflict_id: conflict_id.into(),
+        item_id: item_id.into(),
+        provider: ExternalRefProvider::GitHub,
+        external_ref: external_ref.into(),
+        field: match field {
+            ExternalSyncField::Title => "title",
+            ExternalSyncField::Body => "body",
+            _ => unreachable!("test only covers title and body"),
+        }
+        .into(),
+        base_value: serde_json::json!("base"),
+        local_value: serde_json::json!("local"),
+        remote_value: serde_json::json!("remote"),
+        item_revision: 1,
+        provider_revision: Some("revision-0".into()),
+        state: TaskBoardConflictState::Open,
+    }
+}

--- a/src/daemon/db/task_board/provider_external_create_optional_evidence_tests.rs
+++ b/src/daemon/db/task_board/provider_external_create_optional_evidence_tests.rs
@@ -1,0 +1,187 @@
+use tempfile::tempdir;
+
+use super::provider_external_creates_tests::{begin, connect, create_evidence, create_item, item};
+use crate::task_board::ExternalProvider;
+
+#[tokio::test]
+async fn github_recovery_accepts_none_revision_and_project_evidence() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-github-optional")).await;
+    let intent = begin(&db, "task-create-github-optional", ExternalProvider::GitHub).await;
+    let (mut outcome, mut baseline) =
+        create_evidence(&intent, "example/repository#81", "revision-1");
+    outcome.provider_revision = None;
+    outcome.provider_project_id = None;
+    let state = baseline.sync_state.as_mut().expect("sync state");
+    state.updated_at = None;
+    state.project_id = None;
+
+    let created = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("record optional GitHub evidence");
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize optional GitHub evidence");
+
+    let evidence = created.created_evidence().expect("created evidence");
+    assert_eq!(evidence.outcome.provider_revision, None);
+    assert_eq!(evidence.outcome.provider_project_id, None);
+    let linked = finalized.item.expect("linked item");
+    assert_eq!(
+        linked.execution_repository.as_deref(),
+        Some("example/repository")
+    );
+    let state = linked.external_refs[0]
+        .sync_state
+        .as_ref()
+        .expect("linked sync state");
+    assert_eq!(state.updated_at, None);
+    assert_eq!(state.project_id, None);
+}
+
+#[tokio::test]
+async fn todoist_recovery_accepts_none_project_and_revision_without_backfill() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    let mut board_item = item("task-create-todoist-optional");
+    board_item.project_id = Some("todoist-project".into());
+    create_item(&db, board_item).await;
+    let intent = begin(
+        &db,
+        "task-create-todoist-optional",
+        ExternalProvider::Todoist,
+    )
+    .await;
+    let (mut outcome, mut baseline) = create_evidence(&intent, "todoist-task-81", "revision-1");
+    outcome.provider_revision = None;
+    outcome.provider_project_id = None;
+    let state = baseline.sync_state.as_mut().expect("sync state");
+    state.updated_at = None;
+    state.project_id = None;
+
+    let created = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("record optional Todoist evidence");
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize optional Todoist evidence");
+
+    assert_eq!(finalized.item.expect("linked item").project_id, None);
+    let evidence = created.created_evidence().expect("created evidence");
+    assert_eq!(evidence.outcome.provider_revision, None);
+    assert_eq!(evidence.outcome.provider_project_id, None);
+}
+
+#[tokio::test]
+async fn todoist_finalization_applies_the_exact_recovered_project() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    let mut board_item = item("task-create-todoist-moved");
+    board_item.project_id = Some("todoist-project".into());
+    create_item(&db, board_item).await;
+    let intent = begin(&db, "task-create-todoist-moved", ExternalProvider::Todoist).await;
+    let (mut outcome, mut baseline) = create_evidence(&intent, "todoist-task-82", "revision-2");
+    outcome.provider_project_id = Some("todoist-project-moved".into());
+    baseline.sync_state.as_mut().expect("sync state").project_id =
+        Some("todoist-project-moved".into());
+
+    let created = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("record moved Todoist evidence");
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize moved Todoist evidence");
+
+    assert_eq!(
+        finalized.item.expect("linked item").project_id.as_deref(),
+        Some("todoist-project-moved")
+    );
+}
+
+#[tokio::test]
+async fn optional_project_and_revision_evidence_must_match_exactly() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    let mut board_item = item("task-create-optional-mismatch");
+    board_item.project_id = Some("todoist-project".into());
+    create_item(&db, board_item).await;
+    let intent = begin(
+        &db,
+        "task-create-optional-mismatch",
+        ExternalProvider::Todoist,
+    )
+    .await;
+    let (outcome, baseline) = create_evidence(&intent, "todoist-task-83", "revision-3");
+
+    let mut cases = Vec::new();
+    let mut missing_outcome_revision = outcome.clone();
+    missing_outcome_revision.provider_revision = None;
+    cases.push((
+        "outcome-revision",
+        missing_outcome_revision,
+        baseline.clone(),
+    ));
+    let mut missing_baseline_revision = baseline.clone();
+    missing_baseline_revision
+        .sync_state
+        .as_mut()
+        .expect("sync state")
+        .updated_at = None;
+    cases.push((
+        "baseline-revision",
+        outcome.clone(),
+        missing_baseline_revision,
+    ));
+    let mut missing_outcome_project = outcome.clone();
+    missing_outcome_project.provider_project_id = None;
+    cases.push(("outcome-project", missing_outcome_project, baseline.clone()));
+    let mut missing_baseline_project = baseline.clone();
+    missing_baseline_project
+        .sync_state
+        .as_mut()
+        .expect("sync state")
+        .project_id = None;
+    cases.push((
+        "baseline-project",
+        outcome.clone(),
+        missing_baseline_project,
+    ));
+
+    for (case, outcome, baseline) in cases {
+        let error = db
+            .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+            .await
+            .expect_err("mixed optional evidence must fail");
+        assert_eq!(error.code(), "WORKFLOW_CONCURRENT", "case {case}");
+    }
+}
+
+#[tokio::test]
+async fn github_supplied_project_must_match_the_external_identity() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-github-project-mismatch")).await;
+    let intent = begin(
+        &db,
+        "task-create-github-project-mismatch",
+        ExternalProvider::GitHub,
+    )
+    .await;
+    let (mut outcome, mut baseline) =
+        create_evidence(&intent, "example/repository#84", "revision-4");
+    outcome.provider_project_id = Some("other/repository".into());
+    baseline.sync_state.as_mut().expect("sync state").project_id = Some("other/repository".into());
+
+    let error = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect_err("GitHub project must match external identity");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+}

--- a/src/daemon/db/task_board/provider_external_create_recovery_tests.rs
+++ b/src/daemon/db/task_board/provider_external_create_recovery_tests.rs
@@ -1,0 +1,502 @@
+use tempfile::tempdir;
+
+use super::provider_external_creates_tests::{begin, connect, create_item, item, record};
+use crate::task_board::{
+    ExternalCreateOutcome, ExternalProvider, ExternalRef, ExternalRefSyncState, ExternalSyncField,
+    ExternalTaskRef, TaskBoardExternalCreateBegin, TaskBoardExternalCreateFinalizeDisposition,
+    TaskBoardExternalCreateIntent, TaskBoardStatus,
+};
+
+#[tokio::test]
+async fn begin_derives_create_fields_from_the_atomic_snapshot() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    let cases = [
+        (
+            "github-todo-project",
+            ExternalProvider::GitHub,
+            TaskBoardStatus::Todo,
+            Some("board-project"),
+            "example/repository",
+            vec![
+                ExternalSyncField::Title,
+                ExternalSyncField::Body,
+                ExternalSyncField::Status,
+            ],
+        ),
+        (
+            "github-done-project",
+            ExternalProvider::GitHub,
+            TaskBoardStatus::Done,
+            Some("board-project"),
+            "example/repository",
+            vec![ExternalSyncField::Title, ExternalSyncField::Body],
+        ),
+        (
+            "todoist-todo-project",
+            ExternalProvider::Todoist,
+            TaskBoardStatus::Todo,
+            Some("todoist-project"),
+            "todoist-project",
+            vec![
+                ExternalSyncField::Title,
+                ExternalSyncField::Body,
+                ExternalSyncField::Status,
+                ExternalSyncField::Project,
+            ],
+        ),
+        (
+            "todoist-done-project",
+            ExternalProvider::Todoist,
+            TaskBoardStatus::Done,
+            Some("todoist-project"),
+            "todoist-project",
+            vec![
+                ExternalSyncField::Title,
+                ExternalSyncField::Body,
+                ExternalSyncField::Project,
+            ],
+        ),
+        (
+            "todoist-todo-no-project",
+            ExternalProvider::Todoist,
+            TaskBoardStatus::Todo,
+            None,
+            "todoist-project",
+            vec![
+                ExternalSyncField::Title,
+                ExternalSyncField::Body,
+                ExternalSyncField::Status,
+            ],
+        ),
+    ];
+    for (item_id, provider, status, project_id, target, expected) in cases {
+        let mut board_item = item(item_id);
+        board_item.status = status;
+        board_item.project_id = project_id.map(ToOwned::to_owned);
+        create_item(&db, board_item).await;
+
+        let intent = start(&db, item_id, provider, "scope", target).await;
+
+        assert_eq!(intent.changed_fields, expected, "case {item_id}");
+    }
+}
+
+#[tokio::test]
+async fn create_key_lookup_tracks_every_durable_state() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-key-state")).await;
+    let intent = begin(&db, "task-create-key-state", ExternalProvider::GitHub).await;
+
+    assert_eq!(
+        db.task_board_external_create_intent_by_create_key(
+            ExternalProvider::GitHub,
+            &intent.create_key,
+        )
+        .await
+        .expect("lookup in-flight"),
+        Some(intent.clone())
+    );
+
+    let created = record(&db, &intent, "example/repository#71").await;
+    assert_eq!(
+        db.task_board_external_create_intent_by_create_key(
+            ExternalProvider::GitHub,
+            &intent.create_key,
+        )
+        .await
+        .expect("lookup created"),
+        Some(created.clone())
+    );
+
+    let attached = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize intent")
+        .intent;
+    assert_eq!(
+        db.task_board_external_create_intent_by_create_key(
+            ExternalProvider::GitHub,
+            &intent.create_key,
+        )
+        .await
+        .expect("lookup attached"),
+        Some(attached)
+    );
+}
+
+#[tokio::test]
+async fn create_key_identity_is_unique_within_provider_and_isolated_across_providers() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-key-github-owner")).await;
+    create_item(&db, item("task-key-github-other")).await;
+    let mut todoist = item("task-key-todoist");
+    todoist.project_id = Some("todoist-project".into());
+    create_item(&db, todoist).await;
+    let github = begin(&db, "task-key-github-owner", ExternalProvider::GitHub).await;
+    let github_other = begin(&db, "task-key-github-other", ExternalProvider::GitHub).await;
+    let todoist = begin(&db, "task-key-todoist", ExternalProvider::Todoist).await;
+
+    sqlx::query(
+        "UPDATE task_board_external_create_intents SET create_key = ?1 WHERE intent_id = ?2",
+    )
+    .bind(&github.create_key)
+    .bind(&todoist.intent_id)
+    .execute(db.pool())
+    .await
+    .expect("reuse key for a different provider");
+    let collision = sqlx::query(
+        "UPDATE task_board_external_create_intents SET create_key = ?1 WHERE intent_id = ?2",
+    )
+    .bind(&github.create_key)
+    .bind(&github_other.intent_id)
+    .execute(db.pool())
+    .await
+    .expect_err("same-provider key collision must fail");
+
+    assert!(collision.to_string().contains("UNIQUE"));
+    assert_eq!(
+        db.task_board_external_create_intent_by_create_key(
+            ExternalProvider::GitHub,
+            &github.create_key,
+        )
+        .await
+        .expect("lookup GitHub key")
+        .expect("GitHub intent")
+        .item_id,
+        github.item_id
+    );
+    assert_eq!(
+        db.task_board_external_create_intent_by_create_key(
+            ExternalProvider::Todoist,
+            &github.create_key,
+        )
+        .await
+        .expect("lookup Todoist key")
+        .expect("Todoist intent")
+        .item_id,
+        todoist.item_id
+    );
+}
+
+#[tokio::test]
+async fn provider_wide_in_flight_recovery_is_scope_independent_and_deterministic() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    for item_id in ["task-inflight-a", "task-inflight-b", "task-inflight-c"] {
+        create_item(&db, item(item_id)).await;
+    }
+    let mut todoist_item = item("task-inflight-todoist");
+    todoist_item.project_id = Some("todoist-project".into());
+    create_item(&db, todoist_item).await;
+    let first = start(
+        &db,
+        "task-inflight-a",
+        ExternalProvider::GitHub,
+        "vanished-scope-a",
+        "example/repository",
+    )
+    .await;
+    let second = start(
+        &db,
+        "task-inflight-b",
+        ExternalProvider::GitHub,
+        "vanished-scope-b",
+        "example/repository",
+    )
+    .await;
+    let third = start(
+        &db,
+        "task-inflight-c",
+        ExternalProvider::GitHub,
+        "live-scope",
+        "example/repository",
+    )
+    .await;
+    let _todoist = begin(&db, "task-inflight-todoist", ExternalProvider::Todoist).await;
+    let mut expected = vec![first.clone(), second.clone(), third.clone()];
+    expected.sort_by(|left, right| {
+        (&left.created_at, &left.intent_id).cmp(&(&right.created_at, &right.intent_id))
+    });
+
+    assert_eq!(
+        db.list_in_flight_task_board_external_create_intents(ExternalProvider::GitHub)
+            .await
+            .expect("provider-wide in-flight recovery"),
+        expected
+    );
+
+    let _created = record(&db, &first, "example/repository#72").await;
+    let second = record(&db, &second, "example/repository#73").await;
+    db.finalize_task_board_external_create_intent(&second)
+        .await
+        .expect("attach second intent");
+    assert_eq!(
+        db.list_in_flight_task_board_external_create_intents(ExternalProvider::GitHub)
+            .await
+            .expect("filtered provider-wide recovery"),
+        vec![third]
+    );
+}
+
+#[tokio::test]
+async fn recovery_accepts_edited_closed_and_moved_todoist_evidence() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    let mut board_item = item("task-recovery-drift");
+    board_item.project_id = Some("todoist-project".into());
+    create_item(&db, board_item).await;
+    let intent = begin(&db, "task-recovery-drift", ExternalProvider::Todoist).await;
+    let (outcome, baseline) = current_todoist_evidence();
+
+    let created = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("record drifted current provider task");
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize drifted provider task");
+
+    assert_eq!(
+        created
+            .created_evidence()
+            .expect("created evidence")
+            .provider_baseline,
+        baseline
+    );
+    assert_eq!(
+        finalized.item.expect("linked item").project_id.as_deref(),
+        Some("todoist-project-moved")
+    );
+}
+
+#[tokio::test]
+async fn recovery_accepts_a_github_issue_moved_from_the_original_repository() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-recovery-github-moved")).await;
+    let intent = begin(&db, "task-recovery-github-moved", ExternalProvider::GitHub).await;
+    let reference = ExternalTaskRef::new(ExternalProvider::GitHub, "moved/repository#74")
+        .with_url("https://example.invalid/issues/74");
+    let outcome = ExternalCreateOutcome {
+        reference: reference.clone(),
+        provider_revision: Some("revision-moved".into()),
+        provider_project_id: Some("moved/repository".into()),
+    };
+    let mut baseline = reference.into_core_ref();
+    baseline.sync_state = Some(ExternalRefSyncState {
+        title: Some("Edited GitHub title".into()),
+        body: Some("Edited GitHub body".into()),
+        status: Some(TaskBoardStatus::Done),
+        project_id: Some("moved/repository".into()),
+        updated_at: Some("revision-moved".into()),
+        synced_at: Some("2026-07-16T14:56:00Z".into()),
+    });
+
+    let created = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("record moved GitHub issue");
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize moved GitHub issue");
+
+    assert_eq!(
+        finalized
+            .item
+            .expect("linked item")
+            .execution_repository
+            .as_deref(),
+        Some("moved/repository")
+    );
+}
+
+#[tokio::test]
+async fn moved_github_recovery_accepts_an_already_converged_local_identity() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-recovery-github-converged")).await;
+    let intent = begin(
+        &db,
+        "task-recovery-github-converged",
+        ExternalProvider::GitHub,
+    )
+    .await;
+    let reference = ExternalTaskRef::new(ExternalProvider::GitHub, "moved/repository#75")
+        .with_url("https://example.invalid/issues/75");
+    let outcome = ExternalCreateOutcome {
+        reference: reference.clone(),
+        provider_revision: Some("revision-moved".into()),
+        provider_project_id: Some("moved/repository".into()),
+    };
+    let mut baseline = reference.into_core_ref();
+    baseline.sync_state = Some(ExternalRefSyncState {
+        title: Some("Moved GitHub title".into()),
+        body: Some("Moved GitHub body".into()),
+        status: Some(TaskBoardStatus::Done),
+        project_id: Some("moved/repository".into()),
+        updated_at: Some("revision-moved".into()),
+        synced_at: Some("2026-07-16T15:02:00Z".into()),
+    });
+    let created = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("record moved GitHub issue");
+    db.update_task_board_item("task-recovery-github-converged", |current| {
+        current.execution_repository = Some("moved/repository".into());
+        current.external_refs.push(baseline.clone());
+        Ok(true)
+    })
+    .await
+    .expect("converge local GitHub identity");
+
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize converged GitHub identity");
+
+    assert_eq!(
+        finalized.disposition,
+        TaskBoardExternalCreateFinalizeDisposition::AlreadyLinked
+    );
+    let linked = finalized.item.expect("linked item");
+    assert_eq!(
+        linked.execution_repository.as_deref(),
+        Some("moved/repository")
+    );
+    assert_eq!(linked.external_refs, vec![baseline]);
+}
+
+#[tokio::test]
+async fn recovery_rejects_incomplete_or_internally_inconsistent_evidence() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    let mut board_item = item("task-recovery-invalid");
+    board_item.project_id = Some("todoist-project".into());
+    create_item(&db, board_item).await;
+    let intent = begin(&db, "task-recovery-invalid", ExternalProvider::Todoist).await;
+    let (outcome, baseline) = current_todoist_evidence();
+    let mut cases = Vec::new();
+
+    let mut url = baseline.clone();
+    url.url = Some("https://example.invalid/different".into());
+    cases.push(("url", outcome.clone(), url));
+    let mut project = baseline.clone();
+    project.sync_state.as_mut().unwrap().project_id = Some("other-project".into());
+    cases.push(("project", outcome.clone(), project));
+    let mut revision = baseline.clone();
+    revision.sync_state.as_mut().unwrap().updated_at = Some("other-revision".into());
+    cases.push(("revision", outcome.clone(), revision));
+    let mut provider = baseline.clone();
+    provider.provider = ExternalProvider::GitHub.into();
+    cases.push(("provider", outcome.clone(), provider));
+    let mut identity = baseline.clone();
+    identity.external_id = "different-task".into();
+    cases.push(("identity", outcome.clone(), identity));
+    let mut status = baseline.clone();
+    status.sync_state.as_mut().unwrap().status = Some(TaskBoardStatus::InProgress);
+    cases.push(("status-value", outcome.clone(), status));
+    let mut synced_at = baseline.clone();
+    synced_at.sync_state.as_mut().unwrap().synced_at = Some("invalid".into());
+    cases.push(("synced-at-value", outcome.clone(), synced_at));
+    for field in [
+        "title",
+        "body",
+        "status",
+        "project_id",
+        "updated_at",
+        "synced_at",
+    ] {
+        let mut incomplete = baseline.clone();
+        clear_sync_field(incomplete.sync_state.as_mut().unwrap(), field);
+        cases.push((field, outcome.clone(), incomplete));
+    }
+
+    for (case, outcome, baseline) in cases {
+        let error = db
+            .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+            .await
+            .expect_err("invalid recovery evidence must fail");
+        assert_eq!(error.code(), "WORKFLOW_CONCURRENT", "case {case}");
+    }
+}
+
+#[tokio::test]
+async fn persisted_changed_fields_must_match_the_derived_create_contract() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-fields-corrupt")).await;
+    let intent = begin(&db, "task-create-fields-corrupt", ExternalProvider::GitHub).await;
+    sqlx::query(
+        "UPDATE task_board_external_create_intents
+         SET changed_fields_json = '[\"title\",\"body\"]'
+         WHERE intent_id = ?1",
+    )
+    .bind(&intent.intent_id)
+    .execute(db.pool())
+    .await
+    .expect("corrupt persisted create fields");
+
+    let error = db
+        .task_board_external_create_intent_by_create_key(
+            ExternalProvider::GitHub,
+            &intent.create_key,
+        )
+        .await
+        .expect_err("stale create fields must fail closed");
+
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+}
+
+async fn start(
+    db: &crate::daemon::db::AsyncDaemonDb,
+    item_id: &str,
+    provider: ExternalProvider,
+    scope_id: &str,
+    provider_target: &str,
+) -> TaskBoardExternalCreateIntent {
+    match db
+        .begin_task_board_external_create_intent(item_id, provider, scope_id, provider_target)
+        .await
+        .expect("begin create intent")
+    {
+        TaskBoardExternalCreateBegin::Started(intent) => intent,
+        other => panic!("expected started intent, got {other:?}"),
+    }
+}
+
+fn current_todoist_evidence() -> (ExternalCreateOutcome, ExternalRef) {
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "todoist-task-recovered")
+        .with_url("https://example.invalid/tasks/todoist-task-recovered");
+    let outcome = ExternalCreateOutcome {
+        reference: reference.clone(),
+        provider_revision: Some("revision-recovered".into()),
+        provider_project_id: Some("todoist-project-moved".into()),
+    };
+    let mut baseline = reference.into_core_ref();
+    baseline.sync_state = Some(ExternalRefSyncState {
+        title: Some("Edited provider title".into()),
+        body: Some("Edited provider body".into()),
+        status: Some(TaskBoardStatus::Done),
+        project_id: Some("todoist-project-moved".into()),
+        updated_at: Some("revision-recovered".into()),
+        synced_at: Some("2026-07-16T14:55:00Z".into()),
+    });
+    (outcome, baseline)
+}
+
+fn clear_sync_field(state: &mut ExternalRefSyncState, field: &str) {
+    match field {
+        "title" => state.title = None,
+        "body" => state.body = None,
+        "status" => state.status = None,
+        "project_id" => state.project_id = None,
+        "updated_at" => state.updated_at = None,
+        "synced_at" => state.synced_at = None,
+        _ => panic!("unknown sync field {field}"),
+    }
+}

--- a/src/daemon/db/task_board/provider_external_create_rows.rs
+++ b/src/daemon/db/task_board/provider_external_create_rows.rs
@@ -1,0 +1,424 @@
+use chrono::{DateTime, Duration, Utc};
+use sqlx::{FromRow, Sqlite, Transaction, query, query_as};
+
+use super::mapper::{parse_json, to_json};
+use super::provider_external_create_evidence::validate_create_evidence;
+use crate::daemon::db::{CliError, CliErrorKind, db_error, utc_now};
+use crate::task_board::{
+    ExternalCreateOutcome, ExternalProvider, ExternalRef, ExternalSyncField,
+    TaskBoardExternalCreateEvidence, TaskBoardExternalCreateIntent,
+    TaskBoardExternalCreateIntentState, TaskBoardExternalCreateReceipt,
+    TaskBoardExternalCreateSnapshot, TaskBoardItem, TaskBoardStatus, normalize_repository_slug,
+};
+
+const LOAD_LATEST_INTENT_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE item_id = ?1 AND provider = ?2
+     ORDER BY updated_at DESC, intent_id DESC LIMIT 1";
+const LOAD_INTENT_BY_ID_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents WHERE intent_id = ?1";
+
+pub(super) async fn load_latest_intent(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+    provider: ExternalProvider,
+) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+    query_as::<_, ExternalCreateIntentRow>(LOAD_LATEST_INTENT_SQL)
+        .bind(item_id)
+        .bind(provider_label(provider))
+        .fetch_optional(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load task-board external create history: {error}")))?
+        .map(ExternalCreateIntentRow::into_intent)
+        .transpose()
+}
+
+pub(super) async fn load_intent_by_id(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+    query_as::<_, ExternalCreateIntentRow>(LOAD_INTENT_BY_ID_SQL)
+        .bind(intent_id)
+        .fetch_optional(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load task-board external create intent: {error}")))?
+        .map(ExternalCreateIntentRow::into_intent)
+        .transpose()
+}
+
+pub(super) async fn insert_intent(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent: &TaskBoardExternalCreateIntent,
+) -> Result<(), CliError> {
+    query(
+        "INSERT INTO task_board_external_create_intents (
+            intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+         ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, 'in_flight', ?7, ?8, NULL, NULL,
+            ?9, NULL, NULL, NULL, ?9
+         )",
+    )
+    .bind(&intent.intent_id)
+    .bind(&intent.item_id)
+    .bind(intent.item_revision)
+    .bind(provider_label(intent.provider))
+    .bind(&intent.scope_id)
+    .bind(&intent.create_key)
+    .bind(to_json(
+        &intent.snapshot,
+        "task-board external create snapshot",
+    )?)
+    .bind(to_json(
+        &intent.changed_fields,
+        "task-board external create changed fields",
+    )?)
+    .bind(&intent.created_at)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("insert task-board external create intent: {error}")))?;
+    Ok(())
+}
+
+pub(super) async fn update_created_evidence(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent: &TaskBoardExternalCreateIntent,
+    outcome: &ExternalCreateOutcome,
+    provider_baseline: &ExternalRef,
+    recorded_at: &str,
+) -> Result<(), CliError> {
+    let updated = query(
+        "UPDATE task_board_external_create_intents SET
+            state = 'created', outcome_json = ?4, external_ref_json = ?5,
+            outcome_recorded_at = ?6, updated_at = ?6
+         WHERE intent_id = ?1 AND provider = ?2 AND create_key = ?3 AND state = 'in_flight'",
+    )
+    .bind(&intent.intent_id)
+    .bind(provider_label(intent.provider))
+    .bind(&intent.create_key)
+    .bind(to_json(outcome, "task-board external create outcome")?)
+    .bind(to_json(
+        provider_baseline,
+        "task-board external create provider baseline",
+    )?)
+    .bind(recorded_at)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| {
+        db_error(format!(
+            "record task-board external create outcome: {error}"
+        ))
+    })?
+    .rows_affected();
+    if updated == 1 {
+        Ok(())
+    } else {
+        Err(create_conflict(
+            intent,
+            "intent changed before outcome recording",
+        ))
+    }
+}
+
+pub(super) async fn update_attached_receipt(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent: &TaskBoardExternalCreateIntent,
+    attached_at: &str,
+    attached_item_revision: i64,
+) -> Result<(), CliError> {
+    let updated = query(
+        "UPDATE task_board_external_create_intents SET
+            state = 'attached', attached_at = ?4, attached_item_revision = ?5, updated_at = ?4
+         WHERE intent_id = ?1 AND provider = ?2 AND create_key = ?3 AND state = 'created'",
+    )
+    .bind(&intent.intent_id)
+    .bind(provider_label(intent.provider))
+    .bind(&intent.create_key)
+    .bind(attached_at)
+    .bind(attached_item_revision)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| {
+        db_error(format!(
+            "attach task-board external create receipt: {error}"
+        ))
+    })?
+    .rows_affected();
+    if updated == 1 {
+        Ok(())
+    } else {
+        Err(create_conflict(intent, "intent changed before attachment"))
+    }
+}
+
+pub(super) fn create_snapshot(
+    item: &TaskBoardItem,
+    provider: ExternalProvider,
+    provider_target: &str,
+) -> Result<TaskBoardExternalCreateSnapshot, CliError> {
+    let provider_target = normalize_provider_target(provider, provider_target)?;
+    let execution_repository = match provider {
+        ExternalProvider::GitHub => {
+            normalize_optional_repository(item.execution_repository.as_deref(), &item.id)?
+        }
+        ExternalProvider::Todoist => item.execution_repository.clone(),
+    };
+    let target_matches = match provider {
+        ExternalProvider::GitHub => execution_repository
+            .as_ref()
+            .is_none_or(|repository| repository == &provider_target),
+        ExternalProvider::Todoist => item
+            .project_id
+            .as_ref()
+            .is_none_or(|project| project == &provider_target),
+    };
+    if !target_matches {
+        return Err(create_conflict_for(
+            &item.id,
+            provider,
+            "item target does not match provider scope",
+        ));
+    }
+    Ok(TaskBoardExternalCreateSnapshot {
+        title: item.title.clone(),
+        body: item.body.clone(),
+        status: item.status.canonical_persisted_status(),
+        project_id: item.project_id.clone(),
+        execution_repository,
+        provider_target,
+    })
+}
+
+pub(super) fn create_changed_fields(
+    snapshot: &TaskBoardExternalCreateSnapshot,
+    provider: ExternalProvider,
+) -> Vec<ExternalSyncField> {
+    let mut fields = vec![ExternalSyncField::Title, ExternalSyncField::Body];
+    if snapshot.status != TaskBoardStatus::Done {
+        fields.push(ExternalSyncField::Status);
+    }
+    if provider != ExternalProvider::GitHub && snapshot.project_id.is_some() {
+        fields.push(ExternalSyncField::Project);
+    }
+    fields
+}
+
+pub(super) fn require_same_intent(
+    stored: &TaskBoardExternalCreateIntent,
+    expected: &TaskBoardExternalCreateIntent,
+) -> Result<(), CliError> {
+    let matches = stored.intent_id == expected.intent_id
+        && stored.item_id == expected.item_id
+        && stored.item_revision == expected.item_revision
+        && stored.provider == expected.provider
+        && stored.scope_id == expected.scope_id
+        && stored.create_key == expected.create_key
+        && stored.snapshot == expected.snapshot
+        && stored.changed_fields == expected.changed_fields
+        && stored.created_at == expected.created_at;
+    if matches {
+        Ok(())
+    } else {
+        Err(create_conflict(expected, "intent identity differs"))
+    }
+}
+
+pub(super) fn next_timestamp(previous: &str) -> Result<String, CliError> {
+    let previous = DateTime::parse_from_rfc3339(previous)
+        .map_err(|error| db_error(format!("parse external create timestamp: {error}")))?
+        .with_timezone(&Utc);
+    let now = DateTime::parse_from_rfc3339(&utc_now())
+        .map_err(|error| db_error(format!("parse current external create timestamp: {error}")))?
+        .with_timezone(&Utc);
+    let next = if now > previous {
+        now
+    } else {
+        previous + Duration::seconds(1)
+    };
+    Ok(next.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+}
+
+pub(super) fn provider_label(provider: ExternalProvider) -> &'static str {
+    match provider {
+        ExternalProvider::GitHub => "github",
+        ExternalProvider::Todoist => "todoist",
+    }
+}
+
+pub(super) fn create_conflict(intent: &TaskBoardExternalCreateIntent, reason: &str) -> CliError {
+    create_conflict_for(&intent.item_id, intent.provider, reason)
+}
+
+pub(super) fn create_conflict_for(
+    item_id: &str,
+    provider: ExternalProvider,
+    reason: &str,
+) -> CliError {
+    CliErrorKind::concurrent_modification(format!(
+        "task-board external create for item '{item_id}' provider '{provider}' cannot continue: {reason}"
+    ))
+    .into()
+}
+
+pub(super) fn normalize_provider_target(
+    provider: ExternalProvider,
+    target: &str,
+) -> Result<String, CliError> {
+    match provider {
+        ExternalProvider::GitHub => normalize_repository_slug(Some(target))
+            .ok_or_else(|| db_error(format!("invalid GitHub create target '{target}'"))),
+        ExternalProvider::Todoist => {
+            let target = target.trim();
+            if target.is_empty() {
+                Err(db_error("Todoist create target cannot be empty"))
+            } else {
+                Ok(target.to_owned())
+            }
+        }
+    }
+}
+
+fn normalize_optional_repository(
+    repository: Option<&str>,
+    item_id: &str,
+) -> Result<Option<String>, CliError> {
+    let Some(repository) = repository else {
+        return Ok(None);
+    };
+    normalize_repository_slug(Some(repository))
+        .map(Some)
+        .ok_or_else(|| db_error(format!("invalid execution repository on item '{item_id}'")))
+}
+
+fn parse_provider(value: &str) -> Result<ExternalProvider, CliError> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(|error| {
+        db_error(format!(
+            "parse task-board external create provider: {error}"
+        ))
+    })
+}
+
+#[derive(Debug, FromRow)]
+pub(super) struct ExternalCreateIntentRow {
+    intent_id: String,
+    item_id: String,
+    item_revision: i64,
+    provider: String,
+    scope_id: String,
+    create_key: String,
+    state: String,
+    create_snapshot_json: String,
+    changed_fields_json: String,
+    outcome_json: Option<String>,
+    external_ref_json: Option<String>,
+    created_at: String,
+    outcome_recorded_at: Option<String>,
+    attached_at: Option<String>,
+    attached_item_revision: Option<i64>,
+    updated_at: String,
+}
+
+impl ExternalCreateIntentRow {
+    pub(super) fn into_intent(self) -> Result<TaskBoardExternalCreateIntent, CliError> {
+        let snapshot: TaskBoardExternalCreateSnapshot = parse_json(
+            &self.create_snapshot_json,
+            "task-board external create snapshot",
+        )?;
+        let changed_fields: Vec<ExternalSyncField> = parse_json(
+            &self.changed_fields_json,
+            "task-board external create changed fields",
+        )?;
+        let provider = parse_provider(&self.provider)?;
+        let state = self.decode_state()?;
+        let intent = TaskBoardExternalCreateIntent {
+            intent_id: self.intent_id,
+            item_id: self.item_id,
+            item_revision: self.item_revision,
+            provider,
+            scope_id: self.scope_id,
+            create_key: self.create_key,
+            snapshot,
+            changed_fields,
+            state,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        };
+        validate_decoded_intent(&intent)?;
+        Ok(intent)
+    }
+
+    fn decode_state(&self) -> Result<TaskBoardExternalCreateIntentState, CliError> {
+        match self.state.as_str() {
+            "in_flight" => Ok(TaskBoardExternalCreateIntentState::InFlight),
+            "created" => self
+                .decode_evidence()
+                .map(Box::new)
+                .map(TaskBoardExternalCreateIntentState::Created),
+            "attached" => {
+                let evidence = self.decode_evidence()?;
+                let attached_at = self
+                    .attached_at
+                    .clone()
+                    .ok_or_else(|| db_error("attached external create intent has no timestamp"))?;
+                let attached_item_revision = self.attached_item_revision.ok_or_else(|| {
+                    db_error("attached external create intent has no item revision")
+                })?;
+                Ok(TaskBoardExternalCreateIntentState::Attached(Box::new(
+                    TaskBoardExternalCreateReceipt {
+                        evidence,
+                        attached_at,
+                        attached_item_revision,
+                    },
+                )))
+            }
+            state => Err(db_error(format!(
+                "invalid task-board external create intent state '{state}'"
+            ))),
+        }
+    }
+
+    fn decode_evidence(&self) -> Result<TaskBoardExternalCreateEvidence, CliError> {
+        Ok(TaskBoardExternalCreateEvidence {
+            outcome: parse_json(
+                self.outcome_json
+                    .as_deref()
+                    .ok_or_else(|| db_error("external create intent has no outcome"))?,
+                "task-board external create outcome",
+            )?,
+            provider_baseline: parse_json(
+                self.external_ref_json
+                    .as_deref()
+                    .ok_or_else(|| db_error("external create intent has no baseline"))?,
+                "task-board external create provider baseline",
+            )?,
+            recorded_at: self
+                .outcome_recorded_at
+                .clone()
+                .ok_or_else(|| db_error("external create intent has no recorded timestamp"))?,
+        })
+    }
+}
+
+fn validate_decoded_intent(intent: &TaskBoardExternalCreateIntent) -> Result<(), CliError> {
+    if intent.snapshot.status != intent.snapshot.status.canonical_persisted_status()
+        || intent.changed_fields != create_changed_fields(&intent.snapshot, intent.provider)
+        || normalize_provider_target(intent.provider, &intent.snapshot.provider_target)?
+            != intent.snapshot.provider_target
+    {
+        return Err(create_conflict(
+            intent,
+            "persisted create snapshot is not canonical",
+        ));
+    }
+    if let Some(evidence) = intent.created_evidence() {
+        validate_create_evidence(intent, &evidence.outcome, &evidence.provider_baseline)?;
+    }
+    Ok(())
+}

--- a/src/daemon/db/task_board/provider_external_create_rows.rs
+++ b/src/daemon/db/task_board/provider_external_create_rows.rs
@@ -240,9 +240,18 @@ pub(super) fn next_timestamp(previous: &str) -> Result<String, CliError> {
     let next = if now > previous {
         now
     } else {
-        previous + Duration::seconds(1)
+        previous
+            .checked_add_signed(Duration::seconds(1))
+            .ok_or_else(|| db_error("external create timestamp cannot advance"))?
     };
-    Ok(next.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+    let next = next.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    if next.len() == 20 {
+        Ok(next)
+    } else {
+        Err(db_error(
+            "external create timestamp advances beyond the persisted timestamp range",
+        ))
+    }
 }
 
 pub(super) fn provider_label(provider: ExternalProvider) -> &'static str {

--- a/src/daemon/db/task_board/provider_external_creates.rs
+++ b/src/daemon/db/task_board/provider_external_creates.rs
@@ -1,0 +1,296 @@
+use sqlx::{Sqlite, Transaction, query_as};
+use uuid::Uuid;
+
+use super::ORCHESTRATOR_CHANGE_SCOPE;
+use super::items::{bump_change_in_tx, load_item_in_tx};
+use super::provider_external_create_evidence::validate_create_evidence;
+use super::provider_external_create_rows::{
+    ExternalCreateIntentRow, create_changed_fields, create_conflict, create_conflict_for,
+    create_snapshot, insert_intent, load_intent_by_id, load_latest_intent, next_timestamp,
+    provider_label, require_same_intent, update_created_evidence,
+};
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error, utc_now};
+use crate::infra::io;
+use crate::task_board::{
+    ExternalCreateOutcome, ExternalProvider, ExternalRef, TaskBoardExternalCreateBegin,
+    TaskBoardExternalCreateEvidence, TaskBoardExternalCreateExisting,
+    TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState,
+};
+
+const LIST_PENDING_INTENTS_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE provider = ?1 AND scope_id = ?2 AND state IN ('in_flight', 'created')
+     ORDER BY state, updated_at, intent_id";
+const LIST_CREATED_INTENTS_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE state = 'created' ORDER BY outcome_recorded_at, intent_id";
+const LIST_IN_FLIGHT_PROVIDER_INTENTS_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE provider = ?1 AND state = 'in_flight'
+     ORDER BY created_at, intent_id";
+const LOAD_INTENT_BY_CREATE_KEY_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE provider = ?1 AND create_key = ?2";
+const LOAD_ACTIVE_INTENT_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE item_id = ?1 AND provider = ?2 AND state IN ('in_flight', 'created')
+     ORDER BY updated_at DESC, intent_id DESC LIMIT 1";
+const LOAD_ATTACHED_RECEIPT_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE item_id = ?1 AND provider = ?2 AND state = 'attached'
+     ORDER BY updated_at DESC, intent_id DESC LIMIT 1";
+
+impl AsyncDaemonDb {
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "create admission keeps durable-history, tombstone, and provider-link checks atomic"
+    )]
+    pub(crate) async fn begin_task_board_external_create_intent(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        scope_id: &str,
+        provider_target: &str,
+    ) -> Result<TaskBoardExternalCreateBegin, CliError> {
+        io::validate_safe_segment(item_id)?;
+        let mut transaction = self
+            .begin_immediate_transaction("task board external create intent begin")
+            .await?;
+        if let Some(intent) = load_latest_intent(&mut transaction, item_id, provider).await? {
+            commit(transaction, "existing task-board external create intent").await?;
+            return Ok(existing_begin(intent));
+        }
+        let (item, item_revision) = load_item_in_tx(&mut transaction, item_id)
+            .await?
+            .ok_or_else(|| db_error(format!("task-board item '{item_id}' not found")))?;
+        if item.is_deleted() {
+            return Err(create_conflict_for(
+                item_id,
+                provider,
+                "cannot begin creation for a tombstoned item",
+            ));
+        }
+        if item
+            .external_refs
+            .iter()
+            .any(|reference| ExternalProvider::from(reference.provider) == provider)
+        {
+            return Err(create_conflict_for(
+                item_id,
+                provider,
+                "item is already linked to this provider",
+            ));
+        }
+        let now = utc_now();
+        let snapshot = create_snapshot(&item, provider, provider_target)?;
+        let intent = TaskBoardExternalCreateIntent {
+            intent_id: Uuid::new_v4().to_string(),
+            item_id: item_id.to_owned(),
+            item_revision,
+            provider,
+            scope_id: scope_id.to_owned(),
+            create_key: Uuid::new_v4().to_string(),
+            changed_fields: create_changed_fields(&snapshot, provider),
+            snapshot,
+            state: TaskBoardExternalCreateIntentState::InFlight,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        insert_intent(&mut transaction, &intent).await?;
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        commit(transaction, "task-board external create intent begin").await?;
+        Ok(TaskBoardExternalCreateBegin::Started(intent))
+    }
+
+    pub(crate) async fn record_task_board_external_create_outcome(
+        &self,
+        intent: &TaskBoardExternalCreateIntent,
+        outcome: &ExternalCreateOutcome,
+        provider_baseline: &ExternalRef,
+    ) -> Result<TaskBoardExternalCreateIntent, CliError> {
+        validate_create_evidence(intent, outcome, provider_baseline)?;
+        let mut transaction = self
+            .begin_immediate_transaction("task board external create outcome")
+            .await?;
+        let stored = load_intent_by_id(&mut transaction, &intent.intent_id)
+            .await?
+            .ok_or_else(|| create_conflict(intent, "create intent is missing"))?;
+        require_same_intent(&stored, intent)?;
+        if let Some(evidence) = stored.created_evidence() {
+            if evidence.outcome == *outcome && evidence.provider_baseline == *provider_baseline {
+                commit(transaction, "existing task-board external create outcome").await?;
+                return Ok(stored);
+            }
+            return Err(create_conflict(&stored, "stored create evidence differs"));
+        }
+        let recorded_at = next_timestamp(&stored.updated_at)?;
+        update_created_evidence(
+            &mut transaction,
+            &stored,
+            outcome,
+            provider_baseline,
+            &recorded_at,
+        )
+        .await?;
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        commit(transaction, "task-board external create outcome").await?;
+        let mut created = stored;
+        created.state = TaskBoardExternalCreateIntentState::Created(Box::new(
+            TaskBoardExternalCreateEvidence {
+                outcome: outcome.clone(),
+                provider_baseline: provider_baseline.clone(),
+                recorded_at: recorded_at.clone(),
+            },
+        ));
+        created.updated_at = recorded_at;
+        Ok(created)
+    }
+
+    pub(crate) async fn list_pending_task_board_external_create_intents(
+        &self,
+        provider: ExternalProvider,
+        scope_id: &str,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        load_intents(
+            query_as::<_, ExternalCreateIntentRow>(LIST_PENDING_INTENTS_SQL)
+                .bind(provider_label(provider))
+                .bind(scope_id)
+                .fetch_all(self.pool())
+                .await,
+            "list scoped task-board external create intents",
+        )
+    }
+
+    pub(crate) async fn list_created_task_board_external_create_intents(
+        &self,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        load_intents(
+            query_as::<_, ExternalCreateIntentRow>(LIST_CREATED_INTENTS_SQL)
+                .fetch_all(self.pool())
+                .await,
+            "list created task-board external create intents",
+        )
+    }
+
+    pub(crate) async fn list_in_flight_task_board_external_create_intents(
+        &self,
+        provider: ExternalProvider,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        load_intents(
+            query_as::<_, ExternalCreateIntentRow>(LIST_IN_FLIGHT_PROVIDER_INTENTS_SQL)
+                .bind(provider_label(provider))
+                .fetch_all(self.pool())
+                .await,
+            "list provider task-board external create intents",
+        )
+    }
+
+    pub(crate) async fn task_board_external_create_intent_by_create_key(
+        &self,
+        provider: ExternalProvider,
+        create_key: &str,
+    ) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+        io::validate_safe_segment(create_key)?;
+        decode_optional_intent(
+            query_as::<_, ExternalCreateIntentRow>(LOAD_INTENT_BY_CREATE_KEY_SQL)
+                .bind(provider_label(provider))
+                .bind(create_key)
+                .fetch_optional(self.pool())
+                .await,
+            "read task-board external create intent by key",
+        )
+    }
+
+    pub(crate) async fn task_board_external_create_intent(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+    ) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+        io::validate_safe_segment(item_id)?;
+        load_one(self, LOAD_ACTIVE_INTENT_SQL, item_id, provider).await
+    }
+
+    pub(crate) async fn task_board_external_create_receipt(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+    ) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+        io::validate_safe_segment(item_id)?;
+        load_one(self, LOAD_ATTACHED_RECEIPT_SQL, item_id, provider).await
+    }
+}
+
+fn existing_begin(intent: TaskBoardExternalCreateIntent) -> TaskBoardExternalCreateBegin {
+    let existing = match &intent.state {
+        TaskBoardExternalCreateIntentState::InFlight => {
+            TaskBoardExternalCreateExisting::Recover(intent)
+        }
+        TaskBoardExternalCreateIntentState::Created(_) => {
+            TaskBoardExternalCreateExisting::Finalize(intent)
+        }
+        TaskBoardExternalCreateIntentState::Attached(_) => {
+            TaskBoardExternalCreateExisting::Attached(intent)
+        }
+    };
+    TaskBoardExternalCreateBegin::Existing(existing)
+}
+
+fn load_intents(
+    rows: Result<Vec<ExternalCreateIntentRow>, sqlx::Error>,
+    context: &str,
+) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+    rows.map_err(|error| db_error(format!("{context}: {error}")))?
+        .into_iter()
+        .map(ExternalCreateIntentRow::into_intent)
+        .collect()
+}
+
+async fn load_one(
+    db: &AsyncDaemonDb,
+    sql: &'static str,
+    item_id: &str,
+    provider: ExternalProvider,
+) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+    decode_optional_intent(
+        query_as::<_, ExternalCreateIntentRow>(sql)
+            .bind(item_id)
+            .bind(provider_label(provider))
+            .fetch_optional(db.pool())
+            .await,
+        "read task-board external create intent",
+    )
+}
+
+fn decode_optional_intent(
+    row: Result<Option<ExternalCreateIntentRow>, sqlx::Error>,
+    context: &str,
+) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+    row.map_err(|error| db_error(format!("{context}: {error}")))?
+        .map(ExternalCreateIntentRow::into_intent)
+        .transpose()
+}
+
+async fn commit(transaction: Transaction<'_, Sqlite>, context: &str) -> Result<(), CliError> {
+    transaction
+        .commit()
+        .await
+        .map_err(|error| db_error(format!("commit {context}: {error}")))
+}

--- a/src/daemon/db/task_board/provider_external_creates.rs
+++ b/src/daemon/db/task_board/provider_external_creates.rs
@@ -37,6 +37,24 @@ const LIST_IN_FLIGHT_PROVIDER_INTENTS_SQL: &str =
      FROM task_board_external_create_intents
      WHERE provider = ?1 AND state = 'in_flight'
      ORDER BY created_at, intent_id";
+const LIST_PENDING_PROVIDER_FOLLOW_UPS_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE provider = ?1 AND state = 'attached'
+       AND follow_up_completed_at IS NULL
+       AND follow_up_audit_event_id IS NULL
+     ORDER BY scope_id, attached_at, intent_id";
+const LIST_PENDING_FOLLOW_UPS_SQL: &str =
+    "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
+            create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
+            created_at, outcome_recorded_at, attached_at, attached_item_revision, updated_at
+     FROM task_board_external_create_intents
+     WHERE state = 'attached'
+       AND follow_up_completed_at IS NULL
+       AND follow_up_audit_event_id IS NULL
+     ORDER BY provider, scope_id, attached_at, intent_id";
 const LOAD_INTENT_BY_CREATE_KEY_SQL: &str =
     "SELECT intent_id, item_id, item_revision, provider, scope_id, create_key, state,
             create_snapshot_json, changed_fields_json, outcome_json, external_ref_json,
@@ -201,6 +219,26 @@ impl AsyncDaemonDb {
                 .await,
             "list provider task-board external create intents",
         )
+    }
+
+    pub(crate) async fn list_pending_task_board_external_create_follow_ups(
+        &self,
+        provider: Option<ExternalProvider>,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        let rows = match provider {
+            Some(provider) => {
+                query_as::<_, ExternalCreateIntentRow>(LIST_PENDING_PROVIDER_FOLLOW_UPS_SQL)
+                    .bind(provider_label(provider))
+                    .fetch_all(self.pool())
+                    .await
+            }
+            None => {
+                query_as::<_, ExternalCreateIntentRow>(LIST_PENDING_FOLLOW_UPS_SQL)
+                    .fetch_all(self.pool())
+                    .await
+            }
+        };
+        load_intents(rows, "list pending task-board external create follow-ups")
     }
 
     pub(crate) async fn task_board_external_create_intent_by_create_key(

--- a/src/daemon/db/task_board/provider_external_creates_tests.rs
+++ b/src/daemon/db/task_board/provider_external_creates_tests.rs
@@ -1,0 +1,478 @@
+use tempfile::tempdir;
+
+use super::ORCHESTRATOR_CHANGE_SCOPE;
+use super::provider_external_create_rows::next_timestamp;
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::{
+    ExternalCreateOutcome, ExternalProvider, ExternalRefSyncState, ExternalSyncField,
+    ExternalTaskRef, TaskBoardExternalCreateBegin, TaskBoardExternalCreateExisting,
+    TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState, TaskBoardItem,
+    TaskBoardStatus,
+};
+
+#[tokio::test]
+async fn concurrent_begin_admits_one_create_and_reuses_immutable_cross_scope_snapshot() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-reuse")).await;
+    let before = sequence(&db).await;
+    let first_db = db.clone();
+    let second_db = db.clone();
+
+    let (first, second) = tokio::join!(
+        first_db.begin_task_board_external_create_intent(
+            "task-create-reuse",
+            ExternalProvider::GitHub,
+            "scope-a",
+            "Example/Repository",
+        ),
+        second_db.begin_task_board_external_create_intent(
+            "task-create-reuse",
+            ExternalProvider::GitHub,
+            "scope-b",
+            "example/repository",
+        ),
+    );
+    let (first_started, first) = begin_intent(first.expect("first begin"));
+    let (second_started, second) = begin_intent(second.expect("second begin"));
+
+    assert_ne!(first_started, second_started);
+    assert_eq!(first, second);
+    assert_eq!(first.snapshot.title, "Original title");
+    assert_eq!(first.snapshot.body, "Original body");
+    assert_eq!(first.snapshot.status, TaskBoardStatus::Todo);
+    assert_eq!(first.snapshot.provider_target, "example/repository");
+    assert_eq!(
+        first.changed_fields,
+        vec![
+            ExternalSyncField::Title,
+            ExternalSyncField::Body,
+            ExternalSyncField::Status,
+        ]
+    );
+    uuid::Uuid::parse_str(&first.intent_id).expect("intent UUID");
+    uuid::Uuid::parse_str(&first.create_key).expect("provider create UUID");
+    assert_published(&db, before, ORCHESTRATOR_CHANGE_SCOPE).await;
+
+    db.update_task_board_item("task-create-reuse", |current| {
+        current.title = "Concurrent title".into();
+        current.body = "Concurrent body".into();
+        current.execution_repository = Some("other/repository".into());
+        Ok(true)
+    })
+    .await
+    .expect("concurrent item edit");
+    let before_reuse = sequence(&db).await;
+    let reused = db
+        .begin_task_board_external_create_intent(
+            "task-create-reuse",
+            ExternalProvider::GitHub,
+            "scope-c",
+            "other/repository",
+        )
+        .await
+        .expect("cross-scope reuse");
+    let (started, reused) = begin_intent(reused);
+
+    assert!(!started);
+    assert_eq!(reused, first);
+    assert_eq!(sequence(&db).await, before_reuse);
+    assert_eq!(
+        db.list_pending_task_board_external_create_intents(
+            ExternalProvider::GitHub,
+            &first.scope_id,
+        )
+        .await
+        .expect("list original scope"),
+        vec![first.clone()]
+    );
+    assert_eq!(
+        db.task_board_external_create_intent("task-create-reuse", ExternalProvider::GitHub)
+            .await
+            .expect("active intent"),
+        Some(first)
+    );
+}
+
+#[tokio::test]
+async fn begin_rejects_linked_or_tombstoned_items_without_churn() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    let mut linked = item("task-create-linked");
+    linked.external_refs.push(
+        ExternalTaskRef::new(ExternalProvider::GitHub, "example/repository#9").into_core_ref(),
+    );
+    create_item(&db, linked).await;
+    let before_linked = sequence(&db).await;
+
+    let linked_error = db
+        .begin_task_board_external_create_intent(
+            "task-create-linked",
+            ExternalProvider::GitHub,
+            "scope",
+            "example/repository",
+        )
+        .await
+        .expect_err("linked item must fail");
+    assert_eq!(linked_error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(sequence(&db).await, before_linked);
+
+    create_item(&db, item("task-create-tombstone")).await;
+    db.delete_task_board_item("task-create-tombstone")
+        .await
+        .expect("tombstone item");
+    let before_tombstone = sequence(&db).await;
+    let tombstone_error = db
+        .begin_task_board_external_create_intent(
+            "task-create-tombstone",
+            ExternalProvider::GitHub,
+            "scope",
+            "example/repository",
+        )
+        .await
+        .expect_err("tombstoned item must fail");
+    assert_eq!(tombstone_error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(sequence(&db).await, before_tombstone);
+}
+
+#[tokio::test]
+async fn record_persists_exact_evidence_and_rejects_valid_drift_without_churn() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-record")).await;
+    let intent = begin(&db, "task-create-record", ExternalProvider::GitHub).await;
+    let (outcome, baseline) = create_evidence(&intent, "example/repository#41", "revision-1");
+    let before = sequence(&db).await;
+
+    let created = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("record outcome");
+    assert_published(&db, before, ORCHESTRATOR_CHANGE_SCOPE).await;
+    let evidence = created.created_evidence().expect("created evidence");
+    assert_eq!(evidence.outcome, outcome);
+    assert_eq!(evidence.provider_baseline, baseline);
+    assert!(evidence.recorded_at > created.created_at);
+    assert_exact_json(&db, &created, &outcome, &baseline).await;
+
+    let before_retry = sequence(&db).await;
+    let repeated = db
+        .record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("repeat exact outcome");
+    assert_eq!(repeated, created);
+    assert_eq!(sequence(&db).await, before_retry);
+
+    let (drifted_outcome, drifted_baseline) =
+        create_evidence(&intent, "example/repository#41", "revision-2");
+    let error = db
+        .record_task_board_external_create_outcome(&intent, &drifted_outcome, &drifted_baseline)
+        .await
+        .expect_err("different valid evidence must fail");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(sequence(&db).await, before_retry);
+    assert_eq!(
+        db.task_board_external_create_intent("task-create-record", ExternalProvider::GitHub)
+            .await
+            .expect("reload created intent"),
+        Some(created)
+    );
+}
+
+#[tokio::test]
+async fn record_rejects_provider_revision_project_and_identity_mismatch() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-mismatch")).await;
+    let intent = begin(&db, "task-create-mismatch", ExternalProvider::GitHub).await;
+    let (outcome, baseline) = create_evidence(&intent, "example/repository#42", "revision-1");
+    let before = sequence(&db).await;
+
+    let mut revision_mismatch = outcome.clone();
+    revision_mismatch.provider_revision = Some("revision-2".into());
+    assert_record_conflict(&db, &intent, &revision_mismatch, &baseline).await;
+
+    let mut project_mismatch = outcome.clone();
+    project_mismatch.provider_project_id = Some("other/repository".into());
+    assert_record_conflict(&db, &intent, &project_mismatch, &baseline).await;
+
+    let mut provider_mismatch = outcome;
+    provider_mismatch.reference.provider = ExternalProvider::Todoist;
+    assert_record_conflict(&db, &intent, &provider_mismatch, &baseline).await;
+
+    let (identity_mismatch, identity_baseline) =
+        create_evidence(&intent, "other/repository#42", "revision-1");
+    assert_record_conflict(&db, &intent, &identity_mismatch, &identity_baseline).await;
+    assert_eq!(sequence(&db).await, before);
+}
+
+#[tokio::test]
+async fn created_recovery_is_global_and_hard_delete_retains_active_evidence() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-github")).await;
+    let mut todoist = item("task-create-todoist");
+    todoist.project_id = Some("todoist-project".into());
+    create_item(&db, todoist).await;
+    let github = begin(&db, "task-create-github", ExternalProvider::GitHub).await;
+    let todoist = begin(&db, "task-create-todoist", ExternalProvider::Todoist).await;
+    let github = record(&db, &github, "example/repository#43").await;
+    let todoist = record(&db, &todoist, "todoist-task-43").await;
+    db.delete_task_board_item("task-create-github")
+        .await
+        .expect("tombstone created GitHub item");
+    db.update_task_board_item("task-create-todoist", |current| {
+        current.title = "Concurrent Todoist title".into();
+        current.project_id = Some("todoist-project-concurrent".into());
+        Ok(true)
+    })
+    .await
+    .expect("edit Todoist item after create");
+    let todoist_recovery = db
+        .begin_task_board_external_create_intent(
+            "task-create-todoist",
+            ExternalProvider::Todoist,
+            "replacement-scope",
+            "todoist-project-concurrent",
+        )
+        .await
+        .expect("recover Todoist create");
+    assert!(matches!(
+        todoist_recovery,
+        TaskBoardExternalCreateBegin::Existing(TaskBoardExternalCreateExisting::Finalize(
+            ref recovered
+        )) if recovered == &todoist
+    ));
+
+    let mut recovered = db
+        .list_created_task_board_external_create_intents()
+        .await
+        .expect("global created recovery");
+    recovered.sort_by(|left, right| left.item_id.cmp(&right.item_id));
+    let mut expected = vec![github.clone(), todoist];
+    expected.sort_by(|left, right| left.item_id.cmp(&right.item_id));
+    assert_eq!(recovered, expected);
+    let delete_error =
+        sqlx::query("DELETE FROM task_board_items WHERE item_id = 'task-create-github'")
+            .execute(db.pool())
+            .await
+            .expect_err("active evidence must restrict hard delete");
+    assert!(delete_error.to_string().contains("FOREIGN KEY"));
+    assert_eq!(
+        db.task_board_external_create_intent("task-create-github", ExternalProvider::GitHub)
+            .await
+            .expect("retained active intent"),
+        Some(github)
+    );
+}
+
+#[tokio::test]
+async fn inconsistent_persisted_create_evidence_fails_closed_on_read() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-corrupt")).await;
+    let intent = begin(&db, "task-create-corrupt", ExternalProvider::GitHub).await;
+    let created = record(&db, &intent, "example/repository#44").await;
+    sqlx::query(
+        "UPDATE task_board_external_create_intents
+         SET outcome_json = json_set(outcome_json, '$.provider_revision', 'corrupt')
+         WHERE intent_id = ?1",
+    )
+    .bind(&created.intent_id)
+    .execute(db.pool())
+    .await
+    .expect("corrupt outcome");
+
+    let error = db
+        .task_board_external_create_intent("task-create-corrupt", ExternalProvider::GitHub)
+        .await
+        .expect_err("inconsistent evidence must fail closed");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+}
+
+#[test]
+fn transition_timestamp_advances_when_wall_clock_has_not() {
+    assert_eq!(
+        next_timestamp("2999-12-31T23:59:58Z").expect("next timestamp"),
+        "2999-12-31T23:59:59Z"
+    );
+}
+
+#[tokio::test]
+async fn record_and_finalize_advance_persisted_clock_without_wall_clock_rollover() {
+    let dir = tempdir().expect("tempdir");
+    let db = connect(&dir).await;
+    create_item(&db, item("task-create-monotonic")).await;
+    let intent = begin(&db, "task-create-monotonic", ExternalProvider::GitHub).await;
+    sqlx::query(
+        "UPDATE task_board_external_create_intents
+         SET created_at = '2999-12-31T23:59:58Z',
+             updated_at = '2999-12-31T23:59:58Z'
+         WHERE intent_id = ?1",
+    )
+    .bind(&intent.intent_id)
+    .execute(db.pool())
+    .await
+    .expect("seed future create clock");
+    let intent = db
+        .task_board_external_create_intent("task-create-monotonic", ExternalProvider::GitHub)
+        .await
+        .expect("reload intent")
+        .expect("active intent");
+
+    let created = record(&db, &intent, "example/repository#60").await;
+    let recorded_at = created
+        .created_evidence()
+        .expect("created evidence")
+        .recorded_at
+        .clone();
+    let finalized = db
+        .finalize_task_board_external_create_intent(&created)
+        .await
+        .expect("finalize create");
+    let TaskBoardExternalCreateIntentState::Attached(receipt) = finalized.intent.state else {
+        panic!("expected attached receipt");
+    };
+
+    assert_eq!(recorded_at, "2999-12-31T23:59:59Z");
+    assert_eq!(receipt.attached_at, "3000-01-01T00:00:00Z");
+}
+
+pub(super) async fn connect(dir: &tempfile::TempDir) -> AsyncDaemonDb {
+    AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database")
+}
+
+pub(super) fn item(item_id: &str) -> TaskBoardItem {
+    TaskBoardItem::new(
+        item_id.into(),
+        "Original title".into(),
+        "Original body".into(),
+        "2026-07-16T10:00:00Z".into(),
+    )
+}
+
+pub(super) async fn create_item(db: &AsyncDaemonDb, item: TaskBoardItem) {
+    db.create_task_board_item(item).await.expect("create item");
+}
+
+pub(super) async fn begin(
+    db: &AsyncDaemonDb,
+    item_id: &str,
+    provider: ExternalProvider,
+) -> TaskBoardExternalCreateIntent {
+    let (target, scope) = match provider {
+        ExternalProvider::GitHub => ("example/repository", "github-scope"),
+        ExternalProvider::Todoist => ("todoist-project", "todoist-scope"),
+    };
+    match db
+        .begin_task_board_external_create_intent(item_id, provider, scope, target)
+        .await
+        .expect("begin intent")
+    {
+        TaskBoardExternalCreateBegin::Started(intent) => intent,
+        other => panic!("expected started intent, got {other:?}"),
+    }
+}
+
+pub(super) async fn record(
+    db: &AsyncDaemonDb,
+    intent: &TaskBoardExternalCreateIntent,
+    external_id: &str,
+) -> TaskBoardExternalCreateIntent {
+    let (outcome, baseline) = create_evidence(intent, external_id, "revision-1");
+    db.record_task_board_external_create_outcome(intent, &outcome, &baseline)
+        .await
+        .expect("record intent")
+}
+
+fn begin_intent(decision: TaskBoardExternalCreateBegin) -> (bool, TaskBoardExternalCreateIntent) {
+    match decision {
+        TaskBoardExternalCreateBegin::Started(intent) => (true, intent),
+        TaskBoardExternalCreateBegin::Existing(TaskBoardExternalCreateExisting::Recover(
+            intent,
+        )) => (false, intent),
+        other => panic!("unexpected begin decision: {other:?}"),
+    }
+}
+
+pub(super) fn create_evidence(
+    intent: &TaskBoardExternalCreateIntent,
+    external_id: &str,
+    revision: &str,
+) -> (ExternalCreateOutcome, crate::task_board::ExternalRef) {
+    let reference = ExternalTaskRef::new(intent.provider, external_id)
+        .with_url(format!("https://example.invalid/tasks/{external_id}"));
+    let outcome = ExternalCreateOutcome {
+        reference: reference.clone(),
+        provider_revision: Some(revision.into()),
+        provider_project_id: Some(intent.snapshot.provider_target.clone()),
+    };
+    let mut baseline = reference.into_core_ref();
+    baseline.sync_state = Some(ExternalRefSyncState {
+        title: Some(intent.snapshot.title.clone()),
+        body: Some(intent.snapshot.body.clone()),
+        status: Some(TaskBoardStatus::Backlog),
+        project_id: Some(intent.snapshot.provider_target.clone()),
+        updated_at: Some(revision.into()),
+        synced_at: Some("2026-07-16T10:00:00Z".into()),
+    });
+    (outcome, baseline)
+}
+
+async fn assert_record_conflict(
+    db: &AsyncDaemonDb,
+    intent: &TaskBoardExternalCreateIntent,
+    outcome: &ExternalCreateOutcome,
+    baseline: &crate::task_board::ExternalRef,
+) {
+    let error = db
+        .record_task_board_external_create_outcome(intent, outcome, baseline)
+        .await
+        .expect_err("mismatched evidence must fail");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+}
+
+async fn assert_exact_json(
+    db: &AsyncDaemonDb,
+    intent: &TaskBoardExternalCreateIntent,
+    outcome: &ExternalCreateOutcome,
+    baseline: &crate::task_board::ExternalRef,
+) {
+    let stored = sqlx::query_as::<_, (String, String, String, String)>(
+        "SELECT create_snapshot_json, changed_fields_json, outcome_json, external_ref_json
+         FROM task_board_external_create_intents WHERE intent_id = ?1",
+    )
+    .bind(&intent.intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("stored JSON");
+    assert_eq!(stored.0, serde_json::to_string(&intent.snapshot).unwrap());
+    assert_eq!(
+        stored.1,
+        serde_json::to_string(&intent.changed_fields).unwrap()
+    );
+    assert_eq!(stored.2, serde_json::to_string(outcome).unwrap());
+    assert_eq!(stored.3, serde_json::to_string(baseline).unwrap());
+}
+
+pub(super) async fn sequence(db: &AsyncDaemonDb) -> i64 {
+    db.current_change_sequence().await.expect("change sequence")
+}
+
+pub(super) async fn assert_published(
+    db: &AsyncDaemonDb,
+    previous: i64,
+    expected_scope: &str,
+) -> i64 {
+    let current = sequence(db).await;
+    assert_eq!(current, previous + 1);
+    assert_eq!(
+        db.load_change_tracking_since(previous)
+            .await
+            .expect("published change"),
+        vec![(expected_scope.to_owned(), current)]
+    );
+    current
+}

--- a/src/daemon/db/task_board/provider_external_creates_tests.rs
+++ b/src/daemon/db/task_board/provider_external_creates_tests.rs
@@ -298,6 +298,11 @@ fn transition_timestamp_advances_when_wall_clock_has_not() {
     );
 }
 
+#[test]
+fn transition_timestamp_fails_closed_at_the_persisted_range_boundary() {
+    next_timestamp("9999-12-31T23:59:59Z").expect_err("maximum persisted timestamp cannot advance");
+}
+
 #[tokio::test]
 async fn record_and_finalize_advance_persisted_clock_without_wall_clock_rollover() {
     let dir = tempdir().expect("tempdir");

--- a/src/daemon/db/task_board/provider_sync.rs
+++ b/src/daemon/db/task_board/provider_sync.rs
@@ -1,15 +1,14 @@
 use chrono::{DateTime, Duration};
-use serde::de::DeserializeOwned;
-use sqlx::{SqliteConnection, query, query_as};
+use sqlx::{query, query_as};
 use uuid::Uuid;
 
 use crate::daemon::db::task_board::items::bump_change_in_tx;
-use crate::daemon::db::{AsyncDaemonDb, CliError, CliErrorKind, db_error, utc_now};
+use crate::daemon::db::{AsyncDaemonDb, CliError, CliErrorKind, db_error};
+use crate::task_board::ExternalProvider;
 use crate::task_board::external::{
     ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
     ExternalProviderScopeAvailability, ExternalProviderScopeHealth, ExternalProviderScopeState,
 };
-use crate::task_board::{ExternalProvider, ExternalRefProvider, TaskBoardSyncConflict};
 
 use super::ORCHESTRATOR_CHANGE_SCOPE;
 
@@ -113,6 +112,33 @@ impl AsyncDaemonDb {
                 created_scope,
             ),
         ))
+    }
+
+    pub(crate) async fn renew_task_board_provider_scope_attempt(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        now: &str,
+    ) -> Result<(), CliError> {
+        let attempt_deadline = deadline_from_seconds(now, ATTEMPT_LEASE_SECONDS)?;
+        let updated = query(
+            "UPDATE task_board_provider_scope_state SET
+                backoff_until = ?4, updated_at = ?5
+             WHERE provider = ?1 AND scope_id = ?2 AND health = ?3",
+        )
+        .bind(provider_label(attempt.provider()))
+        .bind(attempt.scope_id())
+        .bind(attempt.fence_marker())
+        .bind(attempt_deadline)
+        .bind(now)
+        .execute(self.pool())
+        .await
+        .map_err(|error| db_error(format!("renew task-board provider attempt: {error}")))?
+        .rows_affected();
+        if updated == 1 {
+            Ok(())
+        } else {
+            Err(stale_attempt_error(attempt))
+        }
     }
 
     pub(crate) async fn complete_task_board_provider_scope_success(
@@ -225,179 +251,6 @@ impl AsyncDaemonDb {
             backoff_until: Some(backoff_until),
         })
     }
-
-    pub(crate) async fn replace_open_task_board_sync_conflicts(
-        &self,
-        item_id: &str,
-        provider: ExternalProvider,
-        external_ref: &str,
-        conflicts: &[TaskBoardSyncConflict],
-    ) -> Result<(), CliError> {
-        let mut transaction = self
-            .begin_immediate_transaction("task board sync conflict replace")
-            .await?;
-        let mut changed = supersede_removed_conflicts(
-            transaction.as_mut(),
-            item_id,
-            provider,
-            external_ref,
-            conflicts,
-        )
-        .await?;
-        for conflict in conflicts {
-            changed |= upsert_open_conflict(transaction.as_mut(), conflict).await?;
-        }
-        if changed {
-            bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
-        }
-        transaction
-            .commit()
-            .await
-            .map_err(|error| db_error(format!("commit task-board sync conflicts: {error}")))
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn open_task_board_sync_conflicts(
-        &self,
-    ) -> Result<Vec<TaskBoardSyncConflict>, CliError> {
-        let rows = query_as::<_, ConflictRow>(
-            "SELECT conflict_id, item_id, provider, external_ref, field,
-                    base_value_json, local_value_json, remote_value_json,
-                    item_revision, provider_revision, state
-             FROM task_board_sync_conflicts WHERE state = 'open'
-             ORDER BY conflict_id",
-        )
-        .fetch_all(self.pool())
-        .await
-        .map_err(|error| db_error(format!("list task-board sync conflicts: {error}")))?;
-        rows.into_iter().map(ConflictRow::into_conflict).collect()
-    }
-}
-
-async fn supersede_removed_conflicts(
-    connection: &mut SqliteConnection,
-    item_id: &str,
-    provider: ExternalProvider,
-    external_ref: &str,
-    conflicts: &[TaskBoardSyncConflict],
-) -> Result<bool, CliError> {
-    let fields = conflicts
-        .iter()
-        .map(|conflict| conflict.field.as_str())
-        .collect::<Vec<_>>();
-    let rows = query_as::<_, (String, String)>(
-        "SELECT conflict_id, field FROM task_board_sync_conflicts
-         WHERE item_id = ?1 AND provider = ?2 AND external_ref = ?3 AND state = 'open'",
-    )
-    .bind(item_id)
-    .bind(provider_label(provider))
-    .bind(external_ref)
-    .fetch_all(&mut *connection)
-    .await
-    .map_err(|error| db_error(format!("read open task-board sync conflicts: {error}")))?;
-    let mut changed = false;
-    for (conflict_id, field) in rows {
-        if !fields.contains(&field.as_str()) {
-            changed |= query(
-                "UPDATE task_board_sync_conflicts
-                 SET state = 'superseded', resolved_at = ?2
-                 WHERE conflict_id = ?1",
-            )
-            .bind(conflict_id)
-            .bind(utc_now())
-            .execute(&mut *connection)
-            .await
-            .map_err(|error| db_error(format!("supersede task-board sync conflict: {error}")))?
-            .rows_affected()
-                > 0;
-        }
-    }
-    Ok(changed)
-}
-
-async fn upsert_open_conflict(
-    connection: &mut SqliteConnection,
-    conflict: &TaskBoardSyncConflict,
-) -> Result<bool, CliError> {
-    let base_value_json = to_json(&conflict.base_value)?;
-    let local_value_json = to_json(&conflict.local_value)?;
-    let remote_value_json = to_json(&conflict.remote_value)?;
-    let updated = query(
-        "UPDATE task_board_sync_conflicts SET
-            base_value_json = ?6, local_value_json = ?7,
-            remote_value_json = ?8, item_revision = ?9, provider_revision = ?10
-         WHERE item_id = ?2 AND provider = ?3 AND external_ref = ?4
-           AND field = ?5 AND state = 'open'
-           AND (base_value_json IS NOT ?6 OR local_value_json IS NOT ?7
-                OR remote_value_json IS NOT ?8 OR item_revision IS NOT ?9
-                OR provider_revision IS NOT ?10)",
-    )
-    .bind(&conflict.conflict_id)
-    .bind(&conflict.item_id)
-    .bind(ref_provider_label(conflict.provider))
-    .bind(&conflict.external_ref)
-    .bind(&conflict.field)
-    .bind(&base_value_json)
-    .bind(&local_value_json)
-    .bind(&remote_value_json)
-    .bind(conflict.item_revision)
-    .bind(&conflict.provider_revision)
-    .execute(&mut *connection)
-    .await
-    .map_err(|error| db_error(format!("update task-board sync conflict: {error}")))?;
-    if updated.rows_affected() > 0 {
-        return Ok(true);
-    }
-    let open_exists = query_as::<_, (i64,)>(
-        "SELECT EXISTS(
-            SELECT 1 FROM task_board_sync_conflicts
-            WHERE item_id = ?1 AND provider = ?2 AND external_ref = ?3
-              AND field = ?4 AND state = 'open'
-         )",
-    )
-    .bind(&conflict.item_id)
-    .bind(ref_provider_label(conflict.provider))
-    .bind(&conflict.external_ref)
-    .bind(&conflict.field)
-    .fetch_one(&mut *connection)
-    .await
-    .map_err(|error| db_error(format!("read task-board sync conflict identity: {error}")))?
-    .0 != 0;
-    if open_exists {
-        return Ok(false);
-    }
-    let changed = query(
-        "INSERT INTO task_board_sync_conflicts (
-            conflict_id, item_id, provider, external_ref, field,
-            base_value_json, local_value_json, remote_value_json,
-            item_revision, provider_revision, state, detected_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'open', ?11)
-         ON CONFLICT(conflict_id) DO UPDATE SET
-            base_value_json = excluded.base_value_json,
-            local_value_json = excluded.local_value_json,
-            remote_value_json = excluded.remote_value_json,
-            item_revision = excluded.item_revision,
-            provider_revision = excluded.provider_revision,
-            state = 'open', detected_at = excluded.detected_at,
-            resolved_at = NULL, resolved_by = NULL",
-    )
-    .bind(&conflict.conflict_id)
-    .bind(&conflict.item_id)
-    .bind(ref_provider_label(conflict.provider))
-    .bind(&conflict.external_ref)
-    .bind(&conflict.field)
-    .bind(base_value_json)
-    .bind(local_value_json)
-    .bind(remote_value_json)
-    .bind(conflict.item_revision)
-    .bind(&conflict.provider_revision)
-    .bind(utc_now())
-    .execute(&mut *connection)
-    .await
-    .map_err(|error| db_error(format!("insert task-board sync conflict: {error}")))?
-    .rows_affected()
-        > 0;
-    Ok(changed)
 }
 
 fn decode_provider_scope_state(
@@ -462,55 +315,5 @@ const fn provider_label(provider: ExternalProvider) -> &'static str {
     match provider {
         ExternalProvider::GitHub => "github",
         ExternalProvider::Todoist => "todoist",
-    }
-}
-
-fn ref_provider_label(provider: ExternalRefProvider) -> &'static str {
-    match provider {
-        ExternalRefProvider::GitHub => "github",
-        ExternalRefProvider::Todoist => "todoist",
-    }
-}
-
-fn to_json(value: &serde_json::Value) -> Result<String, CliError> {
-    serde_json::to_string(value)
-        .map_err(|error| db_error(format!("serialize task-board sync conflict value: {error}")))
-}
-
-fn from_json<T: DeserializeOwned>(value: &str) -> Result<T, CliError> {
-    serde_json::from_str(value)
-        .map_err(|error| db_error(format!("parse task-board sync conflict value: {error}")))
-}
-
-#[derive(sqlx::FromRow)]
-struct ConflictRow {
-    conflict_id: String,
-    item_id: String,
-    provider: String,
-    external_ref: String,
-    field: String,
-    base_value_json: String,
-    local_value_json: String,
-    remote_value_json: String,
-    item_revision: i64,
-    provider_revision: Option<String>,
-    state: String,
-}
-
-impl ConflictRow {
-    fn into_conflict(self) -> Result<TaskBoardSyncConflict, CliError> {
-        Ok(TaskBoardSyncConflict {
-            conflict_id: self.conflict_id,
-            item_id: self.item_id,
-            provider: from_json(&format!("\"{}\"", self.provider))?,
-            external_ref: self.external_ref,
-            field: self.field,
-            base_value: from_json(&self.base_value_json)?,
-            local_value: from_json(&self.local_value_json)?,
-            remote_value: from_json(&self.remote_value_json)?,
-            item_revision: self.item_revision,
-            provider_revision: self.provider_revision,
-            state: from_json(&format!("\"{}\"", self.state))?,
-        })
     }
 }

--- a/src/daemon/db/task_board/provider_sync_conflict_revision_tests.rs
+++ b/src/daemon/db/task_board/provider_sync_conflict_revision_tests.rs
@@ -1,0 +1,99 @@
+use tempfile::tempdir;
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::{
+    ExternalProvider, ExternalRefProvider, TaskBoardConflictState, TaskBoardItem,
+    TaskBoardSyncConflict,
+};
+
+#[tokio::test]
+async fn stale_conflict_snapshot_cannot_replace_newer_item_revision() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    let item = TaskBoardItem::new(
+        "task-revision-fence".into(),
+        "Original title".into(),
+        String::new(),
+        "2026-07-16T10:00:00Z".into(),
+    );
+    db.create_task_board_item(item).await.expect("create item");
+    let conflict = conflict_at_revision(1);
+    db.update_task_board_item("task-revision-fence", |item| {
+        item.title = "Concurrent title".into();
+        Ok(true)
+    })
+    .await
+    .expect("concurrent edit");
+
+    let error = db
+        .replace_open_task_board_sync_conflicts(
+            "task-revision-fence",
+            ExternalProvider::GitHub,
+            "acme/widgets#17",
+            1,
+            &[conflict],
+        )
+        .await
+        .expect_err("stale conflict snapshot must be rejected");
+
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert!(
+        db.open_task_board_sync_conflicts()
+            .await
+            .expect("open conflicts")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn conflict_payload_revision_must_match_replacement_revision() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    let item = TaskBoardItem::new(
+        "task-revision-fence".into(),
+        "Original title".into(),
+        String::new(),
+        "2026-07-16T10:00:00Z".into(),
+    );
+    db.create_task_board_item(item).await.expect("create item");
+    let conflict = conflict_at_revision(0);
+
+    let error = db
+        .replace_open_task_board_sync_conflicts(
+            "task-revision-fence",
+            ExternalProvider::GitHub,
+            "acme/widgets#17",
+            1,
+            &[conflict],
+        )
+        .await
+        .expect_err("mismatched conflict revision must be rejected");
+
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert!(
+        db.open_task_board_sync_conflicts()
+            .await
+            .expect("open conflicts")
+            .is_empty()
+    );
+}
+
+fn conflict_at_revision(item_revision: i64) -> TaskBoardSyncConflict {
+    TaskBoardSyncConflict {
+        conflict_id: "conflict-revision-fence".into(),
+        item_id: "task-revision-fence".into(),
+        provider: ExternalRefProvider::GitHub,
+        external_ref: "acme/widgets#17".into(),
+        field: "title".into(),
+        base_value: serde_json::json!("Base title"),
+        local_value: serde_json::json!("Original title"),
+        remote_value: serde_json::json!("Remote title"),
+        item_revision,
+        provider_revision: Some("provider-revision-2".into()),
+        state: TaskBoardConflictState::Open,
+    }
+}

--- a/src/daemon/db/task_board/provider_sync_conflict_supersession_tests.rs
+++ b/src/daemon/db/task_board/provider_sync_conflict_supersession_tests.rs
@@ -1,0 +1,169 @@
+use tempfile::tempdir;
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::{
+    ExternalProvider, ExternalRefProvider, ExternalSyncField, TaskBoardConflictState,
+    TaskBoardItem, TaskBoardSyncConflict,
+};
+
+#[tokio::test]
+async fn field_scoped_supersession_preserves_unsupported_conflicts_and_publishes_once() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    db.create_task_board_item(TaskBoardItem::new(
+        "task-conflict-fields".into(),
+        "Task".into(),
+        String::new(),
+        "2026-07-16T10:00:00Z".into(),
+    ))
+    .await
+    .expect("create item");
+    let conflicts = [
+        conflict("conflict-title", "title"),
+        conflict("conflict-project", "project"),
+        conflict("conflict-future", "future_field"),
+    ];
+    db.replace_open_task_board_sync_conflicts(
+        "task-conflict-fields",
+        ExternalProvider::GitHub,
+        "example/repository#51",
+        1,
+        &conflicts,
+    )
+    .await
+    .expect("record conflicts");
+    let before = db
+        .current_change_sequence()
+        .await
+        .expect("initial sequence");
+
+    db.supersede_open_task_board_sync_conflicts(
+        "task-conflict-fields",
+        ExternalProvider::GitHub,
+        "example/repository#51",
+        1,
+        &[ExternalSyncField::Title],
+    )
+    .await
+    .expect("supersede selected conflicts");
+
+    assert_eq!(
+        db.current_change_sequence()
+            .await
+            .expect("changed sequence"),
+        before + 1
+    );
+    let open = db
+        .open_task_board_sync_conflicts()
+        .await
+        .expect("open conflicts");
+    let mut open_fields = open
+        .iter()
+        .map(|conflict| conflict.field.as_str())
+        .collect::<Vec<_>>();
+    open_fields.sort_unstable();
+    assert_eq!(open_fields, vec!["future_field", "project"],);
+
+    db.supersede_open_task_board_sync_conflicts(
+        "task-conflict-fields",
+        ExternalProvider::GitHub,
+        "example/repository#51",
+        1,
+        &[ExternalSyncField::Title],
+    )
+    .await
+    .expect("repeat selected supersession");
+    assert_eq!(
+        db.current_change_sequence().await.expect("stable sequence"),
+        before + 1
+    );
+}
+
+#[tokio::test]
+async fn field_scoped_supersession_rejects_stale_item_revision_without_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    db.create_task_board_item(TaskBoardItem::new(
+        "task-conflict-stale".into(),
+        "Task".into(),
+        String::new(),
+        "2026-07-16T10:00:00Z".into(),
+    ))
+    .await
+    .expect("create item");
+    db.replace_open_task_board_sync_conflicts(
+        "task-conflict-stale",
+        ExternalProvider::GitHub,
+        "example/repository#52",
+        1,
+        &[conflict_for_item(
+            "task-conflict-stale",
+            "conflict-stale-title",
+            "title",
+        )],
+    )
+    .await
+    .expect("record conflict");
+    db.update_task_board_item("task-conflict-stale", |item| {
+        item.title = "Concurrent title".into();
+        Ok(true)
+    })
+    .await
+    .expect("concurrent edit");
+    let before = db
+        .current_change_sequence()
+        .await
+        .expect("initial sequence");
+
+    let error = db
+        .supersede_open_task_board_sync_conflicts(
+            "task-conflict-stale",
+            ExternalProvider::GitHub,
+            "example/repository#52",
+            1,
+            &[ExternalSyncField::Title],
+        )
+        .await
+        .expect_err("stale revision must fail");
+
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(
+        db.current_change_sequence().await.expect("stable sequence"),
+        before
+    );
+    assert_eq!(
+        db.open_task_board_sync_conflicts()
+            .await
+            .expect("open conflicts")
+            .len(),
+        1
+    );
+}
+
+fn conflict(conflict_id: &str, field: &str) -> TaskBoardSyncConflict {
+    conflict_for_item("task-conflict-fields", conflict_id, field)
+}
+
+fn conflict_for_item(item_id: &str, conflict_id: &str, field: &str) -> TaskBoardSyncConflict {
+    TaskBoardSyncConflict {
+        conflict_id: conflict_id.into(),
+        item_id: item_id.into(),
+        provider: ExternalRefProvider::GitHub,
+        external_ref: if item_id == "task-conflict-fields" {
+            "example/repository#51".into()
+        } else {
+            "example/repository#52".into()
+        },
+        field: field.into(),
+        base_value: serde_json::json!("base"),
+        local_value: serde_json::json!("local"),
+        remote_value: serde_json::json!("remote"),
+        item_revision: 1,
+        provider_revision: Some("provider-revision-1".into()),
+        state: TaskBoardConflictState::Open,
+    }
+}

--- a/src/daemon/db/task_board/provider_sync_conflicts.rs
+++ b/src/daemon/db/task_board/provider_sync_conflicts.rs
@@ -1,0 +1,295 @@
+use serde::de::DeserializeOwned;
+use sqlx::{SqliteConnection, query, query_as};
+
+use crate::daemon::db::task_board::items::bump_change_in_tx;
+use crate::daemon::db::{AsyncDaemonDb, CliError, CliErrorKind, db_error, utc_now};
+use crate::task_board::{ExternalProvider, ExternalRefProvider, TaskBoardSyncConflict};
+
+use super::ORCHESTRATOR_CHANGE_SCOPE;
+
+impl AsyncDaemonDb {
+    pub(crate) async fn replace_open_task_board_sync_conflicts(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        external_ref: &str,
+        item_revision: i64,
+        conflicts: &[TaskBoardSyncConflict],
+    ) -> Result<(), CliError> {
+        require_conflict_revisions(item_id, item_revision, conflicts)?;
+        let mut transaction = self
+            .begin_immediate_transaction("task board sync conflict replace")
+            .await?;
+        require_item_revision(transaction.as_mut(), item_id, item_revision).await?;
+        let mut changed = supersede_removed_conflicts(
+            transaction.as_mut(),
+            item_id,
+            provider,
+            external_ref,
+            conflicts,
+        )
+        .await?;
+        for conflict in conflicts {
+            changed |= upsert_open_conflict(transaction.as_mut(), conflict).await?;
+        }
+        if changed {
+            bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit task-board sync conflicts: {error}")))
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn open_task_board_sync_conflicts(
+        &self,
+    ) -> Result<Vec<TaskBoardSyncConflict>, CliError> {
+        let rows = query_as::<_, ConflictRow>(
+            "SELECT conflict_id, item_id, provider, external_ref, field,
+                    base_value_json, local_value_json, remote_value_json,
+                    item_revision, provider_revision, state
+             FROM task_board_sync_conflicts WHERE state = 'open'
+             ORDER BY conflict_id",
+        )
+        .fetch_all(self.pool())
+        .await
+        .map_err(|error| db_error(format!("list task-board sync conflicts: {error}")))?;
+        rows.into_iter().map(ConflictRow::into_conflict).collect()
+    }
+}
+
+fn require_conflict_revisions(
+    item_id: &str,
+    expected_revision: i64,
+    conflicts: &[TaskBoardSyncConflict],
+) -> Result<(), CliError> {
+    if conflicts
+        .iter()
+        .all(|conflict| conflict.item_id == item_id && conflict.item_revision == expected_revision)
+    {
+        return Ok(());
+    }
+    Err(CliErrorKind::concurrent_modification(format!(
+        "task-board sync conflicts for '{item_id}' do not match item revision {expected_revision}"
+    ))
+    .into())
+}
+
+async fn require_item_revision(
+    connection: &mut SqliteConnection,
+    item_id: &str,
+    expected_revision: i64,
+) -> Result<(), CliError> {
+    let current = query_as::<_, (i64,)>("SELECT revision FROM task_board_items WHERE item_id = ?1")
+        .bind(item_id)
+        .fetch_optional(&mut *connection)
+        .await
+        .map_err(|error| db_error(format!("read task-board conflict item revision: {error}")))?
+        .ok_or_else(|| db_error(format!("task-board item '{item_id}' not found")))?;
+    if current.0 == expected_revision {
+        return Ok(());
+    }
+    Err(CliErrorKind::concurrent_modification(format!(
+        "task-board item '{item_id}' changed before sync conflict persistence"
+    ))
+    .into())
+}
+
+async fn supersede_removed_conflicts(
+    connection: &mut SqliteConnection,
+    item_id: &str,
+    provider: ExternalProvider,
+    external_ref: &str,
+    conflicts: &[TaskBoardSyncConflict],
+) -> Result<bool, CliError> {
+    let fields = conflicts
+        .iter()
+        .map(|conflict| conflict.field.as_str())
+        .collect::<Vec<_>>();
+    let rows = query_as::<_, (String, String)>(
+        "SELECT conflict_id, field FROM task_board_sync_conflicts
+         WHERE item_id = ?1 AND provider = ?2 AND external_ref = ?3 AND state = 'open'",
+    )
+    .bind(item_id)
+    .bind(provider_label(provider))
+    .bind(external_ref)
+    .fetch_all(&mut *connection)
+    .await
+    .map_err(|error| db_error(format!("read open task-board sync conflicts: {error}")))?;
+    let mut changed = false;
+    for (conflict_id, field) in rows {
+        if !fields.contains(&field.as_str()) {
+            changed |= query(
+                "UPDATE task_board_sync_conflicts
+                 SET state = 'superseded', resolved_at = ?2
+                 WHERE conflict_id = ?1",
+            )
+            .bind(conflict_id)
+            .bind(utc_now())
+            .execute(&mut *connection)
+            .await
+            .map_err(|error| db_error(format!("supersede task-board sync conflict: {error}")))?
+            .rows_affected()
+                > 0;
+        }
+    }
+    Ok(changed)
+}
+
+async fn upsert_open_conflict(
+    connection: &mut SqliteConnection,
+    conflict: &TaskBoardSyncConflict,
+) -> Result<bool, CliError> {
+    let base_value_json = to_json(&conflict.base_value)?;
+    let local_value_json = to_json(&conflict.local_value)?;
+    let remote_value_json = to_json(&conflict.remote_value)?;
+    let updated = query(
+        "UPDATE task_board_sync_conflicts SET
+            base_value_json = ?6, local_value_json = ?7,
+            remote_value_json = ?8, item_revision = ?9, provider_revision = ?10
+         WHERE item_id = ?2 AND provider = ?3 AND external_ref = ?4
+           AND field = ?5 AND state = 'open'
+           AND (base_value_json IS NOT ?6 OR local_value_json IS NOT ?7
+                OR remote_value_json IS NOT ?8 OR item_revision IS NOT ?9
+                OR provider_revision IS NOT ?10)",
+    )
+    .bind(&conflict.conflict_id)
+    .bind(&conflict.item_id)
+    .bind(ref_provider_label(conflict.provider))
+    .bind(&conflict.external_ref)
+    .bind(&conflict.field)
+    .bind(&base_value_json)
+    .bind(&local_value_json)
+    .bind(&remote_value_json)
+    .bind(conflict.item_revision)
+    .bind(&conflict.provider_revision)
+    .execute(&mut *connection)
+    .await
+    .map_err(|error| db_error(format!("update task-board sync conflict: {error}")))?;
+    if updated.rows_affected() > 0 {
+        return Ok(true);
+    }
+    let open_exists = query_as::<_, (i64,)>(
+        "SELECT EXISTS(
+            SELECT 1 FROM task_board_sync_conflicts
+            WHERE item_id = ?1 AND provider = ?2 AND external_ref = ?3
+              AND field = ?4 AND state = 'open'
+         )",
+    )
+    .bind(&conflict.item_id)
+    .bind(ref_provider_label(conflict.provider))
+    .bind(&conflict.external_ref)
+    .bind(&conflict.field)
+    .fetch_one(&mut *connection)
+    .await
+    .map_err(|error| db_error(format!("read task-board sync conflict identity: {error}")))?
+    .0 != 0;
+    if open_exists {
+        return Ok(false);
+    }
+    insert_open_conflict(
+        connection,
+        conflict,
+        base_value_json,
+        local_value_json,
+        remote_value_json,
+    )
+    .await
+}
+
+async fn insert_open_conflict(
+    connection: &mut SqliteConnection,
+    conflict: &TaskBoardSyncConflict,
+    base_value_json: String,
+    local_value_json: String,
+    remote_value_json: String,
+) -> Result<bool, CliError> {
+    query(
+        "INSERT INTO task_board_sync_conflicts (
+            conflict_id, item_id, provider, external_ref, field,
+            base_value_json, local_value_json, remote_value_json,
+            item_revision, provider_revision, state, detected_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'open', ?11)
+         ON CONFLICT(conflict_id) DO UPDATE SET
+            base_value_json = excluded.base_value_json,
+            local_value_json = excluded.local_value_json,
+            remote_value_json = excluded.remote_value_json,
+            item_revision = excluded.item_revision,
+            provider_revision = excluded.provider_revision,
+            state = 'open', detected_at = excluded.detected_at,
+            resolved_at = NULL, resolved_by = NULL",
+    )
+    .bind(&conflict.conflict_id)
+    .bind(&conflict.item_id)
+    .bind(ref_provider_label(conflict.provider))
+    .bind(&conflict.external_ref)
+    .bind(&conflict.field)
+    .bind(base_value_json)
+    .bind(local_value_json)
+    .bind(remote_value_json)
+    .bind(conflict.item_revision)
+    .bind(&conflict.provider_revision)
+    .bind(utc_now())
+    .execute(&mut *connection)
+    .await
+    .map_err(|error| db_error(format!("insert task-board sync conflict: {error}")))
+    .map(|result| result.rows_affected() > 0)
+}
+
+const fn provider_label(provider: ExternalProvider) -> &'static str {
+    match provider {
+        ExternalProvider::GitHub => "github",
+        ExternalProvider::Todoist => "todoist",
+    }
+}
+
+const fn ref_provider_label(provider: ExternalRefProvider) -> &'static str {
+    match provider {
+        ExternalRefProvider::GitHub => "github",
+        ExternalRefProvider::Todoist => "todoist",
+    }
+}
+
+fn to_json(value: &serde_json::Value) -> Result<String, CliError> {
+    serde_json::to_string(value)
+        .map_err(|error| db_error(format!("serialize task-board sync conflict value: {error}")))
+}
+
+fn from_json<T: DeserializeOwned>(value: &str) -> Result<T, CliError> {
+    serde_json::from_str(value)
+        .map_err(|error| db_error(format!("parse task-board sync conflict value: {error}")))
+}
+
+#[derive(sqlx::FromRow)]
+struct ConflictRow {
+    conflict_id: String,
+    item_id: String,
+    provider: String,
+    external_ref: String,
+    field: String,
+    base_value_json: String,
+    local_value_json: String,
+    remote_value_json: String,
+    item_revision: i64,
+    provider_revision: Option<String>,
+    state: String,
+}
+
+impl ConflictRow {
+    fn into_conflict(self) -> Result<TaskBoardSyncConflict, CliError> {
+        Ok(TaskBoardSyncConflict {
+            conflict_id: self.conflict_id,
+            item_id: self.item_id,
+            provider: from_json(&format!("\"{}\"", self.provider))?,
+            external_ref: self.external_ref,
+            field: self.field,
+            base_value: from_json(&self.base_value_json)?,
+            local_value: from_json(&self.local_value_json)?,
+            remote_value: from_json(&self.remote_value_json)?,
+            item_revision: self.item_revision,
+            provider_revision: self.provider_revision,
+            state: from_json(&format!("\"{}\"", self.state))?,
+        })
+    }
+}

--- a/src/daemon/db/task_board/provider_sync_conflicts.rs
+++ b/src/daemon/db/task_board/provider_sync_conflicts.rs
@@ -47,10 +47,6 @@ impl AsyncDaemonDb {
             .map_err(|error| db_error(format!("commit task-board sync conflicts: {error}")))
     }
 
-    #[expect(
-        clippy::cognitive_complexity,
-        reason = "field-scoped supersession keeps revision validation and one atomic publication"
-    )]
     pub(crate) async fn supersede_open_task_board_sync_conflicts(
         &self,
         item_id: &str,
@@ -62,27 +58,17 @@ impl AsyncDaemonDb {
         let mut transaction = self
             .begin_immediate_transaction("task board sync conflict supersession")
             .await?;
-        require_item_revision(transaction.as_mut(), item_id, item_revision).await?;
         let resolved_at = utc_now();
-        let mut changed = false;
-        for field in resolved_fields {
-            changed |= query(
-                "UPDATE task_board_sync_conflicts
-                 SET state = 'superseded', resolved_at = ?5
-                 WHERE item_id = ?1 AND provider = ?2 AND external_ref = ?3
-                   AND field = ?4 AND state = 'open'",
-            )
-            .bind(item_id)
-            .bind(provider_label(provider))
-            .bind(external_ref)
-            .bind(field_label(*field))
-            .bind(&resolved_at)
-            .execute(transaction.as_mut())
-            .await
-            .map_err(|error| db_error(format!("supersede task-board sync field: {error}")))?
-            .rows_affected()
-                > 0;
-        }
+        let changed = supersede_open_sync_conflicts_in_connection(
+            transaction.as_mut(),
+            item_id,
+            provider,
+            external_ref,
+            item_revision,
+            resolved_fields,
+            &resolved_at,
+        )
+        .await?;
         if changed {
             bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
         }
@@ -108,6 +94,38 @@ impl AsyncDaemonDb {
         .map_err(|error| db_error(format!("list task-board sync conflicts: {error}")))?;
         rows.into_iter().map(ConflictRow::into_conflict).collect()
     }
+}
+
+pub(super) async fn supersede_open_sync_conflicts_in_connection(
+    connection: &mut SqliteConnection,
+    item_id: &str,
+    provider: ExternalProvider,
+    external_ref: &str,
+    item_revision: i64,
+    resolved_fields: &[ExternalSyncField],
+    resolved_at: &str,
+) -> Result<bool, CliError> {
+    require_item_revision(connection, item_id, item_revision).await?;
+    let mut changed = false;
+    for field in resolved_fields {
+        changed |= query(
+            "UPDATE task_board_sync_conflicts
+             SET state = 'superseded', resolved_at = ?5
+             WHERE item_id = ?1 AND provider = ?2 AND external_ref = ?3
+               AND field = ?4 AND state = 'open'",
+        )
+        .bind(item_id)
+        .bind(provider_label(provider))
+        .bind(external_ref)
+        .bind(field_label(*field))
+        .bind(resolved_at)
+        .execute(&mut *connection)
+        .await
+        .map_err(|error| db_error(format!("supersede task-board sync field: {error}")))?
+        .rows_affected()
+            > 0;
+    }
+    Ok(changed)
 }
 
 fn require_conflict_revisions(

--- a/src/daemon/db/task_board/provider_sync_conflicts.rs
+++ b/src/daemon/db/task_board/provider_sync_conflicts.rs
@@ -3,11 +3,17 @@ use sqlx::{SqliteConnection, query, query_as};
 
 use crate::daemon::db::task_board::items::bump_change_in_tx;
 use crate::daemon::db::{AsyncDaemonDb, CliError, CliErrorKind, db_error, utc_now};
-use crate::task_board::{ExternalProvider, ExternalRefProvider, TaskBoardSyncConflict};
+use crate::task_board::{
+    ExternalProvider, ExternalRefProvider, ExternalSyncField, TaskBoardSyncConflict,
+};
 
 use super::ORCHESTRATOR_CHANGE_SCOPE;
 
 impl AsyncDaemonDb {
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "conflict replacement keeps revision validation and one atomic publication"
+    )]
     pub(crate) async fn replace_open_task_board_sync_conflicts(
         &self,
         item_id: &str,
@@ -39,6 +45,51 @@ impl AsyncDaemonDb {
             .commit()
             .await
             .map_err(|error| db_error(format!("commit task-board sync conflicts: {error}")))
+    }
+
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "field-scoped supersession keeps revision validation and one atomic publication"
+    )]
+    pub(crate) async fn supersede_open_task_board_sync_conflicts(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        external_ref: &str,
+        item_revision: i64,
+        resolved_fields: &[ExternalSyncField],
+    ) -> Result<(), CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board sync conflict supersession")
+            .await?;
+        require_item_revision(transaction.as_mut(), item_id, item_revision).await?;
+        let resolved_at = utc_now();
+        let mut changed = false;
+        for field in resolved_fields {
+            changed |= query(
+                "UPDATE task_board_sync_conflicts
+                 SET state = 'superseded', resolved_at = ?5
+                 WHERE item_id = ?1 AND provider = ?2 AND external_ref = ?3
+                   AND field = ?4 AND state = 'open'",
+            )
+            .bind(item_id)
+            .bind(provider_label(provider))
+            .bind(external_ref)
+            .bind(field_label(*field))
+            .bind(&resolved_at)
+            .execute(transaction.as_mut())
+            .await
+            .map_err(|error| db_error(format!("supersede task-board sync field: {error}")))?
+            .rows_affected()
+                > 0;
+        }
+        if changed {
+            bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit sync conflict supersession: {error}")))
     }
 
     #[cfg(test)]
@@ -248,6 +299,16 @@ const fn ref_provider_label(provider: ExternalRefProvider) -> &'static str {
     match provider {
         ExternalRefProvider::GitHub => "github",
         ExternalRefProvider::Todoist => "todoist",
+    }
+}
+
+const fn field_label(field: ExternalSyncField) -> &'static str {
+    match field {
+        ExternalSyncField::Title => "title",
+        ExternalSyncField::Body => "body",
+        ExternalSyncField::Status => "status",
+        ExternalSyncField::Project => "project",
+        ExternalSyncField::Url => "url",
     }
 }
 

--- a/src/daemon/db/task_board/provider_sync_publication_tests.rs
+++ b/src/daemon/db/task_board/provider_sync_publication_tests.rs
@@ -68,6 +68,7 @@ async fn conflict_only_changes_publish_without_identical_write_churn() {
         "task-conflict-publication",
         ExternalProvider::GitHub,
         "acme/widgets#17",
+        item_revision,
         &[conflict.clone()],
     )
     .await
@@ -78,6 +79,7 @@ async fn conflict_only_changes_publish_without_identical_write_churn() {
         "task-conflict-publication",
         ExternalProvider::GitHub,
         "acme/widgets#17",
+        item_revision,
         &[conflict.clone()],
     )
     .await
@@ -92,6 +94,7 @@ async fn conflict_only_changes_publish_without_identical_write_churn() {
         "task-conflict-publication",
         ExternalProvider::GitHub,
         "acme/widgets#17",
+        item_revision,
         &[conflict],
     )
     .await
@@ -102,6 +105,7 @@ async fn conflict_only_changes_publish_without_identical_write_churn() {
         "task-conflict-publication",
         ExternalProvider::GitHub,
         "acme/widgets#17",
+        item_revision,
         &[],
     )
     .await
@@ -119,6 +123,7 @@ async fn conflict_only_changes_publish_without_identical_write_churn() {
         "task-conflict-publication",
         ExternalProvider::GitHub,
         "acme/widgets#17",
+        item_revision,
         &[],
     )
     .await

--- a/src/daemon/db/task_board/provider_sync_renewal_tests.rs
+++ b/src/daemon/db/task_board/provider_sync_renewal_tests.rs
@@ -1,0 +1,67 @@
+use tempfile::tempdir;
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::ExternalProvider;
+use crate::task_board::external::{
+    ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
+};
+
+#[tokio::test]
+async fn renewed_scope_lease_blocks_replacement_after_original_deadline() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    let scope_id = "v1:github:write:12:acme/widgets";
+    let attempt = start_attempt(&db, scope_id, "2026-07-16T10:00:00Z").await;
+
+    db.renew_task_board_provider_scope_attempt(&attempt, "2026-07-16T10:14:59Z")
+        .await
+        .expect("renew attempt");
+    let decision = db
+        .begin_task_board_provider_scope_attempt(
+            ExternalProvider::GitHub,
+            scope_id,
+            "2026-07-16T10:20:00Z",
+        )
+        .await
+        .expect("begin contender");
+
+    assert_eq!(decision, ExternalProviderScopeAttemptDecision::Fenced);
+}
+
+#[tokio::test]
+async fn stale_scope_lease_cannot_renew_after_replacement() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    let scope_id = "v1:github:write:12:acme/widgets";
+    let stale = start_attempt(&db, scope_id, "2026-07-16T10:00:00Z").await;
+    let current = start_attempt(&db, scope_id, "2026-07-16T10:16:00Z").await;
+
+    let error = db
+        .renew_task_board_provider_scope_attempt(&stale, "2026-07-16T10:16:01Z")
+        .await
+        .expect_err("stale attempt must not renew");
+
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    db.renew_task_board_provider_scope_attempt(&current, "2026-07-16T10:16:01Z")
+        .await
+        .expect("current attempt renews");
+}
+
+async fn start_attempt(
+    db: &AsyncDaemonDb,
+    scope_id: &str,
+    now: &str,
+) -> ExternalProviderScopeAttempt {
+    match db
+        .begin_task_board_provider_scope_attempt(ExternalProvider::GitHub, scope_id, now)
+        .await
+        .expect("begin provider attempt")
+    {
+        ExternalProviderScopeAttemptDecision::Started(attempt) => attempt,
+        other => panic!("expected started attempt, got {other:?}"),
+    }
+}

--- a/src/daemon/db/task_board/provider_sync_tests.rs
+++ b/src/daemon/db/task_board/provider_sync_tests.rs
@@ -130,6 +130,7 @@ async fn replacing_conflicts_keeps_current_fields_and_supersedes_removed_fields(
         "task-1",
         ExternalProvider::GitHub,
         "acme/widgets#17",
+        1,
         &[title.clone(), status],
     )
     .await
@@ -146,6 +147,7 @@ async fn replacing_conflicts_keeps_current_fields_and_supersedes_removed_fields(
         "task-1",
         ExternalProvider::GitHub,
         "acme/widgets#17",
+        1,
         &[title],
     )
     .await

--- a/src/daemon/db/tests/async_pool.rs
+++ b/src/daemon/db/tests/async_pool.rs
@@ -26,7 +26,7 @@ async fn connect_reads_current_schema_version() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=31).collect::<Vec<i64>>()
+        (1..=32).collect::<Vec<i64>>()
     );
 }
 
@@ -51,7 +51,7 @@ async fn connect_bootstraps_empty_database_with_sqlx_migrations() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=31).collect::<Vec<i64>>()
+        (1..=32).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -143,7 +143,7 @@ async fn connect_migrates_legacy_schema_before_opening_pool() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=31).collect::<Vec<i64>>()
+        (1..=32).collect::<Vec<i64>>()
     );
 }
 
@@ -187,7 +187,7 @@ async fn connect_preserves_existing_db_when_baseline_checksum_drifted() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=31).collect::<Vec<i64>>()
+        (1..=32).collect::<Vec<i64>>()
     );
 }
 
@@ -246,7 +246,7 @@ async fn connect_accepts_v22_db_with_recorded_policy_snapshot_migration() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=31).collect::<Vec<i64>>()
+        (1..=32).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -279,7 +279,7 @@ async fn connect_seeds_v18_sqlx_ledger_when_sync_schema_already_applied() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=31).collect::<Vec<i64>>()
+        (1..=32).collect::<Vec<i64>>()
     );
 }
 
@@ -369,7 +369,7 @@ async fn connect_repairs_v8_active_sessions_without_leader_before_opening_pool()
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=31).collect::<Vec<i64>>()
+        (1..=32).collect::<Vec<i64>>()
     );
     drop(async_db);
 

--- a/src/daemon/db/tests/async_pool_migrations.rs
+++ b/src/daemon/db/tests/async_pool_migrations.rs
@@ -74,7 +74,7 @@ async fn connect_upgrades_applied_original_v34_migration() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=31).collect::<Vec<i64>>()
+        (1..=32).collect::<Vec<i64>>()
     );
     let requires_live = query_scalar::<_, bool>(
         "SELECT spawn_requires_live_policy FROM policy_workspace WHERE singleton = 1",
@@ -176,6 +176,10 @@ fn shipped_daemon_async_migration_checksums_remain_stable() {
         (
             "0031_daemon_v37_task_board_backlog.sql",
             "D55E7ECAA6D350295FB1955CFD42592FAB8026205AEA7E714330E1DD293867F4150FDC52BE3169CE7B3037A569C0AB89",
+        ),
+        (
+            "0032_daemon_v38_task_board_external_create_intents.sql",
+            "C96DD78DA86E8A5D63E71F543A084FE0003814CDDA92F551ABEB06C422F96AEAB4A4C49CCF1AF8603C055DF0CCF990AF",
         ),
     ];
     let migrations_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/daemon/db/migrations");

--- a/src/daemon/db/tests/async_pool_migrations.rs
+++ b/src/daemon/db/tests/async_pool_migrations.rs
@@ -179,7 +179,7 @@ fn shipped_daemon_async_migration_checksums_remain_stable() {
         ),
         (
             "0032_daemon_v38_task_board_external_create_intents.sql",
-            "C96DD78DA86E8A5D63E71F543A084FE0003814CDDA92F551ABEB06C422F96AEAB4A4C49CCF1AF8603C055DF0CCF990AF",
+            "C7D2FB56584DD8D1DE324D944A13B1B5F73F1DE76A78A36E12F9C2CB4485E6B437AA03C5214D8B1DF13743276318FB3E",
         ),
     ];
     let migrations_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/daemon/db/migrations");

--- a/src/daemon/db/tests/schema.rs
+++ b/src/daemon/db/tests/schema.rs
@@ -142,6 +142,7 @@ fn all_tables_exist() {
         "task_board_admission_leases",
         "task_board_execution_attempts",
         "task_board_execution_hosts",
+        "task_board_external_create_intents",
         "task_board_external_refs",
         "task_board_imports",
         "task_board_identity",

--- a/src/daemon/db/tests/schema_shape_repairs.rs
+++ b/src/daemon/db/tests/schema_shape_repairs.rs
@@ -3,6 +3,331 @@ use tempfile::tempdir;
 use super::*;
 
 #[tokio::test]
+async fn async_connect_repairs_current_schema_missing_external_create_intents() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute("DROP TABLE task_board_external_create_intents", [])
+        .expect("drop external create intents");
+    drop(sync_db);
+
+    let async_db = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect("repair external create intents");
+    let exists: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type = 'table' AND name = 'task_board_external_create_intents'",
+    )
+    .fetch_one(async_db.pool())
+    .await
+    .expect("inspect repaired table");
+
+    assert_eq!(exists, 1);
+    assert_eq!(
+        async_db.schema_version().await.expect("schema version"),
+        SCHEMA_VERSION
+    );
+}
+
+#[tokio::test]
+async fn async_connect_repairs_current_schema_missing_external_create_index() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute(
+            "DROP INDEX idx_task_board_external_create_intents_create_key",
+            [],
+        )
+        .expect("drop external create key index");
+    drop(sync_db);
+
+    let async_db = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect("repair external create key index");
+    let exists: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type = 'index'
+           AND name = 'idx_task_board_external_create_intents_create_key'",
+    )
+    .fetch_one(async_db.pool())
+    .await
+    .expect("inspect repaired index");
+
+    assert_eq!(exists, 1);
+}
+
+#[tokio::test]
+async fn async_connect_refuses_nonunique_external_create_index_with_expected_name() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute_batch(
+            "DROP INDEX idx_task_board_external_create_intents_create_key;
+             CREATE INDEX idx_task_board_external_create_intents_create_key
+             ON task_board_external_create_intents(provider, create_key);",
+        )
+        .expect("replace unique create-key index");
+    drop(sync_db);
+
+    let error = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect_err("nonunique create-key index must fail closed");
+
+    assert!(error.to_string().contains("create_key"));
+    let conn = Connection::open(&db_path).expect("reopen incompatible database");
+    let unique: i64 = conn
+        .query_row(
+            "SELECT \"unique\"
+             FROM pragma_index_list('task_board_external_create_intents')
+             WHERE name = 'idx_task_board_external_create_intents_create_key'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("inspect preserved nonunique index");
+    assert_eq!(unique, 0);
+}
+
+#[tokio::test]
+async fn async_connect_inspects_malformed_indexes_even_when_another_index_is_missing() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute_batch(
+            "DROP INDEX idx_task_board_external_create_intents_create_key;
+             DROP INDEX idx_task_board_external_create_intents_one_active;
+             CREATE INDEX idx_task_board_external_create_intents_one_active
+             ON task_board_external_create_intents(provider, item_id)
+             WHERE state = 'created';",
+        )
+        .expect("seed missing and malformed indexes");
+    drop(sync_db);
+
+    let error = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect_err("malformed present index must fail closed");
+
+    assert!(error.to_string().contains("one_active"));
+    let conn = Connection::open(&db_path).expect("reopen incompatible database");
+    let missing: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'index'
+               AND name = 'idx_task_board_external_create_intents_create_key'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("inspect missing index");
+    assert_eq!(missing, 0, "failed validation must not mask repair");
+}
+
+#[tokio::test]
+async fn async_connect_refuses_incompatible_external_create_intent_shape() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute_batch(
+            "DROP TABLE task_board_external_create_intents;
+             CREATE TABLE task_board_external_create_intents (
+                 intent_id TEXT PRIMARY KEY,
+                 sentinel TEXT NOT NULL
+             ) WITHOUT ROWID;
+             INSERT INTO task_board_external_create_intents (intent_id, sentinel)
+             VALUES ('sentinel-intent', 'preserve-me');",
+        )
+        .expect("seed incompatible external create intent table");
+    drop(sync_db);
+
+    let error = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect_err("incompatible intent shape must fail closed");
+    assert!(error.to_string().contains("incompatible"));
+
+    let conn = Connection::open(&db_path).expect("reopen incompatible database");
+    let sentinel: String = conn
+        .query_row(
+            "SELECT sentinel FROM task_board_external_create_intents
+             WHERE intent_id = 'sentinel-intent'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read preserved sentinel");
+    assert_eq!(sentinel, "preserve-me");
+}
+
+#[tokio::test]
+async fn async_connect_refuses_external_create_table_with_weakened_state_checks() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    let migration =
+        include_str!("../migrations/0032_daemon_v38_task_board_external_create_intents.sql");
+    let weakened = migration.replacen(
+        "AND attached_item_revision >= item_revision",
+        "AND attached_item_revision IS NOT NULL",
+        1,
+    );
+    assert_ne!(weakened, migration);
+    sync_db
+        .connection()
+        .execute_batch("DROP TABLE task_board_external_create_intents")
+        .expect("drop constrained external create table");
+    sync_db
+        .connection()
+        .execute_batch(&weakened)
+        .expect("create weakened external create table");
+    drop(sync_db);
+
+    let error = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect_err("weakened state matrix must fail closed");
+
+    assert!(
+        error
+            .to_string()
+            .contains("incompatible task_board_external_create_intents schema")
+    );
+}
+
+#[tokio::test]
+async fn async_connect_refuses_each_omitted_external_create_constraint() {
+    let migration =
+        include_str!("../migrations/0032_daemon_v38_task_board_external_create_intents.sql");
+    for (case, required, weakened) in [
+        ("intent id", "CHECK (length(intent_id) > 0)", "CHECK (1)"),
+        ("item id", "CHECK (length(item_id) > 0)", "CHECK (1)"),
+        ("item revision", "CHECK (item_revision > 0)", "CHECK (1)"),
+        ("scope", "CHECK (length(scope_id) > 0)", "CHECK (1)"),
+        ("create key", "CHECK (length(create_key) > 0)", "CHECK (1)"),
+        (
+            "snapshot JSON",
+            "json_valid(create_snapshot_json)",
+            "json_type(create_snapshot_json) IS NOT NULL",
+        ),
+        (
+            "changed fields JSON",
+            "json_valid(changed_fields_json)",
+            "json_type(changed_fields_json) IS NOT NULL",
+        ),
+        (
+            "created timestamp",
+            "created_at GLOB '????-??-??T??:??:??Z'",
+            "created_at IS NOT NULL",
+        ),
+        (
+            "in-flight recorded timestamp",
+            "AND outcome_recorded_at IS NULL",
+            "AND outcome_recorded_at IS outcome_recorded_at",
+        ),
+        (
+            "created evidence JSON",
+            "AND json_valid(outcome_json)",
+            "AND outcome_json IS outcome_json",
+        ),
+        (
+            "created timestamp order",
+            "AND outcome_recorded_at > created_at",
+            "AND outcome_recorded_at >= created_at",
+        ),
+        (
+            "created attachment null",
+            "AND attached_item_revision IS NULL\n            AND updated_at = outcome_recorded_at",
+            "AND attached_item_revision IS attached_item_revision\n            AND updated_at = outcome_recorded_at",
+        ),
+        (
+            "attached timestamp",
+            "AND attached_at IS NOT NULL",
+            "AND attached_at IS attached_at",
+        ),
+        (
+            "attached timestamp order",
+            "AND attached_at > outcome_recorded_at",
+            "AND attached_at >= outcome_recorded_at",
+        ),
+        (
+            "attached revision",
+            "AND attached_item_revision IS NOT NULL",
+            "AND attached_item_revision IS attached_item_revision",
+        ),
+    ] {
+        let mutated = migration.replacen(required, weakened, 1);
+        assert_ne!(mutated, migration, "missing fixture fragment for {case}");
+        assert_external_create_shape_rejected(case, &mutated).await;
+    }
+}
+
+#[tokio::test]
+async fn async_connect_refuses_external_create_column_shape_drift() {
+    let migration =
+        include_str!("../migrations/0032_daemon_v38_task_board_external_create_intents.sql");
+    let wrong_type = migration.replacen(
+        "provider              TEXT NOT NULL",
+        "provider              BLOB NOT NULL",
+        1,
+    );
+    assert_external_create_shape_rejected("wrong type", &wrong_type).await;
+    let nullable = migration.replacen(
+        "scope_id              TEXT NOT NULL",
+        "scope_id              TEXT",
+        1,
+    );
+    assert_external_create_shape_rejected("nullable column", &nullable).await;
+    let extra = migration.replacen(
+        "updated_at            TEXT NOT NULL",
+        "extra_column          TEXT,\n    updated_at            TEXT NOT NULL",
+        1,
+    );
+    assert_external_create_shape_rejected("extra column", &extra).await;
+    let wrong_primary_key = migration
+        .replacen(
+            "intent_id             TEXT PRIMARY KEY",
+            "intent_id             TEXT NOT NULL UNIQUE",
+            1,
+        )
+        .replacen(
+            "item_id               TEXT NOT NULL",
+            "item_id               TEXT PRIMARY KEY",
+            1,
+        );
+    assert_external_create_shape_rejected("wrong primary key", &wrong_primary_key).await;
+}
+
+async fn assert_external_create_shape_rejected(case: &str, migration: &str) {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute_batch("DROP TABLE task_board_external_create_intents")
+        .expect("drop constrained external create table");
+    sync_db
+        .connection()
+        .execute_batch(migration)
+        .unwrap_or_else(|error| panic!("create {case} fixture: {error}"));
+    drop(sync_db);
+
+    let error = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect_err("weakened external create shape must fail closed");
+
+    assert!(
+        error
+            .to_string()
+            .contains("incompatible task_board_external_create_intents schema"),
+        "case {case}: {error}"
+    );
+}
+
+#[tokio::test]
 async fn async_connect_repairs_current_schema_missing_policy_columns() {
     let tmp = tempdir().expect("tempdir");
     let db_path = tmp.path().join("harness.db");

--- a/src/daemon/db/tests/schema_shape_repairs.rs
+++ b/src/daemon/db/tests/schema_shape_repairs.rs
@@ -94,6 +94,29 @@ async fn async_connect_refuses_nonunique_external_create_index_with_expected_nam
 }
 
 #[tokio::test]
+async fn async_connect_refuses_malformed_pending_follow_up_index() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute_batch(
+            "DROP INDEX idx_task_board_external_create_intents_pending_follow_up;
+             CREATE INDEX idx_task_board_external_create_intents_pending_follow_up
+             ON task_board_external_create_intents(provider, attached_at, intent_id)
+             WHERE state = 'attached';",
+        )
+        .expect("replace pending follow-up index");
+    drop(sync_db);
+
+    let error = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect_err("malformed pending follow-up index must fail closed");
+
+    assert!(error.to_string().contains("pending_follow_up"));
+}
+
+#[tokio::test]
 async fn async_connect_inspects_malformed_indexes_even_when_another_index_is_missing() {
     let tmp = tempdir().expect("tempdir");
     let db_path = tmp.path().join("harness.db");
@@ -240,8 +263,8 @@ async fn async_connect_refuses_each_omitted_external_create_constraint() {
         ),
         (
             "created attachment null",
-            "AND attached_item_revision IS NULL\n            AND updated_at = outcome_recorded_at",
-            "AND attached_item_revision IS attached_item_revision\n            AND updated_at = outcome_recorded_at",
+            "AND attached_item_revision IS NULL\n            AND follow_up_completed_at IS NULL",
+            "AND attached_item_revision IS attached_item_revision\n            AND follow_up_completed_at IS NULL",
         ),
         (
             "attached timestamp",
@@ -257,6 +280,16 @@ async fn async_connect_refuses_each_omitted_external_create_constraint() {
             "attached revision",
             "AND attached_item_revision IS NOT NULL",
             "AND attached_item_revision IS attached_item_revision",
+        ),
+        (
+            "in-flight follow-up null",
+            "AND follow_up_completed_at IS NULL\n            AND follow_up_audit_event_id IS NULL\n            AND updated_at = created_at",
+            "AND follow_up_completed_at IS follow_up_completed_at\n            AND follow_up_audit_event_id IS NULL\n            AND updated_at = created_at",
+        ),
+        (
+            "attached follow-up pair",
+            "follow_up_completed_at IS NULL\n                    AND follow_up_audit_event_id IS NULL",
+            "follow_up_completed_at IS follow_up_completed_at\n                    AND follow_up_audit_event_id IS NULL",
         ),
     ] {
         let mutated = migration.replacen(required, weakened, 1);

--- a/src/daemon/service/task_board_db.rs
+++ b/src/daemon/service/task_board_db.rs
@@ -17,9 +17,9 @@ use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::external::sync_external_tasks_scoped;
 use crate::task_board::planning::PlanningTransition;
 use crate::task_board::{
-    ExternalRef, ExternalSyncConfig, Machine, PlanningState, SpawnGateSwitches, TaskBoardItem,
-    TaskBoardWorkflowState, approve_plan, begin_planning, build_audit_summary_with_policy,
-    build_machine_summaries, build_project_summaries,
+    ExternalRef, ExternalSyncClient, ExternalSyncConfig, Machine, PlanningState, SpawnGateSwitches,
+    TaskBoardItem, TaskBoardWorkflowState, approve_plan, begin_planning,
+    build_audit_summary_with_policy, build_machine_summaries, build_project_summaries,
     configured_sync_clients_without_review_requests, revoke_plan, submit_plan,
 };
 use crate::workspace::utc_now;
@@ -33,7 +33,7 @@ mod reviews_sync;
 mod sync_audit;
 
 pub(crate) use reviews_sync::reconcile_shared_review_items_db;
-use reviews_sync::shared_review_request_client;
+use reviews_sync::shared_review_request_clients;
 use sync_audit::SyncExecutionMetrics;
 pub(crate) use sync_audit::{
     ReviewsProjectionAuditSummary, record_reviews_projection_result,
@@ -261,9 +261,12 @@ async fn sync_task_board_db_inner(
 ) -> Result<TaskBoardSyncResponse, CliError> {
     let config = active_external_sync_config_db(db).await?;
     let mut clients = configured_sync_clients_without_review_requests(&config, request.provider)?;
-    if let Some(shared_reviews) = shared_review_request_client(db, request).await? {
-        clients.push(Box::new(shared_reviews));
-    }
+    clients.extend(
+        shared_review_request_clients(db, request)
+            .await?
+            .into_iter()
+            .map(|client| Box::new(client) as Box<dyn ExternalSyncClient>),
+    );
     super::task_board::log_sync_request(request, &config, clients.len());
     super::task_board::ensure_sync_request_can_run(request, &config, &clients)?;
     let batch =

--- a/src/daemon/service/task_board_db.rs
+++ b/src/daemon/service/task_board_db.rs
@@ -14,13 +14,11 @@ use crate::daemon::protocol::{
     TaskBoardUpdateItemRequest,
 };
 use crate::errors::{CliError, CliErrorKind};
-use crate::task_board::external::sync_external_tasks_scoped;
 use crate::task_board::planning::PlanningTransition;
 use crate::task_board::{
-    ExternalRef, ExternalSyncClient, ExternalSyncConfig, Machine, PlanningState, SpawnGateSwitches,
-    TaskBoardItem, TaskBoardWorkflowState, approve_plan, begin_planning,
-    build_audit_summary_with_policy, build_machine_summaries, build_project_summaries,
-    configured_sync_clients_without_review_requests, revoke_plan, submit_plan,
+    ExternalRef, ExternalSyncConfig, Machine, PlanningState, SpawnGateSwitches, TaskBoardItem,
+    TaskBoardWorkflowState, approve_plan, begin_planning, build_audit_summary_with_policy,
+    build_machine_summaries, build_project_summaries, revoke_plan, submit_plan,
 };
 use crate::workspace::utc_now;
 
@@ -28,6 +26,7 @@ use super::task_board::load_live_spawn_grants;
 
 #[cfg(test)]
 mod external_ref_tests;
+mod provider_sync_execution;
 mod provider_sync_store;
 mod reviews_sync;
 mod sync_audit;
@@ -249,35 +248,9 @@ async fn sync_task_board_db_with_trigger(
     trigger: sync_audit::TaskBoardSyncAuditTrigger,
 ) -> Result<TaskBoardSyncResponse, CliError> {
     let mut metrics = SyncExecutionMetrics::default();
-    let result = sync_task_board_db_inner(db, request, &mut metrics).await;
+    let result = provider_sync_execution::execute(db, request, &mut metrics).await;
     let audit = sync_audit::record_request_result(db, request, trigger, &result, &metrics).await;
     combine_sync_and_audit_results(result, audit)
-}
-
-async fn sync_task_board_db_inner(
-    db: &AsyncDaemonDb,
-    request: &TaskBoardSyncRequest,
-    metrics: &mut SyncExecutionMetrics,
-) -> Result<TaskBoardSyncResponse, CliError> {
-    let config = active_external_sync_config_db(db).await?;
-    let mut clients = configured_sync_clients_without_review_requests(&config, request.provider)?;
-    clients.extend(
-        shared_review_request_clients(db, request)
-            .await?
-            .into_iter()
-            .map(|client| Box::new(client) as Box<dyn ExternalSyncClient>),
-    );
-    super::task_board::log_sync_request(request, &config, clients.len());
-    super::task_board::ensure_sync_request_can_run(request, &config, &clients)?;
-    let batch =
-        sync_external_tasks_scoped(db, super::task_board::sync_options(request), &clients).await?;
-    metrics.capture(&batch);
-    let batch = batch.into_completed()?;
-    let items = db.list_task_board_items(request.status).await?;
-    let summary =
-        super::task_board::build_sync_response_from_items(&items, &config, batch.operations);
-    super::task_board::log_sync_completion(&summary);
-    Ok(summary)
 }
 
 fn combine_sync_and_audit_results(

--- a/src/daemon/service/task_board_db/provider_sync_execution.rs
+++ b/src/daemon/service/task_board_db/provider_sync_execution.rs
@@ -1,0 +1,316 @@
+use crate::daemon::db::AsyncDaemonDb;
+use crate::daemon::protocol::{TaskBoardSyncRequest, TaskBoardSyncResponse};
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::external::{
+    ExternalSyncBatch, TaskBoardExternalCreateStore, assign_external_create_recovery,
+    blocked_external_create_follow_ups, blocked_external_create_recovery,
+    load_external_create_recovery_work, prepare_external_create_recovery,
+    sync_external_tasks_scoped_with_recovery,
+};
+use crate::task_board::{ExternalSyncClient, configured_sync_clients_without_review_requests};
+
+use super::sync_audit::SyncExecutionMetrics;
+
+pub(super) async fn execute(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardSyncRequest,
+    metrics: &mut SyncExecutionMetrics,
+) -> Result<TaskBoardSyncResponse, CliError> {
+    let options = super::super::task_board::sync_options(request);
+    let follow_ups = db
+        .list_pending_external_create_follow_ups(request.provider)
+        .await?;
+    if options.dry_run && !follow_ups.is_empty() {
+        let error =
+            CliErrorKind::workflow_io("pending provider create follow-up blocks dry-run sync")
+                .into();
+        return finish_blocked(
+            metrics,
+            blocked_external_create_follow_ups(follow_ups, error),
+        );
+    }
+    if !options.dry_run
+        && let Err(error) =
+            super::sync_audit::record_external_create_follow_ups(db, &follow_ups).await
+    {
+        return finish_blocked(
+            metrics,
+            blocked_external_create_follow_ups(follow_ups, error),
+        );
+    }
+    let work = load_external_create_recovery_work(db, request.provider).await?;
+    let mut prepared = match prepare_external_create_recovery(db, options, work).await {
+        Ok(prepared) => prepared,
+        Err(batch) => return finish_blocked(metrics, batch),
+    };
+    if !options.dry_run
+        && let Err(error) =
+            super::sync_audit::record_external_create_follow_ups(db, prepared.follow_ups()).await
+    {
+        return finish_blocked(metrics, blocked_external_create_recovery(prepared, error));
+    }
+    prepared.clear_follow_ups();
+    let config = match super::active_external_sync_config_db(db).await {
+        Ok(config) => config,
+        Err(error) if prepared.is_empty() => return Err(error),
+        Err(error) => {
+            return finish_blocked(metrics, blocked_external_create_recovery(prepared, error));
+        }
+    };
+    let mut clients =
+        match configured_sync_clients_without_review_requests(&config, request.provider) {
+            Ok(clients) => clients,
+            Err(error) if prepared.is_empty() => return Err(error),
+            Err(error) => {
+                return finish_blocked(metrics, blocked_external_create_recovery(prepared, error));
+            }
+        };
+    let plan = match assign_external_create_recovery(prepared, &clients) {
+        Ok(plan) => plan,
+        Err(batch) => return finish_blocked(metrics, batch),
+    };
+    let has_recovery = plan.has_recovery();
+    let shared_clients = match super::shared_review_request_clients(db, request).await {
+        Ok(clients) => clients,
+        Err(error) if plan.is_empty() => return Err(error),
+        Err(error) => return finish_blocked(metrics, plan.into_blocked(error)),
+    };
+    clients.extend(
+        shared_clients
+            .into_iter()
+            .map(|client| Box::new(client) as Box<dyn ExternalSyncClient>),
+    );
+    super::super::task_board::log_sync_request(request, &config, clients.len());
+    if !has_recovery {
+        super::super::task_board::ensure_sync_request_can_run(request, &config, &clients)?;
+    }
+    let mut batch = sync_external_tasks_scoped_with_recovery(db, options, &clients, plan).await?;
+    if !options.dry_run
+        && let Err(error) = super::sync_audit::record_external_create_follow_ups(
+            db,
+            &batch.external_create_follow_ups,
+        )
+        .await
+    {
+        batch.terminal_error = Some(combine_follow_up_error(batch.terminal_error.take(), error));
+    }
+    metrics.capture(&batch);
+    let batch = batch.into_completed()?;
+    let items = db.list_task_board_items(request.status).await?;
+    let summary =
+        super::super::task_board::build_sync_response_from_items(&items, &config, batch.operations);
+    super::super::task_board::log_sync_completion(&summary);
+    Ok(summary)
+}
+
+fn combine_follow_up_error(existing: Option<CliError>, follow_up: CliError) -> CliError {
+    let Some(existing) = existing else {
+        return follow_up;
+    };
+    crate::errors::CliErrorKind::workflow_io(format!(
+        "task-board provider sync failed: {existing}; \
+external create follow-up persistence failed: {follow_up}"
+    ))
+    .into()
+}
+
+fn finish_blocked(
+    metrics: &mut SyncExecutionMetrics,
+    batch: ExternalSyncBatch,
+) -> Result<TaskBoardSyncResponse, CliError> {
+    metrics.capture(&batch);
+    match batch.into_completed() {
+        Ok(_) => unreachable!("blocked provider create recovery must remain terminal"),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::query;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::daemon::protocol::HarnessMonitorAuditEventsRequest;
+    use crate::task_board::{
+        ExternalCreateOutcome, ExternalProvider, ExternalRefSyncState, ExternalSyncDirection,
+        ExternalTaskRef, TaskBoardExternalCreateBegin, TaskBoardItem, TaskBoardStatus,
+    };
+
+    #[tokio::test]
+    async fn config_failure_reports_create_once_and_acks_the_follow_up() {
+        let (_dir, db, request) = config_failure_fixture().await;
+        let mut metrics = SyncExecutionMetrics::default();
+
+        execute(&db, &request, &mut metrics)
+            .await
+            .expect_err("configuration load must fail");
+
+        assert_eq!(metrics.operations().len(), 1);
+        assert!(metrics.operations()[0].applied);
+        assert_eq!(
+            metrics.operations()[0].external_id.as_deref(),
+            Some("remote-config-recovery")
+        );
+        assert!(
+            db.task_board_external_create_receipt(
+                "task-config-recovery",
+                ExternalProvider::Todoist,
+            )
+            .await
+            .expect("create receipt")
+            .is_some()
+        );
+        assert!(
+            db.list_pending_task_board_external_create_follow_ups(Some(ExternalProvider::Todoist))
+                .await
+                .expect("pending follow-ups")
+                .is_empty()
+        );
+        let events = follow_up_events(&db).await;
+        assert_eq!(events.len(), 1);
+        let payload = events[0].payload_json.as_ref().expect("follow-up payload");
+        assert_eq!(payload["operation_count"].as_u64(), Some(0));
+        assert_eq!(payload["applied_operation_count"].as_u64(), Some(0));
+
+        let mut second_metrics = SyncExecutionMetrics::default();
+        execute(&db, &request, &mut second_metrics)
+            .await
+            .expect_err("configuration remains invalid");
+
+        assert!(second_metrics.operations().is_empty());
+        assert_eq!(follow_up_events(&db).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pending_attached_follow_up_never_reemits_an_applied_sync_operation() {
+        let (_dir, db, request) = config_failure_fixture().await;
+        let created = db
+            .list_created_task_board_external_create_intents()
+            .await
+            .expect("created intents")
+            .into_iter()
+            .next()
+            .expect("created intent");
+        db.finalize_task_board_external_create_intent(&created)
+            .await
+            .expect("finalize before simulated crash");
+        let mut first_metrics = SyncExecutionMetrics::default();
+
+        execute(&db, &request, &mut first_metrics)
+            .await
+            .expect_err("configuration remains invalid");
+
+        assert!(first_metrics.operations().is_empty());
+        assert_eq!(follow_up_events(&db).await.len(), 1);
+        let mut second_metrics = SyncExecutionMetrics::default();
+        execute(&db, &request, &mut second_metrics)
+            .await
+            .expect_err("configuration remains invalid");
+        assert!(second_metrics.operations().is_empty());
+        assert_eq!(follow_up_events(&db).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn dry_run_leaves_pending_attached_follow_up_untouched() {
+        let (_dir, db, mut request) = config_failure_fixture().await;
+        let created = db
+            .list_created_task_board_external_create_intents()
+            .await
+            .expect("created intents")
+            .into_iter()
+            .next()
+            .expect("created intent");
+        db.finalize_task_board_external_create_intent(&created)
+            .await
+            .expect("finalize before preview");
+        request.dry_run = true;
+        let mut metrics = SyncExecutionMetrics::default();
+
+        let error = execute(&db, &request, &mut metrics)
+            .await
+            .expect_err("pending follow-up must block preview");
+
+        assert!(error.message().contains("blocks dry-run"));
+        assert!(metrics.operations().is_empty());
+        assert!(follow_up_events(&db).await.is_empty());
+        assert_eq!(
+            db.list_pending_task_board_external_create_follow_ups(Some(ExternalProvider::Todoist))
+                .await
+                .expect("pending follow-ups")
+                .len(),
+            1
+        );
+    }
+
+    async fn config_failure_fixture() -> (tempfile::TempDir, AsyncDaemonDb, TaskBoardSyncRequest) {
+        let dir = tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+            .await
+            .expect("database");
+        let mut item = TaskBoardItem::new(
+            "task-config-recovery".into(),
+            "Create title".into(),
+            "Create body".into(),
+            "2026-07-16T10:00:00Z".into(),
+        );
+        item.project_id = Some("provider-project".into());
+        db.create_task_board_item(item).await.expect("create item");
+        let started = db
+            .begin_task_board_external_create_intent(
+                "task-config-recovery",
+                ExternalProvider::Todoist,
+                "todoist:scope",
+                "provider-project",
+            )
+            .await
+            .expect("begin create");
+        let TaskBoardExternalCreateBegin::Started(intent) = started else {
+            panic!("expected started create intent");
+        };
+        let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-config-recovery");
+        let outcome = ExternalCreateOutcome {
+            reference: reference.clone(),
+            provider_revision: None,
+            provider_project_id: Some("provider-project".into()),
+        };
+        let mut baseline = reference.into_core_ref();
+        baseline.sync_state = Some(ExternalRefSyncState {
+            title: Some("Create title".into()),
+            body: Some("Create body".into()),
+            status: Some(TaskBoardStatus::Backlog),
+            project_id: Some("provider-project".into()),
+            updated_at: None,
+            synced_at: Some("2026-07-16T10:00:00Z".into()),
+        });
+        db.record_task_board_external_create_outcome(&intent, &outcome, &baseline)
+            .await
+            .expect("record create");
+        query(
+            "UPDATE task_board_orchestrator_settings
+             SET settings_json = '{' WHERE singleton = 1",
+        )
+        .execute(db.pool())
+        .await
+        .expect("corrupt settings");
+        let request = TaskBoardSyncRequest {
+            provider: Some(ExternalProvider::Todoist),
+            direction: ExternalSyncDirection::Pull,
+            dry_run: false,
+            ..TaskBoardSyncRequest::default()
+        };
+        (dir, db, request)
+    }
+
+    async fn follow_up_events(
+        db: &AsyncDaemonDb,
+    ) -> Vec<crate::daemon::protocol::HarnessMonitorAuditEvent> {
+        db.load_audit_events(&HarnessMonitorAuditEventsRequest {
+            action_keys: vec!["task_board.external_create_follow_up".into()],
+            ..HarnessMonitorAuditEventsRequest::default()
+        })
+        .await
+        .expect("load follow-up events")
+        .events
+    }
+}

--- a/src/daemon/service/task_board_db/provider_sync_store.rs
+++ b/src/daemon/service/task_board_db/provider_sync_store.rs
@@ -3,13 +3,79 @@ use async_trait::async_trait;
 use crate::daemon::db::{AsyncDaemonDb, db_error};
 use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::external::{
-    ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
-    TaskBoardSyncItemSnapshot,
+    ExternalCreateOutcome, ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
+    ExternalProviderScopeState, TaskBoardSyncItemSnapshot,
 };
 use crate::task_board::store::{TaskBoardItemPatch, apply_patch};
 use crate::task_board::{
-    ExternalProvider, TaskBoardItem, TaskBoardStatus, TaskBoardSyncConflict, TaskBoardSyncStore,
+    ExternalProvider, ExternalRef, ExternalSyncField, TaskBoardExternalCreateBegin,
+    TaskBoardExternalCreateFinalizeResult, TaskBoardExternalCreateIntent,
+    TaskBoardExternalCreateStore, TaskBoardItem, TaskBoardStatus, TaskBoardSyncConflict,
+    TaskBoardSyncStore,
 };
+
+#[async_trait]
+impl TaskBoardExternalCreateStore for AsyncDaemonDb {
+    async fn begin_external_create_intent(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        scope_id: &str,
+        provider_target: &str,
+    ) -> Result<TaskBoardExternalCreateBegin, CliError> {
+        self.begin_task_board_external_create_intent(item_id, provider, scope_id, provider_target)
+            .await
+    }
+
+    async fn record_external_create_outcome(
+        &self,
+        intent: &TaskBoardExternalCreateIntent,
+        outcome: &ExternalCreateOutcome,
+        provider_baseline: &ExternalRef,
+    ) -> Result<TaskBoardExternalCreateIntent, CliError> {
+        self.record_task_board_external_create_outcome(intent, outcome, provider_baseline)
+            .await
+    }
+
+    async fn finalize_external_create_intent(
+        &self,
+        intent: &TaskBoardExternalCreateIntent,
+    ) -> Result<TaskBoardExternalCreateFinalizeResult, CliError> {
+        self.finalize_task_board_external_create_intent(intent)
+            .await
+    }
+
+    async fn list_created_external_create_intents(
+        &self,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        self.list_created_task_board_external_create_intents().await
+    }
+
+    async fn list_in_flight_external_create_intents(
+        &self,
+        provider: ExternalProvider,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        self.list_in_flight_task_board_external_create_intents(provider)
+            .await
+    }
+
+    async fn external_create_intent_by_create_key(
+        &self,
+        provider: ExternalProvider,
+        create_key: &str,
+    ) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+        self.task_board_external_create_intent_by_create_key(provider, create_key)
+            .await
+    }
+
+    async fn list_pending_external_create_follow_ups(
+        &self,
+        provider: Option<ExternalProvider>,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        self.list_pending_task_board_external_create_follow_ups(provider)
+            .await
+    }
+}
 
 #[async_trait]
 impl TaskBoardSyncStore for AsyncDaemonDb {
@@ -121,6 +187,24 @@ impl TaskBoardSyncStore for AsyncDaemonDb {
         )
         .await
     }
+
+    async fn supersede_open_sync_conflicts(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        external_ref: &str,
+        item_revision: i64,
+        resolved_fields: &[ExternalSyncField],
+    ) -> Result<(), CliError> {
+        self.supersede_open_task_board_sync_conflicts(
+            item_id,
+            provider,
+            external_ref,
+            item_revision,
+            resolved_fields,
+        )
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -128,6 +212,11 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::task_board::{
+        ExternalCreateOutcome, ExternalRefProvider, ExternalRefSyncState, ExternalSyncField,
+        ExternalTaskRef, TaskBoardConflictState, TaskBoardExternalCreateBegin,
+        TaskBoardExternalCreateFinalizeDisposition, TaskBoardExternalCreateIntent,
+    };
 
     #[tokio::test]
     async fn external_sync_update_rejects_a_concurrent_local_edit() {
@@ -167,5 +256,182 @@ mod tests {
         assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
         assert_eq!(current.title, "Original title");
         assert_eq!(current.body, "Concurrent local edit");
+    }
+
+    #[tokio::test]
+    async fn external_create_store_delegates_the_durable_intent_lifecycle() {
+        let dir = tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+            .await
+            .expect("open database");
+        db.create_task_board_item(TaskBoardItem::new(
+            "task-create-store".into(),
+            "Create title".into(),
+            "Create body".into(),
+            "2026-07-16T15:00:00Z".into(),
+        ))
+        .await
+        .expect("create item");
+
+        let started =
+            <AsyncDaemonDb as TaskBoardExternalCreateStore>::begin_external_create_intent(
+                &db,
+                "task-create-store",
+                ExternalProvider::Todoist,
+                "todoist:scope",
+                "todoist-project",
+            )
+            .await
+            .expect("begin create");
+        let TaskBoardExternalCreateBegin::Started(intent) = started else {
+            panic!("expected a newly started create intent");
+        };
+        assert_eq!(
+            <AsyncDaemonDb as TaskBoardExternalCreateStore>::
+                list_in_flight_external_create_intents(&db, ExternalProvider::Todoist)
+                .await
+                .expect("list in-flight"),
+            vec![intent.clone()]
+        );
+        assert_eq!(
+            <AsyncDaemonDb as TaskBoardExternalCreateStore>::external_create_intent_by_create_key(
+                &db,
+                ExternalProvider::Todoist,
+                &intent.create_key,
+            )
+            .await
+            .expect("lookup intent"),
+            Some(intent.clone())
+        );
+
+        let (outcome, baseline) = create_evidence(&intent);
+        let created =
+            <AsyncDaemonDb as TaskBoardExternalCreateStore>::record_external_create_outcome(
+                &db, &intent, &outcome, &baseline,
+            )
+            .await
+            .expect("record create outcome");
+        assert_eq!(
+            <AsyncDaemonDb as TaskBoardExternalCreateStore>::list_created_external_create_intents(
+                &db
+            )
+            .await
+            .expect("list created"),
+            vec![created.clone()]
+        );
+        let finalized =
+            <AsyncDaemonDb as TaskBoardExternalCreateStore>::finalize_external_create_intent(
+                &db, &created,
+            )
+            .await
+            .expect("finalize create");
+
+        assert_eq!(
+            finalized.disposition,
+            TaskBoardExternalCreateFinalizeDisposition::Attached
+        );
+        assert_eq!(
+            <AsyncDaemonDb as TaskBoardExternalCreateStore>::external_create_intent_by_create_key(
+                &db,
+                ExternalProvider::Todoist,
+                &intent.create_key,
+            )
+            .await
+            .expect("lookup attached intent"),
+            Some(finalized.intent.clone())
+        );
+        assert_eq!(
+            <AsyncDaemonDb as TaskBoardExternalCreateStore>::list_pending_external_create_follow_ups(
+                &db,
+                Some(ExternalProvider::Todoist),
+            )
+            .await
+            .expect("list pending attached receipts"),
+            vec![finalized.intent]
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_store_delegates_field_scoped_conflict_supersession() {
+        let dir = tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+            .await
+            .expect("open database");
+        db.create_task_board_item(TaskBoardItem::new(
+            "task-conflict-store".into(),
+            "Conflict title".into(),
+            String::new(),
+            "2026-07-16T15:00:00Z".into(),
+        ))
+        .await
+        .expect("create item");
+        db.replace_open_task_board_sync_conflicts(
+            "task-conflict-store",
+            ExternalProvider::Todoist,
+            "todoist-task",
+            1,
+            &[
+                conflict("conflict-title", "title"),
+                conflict("conflict-future", "future_field"),
+            ],
+        )
+        .await
+        .expect("record conflicts");
+
+        <AsyncDaemonDb as TaskBoardSyncStore>::supersede_open_sync_conflicts(
+            &db,
+            "task-conflict-store",
+            ExternalProvider::Todoist,
+            "todoist-task",
+            1,
+            &[ExternalSyncField::Title],
+        )
+        .await
+        .expect("supersede title conflict");
+
+        let open = db
+            .open_task_board_sync_conflicts()
+            .await
+            .expect("open conflicts");
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].field, "future_field");
+    }
+
+    fn create_evidence(
+        intent: &TaskBoardExternalCreateIntent,
+    ) -> (ExternalCreateOutcome, crate::task_board::ExternalRef) {
+        let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "todoist-task")
+            .with_url("https://example.invalid/tasks/todoist-task");
+        let outcome = ExternalCreateOutcome {
+            reference: reference.clone(),
+            provider_revision: Some("provider-revision".into()),
+            provider_project_id: Some("todoist-project".into()),
+        };
+        let mut baseline = reference.into_core_ref();
+        baseline.sync_state = Some(ExternalRefSyncState {
+            title: Some(intent.snapshot.title.clone()),
+            body: Some(intent.snapshot.body.clone()),
+            status: Some(TaskBoardStatus::Backlog),
+            project_id: Some("todoist-project".into()),
+            updated_at: Some("provider-revision".into()),
+            synced_at: Some("2026-07-16T15:01:00Z".into()),
+        });
+        (outcome, baseline)
+    }
+
+    fn conflict(conflict_id: &str, field: &str) -> TaskBoardSyncConflict {
+        TaskBoardSyncConflict {
+            conflict_id: conflict_id.into(),
+            item_id: "task-conflict-store".into(),
+            provider: ExternalRefProvider::Todoist,
+            external_ref: "todoist-task".into(),
+            field: field.into(),
+            base_value: serde_json::json!("base"),
+            local_value: serde_json::json!("local"),
+            remote_value: serde_json::json!("remote"),
+            item_revision: 1,
+            provider_revision: Some("provider-revision".into()),
+            state: TaskBoardConflictState::Open,
+        }
     }
 }

--- a/src/daemon/service/task_board_db/provider_sync_store.rs
+++ b/src/daemon/service/task_board_db/provider_sync_store.rs
@@ -4,6 +4,7 @@ use crate::daemon::db::{AsyncDaemonDb, db_error};
 use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::external::{
     ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
+    TaskBoardSyncItemSnapshot,
 };
 use crate::task_board::store::{TaskBoardItemPatch, apply_patch};
 use crate::task_board::{
@@ -50,10 +51,10 @@ impl TaskBoardSyncStore for AsyncDaemonDb {
         .ok_or_else(|| db_error("Task Board sync update produced no mutation"))
     }
 
-    async fn item_revision(&self, item_id: &str) -> Result<i64, CliError> {
+    async fn item_snapshot(&self, item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
         self.task_board_item_snapshot(item_id)
             .await
-            .map(|snapshot| snapshot.item_revision)
+            .map(|snapshot| TaskBoardSyncItemSnapshot::new(snapshot.item, snapshot.item_revision))
     }
 
     async fn provider_scope_state(
@@ -72,6 +73,15 @@ impl TaskBoardSyncStore for AsyncDaemonDb {
         now: &str,
     ) -> Result<ExternalProviderScopeAttemptDecision, CliError> {
         self.begin_task_board_provider_scope_attempt(provider, scope_id, now)
+            .await
+    }
+
+    async fn renew_provider_scope_attempt(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        now: &str,
+    ) -> Result<(), CliError> {
+        self.renew_task_board_provider_scope_attempt(attempt, now)
             .await
     }
 
@@ -99,10 +109,17 @@ impl TaskBoardSyncStore for AsyncDaemonDb {
         item_id: &str,
         provider: ExternalProvider,
         external_ref: &str,
+        item_revision: i64,
         conflicts: &[TaskBoardSyncConflict],
     ) -> Result<(), CliError> {
-        self.replace_open_task_board_sync_conflicts(item_id, provider, external_ref, conflicts)
-            .await
+        self.replace_open_task_board_sync_conflicts(
+            item_id,
+            provider,
+            external_ref,
+            item_revision,
+            conflicts,
+        )
+        .await
     }
 }
 

--- a/src/daemon/service/task_board_db/reviews_sync.rs
+++ b/src/daemon/service/task_board_db/reviews_sync.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::SecondsFormat;
@@ -12,26 +13,46 @@ use crate::reviews::{ReviewItem, ReviewPullRequestState, ReviewsQueryRequest};
 use crate::task_board::{
     ExternalProvider, ExternalSyncClient, ExternalSyncDirection, ExternalSyncOperation,
     ExternalSyncOptions, ExternalTask, ExternalTaskRef, TaskBoardItem, TaskBoardStatus,
-    sync_external_tasks,
+    normalize_repository_slug, sync_external_tasks,
 };
 
 pub(super) struct SharedReviewRequestClient {
+    repository: String,
     tasks: Option<Vec<ExternalTask>>,
     query: Option<SharedReviewQuery>,
     authoritative_review_inbox: bool,
-    github_revision_guard: AsyncMutex<Option<OwnedMutexGuard<()>>>,
+    github_revision_guard: SharedGitHubRevisionGuard,
 }
 
 struct SharedReviewQuery {
     request: ReviewsQueryRequest,
-    repositories: Vec<String>,
     labels: Vec<String>,
+}
+
+type SharedGitHubRevisionGuard = Arc<AsyncMutex<Option<HeldGitHubRevisionGuard>>>;
+
+struct HeldGitHubRevisionGuard {
+    revision: u64,
+    _guard: OwnedMutexGuard<()>,
 }
 
 #[async_trait]
 impl ExternalSyncClient for SharedReviewRequestClient {
     fn provider(&self) -> ExternalProvider {
         ExternalProvider::GitHub
+    }
+
+    fn scope_id(&self) -> String {
+        self.repository.clone()
+    }
+
+    fn scope_for_item(&self, item: &TaskBoardItem) -> String {
+        normalize_repository_slug(
+            item.execution_repository
+                .as_deref()
+                .or(item.project_id.as_deref()),
+        )
+        .unwrap_or_else(|| self.scope_id())
     }
 
     fn allows_push(&self) -> bool {
@@ -52,16 +73,13 @@ impl ExternalSyncClient for SharedReviewRequestClient {
             .expect("shared Reviews client has tasks or a query");
         let source =
             super::super::reviews::query_reviews_repositories_source(&query.request).await?;
-        let revision_guard = stable_data_revision_guard(source.github_data_revision)
-            .await
-            .ok_or_else(|| {
-                CliError::from(CliErrorKind::concurrent_modification(
-                    "GitHub data changed before Task Board could reconcile the Reviews snapshot",
-                ))
-            })?;
-        let tasks =
-            review_external_tasks(&query.repositories, &query.labels, &source.response.items);
-        *self.github_revision_guard.lock().await = Some(revision_guard);
+        self.hold_github_revision(source.github_data_revision)
+            .await?;
+        let tasks = review_external_tasks(
+            std::slice::from_ref(&self.repository),
+            &query.labels,
+            &source.response.items,
+        );
         Ok(tasks)
     }
 
@@ -70,10 +88,30 @@ impl ExternalSyncClient for SharedReviewRequestClient {
     }
 }
 
-pub(super) async fn shared_review_request_client(
+impl SharedReviewRequestClient {
+    async fn hold_github_revision(&self, revision: u64) -> Result<(), CliError> {
+        let mut held = self.github_revision_guard.lock().await;
+        if let Some(current) = held.as_ref() {
+            if current.revision == revision {
+                return Ok(());
+            }
+            return Err(github_revision_changed_error());
+        }
+        let guard = stable_data_revision_guard(revision)
+            .await
+            .ok_or_else(github_revision_changed_error)?;
+        *held = Some(HeldGitHubRevisionGuard {
+            revision,
+            _guard: guard,
+        });
+        Ok(())
+    }
+}
+
+pub(super) async fn shared_review_request_clients(
     db: &AsyncDaemonDb,
     request: &TaskBoardSyncRequest,
-) -> Result<Option<SharedReviewRequestClient>, CliError> {
+) -> Result<Vec<SharedReviewRequestClient>, CliError> {
     if !matches!(
         request.direction,
         ExternalSyncDirection::Pull | ExternalSyncDirection::Both
@@ -81,25 +119,16 @@ pub(super) async fn shared_review_request_client(
         .provider
         .is_some_and(|provider| provider != ExternalProvider::GitHub)
     {
-        return Ok(None);
+        return Ok(Vec::new());
     }
     let settings = db.task_board_orchestrator_settings().await?;
     if settings.github_inbox.repositories.is_empty() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
-    Ok(Some(SharedReviewRequestClient {
-        tasks: None,
-        query: Some(SharedReviewQuery {
-            request: ReviewsQueryRequest {
-                repositories: settings.github_inbox.repositories.clone(),
-                ..ReviewsQueryRequest::default()
-            },
-            repositories: settings.github_inbox.repositories,
-            labels: settings.github_inbox.label_filter,
-        }),
-        authoritative_review_inbox: true,
-        github_revision_guard: AsyncMutex::new(None),
-    }))
+    Ok(shared_review_query_clients(
+        &settings.github_inbox.repositories,
+        &settings.github_inbox.label_filter,
+    ))
 }
 
 pub(crate) async fn reconcile_shared_review_items_db(
@@ -118,15 +147,16 @@ pub(crate) async fn reconcile_shared_review_items_db(
         })
         .map(review_key)
         .collect::<HashSet<_>>();
-    let Some(client) = shared_review_request_client_from_settings(
+    let clients = shared_review_request_clients_from_settings(
         &settings.github_inbox.repositories,
         &settings.github_inbox.label_filter,
         items,
         false,
-    ) else {
+    );
+    if clients.is_empty() {
         return Ok((configured_keys, Vec::new()));
-    };
-    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
+    }
+    let clients = boxed_review_clients(clients);
     let operations = sync_external_tasks(
         db,
         ExternalSyncOptions {
@@ -141,22 +171,74 @@ pub(crate) async fn reconcile_shared_review_items_db(
     Ok((configured_keys, operations))
 }
 
-fn shared_review_request_client_from_settings(
+fn shared_review_request_clients_from_settings(
     repositories: &[String],
     labels: &[String],
     items: &[ReviewItem],
     authoritative_review_inbox: bool,
-) -> Option<SharedReviewRequestClient> {
-    if repositories.is_empty() {
-        return None;
-    }
-    let tasks = review_external_tasks(repositories, labels, items);
-    Some(SharedReviewRequestClient {
-        tasks: Some(tasks),
-        query: None,
-        authoritative_review_inbox,
-        github_revision_guard: AsyncMutex::new(None),
-    })
+) -> Vec<SharedReviewRequestClient> {
+    normalized_repositories(repositories)
+        .into_iter()
+        .map(|repository| SharedReviewRequestClient {
+            tasks: Some(review_external_tasks(
+                std::slice::from_ref(&repository),
+                labels,
+                items,
+            )),
+            query: None,
+            repository,
+            authoritative_review_inbox,
+            github_revision_guard: Arc::new(AsyncMutex::new(None)),
+        })
+        .collect()
+}
+
+fn shared_review_query_clients(
+    repositories: &[String],
+    labels: &[String],
+) -> Vec<SharedReviewRequestClient> {
+    let github_revision_guard = Arc::new(AsyncMutex::new(None));
+    normalized_repositories(repositories)
+        .into_iter()
+        .map(|repository| SharedReviewRequestClient {
+            tasks: None,
+            query: Some(SharedReviewQuery {
+                request: ReviewsQueryRequest {
+                    repositories: vec![repository.clone()],
+                    ..ReviewsQueryRequest::default()
+                },
+                labels: labels.to_vec(),
+            }),
+            repository,
+            authoritative_review_inbox: true,
+            github_revision_guard: Arc::clone(&github_revision_guard),
+        })
+        .collect()
+}
+
+fn boxed_review_clients(
+    clients: Vec<SharedReviewRequestClient>,
+) -> Vec<Box<dyn ExternalSyncClient>> {
+    clients
+        .into_iter()
+        .map(|client| Box::new(client) as Box<dyn ExternalSyncClient>)
+        .collect()
+}
+
+fn normalized_repositories(repositories: &[String]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    repositories
+        .iter()
+        .filter_map(|repository| normalize_repository_slug(Some(repository.as_str())))
+        .filter(|repository| seen.insert(repository.clone()))
+        .collect()
+}
+
+fn github_revision_changed_error() -> CliError {
+    CliErrorKind::concurrent_modification(
+        "GitHub data changed before Task Board could reconcile the Reviews snapshot",
+    )
+    .into()
 }
 
 fn review_external_tasks(
@@ -215,3 +297,7 @@ fn review_external_task(item: &ReviewItem) -> ExternalTask {
         updated_at: Some(item.updated_at.to_rfc3339_opts(SecondsFormat::Secs, true)),
     }
 }
+
+#[cfg(test)]
+#[path = "reviews_sync_tests.rs"]
+mod tests;

--- a/src/daemon/service/task_board_db/reviews_sync_tests.rs
+++ b/src/daemon/service/task_board_db/reviews_sync_tests.rs
@@ -1,0 +1,155 @@
+use chrono::{TimeZone, Utc};
+use tempfile::tempdir;
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::reviews::{
+    ReviewAuthorAssociation, ReviewCheckStatus, ReviewItem, ReviewItemFlags, ReviewMergeableState,
+    ReviewPullRequestState, ReviewReviewStatus,
+};
+use crate::task_board::external::{
+    ExternalProviderScopeAttemptDecision, ExternalProviderScopeIdentity,
+};
+use crate::task_board::{
+    ExternalProvider, TaskBoardGitHubInboxConfig, TaskBoardOrchestratorSettings,
+};
+use crate::task_board::{ExternalSyncClient, TaskBoardItem};
+use crate::workspace::utc_now;
+
+use super::{reconcile_shared_review_items_db, shared_review_request_clients_from_settings};
+
+#[test]
+fn shared_review_clients_split_scope_and_ownership_by_repository() {
+    let repositories = vec!["Acme/Widgets".into(), "acme/tools".into()];
+    let clients = shared_review_request_clients_from_settings(&repositories, &[], &[], false);
+    let scope_ids = clients
+        .iter()
+        .map(ExternalSyncClient::scope_id)
+        .collect::<Vec<_>>();
+    let persistence_scope_ids = clients
+        .iter()
+        .map(|client| {
+            ExternalProviderScopeIdentity::for_client(client)
+                .scope_id()
+                .to_owned()
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(scope_ids, ["acme/widgets", "acme/tools"]);
+    assert_eq!(
+        persistence_scope_ids,
+        [
+            "v1:github:read:12:acme/widgets",
+            "v1:github:read:10:acme/tools",
+        ]
+    );
+
+    let mut item = TaskBoardItem::new(
+        "task-review".into(),
+        "Review".into(),
+        String::new(),
+        "2026-07-16T10:00:00Z".into(),
+    );
+    item.execution_repository = Some("ACME/WIDGETS".into());
+    assert_eq!(clients[0].scope_for_item(&item), "acme/widgets");
+    assert_eq!(clients[1].scope_for_item(&item), "acme/widgets");
+    assert_eq!(clients[0].scope_id(), clients[0].scope_for_item(&item));
+    assert_ne!(clients[1].scope_id(), clients[1].scope_for_item(&item));
+}
+
+#[tokio::test]
+async fn backed_off_review_repository_does_not_block_another_repository() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    let repositories = vec!["acme/broken".into(), "acme/widgets".into()];
+    db.replace_task_board_orchestrator_settings(&TaskBoardOrchestratorSettings {
+        github_inbox: TaskBoardGitHubInboxConfig {
+            repositories: repositories.clone(),
+            label_filter: Vec::new(),
+        },
+        ..TaskBoardOrchestratorSettings::default()
+    })
+    .await
+    .expect("configure review inbox");
+    let clients = shared_review_request_clients_from_settings(&repositories, &[], &[], false);
+    let broken_scope = ExternalProviderScopeIdentity::for_client(&clients[0])
+        .scope_id()
+        .to_owned();
+    let now = utc_now();
+    let attempt = match db
+        .begin_task_board_provider_scope_attempt(ExternalProvider::GitHub, &broken_scope, &now)
+        .await
+        .expect("begin failed repository attempt")
+    {
+        ExternalProviderScopeAttemptDecision::Started(attempt) => attempt,
+        other => panic!("expected started attempt, got {other:?}"),
+    };
+    db.complete_task_board_provider_scope_failure(&attempt, &now)
+        .await
+        .expect("back off failed repository");
+
+    let items = vec![
+        review_item("acme/broken", 17),
+        review_item("acme/widgets", 18),
+    ];
+    let (_, operations) = reconcile_shared_review_items_db(&db, &items)
+        .await
+        .expect("reconcile available repository");
+    let board_items = db.list_task_board_items(None).await.expect("board items");
+
+    assert_eq!(operations.len(), 1);
+    assert_eq!(board_items.len(), 1);
+    assert_eq!(
+        board_items[0].execution_repository.as_deref(),
+        Some("acme/widgets")
+    );
+}
+
+fn review_item(repository: &str, number: u64) -> ReviewItem {
+    ReviewItem {
+        pull_request_id: format!("pr-{repository}-{number}"),
+        repository_id: format!("repo-{repository}"),
+        repository: repository.into(),
+        number,
+        title: format!("Review {repository}#{number}"),
+        url: format!("https://github.com/{repository}/pull/{number}"),
+        base_ref_name: None,
+        default_branch_name: None,
+        backport_source: None,
+        author_login: "author".into(),
+        author_avatar_url: None,
+        author_association: ReviewAuthorAssociation::Member,
+        state: ReviewPullRequestState::Open,
+        mergeable: ReviewMergeableState::Mergeable,
+        review_status: ReviewReviewStatus::ReviewRequired,
+        check_status: ReviewCheckStatus::Success,
+        flags: ReviewItemFlags {
+            policy_blocked: false,
+            is_draft: false,
+            viewer_can_update: true,
+            viewer_is_requested_reviewer: true,
+        },
+        viewer_can_merge_as_admin: false,
+        head_sha: format!("head-{number}"),
+        labels: Vec::new(),
+        checks: Vec::new(),
+        reviews: Vec::new(),
+        additions: 1,
+        deletions: 1,
+        created_at: Utc
+            .with_ymd_and_hms(2026, 7, 16, 10, 0, 0)
+            .single()
+            .expect("created at"),
+        updated_at: Utc
+            .with_ymd_and_hms(2026, 7, 16, 10, 5, 0)
+            .single()
+            .expect("updated at"),
+        required_failed_check_names: Vec::new(),
+        required_approving_review_count: None,
+        has_conflict_markers: None,
+        viewer_has_active_approval: None,
+        auto_merge_enabled: None,
+        approval_requirement_satisfied_after_viewer_approval: None,
+    }
+}

--- a/src/daemon/service/task_board_db/sync_audit.rs
+++ b/src/daemon/service/task_board_db/sync_audit.rs
@@ -8,8 +8,8 @@ use crate::task_board::{
 };
 
 use metrics::{add_execution_metrics, add_summary_counts, applied_operation_count, conflict_count};
-use persistence::persist_sync_audit_result;
-use state::{AuditObservation, PendingAudit, plan_audit};
+use persistence::{SyncAuditClassification, persist_sync_audit_result};
+use state::{AuditObservation, PendingAudit, acquire_audit_lane, plan_audit};
 
 #[path = "sync_audit_metrics.rs"]
 mod metrics;
@@ -91,6 +91,7 @@ pub(super) async fn record_request_result(
     result: &Result<TaskBoardSyncResponse, CliError>,
     metrics: &SyncExecutionMetrics,
 ) -> Result<(), CliError> {
+    let _audit_lane = acquire_audit_lane(db, trigger).await;
     let observation = AuditObservation::for_request(result.as_ref().err(), metrics);
     let Some(pending) = plan_audit(db, trigger, observation) else {
         return Ok(());
@@ -101,7 +102,8 @@ pub(super) async fn record_request_result(
     if let Ok(summary) = result {
         add_summary_counts(&mut payload, summary.total, &summary.operations);
     }
-    persist_sync_audit_result(db, trigger, payload, result).await?;
+    let classification = SyncAuditClassification::for_request(result, metrics);
+    persist_sync_audit_result(db, trigger, payload, classification, result).await?;
     pending.commit();
     Ok(())
 }
@@ -130,6 +132,7 @@ async fn record_reviews_result(
     trigger: TaskBoardSyncAuditTrigger,
     result: &Result<ReviewsProjectionAuditSummary, CliError>,
 ) {
+    let _audit_lane = acquire_audit_lane(db, trigger).await;
     let Some(pending) = reviews_pending_audit(db, trigger, result) else {
         return;
     };
@@ -166,7 +169,10 @@ async fn persist_reviews_audit(
     payload: Value,
     result: &Result<ReviewsProjectionAuditSummary, CliError>,
 ) {
-    if let Err(error) = persist_sync_audit_result(db, trigger, payload, result).await {
+    let classification = SyncAuditClassification::for_result(result);
+    if let Err(error) =
+        persist_sync_audit_result(db, trigger, payload, classification, result).await
+    {
         log_reviews_audit_failure(trigger, &error);
         return;
     }

--- a/src/daemon/service/task_board_db/sync_audit.rs
+++ b/src/daemon/service/task_board_db/sync_audit.rs
@@ -19,6 +19,7 @@ mod persistence;
 mod state;
 
 pub(super) use metrics::SyncExecutionMetrics;
+pub(super) use persistence::record_external_create_follow_ups;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum TaskBoardSyncAuditTrigger {

--- a/src/daemon/service/task_board_db/sync_audit_acceptance_tests.rs
+++ b/src/daemon/service/task_board_db/sync_audit_acceptance_tests.rs
@@ -81,6 +81,9 @@ async fn requested_partial_batch_records_scope_and_operation_evidence() {
 
     let events = sync_events(&db).await;
     assert_eq!(events.len(), 1);
+    assert_eq!(events[0].severity, "warning");
+    assert_eq!(events[0].outcome, "failure");
+    assert!(events[0].summary.contains("1 failed scope"));
     let payload = payload(&events[0]);
     assert_eq!(payload["operation_count"].as_u64(), Some(1));
     assert_eq!(payload["observed_operation_count"].as_u64(), Some(2));
@@ -256,10 +259,55 @@ async fn orchestrator_records_backoff_once_and_suppresses_unchanged_repeat() {
 
     let events = sync_events(&db).await;
     assert_eq!(events.len(), 1);
+    assert_eq!(events[0].severity, "warning");
+    assert_eq!(events[0].outcome, "waiting");
+    assert!(events[0].summary.contains("backing off"));
     assert_eq!(
         payload(&events[0])["scope_outcomes"][0]["outcome"].as_str(),
         Some("backing_off")
     );
+}
+
+#[tokio::test]
+async fn concurrent_identical_background_audits_persist_once() {
+    let (_dir, db) = open_db().await;
+    let request = TaskBoardSyncRequest::default();
+    let provider_error = CliErrorKind::workflow_io("provider unavailable").into();
+    let batch = batch(
+        Vec::new(),
+        vec![ExternalSyncScopeOutcome::failed(
+            ExternalProvider::GitHub,
+            "acme/api".into(),
+            &provider_error,
+        )],
+        Some(provider_error),
+    );
+    let mut metrics = SyncExecutionMetrics::default();
+    metrics.capture(&batch);
+    let result = batch
+        .into_completed()
+        .map(|completed| sync_summary(completed.operations));
+
+    let (first, second) = tokio::join!(
+        record_request_result(
+            &db,
+            &request,
+            TaskBoardSyncAuditTrigger::Orchestrator,
+            &result,
+            &metrics,
+        ),
+        record_request_result(
+            &db,
+            &request,
+            TaskBoardSyncAuditTrigger::Orchestrator,
+            &result,
+            &metrics,
+        ),
+    );
+
+    first.expect("record initial background failure");
+    second.expect("suppress concurrent duplicate");
+    assert_eq!(sync_events(&db).await.len(), 1);
 }
 
 #[tokio::test]

--- a/src/daemon/service/task_board_db/sync_audit_acceptance_tests.rs
+++ b/src/daemon/service/task_board_db/sync_audit_acceptance_tests.rs
@@ -155,6 +155,57 @@ async fn into_completed_error_keeps_partial_batch_evidence() {
 }
 
 #[tokio::test]
+async fn terminal_local_error_keeps_captured_batch_evidence() {
+    let (_dir, db) = open_db().await;
+    let request = TaskBoardSyncRequest::default();
+    let terminal_error = CliErrorKind::workflow_io("local persistence failed").into();
+    let scope_error = CliErrorKind::workflow_io("local persistence failed").into();
+    let batch = ExternalSyncBatch {
+        operations: vec![operation(
+            true,
+            ExternalSyncAction::Pull,
+            "task-before-local-failure",
+        )],
+        scope_outcomes: vec![ExternalSyncScopeOutcome::failed(
+            ExternalProvider::Todoist,
+            "scope/primary".into(),
+            &scope_error,
+        )],
+        first_provider_failure: None,
+        terminal_error: Some(terminal_error),
+    };
+    let mut metrics = SyncExecutionMetrics::default();
+    metrics.capture(&batch);
+    let result = batch
+        .into_completed()
+        .map(|completed| sync_summary(completed.operations));
+
+    record_request_result(
+        &db,
+        &request,
+        TaskBoardSyncAuditTrigger::Requested,
+        &result,
+        &metrics,
+    )
+    .await
+    .expect("record terminal local failure audit");
+
+    let events = sync_events(&db).await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].outcome, "failure");
+    let payload = payload(&events[0]);
+    assert_eq!(payload["observed_operation_count"].as_u64(), Some(1));
+    assert_eq!(
+        payload["operation_evidence"][0]["board_item_id"].as_str(),
+        Some("task-before-local-failure")
+    );
+    assert_eq!(
+        payload["scope_outcomes"][0]["scope_id"].as_str(),
+        Some("scope/primary")
+    );
+}
+
+#[tokio::test]
 async fn orchestrator_records_scope_recovery_without_applied_operations() {
     let (_dir, db) = open_db().await;
     let request = TaskBoardSyncRequest::default();
@@ -411,6 +462,7 @@ fn batch(
         operations,
         scope_outcomes,
         first_provider_failure,
+        terminal_error: None,
     }
 }
 

--- a/src/daemon/service/task_board_db/sync_audit_acceptance_tests.rs
+++ b/src/daemon/service/task_board_db/sync_audit_acceptance_tests.rs
@@ -166,6 +166,7 @@ async fn terminal_local_error_keeps_captured_batch_evidence() {
             ExternalSyncAction::Pull,
             "task-before-local-failure",
         )],
+        external_create_follow_ups: Vec::new(),
         scope_outcomes: vec![ExternalSyncScopeOutcome::failed(
             ExternalProvider::Todoist,
             "scope/primary".into(),
@@ -460,6 +461,7 @@ fn batch(
 ) -> ExternalSyncBatch {
     ExternalSyncBatch {
         operations,
+        external_create_follow_ups: Vec::new(),
         scope_outcomes,
         first_provider_failure,
         terminal_error: None,

--- a/src/daemon/service/task_board_db/sync_audit_metrics.rs
+++ b/src/daemon/service/task_board_db/sync_audit_metrics.rs
@@ -118,6 +118,11 @@ impl SyncExecutionMetrics {
     pub(super) fn scope_outcomes(&self) -> &[ScopeAuditEvidence] {
         &self.scope_outcomes
     }
+
+    #[cfg(test)]
+    pub(in crate::daemon::service::task_board_db) fn operations(&self) -> &[ExternalSyncOperation] {
+        &self.operations
+    }
 }
 
 pub(super) fn add_summary_counts(

--- a/src/daemon/service/task_board_db/sync_audit_metrics.rs
+++ b/src/daemon/service/task_board_db/sync_audit_metrics.rs
@@ -100,6 +100,21 @@ impl SyncExecutionMetrics {
         self.operations.iter().any(|operation| operation.applied)
     }
 
+    pub(super) const fn failed_scope_count(&self) -> usize {
+        self.failed_scope_count
+    }
+
+    pub(super) const fn backing_off_scope_count(&self) -> usize {
+        self.backing_off_scope_count
+    }
+
+    pub(super) const fn all_scopes_backing_off(&self) -> bool {
+        self.result_scope_count > 0
+            && self.backing_off_scope_count == self.result_scope_count
+            && self.failed_scope_count == 0
+            && self.succeeded_scope_count == 0
+    }
+
     pub(super) fn scope_outcomes(&self) -> &[ScopeAuditEvidence] {
         &self.scope_outcomes
     }

--- a/src/daemon/service/task_board_db/sync_audit_persistence.rs
+++ b/src/daemon/service/task_board_db/sync_audit_persistence.rs
@@ -8,14 +8,74 @@ use crate::errors::CliError;
 use crate::workspace::utc_now;
 
 use super::TaskBoardSyncAuditTrigger;
+use super::metrics::SyncExecutionMetrics;
+
+const SYNC_AUDIT_TITLE: &str = "Sync task-board providers";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SyncAuditClassification {
+    Success,
+    PartialFailure {
+        failed_scope_count: usize,
+        backing_off_scope_count: usize,
+    },
+    BackingOff {
+        scope_count: usize,
+    },
+    Failure,
+}
+
+impl SyncAuditClassification {
+    pub(super) fn for_request<T>(
+        result: &Result<T, CliError>,
+        metrics: &SyncExecutionMetrics,
+    ) -> Self {
+        if result.is_err() {
+            return Self::Failure;
+        }
+        if metrics.failed_scope_count() > 0 {
+            return Self::PartialFailure {
+                failed_scope_count: metrics.failed_scope_count(),
+                backing_off_scope_count: metrics.backing_off_scope_count(),
+            };
+        }
+        if metrics.all_scopes_backing_off() {
+            return Self::BackingOff {
+                scope_count: metrics.backing_off_scope_count(),
+            };
+        }
+        Self::Success
+    }
+
+    pub(super) fn for_result<T>(result: &Result<T, CliError>) -> Self {
+        if result.is_ok() {
+            Self::Success
+        } else {
+            Self::Failure
+        }
+    }
+
+    fn presentation(self, error: Option<&CliError>) -> AuditPresentation {
+        match self {
+            Self::Success => AuditPresentation::success(),
+            Self::PartialFailure {
+                failed_scope_count,
+                backing_off_scope_count,
+            } => AuditPresentation::partial_failure(failed_scope_count, backing_off_scope_count),
+            Self::BackingOff { scope_count } => AuditPresentation::backing_off(scope_count),
+            Self::Failure => AuditPresentation::failure(error),
+        }
+    }
+}
 
 pub(super) async fn persist_sync_audit_result<T>(
     db: &AsyncDaemonDb,
     trigger: TaskBoardSyncAuditTrigger,
     payload_json: Value,
+    classification: SyncAuditClassification,
     result: &Result<T, CliError>,
 ) -> Result<(), CliError> {
-    let event = sync_audit_event(trigger, payload_json, result);
+    let event = sync_audit_event(trigger, payload_json, classification, result);
     db.upsert_audit_event(&event).await?;
     broadcast_audit_event(&event);
     Ok(())
@@ -24,22 +84,13 @@ pub(super) async fn persist_sync_audit_result<T>(
 fn sync_audit_event<T>(
     trigger: TaskBoardSyncAuditTrigger,
     payload_json: Value,
+    classification: SyncAuditClassification,
     result: &Result<T, CliError>,
 ) -> HarnessMonitorAuditEvent {
-    let title = "Sync task-board providers";
-    let (severity, outcome, summary, payload_json) = match result {
-        Ok(_) => (
-            "info".to_owned(),
-            "success".to_owned(),
-            format!("{title} succeeded"),
-            payload_json,
-        ),
-        Err(error) => (
-            "error".to_owned(),
-            "failure".to_owned(),
-            format!("{title} failed: {error}"),
-            payload_with_error(payload_json, error),
-        ),
+    let presentation = classification.presentation(result.as_ref().err());
+    let payload_json = match result {
+        Ok(_) => payload_json,
+        Err(error) => payload_with_error(payload_json, error),
     };
     HarnessMonitorAuditEvent {
         id: format!("audit-{}", Uuid::new_v4().simple()),
@@ -47,10 +98,10 @@ fn sync_audit_event<T>(
         source: "taskBoard".to_owned(),
         category: "taskBoardMutation".to_owned(),
         kind: "task_board.sync".to_owned(),
-        severity,
-        outcome,
-        title: title.to_owned(),
-        summary,
+        severity: presentation.severity.to_owned(),
+        outcome: presentation.outcome.to_owned(),
+        title: SYNC_AUDIT_TITLE.to_owned(),
+        summary: presentation.summary,
         subject: None,
         actor: Some(trigger.actor().to_owned()),
         correlation_id: None,
@@ -59,6 +110,72 @@ fn sync_audit_event<T>(
         legacy_message: None,
         related_urls: Vec::new(),
     }
+}
+
+struct AuditPresentation {
+    severity: &'static str,
+    outcome: &'static str,
+    summary: String,
+}
+
+impl AuditPresentation {
+    fn success() -> Self {
+        Self {
+            severity: "info",
+            outcome: "success",
+            summary: format!("{SYNC_AUDIT_TITLE} succeeded"),
+        }
+    }
+
+    fn partial_failure(failed_scope_count: usize, backing_off_scope_count: usize) -> Self {
+        let mut details = vec![scope_detail(failed_scope_count, "failed")];
+        if backing_off_scope_count > 0 {
+            details.push(scope_detail(backing_off_scope_count, "backing-off"));
+        }
+        Self {
+            severity: "warning",
+            outcome: "failure",
+            summary: format!(
+                "{SYNC_AUDIT_TITLE} completed with {}",
+                details.join(" and ")
+            ),
+        }
+    }
+
+    fn backing_off(scope_count: usize) -> Self {
+        Self {
+            severity: "warning",
+            outcome: "waiting",
+            summary: format!(
+                "{SYNC_AUDIT_TITLE} skipped {} while backing off",
+                scope_count_label(scope_count)
+            ),
+        }
+    }
+
+    fn failure(error: Option<&CliError>) -> Self {
+        let summary = error.map_or_else(
+            || format!("{SYNC_AUDIT_TITLE} failed"),
+            |error| format!("{SYNC_AUDIT_TITLE} failed: {error}"),
+        );
+        Self {
+            severity: "error",
+            outcome: "failure",
+            summary,
+        }
+    }
+}
+
+fn scope_detail(count: usize, outcome: &str) -> String {
+    format!("{count} {outcome} scope{}", plural_suffix(count))
+}
+
+fn scope_count_label(count: usize) -> String {
+    format!("{count} scope{}", plural_suffix(count))
+}
+
+const fn plural_suffix(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
 }
 
 fn payload_with_error(payload: Value, error: &CliError) -> Value {

--- a/src/daemon/service/task_board_db/sync_audit_persistence.rs
+++ b/src/daemon/service/task_board_db/sync_audit_persistence.rs
@@ -5,6 +5,7 @@ use crate::daemon::db::AsyncDaemonDb;
 use crate::daemon::protocol::{HarnessMonitorAuditEvent, StreamEvent};
 use crate::daemon::service::observe_sender;
 use crate::errors::CliError;
+use crate::task_board::TaskBoardExternalCreateIntent;
 use crate::workspace::utc_now;
 
 use super::TaskBoardSyncAuditTrigger;
@@ -78,6 +79,19 @@ pub(super) async fn persist_sync_audit_result<T>(
     let event = sync_audit_event(trigger, payload_json, classification, result);
     db.upsert_audit_event(&event).await?;
     broadcast_audit_event(&event);
+    Ok(())
+}
+
+pub(in crate::daemon::service::task_board_db) async fn record_external_create_follow_ups(
+    db: &AsyncDaemonDb,
+    intents: &[TaskBoardExternalCreateIntent],
+) -> Result<(), CliError> {
+    for event in db
+        .complete_task_board_external_create_follow_ups(intents)
+        .await?
+    {
+        broadcast_audit_event(&event);
+    }
     Ok(())
 }
 

--- a/src/daemon/service/task_board_db/sync_audit_state.rs
+++ b/src/daemon/service/task_board_db/sync_audit_state.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::sync::{Mutex, OnceLock, PoisonError};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError, Weak};
 use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
 use crate::daemon::db::AsyncDaemonDb;
 use crate::errors::CliError;
@@ -14,6 +15,9 @@ use super::metrics::{ScopeAuditEvidence, ScopeOutcomeKind, SyncExecutionMetrics}
 const BACKGROUND_FAILURE_REPEAT_INTERVAL: Duration = Duration::from_mins(15);
 
 static BACKGROUND_AUDIT_STATE: OnceLock<Mutex<BackgroundAuditState>> = OnceLock::new();
+static AUDIT_LANES: OnceLock<Mutex<HashMap<AuditLaneKey, Weak<AsyncMutex<()>>>>> = OnceLock::new();
+
+type AuditLaneKey = (u64, TaskBoardSyncAuditTrigger);
 
 #[derive(Debug, Clone)]
 pub(super) struct AuditObservation {
@@ -102,6 +106,23 @@ pub(super) fn plan_audit(
     )
 }
 
+pub(super) async fn acquire_audit_lane(
+    db: &AsyncDaemonDb,
+    trigger: TaskBoardSyncAuditTrigger,
+) -> OwnedMutexGuard<()> {
+    let key = (database_fingerprint(db), trigger);
+    let lane = {
+        let mut lanes = audit_lanes().lock().unwrap_or_else(PoisonError::into_inner);
+        lanes.retain(|_, lane| lane.strong_count() > 0);
+        lanes.get(&key).and_then(Weak::upgrade).unwrap_or_else(|| {
+            let lane = Arc::new(AsyncMutex::new(()));
+            lanes.insert(key, Arc::downgrade(&lane));
+            lane
+        })
+    };
+    lane.lock_owned().await
+}
+
 fn plan_audit_at(
     database_fingerprint: u64,
     trigger: TaskBoardSyncAuditTrigger,
@@ -122,6 +143,10 @@ fn plan_audit_at(
 
 fn background_state() -> &'static Mutex<BackgroundAuditState> {
     BACKGROUND_AUDIT_STATE.get_or_init(|| Mutex::new(BackgroundAuditState::default()))
+}
+
+fn audit_lanes() -> &'static Mutex<HashMap<AuditLaneKey, Weak<AsyncMutex<()>>>> {
+    AUDIT_LANES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 #[derive(Debug, Default)]

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -10,6 +10,7 @@ use crate::errors::{CliError, CliErrorKind};
 use super::types::{ExternalRef, ExternalRefProvider, TaskBoardItem, TaskBoardStatus};
 
 mod capabilities;
+mod create_recovery;
 mod github;
 mod scopes;
 mod sync;
@@ -20,6 +21,12 @@ pub use capabilities::{
     ExternalProviderCapabilities, ExternalSyncConflictPolicy, ExternalSyncField,
     ExternalTaskUpdate, ExternalUpdateOutcome,
 };
+pub(crate) use create_recovery::ExternalCreateRecoveryClient;
+#[allow(
+    unused_imports,
+    reason = "shared contract is consumed by follow-up provider recovery slices"
+)]
+pub(crate) use create_recovery::{ExternalCreateLease, ExternalCreateProbe, ExternalCreateRequest};
 pub use github::{GitHubInboxSyncClient, GitHubSyncClient};
 pub(crate) use github::{
     imported_review_references_from_items, reconcile_review_item_from_snapshots,
@@ -340,6 +347,19 @@ fn normalize_string_list(values: &[String]) -> Vec<String> {
 pub trait ExternalSyncClient: Send + Sync {
     #[must_use]
     fn provider(&self) -> ExternalProvider;
+
+    /// Return the crash-safe provider-create capability when implemented.
+    ///
+    /// Absence is fail-closed by the recovery engine; it never authorizes a
+    /// create or treats an existing durable attempt as recovered.
+    #[must_use]
+    #[allow(
+        private_interfaces,
+        reason = "provider-create recovery is intentionally crate-private"
+    )]
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        None
+    }
 
     #[must_use]
     fn scope_id(&self) -> String {

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -34,8 +34,8 @@ pub use sync::{
     configured_sync_clients,
 };
 pub(crate) use sync::{
-    TaskBoardSyncStore, configured_sync_clients_without_review_requests, sync_external_tasks,
-    sync_external_tasks_scoped,
+    TaskBoardSyncItemSnapshot, TaskBoardSyncStore, configured_sync_clients_without_review_requests,
+    sync_external_tasks, sync_external_tasks_scoped,
 };
 pub use todoist::TodoistSyncClient;
 

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -127,6 +127,13 @@ impl ExternalTaskRef {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalCreateOutcome {
+    pub reference: ExternalTaskRef,
+    pub provider_revision: Option<String>,
+    pub provider_project_id: Option<String>,
+}
+
 impl From<ExternalRef> for ExternalTaskRef {
     fn from(reference: ExternalRef) -> Self {
         Self {
@@ -382,6 +389,23 @@ pub trait ExternalSyncClient: Send + Sync {
     /// # Errors
     /// Returns provider or transport errors surfaced by the implementation.
     async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError>;
+
+    /// Push one task-board item and return provider state needed for later writes.
+    ///
+    /// # Errors
+    /// Returns provider or transport errors surfaced by the implementation.
+    async fn push_task_with_outcome(
+        &self,
+        item: &TaskBoardItem,
+    ) -> Result<ExternalCreateOutcome, CliError> {
+        Ok(ExternalCreateOutcome {
+            reference: self.push_task(item).await?,
+            provider_revision: None,
+            provider_project_id: (self.provider() != ExternalProvider::GitHub)
+                .then(|| item.project_id.clone())
+                .flatten(),
+        })
+    }
 
     /// Update one linked provider task.
     ///

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -127,7 +127,7 @@ impl ExternalTaskRef {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExternalCreateOutcome {
     pub reference: ExternalTaskRef,
     pub provider_revision: Option<String>,

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -36,13 +36,18 @@ pub(crate) use scopes::{
     ExternalProviderScopeAvailability, ExternalProviderScopeHealth, ExternalProviderScopeIdentity,
     ExternalProviderScopeState, ExternalSyncBatch, ExternalSyncScopeOutcome,
 };
+#[cfg(test)]
+pub(crate) use sync::sync_external_tasks_scoped;
 pub use sync::{
     ExternalSyncAction, ExternalSyncDirection, ExternalSyncOperation, ExternalSyncOptions,
     configured_sync_clients,
 };
 pub(crate) use sync::{
-    TaskBoardSyncItemSnapshot, TaskBoardSyncStore, configured_sync_clients_without_review_requests,
-    sync_external_tasks, sync_external_tasks_scoped,
+    TaskBoardExternalCreateStore, TaskBoardSyncItemSnapshot, TaskBoardSyncStore,
+    assign_external_create_recovery, blocked_external_create_follow_ups,
+    blocked_external_create_recovery, configured_sync_clients_without_review_requests,
+    load_external_create_recovery_work, prepare_external_create_recovery, sync_external_tasks,
+    sync_external_tasks_scoped_with_recovery,
 };
 pub use todoist::TodoistSyncClient;
 

--- a/src/task_board/external/create_recovery.rs
+++ b/src/task_board/external/create_recovery.rs
@@ -1,0 +1,346 @@
+#![allow(
+    dead_code,
+    reason = "shared contract is consumed by follow-up provider recovery slices"
+)]
+
+use async_trait::async_trait;
+
+use crate::errors::CliError;
+
+use super::{ExternalProvider, ExternalTask};
+
+/// Immutable provider-create input captured before the first remote side effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExternalCreateRequest {
+    item_id: String,
+    create_key: String,
+    title: String,
+    body: String,
+    provider_target: String,
+}
+
+impl ExternalCreateRequest {
+    #[must_use]
+    pub(crate) fn new(
+        item_id: impl Into<String>,
+        create_key: impl Into<String>,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        provider_target: impl Into<String>,
+    ) -> Self {
+        Self {
+            item_id: item_id.into(),
+            create_key: create_key.into(),
+            title: title.into(),
+            body: body.into(),
+            provider_target: provider_target.into(),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn item_id(&self) -> &str {
+        &self.item_id
+    }
+
+    #[must_use]
+    pub(crate) fn create_key(&self) -> &str {
+        &self.create_key
+    }
+
+    #[must_use]
+    pub(crate) fn title(&self) -> &str {
+        &self.title
+    }
+
+    #[must_use]
+    pub(crate) fn body(&self) -> &str {
+        &self.body
+    }
+
+    #[must_use]
+    pub(crate) fn provider_target(&self) -> &str {
+        &self.provider_target
+    }
+}
+
+/// Result of probing a provider for an earlier create attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExternalCreateProbe {
+    Found(ExternalTask),
+    Absent,
+}
+
+/// Fenced provider-scope lease available to long-running recovery operations.
+#[async_trait]
+pub(crate) trait ExternalCreateLease: Send + Sync {
+    /// Renew and validate the current provider-scope lease.
+    ///
+    /// Provider implementations call this before every remote page or side effect.
+    ///
+    /// # Errors
+    /// Returns `CliError` when the attempt is stale or the lease cannot be persisted.
+    async fn renew(&self) -> Result<(), CliError>;
+}
+
+/// Provider capability for crash-safe external-create admission and recovery.
+///
+/// Only a durable `Started` decision may call [`Self::create_started`].
+/// `recover_existing` never grants fresh create admission: GitHub recovery is
+/// scan-only and an [`ExternalCreateProbe::Absent`] result remains blocked,
+/// while Todoist may replay the identical request with the persisted create key.
+/// Implementations can renew the supplied lease before every remote page or
+/// side effect.
+#[async_trait]
+pub(crate) trait ExternalCreateRecoveryClient: Send + Sync {
+    #[must_use]
+    fn provider(&self) -> ExternalProvider;
+
+    #[must_use]
+    fn supports_target(&self, provider_target: &str) -> bool;
+
+    /// Create a provider task after durable create admission returned `Started`.
+    ///
+    /// # Errors
+    /// Returns provider, transport, or lease errors.
+    async fn create_started(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError>;
+
+    /// Recover an existing durable create attempt without widening admission.
+    ///
+    /// GitHub implementations only scan for the persisted marker. Todoist
+    /// implementations may replay with `request.create_key()` as `X-Request-Id`.
+    ///
+    /// # Errors
+    /// Returns provider, transport, parsing, or lease errors.
+    async fn recover_existing(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError>;
+
+    /// Extract a provider create key and remove its hidden marker when present.
+    ///
+    /// Providers without embedded create markers safely report no key. Marker
+    /// parsers return errors for malformed, noncanonical, or duplicate reserved
+    /// markers so later pull deduplication cannot silently import them.
+    ///
+    /// # Errors
+    /// Returns `CliError` when reserved marker evidence is invalid.
+    fn extract_create_key(&self, _task: &mut ExternalTask) -> Result<Option<String>, CliError> {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::task_board::{ExternalSyncClient, ExternalTaskRef, TaskBoardItem, TaskBoardStatus};
+
+    #[tokio::test]
+    async fn external_sync_client_defaults_to_no_create_recovery_capability() {
+        let client: &dyn ExternalSyncClient = &DefaultSyncClient;
+
+        assert!(client.external_create_recovery().is_none());
+    }
+
+    #[test]
+    fn create_recovery_marker_extraction_defaults_to_no_key() {
+        let recovery: &dyn ExternalCreateRecoveryClient = &NoMarkerRecoveryClient;
+        let mut task = task_from_request(&request());
+
+        assert_eq!(
+            recovery
+                .extract_create_key(&mut task)
+                .expect("default marker extraction"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn external_sync_client_exposes_an_object_safe_create_recovery_capability() {
+        let client = CapableSyncClient {
+            recovery: FakeRecoveryClient,
+        };
+        let client: &dyn ExternalSyncClient = &client;
+        let recovery: &dyn ExternalCreateRecoveryClient = client
+            .external_create_recovery()
+            .expect("create recovery capability");
+        let request = request();
+        let lease = CountingLease::default();
+
+        let created = recovery
+            .create_started(&request, &lease)
+            .await
+            .expect("create started");
+        let probe = recovery
+            .recover_existing(&request, &lease)
+            .await
+            .expect("recover existing");
+        let mut marked = created.clone();
+        marked.body.push_str("\n<!-- create-key:create-key-1 -->");
+
+        assert_eq!(recovery.provider(), ExternalProvider::Todoist);
+        assert!(recovery.supports_target(request.provider_target()));
+        assert_eq!(created.reference.external_id, request.item_id());
+        assert_eq!(created.title, request.title());
+        assert_eq!(created.body, request.body());
+        assert_eq!(probe, ExternalCreateProbe::Found(created));
+        assert_eq!(
+            recovery
+                .extract_create_key(&mut marked)
+                .expect("extract create key")
+                .as_deref(),
+            Some(request.create_key())
+        );
+        assert_eq!(marked.body, request.body());
+        assert_eq!(lease.renewals.load(Ordering::SeqCst), 2);
+    }
+
+    #[derive(Default)]
+    struct CountingLease {
+        renewals: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ExternalCreateLease for CountingLease {
+        async fn renew(&self) -> Result<(), CliError> {
+            self.renewals.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct FakeRecoveryClient;
+
+    #[async_trait]
+    impl ExternalCreateRecoveryClient for FakeRecoveryClient {
+        fn provider(&self) -> ExternalProvider {
+            ExternalProvider::Todoist
+        }
+
+        fn supports_target(&self, provider_target: &str) -> bool {
+            provider_target == "project-1"
+        }
+
+        async fn create_started(
+            &self,
+            request: &ExternalCreateRequest,
+            lease: &dyn ExternalCreateLease,
+        ) -> Result<ExternalTask, CliError> {
+            lease.renew().await?;
+            Ok(task_from_request(request))
+        }
+
+        async fn recover_existing(
+            &self,
+            request: &ExternalCreateRequest,
+            lease: &dyn ExternalCreateLease,
+        ) -> Result<ExternalCreateProbe, CliError> {
+            lease.renew().await?;
+            Ok(ExternalCreateProbe::Found(task_from_request(request)))
+        }
+
+        fn extract_create_key(&self, task: &mut ExternalTask) -> Result<Option<String>, CliError> {
+            let marker = "\n<!-- create-key:create-key-1 -->";
+            let Some(body) = task.body.strip_suffix(marker).map(ToOwned::to_owned) else {
+                return Ok(None);
+            };
+            task.body = body;
+            Ok(Some("create-key-1".to_owned()))
+        }
+    }
+
+    struct NoMarkerRecoveryClient;
+
+    #[async_trait]
+    impl ExternalCreateRecoveryClient for NoMarkerRecoveryClient {
+        fn provider(&self) -> ExternalProvider {
+            ExternalProvider::GitHub
+        }
+
+        fn supports_target(&self, _provider_target: &str) -> bool {
+            false
+        }
+
+        async fn create_started(
+            &self,
+            _request: &ExternalCreateRequest,
+            _lease: &dyn ExternalCreateLease,
+        ) -> Result<ExternalTask, CliError> {
+            unreachable!("default marker test does not create")
+        }
+
+        async fn recover_existing(
+            &self,
+            _request: &ExternalCreateRequest,
+            _lease: &dyn ExternalCreateLease,
+        ) -> Result<ExternalCreateProbe, CliError> {
+            unreachable!("default marker test does not recover")
+        }
+    }
+
+    fn request() -> ExternalCreateRequest {
+        ExternalCreateRequest::new(
+            "task-1",
+            "create-key-1",
+            "Task title",
+            "Task body",
+            "project-1",
+        )
+    }
+
+    fn task_from_request(request: &ExternalCreateRequest) -> ExternalTask {
+        ExternalTask {
+            reference: ExternalTaskRef::new(ExternalProvider::Todoist, request.item_id()),
+            title: request.title().to_owned(),
+            body: request.body().to_owned(),
+            status: TaskBoardStatus::Backlog,
+            project_id: Some(request.provider_target().to_owned()),
+            updated_at: Some("revision-1".into()),
+        }
+    }
+
+    struct DefaultSyncClient;
+
+    #[async_trait]
+    impl ExternalSyncClient for DefaultSyncClient {
+        fn provider(&self) -> ExternalProvider {
+            ExternalProvider::GitHub
+        }
+
+        async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+            unreachable!("contract test does not pull")
+        }
+
+        async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+            unreachable!("contract test does not push")
+        }
+    }
+
+    struct CapableSyncClient {
+        recovery: FakeRecoveryClient,
+    }
+
+    #[async_trait]
+    impl ExternalSyncClient for CapableSyncClient {
+        fn provider(&self) -> ExternalProvider {
+            ExternalProvider::Todoist
+        }
+
+        fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+            Some(&self.recovery)
+        }
+
+        async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+            unreachable!("contract test does not pull")
+        }
+
+        async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+            unreachable!("contract test does not push")
+        }
+    }
+}

--- a/src/task_board/external/github.rs
+++ b/src/task_board/external/github.rs
@@ -11,9 +11,10 @@ use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 
 use super::targeting::github_repository_for_item;
 use super::{
-    ExternalProvider, ExternalProviderCapabilities, ExternalSyncClient, ExternalSyncConfig,
-    ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome,
-    GITHUB_REPOSITORY_ENV, HARNESS_GITHUB_REPOSITORY_ENV, non_empty_body, normalize_token,
+    ExternalCreateOutcome, ExternalProvider, ExternalProviderCapabilities, ExternalSyncClient,
+    ExternalSyncConfig, ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate,
+    ExternalUpdateOutcome, GITHUB_REPOSITORY_ENV, HARNESS_GITHUB_REPOSITORY_ENV, non_empty_body,
+    normalize_token,
 };
 
 mod errors;
@@ -215,13 +216,16 @@ impl ExternalSyncClient for GitHubSyncClient {
     }
 
     async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        Ok(self.push_task_with_outcome(item).await?.reference)
+    }
+
+    async fn push_task_with_outcome(
+        &self,
+        item: &TaskBoardItem,
+    ) -> Result<ExternalCreateOutcome, CliError> {
         let repository = self.repository_for(Some(item))?;
         let issue = self.create_issue(&repository, item).await?;
-        Ok(ExternalTaskRef::new(
-            ExternalProvider::GitHub,
-            github_external_id(&repository, issue.number),
-        )
-        .with_url(issue.html_url))
+        Ok(created_issue_outcome(&repository, issue))
     }
 
     async fn update_task(
@@ -299,6 +303,21 @@ impl GitHubRepository {
     }
 }
 
+fn created_issue_outcome(
+    repository: &GitHubRepository,
+    issue: write::GitHubIssueResponse,
+) -> ExternalCreateOutcome {
+    ExternalCreateOutcome {
+        reference: ExternalTaskRef::new(
+            ExternalProvider::GitHub,
+            github_external_id(repository, issue.number),
+        )
+        .with_url(issue.html_url),
+        provider_revision: issue.updated_at,
+        provider_project_id: Some(repository.slug()),
+    }
+}
+
 fn parse_github_repository(value: &str) -> Result<GitHubRepository, CliError> {
     let mut parts = value.split('/');
     let owner = parts.next().unwrap_or_default().trim();
@@ -318,7 +337,7 @@ fn parse_github_repository(value: &str) -> Result<GitHubRepository, CliError> {
 fn missing_github_repository_error() -> CliError {
     CliErrorKind::workflow_io(format!(
         "task-board github repository missing; set {HARNESS_GITHUB_REPOSITORY_ENV}, \
-         {GITHUB_REPOSITORY_ENV}, or item project_id as owner/repo"
+         {GITHUB_REPOSITORY_ENV}, or item execution_repository as owner/repo"
     ))
     .into()
 }

--- a/src/task_board/external/github.rs
+++ b/src/task_board/external/github.rs
@@ -11,16 +11,20 @@ use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 
 use super::targeting::github_repository_for_item;
 use super::{
-    ExternalCreateOutcome, ExternalProvider, ExternalProviderCapabilities, ExternalSyncClient,
-    ExternalSyncConfig, ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate,
-    ExternalUpdateOutcome, GITHUB_REPOSITORY_ENV, HARNESS_GITHUB_REPOSITORY_ENV, non_empty_body,
-    normalize_token,
+    ExternalCreateOutcome, ExternalCreateRecoveryClient, ExternalProvider,
+    ExternalProviderCapabilities, ExternalSyncClient, ExternalSyncConfig, ExternalSyncField,
+    ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome,
+    GITHUB_REPOSITORY_ENV, HARNESS_GITHUB_REPOSITORY_ENV, non_empty_body, normalize_token,
 };
 
+mod create_marker;
+mod create_recovery;
 mod errors;
 mod graphql;
 mod inbox;
 mod review_projection;
+#[cfg(test)]
+mod test_support;
 mod write;
 
 use errors::warn_github_message;
@@ -172,6 +176,14 @@ impl fmt::Debug for GitHubSyncClient {
 impl ExternalSyncClient for GitHubSyncClient {
     fn provider(&self) -> ExternalProvider {
         ExternalProvider::GitHub
+    }
+
+    #[allow(
+        private_interfaces,
+        reason = "provider-create recovery is intentionally crate-private"
+    )]
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        Some(self)
     }
 
     fn scope_id(&self) -> String {

--- a/src/task_board/external/github/create_marker.rs
+++ b/src/task_board/external/github/create_marker.rs
@@ -1,0 +1,112 @@
+use uuid::Uuid;
+
+use crate::errors::{CliError, CliErrorKind};
+
+const DELIMITER: &str = "\n\n";
+const COMMENT_OPEN: &str = "<!--";
+const RESERVED_STEM: &str = "harness-task-board-create";
+const MARKER_PREFIX: &str = "<!-- harness-task-board-create:v1:";
+const MARKER_SUFFIX: &str = " -->";
+
+pub(super) fn render_body(body: &str, create_key: &str) -> Result<String, CliError> {
+    let create_key = parse_canonical_key(create_key)?;
+    reject_terminal_reserved(body, "user body already ends with reserved evidence")?;
+    Ok(format!(
+        "{body}{DELIMITER}{MARKER_PREFIX}{create_key}{MARKER_SUFFIX}"
+    ))
+}
+
+pub(super) fn extract_from_body(body: &mut String) -> Result<Option<String>, CliError> {
+    let Some(evidence) = terminal_reserved(body) else {
+        return Ok(None);
+    };
+    if evidence.has_trailing_whitespace {
+        return Err(marker_error(
+            "must be byte-terminal without trailing whitespace",
+        ));
+    }
+    let create_key = parse_marker(evidence.comment)?;
+    let encoded_prefix = &body[..evidence.start];
+    let user_body = encoded_prefix
+        .strip_suffix(DELIMITER)
+        .ok_or_else(|| marker_error("must be preceded by the canonical delimiter"))?;
+    reject_terminal_reserved(user_body, "contains duplicate terminal reserved evidence")?;
+    let cleaned = user_body.to_owned();
+    *body = cleaned;
+    Ok(Some(create_key))
+}
+
+fn parse_marker(comment: &str) -> Result<String, CliError> {
+    let create_key = comment
+        .strip_prefix(MARKER_PREFIX)
+        .and_then(|value| value.strip_suffix(MARKER_SUFFIX))
+        .ok_or_else(|| marker_error("is not canonical"))?;
+    parse_canonical_key(create_key)
+}
+
+fn parse_canonical_key(create_key: &str) -> Result<String, CliError> {
+    let parsed = Uuid::parse_str(create_key)
+        .map_err(|error| marker_error(format!("has an invalid create key: {error}")))?;
+    let canonical = parsed.hyphenated().to_string();
+    if create_key != canonical {
+        return Err(marker_error("create key is not canonical"));
+    }
+    Ok(canonical)
+}
+
+fn reject_terminal_reserved(body: &str, detail: &str) -> Result<(), CliError> {
+    if terminal_reserved(body).is_some() {
+        return Err(marker_error(detail));
+    }
+    Ok(())
+}
+
+fn terminal_reserved(body: &str) -> Option<TerminalReserved<'_>> {
+    let trimmed = body.trim_end_matches(char::is_whitespace);
+    for (start, _) in trimmed.rmatch_indices(COMMENT_OPEN) {
+        let comment = &trimmed[start..];
+        if reserved_comment(comment)
+            && comment
+                .find("-->")
+                .is_none_or(|close| close + "-->".len() == comment.len())
+        {
+            return Some(TerminalReserved {
+                start,
+                comment,
+                has_trailing_whitespace: trimmed.len() != body.len(),
+            });
+        }
+    }
+    None
+}
+
+fn reserved_comment(comment: &str) -> bool {
+    let content = comment
+        .strip_prefix(COMMENT_OPEN)
+        .unwrap_or(comment)
+        .trim_start_matches(char::is_whitespace);
+    let Some(stem) = content.get(..RESERVED_STEM.len()) else {
+        return false;
+    };
+    if !stem.eq_ignore_ascii_case(RESERVED_STEM) {
+        return false;
+    }
+    content[RESERVED_STEM.len()..]
+        .chars()
+        .next()
+        .is_none_or(|next| next == ':' || next.is_whitespace())
+}
+
+fn marker_error(detail: impl Into<String>) -> CliError {
+    CliErrorKind::workflow_parse(format!("task-board github create marker {}", detail.into()))
+        .into()
+}
+
+struct TerminalReserved<'a> {
+    start: usize,
+    comment: &'a str,
+    has_trailing_whitespace: bool,
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/task_board/external/github/create_marker/tests.rs
+++ b/src/task_board/external/github/create_marker/tests.rs
@@ -1,0 +1,142 @@
+use super::*;
+
+const KEY: &str = "123e4567-e89b-12d3-a456-426614174000";
+const OTHER_KEY: &str = "123e4567-e89b-12d3-a456-426614174001";
+
+#[test]
+fn marker_round_trip_preserves_body_bytes() {
+    for body in [
+        "",
+        "Task body",
+        " \t",
+        "Zażółć gęślą jaźń 🐋",
+        "trailing ",
+        "trailing\t",
+        "trailing\n",
+        "trailing\r\n",
+        "trailing\n\n\n",
+    ] {
+        let mut encoded = render_body(body, KEY).expect("render marker");
+
+        assert_eq!(
+            encoded,
+            format!("{body}\n\n<!-- harness-task-board-create:v1:{KEY} -->")
+        );
+        assert_eq!(
+            extract_from_body(&mut encoded).expect("extract marker"),
+            Some(KEY.to_owned())
+        );
+        assert_eq!(encoded.as_bytes(), body.as_bytes());
+    }
+}
+
+#[test]
+fn renderer_rejects_noncanonical_create_keys() {
+    for key in [
+        "",
+        "123E4567-E89B-12D3-A456-426614174000",
+        "123e4567e89b12d3a456426614174000",
+        "{123e4567-e89b-12d3-a456-426614174000}",
+        "urn:uuid:123e4567-e89b-12d3-a456-426614174000",
+        " 123e4567-e89b-12d3-a456-426614174000",
+        "123e4567-e89b-12d3-a456-426614174000 ",
+        "123e4567-e89b-12d3-a456-42661417400g",
+    ] {
+        assert!(render_body("body", key).is_err(), "{key}");
+    }
+}
+
+#[test]
+fn embedded_lookalikes_are_ignored_without_mutation() {
+    for original in [
+        format!("<!-- harness-task-board-create:v1:{KEY} -->\nvisible"),
+        format!("<!-- harness-task-board-create:v1:{KEY} -->\nvisible -->"),
+        "<!-- harness-task-board-create:v1:not-a-key -->\nvisible".to_owned(),
+        "<!-- harness-task-board-created:v1:not-a-key -->".to_owned(),
+        "<!-- ordinary comment -->".to_owned(),
+    ] {
+        let mut body = original.clone();
+
+        assert_eq!(extract_from_body(&mut body).expect("ignore embedded"), None);
+        assert_eq!(body, original);
+    }
+}
+
+#[test]
+fn terminal_noncanonical_reserved_forms_fail_without_mutation() {
+    let marker = format!("<!-- harness-task-board-create:v1:{KEY} -->");
+    for original in [
+        marker.clone(),
+        format!("body\n{marker}"),
+        format!("body\r\n\r\n{marker}"),
+        format!("body\n\n{marker}\n"),
+        format!("body\n\n{marker} "),
+        format!("body\n\n{marker}\u{a0}"),
+        format!("body\n\n<!-- harness-task-board-create:v2:{KEY} -->"),
+        format!("body\n\n<!-- HARNESS-TASK-BOARD-CREATE:v1:{KEY} -->"),
+        format!("body\n\n<!-- harness-task-board-create:V1:{KEY} -->"),
+        format!("body\n\n<!-- harness-task-board-create:v1: {KEY} -->"),
+        format!("body\n\n<!-- harness-task-board-create:v1:{KEY}-->"),
+        format!("body\n\n<!-- harness-task-board-create:v1:{KEY} -- >"),
+        format!("body\n\n<!-- harness-task-board-create:v1:{KEY} <!-- -->"),
+        "body\n\n<!-- harness-task-board-create:v1:not-a-key -->".to_owned(),
+    ] {
+        let mut body = original.clone();
+
+        assert!(extract_from_body(&mut body).is_err(), "{original:?}");
+        assert_eq!(body, original);
+    }
+}
+
+#[test]
+fn duplicate_terminal_reserved_forms_fail_without_mutation() {
+    for original in [
+        format!(
+            "body\n\n<!-- harness-task-board-create:v1:{KEY} -->\n\n\
+             <!-- harness-task-board-create:v1:{KEY} -->"
+        ),
+        format!(
+            "body\n\n<!-- harness-task-board-create:v1:{KEY} -->\n\n\
+             <!-- harness-task-board-create:v1:{OTHER_KEY} -->"
+        ),
+        format!(
+            "body\n\n<!-- harness-task-board-create:v1:not-a-key -->\n\n\
+             <!-- harness-task-board-create:v1:{KEY} -->"
+        ),
+    ] {
+        let mut body = original.clone();
+
+        assert!(extract_from_body(&mut body).is_err());
+        assert_eq!(body, original);
+    }
+}
+
+#[test]
+fn renderer_rejects_terminal_reserved_evidence() {
+    let canonical = format!("body\n\n<!-- harness-task-board-create:v1:{KEY} -->");
+    let malformed = "body\n\n<!-- harness-task-board-create:v1:not-a-key -->";
+    let ambiguous = format!("body\n\n<!-- harness-task-board-create:v1:{KEY} <!-- -->");
+
+    assert!(render_body(&canonical, KEY).is_err());
+    assert!(render_body(&format!("{canonical}\nvisible"), KEY).is_ok());
+    assert!(render_body(malformed, KEY).is_err());
+    assert!(render_body(&format!("{malformed}\nvisible"), KEY).is_ok());
+    assert!(render_body(&ambiguous, KEY).is_err());
+}
+
+#[test]
+fn embedded_lookalikes_are_preserved_when_terminal_marker_is_removed() {
+    for original in [
+        format!("body\n<!-- harness-task-board-create:v1:{OTHER_KEY} -->\nvisible"),
+        format!("body\n<!-- harness-task-board-create:v1:{OTHER_KEY} -->\nvisible -->"),
+        "body\n<!-- harness-task-board-create:v1:not-a-key -->\nvisible".to_owned(),
+    ] {
+        let mut marked = render_body(&original, KEY).expect("render terminal marker");
+
+        assert_eq!(
+            extract_from_body(&mut marked).expect("extract terminal marker"),
+            Some(KEY.to_owned())
+        );
+        assert_eq!(marked, original);
+    }
+}

--- a/src/task_board/external/github/create_recovery.rs
+++ b/src/task_board/external/github/create_recovery.rs
@@ -1,0 +1,506 @@
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use reqwest::header::{HeaderMap, LINK};
+use reqwest::{Method, Url};
+use serde::Deserialize;
+
+use crate::errors::{CliError, CliErrorKind};
+use crate::github_api::{
+    GitHubCachePolicy, GitHubPriority, GitHubRequestDescriptor, retry_stable_read,
+};
+use crate::task_board::normalize_repository_slug;
+
+use super::super::{
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
+    ExternalProvider, ExternalTask,
+};
+use super::create_marker::{extract_from_body, render_body};
+use super::write::GitHubIssueResponse;
+use super::{GitHubRepository, GitHubSyncClient, parse_github_repository};
+
+const PAGE_SIZE: usize = 100;
+const MAX_SCAN_PAGES: u32 = 10_000;
+
+#[async_trait]
+impl ExternalCreateRecoveryClient for GitHubSyncClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::GitHub
+    }
+
+    fn supports_target(&self, provider_target: &str) -> bool {
+        let Some(normalized) = normalize_repository_slug(Some(provider_target)) else {
+            return false;
+        };
+        if normalized != provider_target {
+            return false;
+        }
+        self.repository.as_ref().is_none_or(|configured| {
+            normalize_repository_slug(Some(&configured.slug())).as_deref() == Some(&normalized)
+        })
+    }
+
+    async fn create_started(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError> {
+        let repository = self.recovery_repository(request.provider_target())?;
+        let marked_body = render_body(request.body(), request.create_key())?;
+        lease.renew().await?;
+        match self
+            .create_issue_fields(&repository, request.title(), Some(&marked_body))
+            .await
+        {
+            Ok(issue) => exact_created_task(issue, &repository, request.create_key()),
+            Err(create_error) => {
+                match self
+                    .scan_create_marker(&repository, request.create_key(), lease)
+                    .await
+                {
+                    Ok(RecoveryScanCompletion::Probe(ExternalCreateProbe::Found(task))) => Ok(task),
+                    Ok(RecoveryScanCompletion::Probe(ExternalCreateProbe::Absent)) => {
+                        Err(create_error)
+                    }
+                    Ok(RecoveryScanCompletion::DuplicateMatches) => {
+                        Err(duplicate_match_error(request.create_key()))
+                    }
+                    Err(scan_error) => {
+                        Err(combine_create_and_scan_errors(create_error, &scan_error))
+                    }
+                }
+            }
+        }
+    }
+
+    async fn recover_existing(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError> {
+        let repository = self.recovery_repository(request.provider_target())?;
+        let completion = self
+            .scan_create_marker(&repository, request.create_key(), lease)
+            .await?;
+        match completion {
+            RecoveryScanCompletion::Probe(found @ ExternalCreateProbe::Found(_)) => Ok(found),
+            RecoveryScanCompletion::Probe(ExternalCreateProbe::Absent) => {
+                Err(CliErrorKind::workflow_io(format!(
+                    "task-board github create recovery found no issue in {}; refusing to create again",
+                    repository.slug()
+                ))
+                .into())
+            }
+            RecoveryScanCompletion::DuplicateMatches => {
+                Err(duplicate_match_error(request.create_key()))
+            }
+        }
+    }
+
+    fn extract_create_key(&self, task: &mut ExternalTask) -> Result<Option<String>, CliError> {
+        extract_from_body(&mut task.body)
+    }
+}
+
+impl GitHubSyncClient {
+    fn recovery_repository(&self, provider_target: &str) -> Result<GitHubRepository, CliError> {
+        if !ExternalCreateRecoveryClient::supports_target(self, provider_target) {
+            return Err(CliErrorKind::workflow_io(format!(
+                "task-board github create recovery does not support target '{provider_target}'"
+            ))
+            .into());
+        }
+        parse_github_repository(provider_target)
+    }
+
+    async fn scan_create_marker(
+        &self,
+        repository: &GitHubRepository,
+        create_key: &str,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<RecoveryScanCompletion, CliError> {
+        retry_stable_read("task_board.github.create_recovery", |_| {
+            self.scan_create_marker_once(repository, create_key, lease)
+        })
+        .await
+        .map(|(probe, _)| probe)
+    }
+
+    async fn scan_create_marker_once(
+        &self,
+        repository: &GitHubRepository,
+        create_key: &str,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<RecoveryScanCompletion, CliError> {
+        let mut state = RecoveryScanState::default();
+        loop {
+            state.visit_page()?;
+            lease.renew().await?;
+            let route = recovery_route(repository, state.page);
+            let response = self
+                .protected()
+                .rest_json_with_headers::<Vec<GitHubRecoveryIssue>>(
+                    Method::GET,
+                    route,
+                    None,
+                    recovery_read_descriptor(),
+                    HeaderMap::new(),
+                )
+                .await?;
+            let issues = response.body.ok_or_else(|| {
+                CliErrorKind::workflow_io(
+                    "task-board github create recovery page returned no response body",
+                )
+            })?;
+            let next = validate_link_headers(&response.headers, state.page)?;
+            if issues.is_empty() {
+                if next.is_some() {
+                    return Err(scan_error(
+                        "empty terminal page unexpectedly advertised rel=next",
+                    ));
+                }
+                return Ok(state.finish());
+            }
+            if issues.len() > PAGE_SIZE {
+                return Err(scan_error(format!(
+                    "page {} exceeded the requested {PAGE_SIZE} rows",
+                    state.page
+                )));
+            }
+            for issue in issues {
+                state.observe_issue(issue, repository, create_key)?;
+            }
+            state.advance(next)?;
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct GitHubRecoveryIssue {
+    #[serde(flatten)]
+    issue: GitHubIssueResponse,
+    #[serde(default)]
+    pull_request: Option<serde_json::Value>,
+}
+
+#[derive(Default)]
+struct RecoveryScanState {
+    page: u32,
+    seen_pages: HashSet<u32>,
+    seen_issue_numbers: HashSet<u64>,
+    found: Option<ExternalTask>,
+    duplicate_match: bool,
+}
+
+impl RecoveryScanState {
+    fn visit_page(&mut self) -> Result<(), CliError> {
+        if self.page == 0 {
+            self.page = 1;
+        }
+        if self.page > MAX_SCAN_PAGES {
+            return Err(scan_error(format!(
+                "exceeded the {MAX_SCAN_PAGES}-page safety cap"
+            )));
+        }
+        if !self.seen_pages.insert(self.page) {
+            return Err(scan_error(format!("repeated page {}", self.page)));
+        }
+        Ok(())
+    }
+
+    fn observe_issue(
+        &mut self,
+        issue: GitHubRecoveryIssue,
+        repository: &GitHubRepository,
+        create_key: &str,
+    ) -> Result<(), CliError> {
+        let number = issue.issue.number;
+        if !self.seen_issue_numbers.insert(number) {
+            return Err(CliErrorKind::concurrent_modification(format!(
+                "task-board github create recovery repeated raw issue number {number}"
+            ))
+            .into());
+        }
+        if issue.pull_request.is_some() {
+            return Ok(());
+        }
+        let mut task = issue.issue.into_external_task(repository);
+        if extract_from_body(&mut task.body)?.as_deref() != Some(create_key) {
+            return Ok(());
+        }
+        if self.found.is_some() {
+            self.duplicate_match = true;
+        } else {
+            self.found = Some(task);
+        }
+        Ok(())
+    }
+
+    fn advance(&mut self, linked_next: Option<u32>) -> Result<(), CliError> {
+        let expected = self
+            .page
+            .checked_add(1)
+            .ok_or_else(|| scan_error("page number overflow"))?;
+        if expected > MAX_SCAN_PAGES {
+            return Err(scan_error(format!(
+                "reached the {MAX_SCAN_PAGES}-page safety cap before an empty terminal page"
+            )));
+        }
+        if let Some(linked_next) = linked_next
+            && linked_next != expected
+        {
+            return Err(scan_error(format!(
+                "rel=next page {linked_next} did not equal sequential page {expected}"
+            )));
+        }
+        self.page = expected;
+        Ok(())
+    }
+
+    fn finish(self) -> RecoveryScanCompletion {
+        if self.duplicate_match {
+            return RecoveryScanCompletion::DuplicateMatches;
+        }
+        RecoveryScanCompletion::Probe(
+            self.found
+                .map_or(ExternalCreateProbe::Absent, ExternalCreateProbe::Found),
+        )
+    }
+}
+
+enum RecoveryScanCompletion {
+    Probe(ExternalCreateProbe),
+    DuplicateMatches,
+}
+
+fn exact_created_task(
+    issue: GitHubIssueResponse,
+    repository: &GitHubRepository,
+    expected_key: &str,
+) -> Result<ExternalTask, CliError> {
+    let mut task = issue.into_external_task(repository);
+    let actual_key = extract_from_body(&mut task.body)?;
+    if actual_key.as_deref() != Some(expected_key) {
+        return Err(CliErrorKind::workflow_parse(
+            "task-board github created issue response did not contain the persisted create marker",
+        )
+        .into());
+    }
+    Ok(task)
+}
+
+fn recovery_route(repository: &GitHubRepository, page: u32) -> String {
+    format!(
+        "/repos/{}/{}/issues?filter=all&state=all&sort=created&direction=asc&per_page={PAGE_SIZE}&page={page}",
+        repository.owner, repository.repo
+    )
+}
+
+fn recovery_read_descriptor() -> GitHubRequestDescriptor {
+    GitHubRequestDescriptor::rest_core(
+        "task_board.github.create_recovery_page",
+        GitHubPriority::FreshRead,
+        GitHubCachePolicy::no_store(),
+    )
+}
+
+fn validate_link_headers(headers: &HeaderMap, current_page: u32) -> Result<Option<u32>, CliError> {
+    let mut next_page = None;
+    for value in headers.get_all(LINK) {
+        let value = value
+            .to_str()
+            .map_err(|error| scan_error(format!("Link header is not UTF-8: {error}")))?;
+        for entry in value.split(',') {
+            let parsed = parse_link_entry(entry.trim())?;
+            if parsed
+                .relations
+                .iter()
+                .any(|relation| relation.eq_ignore_ascii_case("next"))
+                && next_page.replace(parsed.page).is_some()
+            {
+                return Err(scan_error("duplicate rel=next Link entries"));
+            }
+        }
+    }
+    if let Some(next_page) = next_page {
+        let expected = current_page
+            .checked_add(1)
+            .ok_or_else(|| scan_error("page number overflow"))?;
+        if next_page <= current_page || next_page != expected {
+            return Err(scan_error(format!(
+                "rel=next page {next_page} did not equal sequential page {expected}"
+            )));
+        }
+    }
+    Ok(next_page)
+}
+
+struct ParsedLink {
+    page: u32,
+    relations: Vec<String>,
+}
+
+fn parse_link_entry(entry: &str) -> Result<ParsedLink, CliError> {
+    if entry.is_empty() {
+        return Err(scan_error("Link header contained an empty entry"));
+    }
+    let (target, parameters) = entry
+        .strip_prefix('<')
+        .and_then(|value| value.split_once('>'))
+        .ok_or_else(|| scan_error("Link entry must contain an angle-bracketed URL"))?;
+    if !parameters.starts_with(';') {
+        return Err(scan_error("Link entry URL must be followed by parameters"));
+    }
+    let url = Url::parse(target)
+        .map_err(|error| scan_error(format!("Link entry URL is invalid: {error}")))?;
+    validate_link_url(&url)?;
+    let relations = parse_link_relations(parameters)?;
+    let page = parse_link_page(&url)?;
+    Ok(ParsedLink { page, relations })
+}
+
+fn parse_link_relations(parameters: &str) -> Result<Vec<String>, CliError> {
+    let mut relations = None;
+    for parameter in parameters.split(';').skip(1) {
+        let (name, value) = parameter
+            .trim()
+            .split_once('=')
+            .ok_or_else(|| scan_error("Link parameter must use name=value syntax"))?;
+        let name = name.trim();
+        let value = value.trim();
+        if !valid_link_token(name) || value.is_empty() {
+            return Err(scan_error(
+                "Link parameter name must be a token and value must be nonempty",
+            ));
+        }
+        if name.eq_ignore_ascii_case("rel") {
+            if relations.is_some() {
+                return Err(scan_error("Link entry contained duplicate rel parameters"));
+            }
+            let value = value
+                .strip_prefix('"')
+                .and_then(|value| value.strip_suffix('"'))
+                .ok_or_else(|| scan_error("Link rel value must be quoted"))?;
+            let parsed = value
+                .split_ascii_whitespace()
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>();
+            if parsed.is_empty() {
+                return Err(scan_error("Link rel value must be nonempty"));
+            }
+            if parsed.iter().any(|relation| !valid_link_token(relation)) {
+                return Err(scan_error("Link rel value contained an invalid token"));
+            }
+            if parsed
+                .iter()
+                .filter(|relation| relation.eq_ignore_ascii_case("next"))
+                .count()
+                > 1
+            {
+                return Err(scan_error("Link entry contained duplicate next relations"));
+            }
+            relations = Some(parsed);
+        } else {
+            return Err(scan_error(format!(
+                "Link entry contained unsupported parameter '{name}'"
+            )));
+        }
+    }
+    relations.ok_or_else(|| scan_error("Link entry is missing a rel parameter"))
+}
+
+fn valid_link_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+fn validate_link_url(url: &Url) -> Result<(), CliError> {
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        return Err(scan_error("Link target must be an absolute HTTP URL"));
+    }
+    if !url.username().is_empty() || url.password().is_some() || url.fragment().is_some() {
+        return Err(scan_error(
+            "Link target must not contain credentials or a fragment",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_link_page(url: &Url) -> Result<u32, CliError> {
+    let mut page = None;
+    for (name, value) in url.query_pairs() {
+        if name == "page" {
+            if page.is_some() {
+                return Err(scan_error(
+                    "Link target contained a duplicate page parameter",
+                ));
+            }
+            page = Some(value.into_owned());
+        }
+    }
+    let page = page
+        .as_deref()
+        .ok_or_else(|| scan_error("Link target is missing the page parameter"))?;
+    let parsed = page
+        .parse::<u32>()
+        .map_err(|error| scan_error(format!("Link page is invalid: {error}")))?;
+    let canonical = parsed.to_string();
+    if parsed == 0 || page != canonical.as_str() {
+        return Err(scan_error("Link page is not a canonical positive integer"));
+    }
+    Ok(parsed)
+}
+
+fn combine_create_and_scan_errors(create_error: CliError, scan_error: &CliError) -> CliError {
+    let scan_details = error_with_details(scan_error);
+    let combined = format!("provider recovery scan also failed with {scan_details}");
+    let details = create_error.details().map_or_else(
+        || combined.clone(),
+        |details| format!("{details}; {combined}"),
+    );
+    create_error.with_details(details)
+}
+
+fn duplicate_match_error(create_key: &str) -> CliError {
+    CliErrorKind::concurrent_modification(format!(
+        "task-board github create recovery found multiple issues for create key '{create_key}'"
+    ))
+    .into()
+}
+
+fn error_with_details(error: &CliError) -> String {
+    error.details().map_or_else(
+        || error.to_string(),
+        |details| format!("{error}; {details}"),
+    )
+}
+
+fn scan_error(detail: impl Into<String>) -> CliError {
+    CliErrorKind::workflow_io(format!(
+        "task-board github create recovery scan was incomplete: {}",
+        detail.into()
+    ))
+    .into()
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/task_board/external/github/create_recovery/tests.rs
+++ b/src/task_board/external/github/create_recovery/tests.rs
@@ -1,0 +1,492 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use reqwest::header::{HeaderValue, LINK};
+use serde_json::json;
+
+use super::*;
+use crate::github_api::{GitHubProtectedClient, acquire_global_budget_test_lock};
+use crate::task_board::TaskBoardStatus;
+use crate::task_board::external::ExternalSyncClient;
+
+use super::super::test_support::{MockResponse, spawn_sequence_mock};
+
+const KEY: &str = "123e4567-e89b-12d3-a456-426614174000";
+
+mod post_error_tests;
+
+#[test]
+fn github_client_exposes_target_scoped_recovery_capability() {
+    let configured = sync_client("http://127.0.0.1:1", Some("acme/widgets"));
+    let linked = sync_client("http://127.0.0.1:1", None);
+    let recovery = configured
+        .external_create_recovery()
+        .expect("recovery capability");
+
+    assert_eq!(recovery.provider(), ExternalProvider::GitHub);
+    assert!(recovery.supports_target("acme/widgets"));
+    assert!(!recovery.supports_target("acme/other"));
+    assert!(!recovery.supports_target("Acme/Widgets"));
+    assert!(!recovery.supports_target(" acme/widgets "));
+    assert!(
+        linked
+            .external_create_recovery()
+            .expect("linked recovery")
+            .supports_target("other/repository")
+    );
+}
+
+#[tokio::test]
+async fn create_started_renews_then_posts_exact_marked_body() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let body = "Unicode 🐋 with trailing \t";
+    let marked = render_body(body, KEY).expect("marker");
+    let response = issue_json(17, &marked, false);
+    let (endpoint, captured, handle) = spawn_sequence_mock(vec![MockResponse::json(response)]);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+    let lease = TestLease::default();
+
+    let task = recovery(&client)
+        .create_started(&request(body), &lease)
+        .await
+        .expect("created task");
+
+    handle.join().expect("mock server");
+    assert_eq!(lease.count(), 1);
+    assert_task(&task, 17, body);
+    let captured = captured.lock().expect("captured");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].method, "POST");
+    assert_eq!(captured[0].path, "/repos/acme/widgets/issues");
+    let posted: serde_json::Value = serde_json::from_str(&captured[0].body).expect("posted JSON");
+    assert_eq!(posted["title"], "Task title");
+    assert_eq!(posted["body"], marked);
+}
+
+#[tokio::test]
+async fn lease_failure_prevents_initial_post() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let (endpoint, captured, handle) = spawn_sequence_mock(Vec::new());
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+    let lease = TestLease::failing_on(1);
+
+    let error = recovery(&client)
+        .create_started(&request("body"), &lease)
+        .await
+        .expect_err("lease failure");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert!(captured.lock().expect("captured").is_empty());
+}
+
+#[tokio::test]
+async fn created_response_without_marker_fails_closed_after_one_post() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let (endpoint, captured, handle) =
+        spawn_sequence_mock(vec![MockResponse::json(issue_json(16, "ordinary", false))]);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+
+    let error = recovery(&client)
+        .create_started(&request("body"), &TestLease::default())
+        .await
+        .expect_err("missing response marker");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_PARSE");
+    let captured = captured.lock().expect("captured");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].method, "POST");
+}
+
+#[tokio::test]
+async fn post_error_recovers_found_issue_with_one_exhaustive_scan() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let marked = render_body("body", KEY).expect("marker");
+    let responses = vec![
+        MockResponse::status(500, r#"{"message":"post failed"}"#),
+        MockResponse::json(format!("[{}]", issue_json(18, &marked, false))),
+        MockResponse::json("[]"),
+    ];
+    let (endpoint, captured, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+    let lease = TestLease::default();
+
+    let task = recovery(&client)
+        .create_started(&request("body"), &lease)
+        .await
+        .expect("recovered task");
+
+    handle.join().expect("mock server");
+    assert_task(&task, 18, "body");
+    assert_eq!(lease.count(), 3);
+    let captured = captured.lock().expect("captured");
+    assert_eq!(
+        captured
+            .iter()
+            .filter(|request| request.method == "POST")
+            .count(),
+        1
+    );
+    assert_eq!(captured[1].path, recovery_path(1));
+    assert_eq!(captured[2].path, recovery_path(2));
+}
+
+#[tokio::test]
+async fn post_error_absent_returns_original_and_incomplete_adds_scan_details() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let absent = run_failed_create(vec![
+        MockResponse::status(500, r#"{"message":"post failed"}"#),
+        MockResponse::json("[]"),
+    ])
+    .await;
+    let incomplete = run_failed_create(vec![
+        MockResponse::status(500, r#"{"message":"post failed"}"#),
+        MockResponse::status(500, r#"{"message":"scan failed"}"#),
+    ])
+    .await;
+
+    assert_eq!(absent.code(), "WORKFLOW_IO");
+    assert_eq!(incomplete.code(), absent.code());
+    assert_eq!(incomplete.message(), absent.message());
+    let original_details = absent.details().expect("original provider details");
+    assert!(
+        incomplete
+            .details()
+            .is_some_and(|details| details.starts_with(original_details)
+                && details.contains("provider recovery scan also failed"))
+    );
+}
+
+#[tokio::test]
+async fn recover_existing_is_get_only_and_returns_exact_found_task() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let marked = render_body("body", KEY).expect("marker");
+    let responses = vec![
+        MockResponse::json(format!("[{}]", issue_json(19, &marked, false))),
+        MockResponse::json("[]"),
+    ];
+    let (endpoint, captured, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+    let lease = TestLease::default();
+
+    let probe = recovery(&client)
+        .recover_existing(&request("body"), &lease)
+        .await
+        .expect("recovered");
+
+    handle.join().expect("mock server");
+    let ExternalCreateProbe::Found(task) = probe else {
+        panic!("expected found task");
+    };
+    assert_task(&task, 19, "body");
+    assert_eq!(lease.count(), 2);
+    assert!(
+        captured
+            .lock()
+            .expect("captured")
+            .iter()
+            .all(|request| request.method == "GET")
+    );
+}
+
+#[tokio::test]
+async fn recover_absent_is_blocked_without_posting() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let (endpoint, captured, handle) = spawn_sequence_mock(vec![MockResponse::json("[]")]);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+    let lease = TestLease::default();
+
+    let error = recovery(&client)
+        .recover_existing(&request("body"), &lease)
+        .await
+        .expect_err("absent recovery must stay blocked");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+    let captured = captured.lock().expect("captured");
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].method, "GET");
+}
+
+#[tokio::test]
+async fn scan_continues_after_first_match_and_rejects_a_second_issue() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let marked = render_body("body", KEY).expect("marker");
+    let responses = vec![
+        MockResponse::json(format!("[{}]", issue_json(20, &marked, false))),
+        MockResponse::json(format!("[{}]", issue_json(21, &marked, false))),
+        MockResponse::json("[]"),
+    ];
+    let (endpoint, captured, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+
+    let error = recovery(&client)
+        .recover_existing(&request("body"), &TestLease::default())
+        .await
+        .expect_err("duplicate marker");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    let captured = captured.lock().expect("captured");
+    assert_eq!(captured.len(), 3);
+    assert_eq!(captured[1].path, recovery_path(2));
+    assert_eq!(captured[2].path, recovery_path(3));
+}
+
+#[tokio::test]
+async fn repeated_raw_issue_number_is_rejected_before_pull_request_filtering() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let marked = render_body("body", KEY).expect("marker");
+    let responses = vec![
+        MockResponse::json(format!("[{}]", issue_json(22, &marked, true))),
+        MockResponse::json(format!("[{}]", issue_json(22, &marked, false))),
+    ];
+    let (endpoint, _, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+
+    let error = recovery(&client)
+        .recover_existing(&request("body"), &TestLease::default())
+        .await
+        .expect_err("repeated raw issue");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+}
+
+#[tokio::test]
+async fn pull_request_marker_is_skipped_and_absence_stays_blocked() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let marked = render_body("body", KEY).expect("marker");
+    let responses = vec![
+        MockResponse::json(format!("[{}]", issue_json(24, &marked, true))),
+        MockResponse::json("[]"),
+    ];
+    let (endpoint, captured, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+
+    let error = recovery(&client)
+        .recover_existing(&request("body"), &TestLease::default())
+        .await
+        .expect_err("pull request marker must not recover an issue");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+    assert_eq!(captured.lock().expect("captured").len(), 2);
+}
+
+#[tokio::test]
+async fn lease_failure_before_second_page_prevents_the_request() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let responses = vec![MockResponse::json(format!(
+        "[{}]",
+        issue_json(25, "ordinary", false)
+    ))];
+    let (endpoint, captured, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+
+    let error = recovery(&client)
+        .recover_existing(&request("body"), &TestLease::failing_on(2))
+        .await
+        .expect_err("second renewal");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(captured.lock().expect("captured").len(), 1);
+}
+
+#[tokio::test]
+async fn link_target_is_consistency_evidence_not_a_followed_url() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let next = alternate_link_url(2);
+    let responses = vec![
+        MockResponse::json(format!("[{}]", issue_json(23, "ordinary", false)))
+            .with_header("Link", format!("<{next}>; rel=\"next\"")),
+        MockResponse::json("[]"),
+    ];
+    let (endpoint, captured, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+
+    let error = recovery(&client)
+        .recover_existing(&request("body"), &TestLease::default())
+        .await
+        .expect_err("absent remains blocked");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+    let captured = captured.lock().expect("captured");
+    assert_eq!(captured[1].path, recovery_path(2));
+}
+
+#[tokio::test]
+async fn empty_page_with_next_link_is_incomplete() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let response =
+        MockResponse::json("[]").with_header("Link", format!("<{}>; rel=\"next\"", link_url(2)));
+    let (endpoint, _, handle) = spawn_sequence_mock(vec![response]);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+
+    let error = recovery(&client)
+        .recover_existing(&request("body"), &TestLease::default())
+        .await
+        .expect_err("empty page with next");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+    assert!(error.message().contains("empty terminal page"));
+}
+
+#[test]
+fn link_validation_rejects_incomplete_or_nonsequential_evidence() {
+    for value in [
+        "not-a-link".to_owned(),
+        format!("<{}>; rel=next", link_url(2)),
+        format!("<{}>; rel=\"next\"", link_url(1)),
+        format!("<{}>; rel=\"next\"", link_url(3)),
+        format!("<{}&page=2>; rel=\"next\"", link_url(2)),
+        format!("<{}>; rel=\"next\"", link_url_with_page("02")),
+        format!(
+            "<{}>; rel=\"next\", <{}>; rel=\"next\"",
+            link_url(2),
+            link_url(2)
+        ),
+        format!("<{}>; rel=\"next NEXT\"", link_url(2)),
+        format!("<{}>; rel=\"next\"; bad name=x", link_url(2)),
+        format!("<{}>; rel=\"next\"; title=\"unterminated", link_url(2)),
+    ] {
+        let mut headers = HeaderMap::new();
+        headers.insert(LINK, HeaderValue::from_str(&value).expect("header"));
+        assert!(validate_link_headers(&headers, 1).is_err(), "{value}");
+    }
+    let mut invalid_utf8 = HeaderMap::new();
+    invalid_utf8.insert(
+        LINK,
+        HeaderValue::from_bytes(b"\xff").expect("opaque header"),
+    );
+    assert!(validate_link_headers(&invalid_utf8, 1).is_err());
+}
+
+#[test]
+fn pagination_cap_and_overflow_fail_closed() {
+    let mut capped = RecoveryScanState {
+        page: MAX_SCAN_PAGES,
+        ..RecoveryScanState::default()
+    };
+    assert!(capped.advance(None).is_err());
+    assert!(
+        validate_link_headers(&HeaderMap::new(), u32::MAX).is_ok(),
+        "no Link does not claim a next page"
+    );
+    capped.page = u32::MAX;
+    assert!(capped.advance(None).is_err());
+    let mut repeated = RecoveryScanState::default();
+    repeated.visit_page().expect("first visit");
+    assert!(repeated.visit_page().is_err());
+}
+
+async fn run_failed_create(responses: Vec<MockResponse>) -> CliError {
+    let (endpoint, _, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+    let error = recovery(&client)
+        .create_started(&request("body"), &TestLease::default())
+        .await
+        .expect_err("failed create");
+    handle.join().expect("mock server");
+    error
+}
+
+fn sync_client(endpoint: &str, repository: Option<&str>) -> GitHubSyncClient {
+    GitHubSyncClient {
+        client: GitHubProtectedClient::with_base_url("token", endpoint).expect("client"),
+        repository: repository.map(|value| parse_github_repository(value).expect("repository")),
+        pull_enabled: false,
+        import_labels: Vec::new(),
+    }
+}
+
+fn recovery(client: &GitHubSyncClient) -> &dyn ExternalCreateRecoveryClient {
+    client
+        .external_create_recovery()
+        .expect("recovery capability")
+}
+
+fn request(body: &str) -> ExternalCreateRequest {
+    ExternalCreateRequest::new("task-1", KEY, "Task title", body, "acme/widgets")
+}
+
+fn issue_json(number: u64, body: &str, pull_request: bool) -> String {
+    let mut issue = json!({
+        "number": number,
+        "html_url": format!("https://example.test/acme/widgets/issues/{number}"),
+        "title": "Task title",
+        "body": body,
+        "state": "open",
+        "updated_at": "revision-1",
+    });
+    if pull_request {
+        issue["pull_request"] = json!({ "url": "https://example.test/pulls/1" });
+    }
+    issue.to_string()
+}
+
+fn assert_task(task: &ExternalTask, number: u64, body: &str) {
+    assert_eq!(task.reference.external_id, format!("acme/widgets#{number}"));
+    assert_eq!(
+        task.reference.url.as_deref(),
+        Some(format!("https://example.test/acme/widgets/issues/{number}").as_str())
+    );
+    assert_eq!(task.title, "Task title");
+    assert_eq!(task.body, body);
+    assert_eq!(task.status, TaskBoardStatus::Backlog);
+    assert_eq!(task.project_id.as_deref(), Some("acme/widgets"));
+    assert_eq!(task.updated_at.as_deref(), Some("revision-1"));
+}
+
+fn recovery_path(page: u32) -> String {
+    format!(
+        "/repos/acme/widgets/issues?filter=all&state=all&sort=created&direction=asc&per_page=100&page={page}"
+    )
+}
+
+fn link_url(page: u32) -> String {
+    link_url_with_page(&page.to_string())
+}
+
+fn link_url_with_page(page: &str) -> String {
+    format!(
+        "https://evidence.test/repos/acme/widgets/issues?filter=all&state=all&sort=created&direction=asc&per_page=100&page={page}"
+    )
+}
+
+fn alternate_link_url(page: u32) -> String {
+    format!("https://evidence.test/repositories/42/issues?cursor=opaque&page={page}")
+}
+
+#[derive(Default)]
+struct TestLease {
+    renewals: AtomicUsize,
+    fail_on: Option<usize>,
+}
+
+impl TestLease {
+    fn failing_on(call: usize) -> Self {
+        Self {
+            renewals: AtomicUsize::new(0),
+            fail_on: Some(call),
+        }
+    }
+
+    fn count(&self) -> usize {
+        self.renewals.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ExternalCreateLease for TestLease {
+    async fn renew(&self) -> Result<(), CliError> {
+        let call = self.renewals.fetch_add(1, Ordering::SeqCst) + 1;
+        if self.fail_on == Some(call) {
+            return Err(CliErrorKind::concurrent_modification("test lease was replaced").into());
+        }
+        Ok(())
+    }
+}

--- a/src/task_board/external/github/create_recovery/tests/post_error_tests.rs
+++ b/src/task_board/external/github/create_recovery/tests/post_error_tests.rs
@@ -1,0 +1,90 @@
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use super::*;
+use crate::github_api::begin_external_mutation;
+
+#[tokio::test]
+async fn post_error_with_duplicate_matches_returns_concurrent_evidence() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let marked = render_body("body", KEY).expect("marker");
+    let responses = vec![
+        MockResponse::status(500, r#"{"message":"post failed"}"#),
+        MockResponse::json(format!("[{}]", issue_json(26, &marked, false))),
+        MockResponse::json(format!("[{}]", issue_json(27, &marked, false))),
+        MockResponse::json("[]"),
+    ];
+    let (endpoint, captured, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+
+    let error = recovery(&client)
+        .create_started(&request("body"), &TestLease::default())
+        .await
+        .expect_err("duplicate recovered issues");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    let captured = captured.lock().expect("captured");
+    assert_eq!(captured.len(), 4);
+    assert_eq!(
+        captured
+            .iter()
+            .filter(|request| request.method == "POST")
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn data_revision_change_between_pages_restarts_the_entire_scan() {
+    let _guard = acquire_global_budget_test_lock().await;
+    let responses = vec![
+        MockResponse::json(format!("[{}]", issue_json(28, "ordinary", false))),
+        MockResponse::json("[]"),
+        MockResponse::json(format!("[{}]", issue_json(28, "ordinary", false))),
+        MockResponse::json("[]"),
+    ];
+    let (endpoint, captured, handle) = spawn_sequence_mock(responses);
+    let client = sync_client(&endpoint, Some("acme/widgets"));
+    let lease = RevisionChangingLease::default();
+
+    let error = recovery(&client)
+        .recover_existing(&request("body"), &lease)
+        .await
+        .expect_err("absent recovery remains blocked");
+
+    handle.join().expect("mock server");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+    assert_eq!(lease.renewals.load(Ordering::SeqCst), 4);
+    let captured = captured.lock().expect("captured");
+    assert_eq!(
+        captured
+            .iter()
+            .map(|request| request.path.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            recovery_path(1),
+            recovery_path(2),
+            recovery_path(1),
+            recovery_path(2),
+        ]
+    );
+}
+
+#[derive(Default)]
+struct RevisionChangingLease {
+    renewals: AtomicUsize,
+    changed: AtomicBool,
+}
+
+#[async_trait]
+impl ExternalCreateLease for RevisionChangingLease {
+    async fn renew(&self) -> Result<(), CliError> {
+        let call = self.renewals.fetch_add(1, Ordering::SeqCst) + 1;
+        if call == 2 && !self.changed.swap(true, Ordering::SeqCst) {
+            let mut mutation = begin_external_mutation("test.github.create_recovery_restart").await;
+            mutation.mark_remote_success();
+            drop(mutation);
+        }
+        Ok(())
+    }
+}

--- a/src/task_board/external/github/inbox/tests.rs
+++ b/src/task_board/external/github/inbox/tests.rs
@@ -6,6 +6,7 @@ use std::thread;
 use serde_json::json;
 
 use super::*;
+use crate::github_api::acquire_global_budget_test_lock;
 
 #[test]
 fn github_inbox_search_queries_use_github_all_state_issue_form() {
@@ -41,6 +42,7 @@ fn search_label_filter_admits_only_matching_labels() {
 
 #[tokio::test]
 async fn github_inbox_pull_skips_failed_repository_and_keeps_pullable_tasks() {
+    let _guard = acquire_global_budget_test_lock().await;
     let (endpoint, requests, handle) = spawn_sequence_mock(vec![
         MockResponse::json(200, viewer_response("octo-user")),
         MockResponse::json(
@@ -79,6 +81,7 @@ async fn github_inbox_pull_skips_failed_repository_and_keeps_pullable_tasks() {
 
 #[tokio::test]
 async fn github_inbox_pull_imports_review_requests_as_backlog() {
+    let _guard = acquire_global_budget_test_lock().await;
     let (endpoint, requests, handle) = spawn_sequence_mock(vec![
         MockResponse::json(200, viewer_response("octo-user")),
         MockResponse::json(200, empty_search_response()),
@@ -101,6 +104,7 @@ async fn github_inbox_pull_imports_review_requests_as_backlog() {
 
 #[tokio::test]
 async fn github_inbox_pull_maps_closed_assigned_issues_to_done() {
+    let _guard = acquire_global_budget_test_lock().await;
     let (endpoint, _requests, handle) = spawn_sequence_mock(vec![
         MockResponse::json(200, viewer_response("octo-user")),
         MockResponse::json(
@@ -120,6 +124,7 @@ async fn github_inbox_pull_maps_closed_assigned_issues_to_done() {
 
 #[tokio::test]
 async fn github_inbox_pull_fails_when_no_repository_can_be_pulled() {
+    let _guard = acquire_global_budget_test_lock().await;
     let (endpoint, _requests, handle) = spawn_sequence_mock(vec![
         MockResponse::json(200, viewer_response("octo-user")),
         MockResponse::json(

--- a/src/task_board/external/github/test_support.rs
+++ b/src/task_board/external/github/test_support.rs
@@ -1,0 +1,162 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Default)]
+pub(super) struct CapturedRequest {
+    pub(super) method: String,
+    pub(super) path: String,
+    pub(super) body: String,
+}
+
+pub(super) struct MockResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: String,
+}
+
+impl MockResponse {
+    pub(super) fn json(body: impl Into<String>) -> Self {
+        Self {
+            status: 200,
+            headers: Vec::new(),
+            body: body.into(),
+        }
+    }
+
+    pub(super) fn status(status: u16, body: impl Into<String>) -> Self {
+        Self {
+            status,
+            headers: Vec::new(),
+            body: body.into(),
+        }
+    }
+
+    #[must_use]
+    pub(super) fn with_header(mut self, name: &str, value: impl Into<String>) -> Self {
+        self.headers.push((name.to_owned(), value.into()));
+        self
+    }
+}
+
+pub(super) fn spawn_sequence_mock(
+    responses: Vec<MockResponse>,
+) -> (
+    String,
+    Arc<Mutex<Vec<CapturedRequest>>>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    listener.set_nonblocking(true).expect("nonblocking");
+    let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let captured_clone = Arc::clone(&captured);
+    let handle = thread::spawn(move || {
+        for response in responses {
+            let mut stream = accept_before_deadline(&listener);
+            let request = read_http_request(&mut stream);
+            captured_clone
+                .lock()
+                .expect("captured requests")
+                .push(capture_request(&request));
+            write_response(&mut stream, response);
+        }
+    });
+    (endpoint, captured, handle)
+}
+
+fn accept_before_deadline(listener: &TcpListener) -> TcpStream {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => return stream,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                assert!(Instant::now() < deadline, "timed out waiting for request");
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => panic!("accept request: {error}"),
+        }
+    }
+}
+
+fn read_http_request(stream: &mut TcpStream) -> String {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("read timeout");
+    let mut buffer = Vec::new();
+    loop {
+        let mut chunk = [0_u8; 1024];
+        let read = stream.read(&mut chunk).expect("read request");
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+        if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    read_http_request_body(stream, &mut buffer);
+    String::from_utf8(buffer).expect("utf8 request")
+}
+
+fn read_http_request_body(stream: &mut TcpStream, buffer: &mut Vec<u8>) {
+    let header_end = buffer
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map_or(buffer.len(), |position| position + 4);
+    let headers = String::from_utf8(buffer[..header_end].to_vec()).expect("utf8 headers");
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            line.split_once(':').and_then(|(name, value)| {
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+        })
+        .unwrap_or_default();
+    while buffer.len().saturating_sub(header_end) < content_length {
+        let mut chunk = [0_u8; 1024];
+        let read = stream.read(&mut chunk).expect("read request body");
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+}
+
+fn capture_request(request: &str) -> CapturedRequest {
+    let mut request_line = request
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace();
+    CapturedRequest {
+        method: request_line.next().unwrap_or_default().into(),
+        path: request_line.next().unwrap_or_default().into(),
+        body: request.split("\r\n\r\n").nth(1).unwrap_or_default().into(),
+    }
+}
+
+fn write_response(stream: &mut TcpStream, response: MockResponse) {
+    let reason = if response.status == 200 {
+        "OK"
+    } else {
+        "Server Error"
+    };
+    let extra_headers = response
+        .headers
+        .into_iter()
+        .map(|(name, value)| format!("{name}: {value}\r\n"))
+        .collect::<String>();
+    let raw = format!(
+        "HTTP/1.1 {} {reason}\r\nContent-Type: application/json\r\n{extra_headers}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response.status,
+        response.body.len(),
+        response.body
+    );
+    stream.write_all(raw.as_bytes()).expect("write response");
+    stream.flush().expect("flush response");
+}

--- a/src/task_board/external/github/write.rs
+++ b/src/task_board/external/github/write.rs
@@ -17,9 +17,20 @@ impl GitHubSyncClient {
         repository: &GitHubRepository,
         item: &TaskBoardItem,
     ) -> Result<GitHubIssueResponse, CliError> {
+        let body = non_empty_body(&item.body);
+        self.create_issue_fields(repository, &item.title, body.as_deref())
+            .await
+    }
+
+    pub(super) async fn create_issue_fields(
+        &self,
+        repository: &GitHubRepository,
+        title: &str,
+        body_text: Option<&str>,
+    ) -> Result<GitHubIssueResponse, CliError> {
         let mut body = serde_json::Map::new();
-        body.insert("title".into(), serde_json::json!(item.title));
-        if let Some(body_text) = non_empty_body(&item.body) {
+        body.insert("title".into(), serde_json::json!(title));
+        if let Some(body_text) = body_text {
             body.insert("body".into(), serde_json::json!(body_text));
         }
         let route = format!("/repos/{}/{}/issues", repository.owner, repository.repo);

--- a/src/task_board/external/github/write/tests.rs
+++ b/src/task_board/external/github/write/tests.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use super::super::*;
+use super::GitHubIssueResponse;
 use crate::github_api::GitHubProtectedClient;
 
 #[derive(Debug, Default)]
@@ -11,6 +12,35 @@ struct CapturedRequest {
     method: String,
     path: String,
     body: String,
+}
+
+#[test]
+fn github_create_uses_configured_repository_and_returns_provider_revision() {
+    let client = sync_client("http://127.0.0.1:1");
+    let item = local_item();
+    let repository = client
+        .repository_for(Some(&item))
+        .expect("configured repository");
+    let issue = GitHubIssueResponse {
+        number: 17,
+        html_url: "https://github.test/acme/widgets/issues/17".to_owned(),
+        title: "Local edit".to_owned(),
+        body: Some("Local body".to_owned()),
+        state: "open".to_owned(),
+        updated_at: Some("provider-revision-1".to_owned()),
+    };
+
+    let outcome = created_issue_outcome(&repository, issue);
+
+    assert_eq!(
+        outcome.reference.external_id, "acme/widgets#17",
+        "provider reference must identify the configured repository"
+    );
+    assert_eq!(
+        outcome.provider_revision.as_deref(),
+        Some("provider-revision-1")
+    );
+    assert_eq!(outcome.provider_project_id.as_deref(), Some("acme/widgets"));
 }
 
 #[tokio::test]
@@ -115,7 +145,7 @@ fn local_item() -> TaskBoardItem {
         "Local body".into(),
         "2026-07-16T10:00:00Z".into(),
     );
-    item.project_id = Some("acme/widgets".into());
+    item.project_id = Some("portfolio-a".into());
     item
 }
 

--- a/src/task_board/external/github/write/tests.rs
+++ b/src/task_board/external/github/write/tests.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use super::super::*;
 use super::GitHubIssueResponse;
-use crate::github_api::GitHubProtectedClient;
+use crate::github_api::{GitHubProtectedClient, acquire_global_budget_test_lock};
 
 #[derive(Debug, Default)]
 struct CapturedRequest {
@@ -45,6 +45,7 @@ fn github_create_uses_configured_repository_and_returns_provider_revision() {
 
 #[tokio::test]
 async fn stale_github_precondition_returns_fresh_remote_snapshot_without_patch() {
+    let _guard = acquire_global_budget_test_lock().await;
     let (endpoint, captured, handle) = spawn_sequence_mock(vec![
         issue_revision_response("provider-revision-2"),
         issue_response(
@@ -87,6 +88,7 @@ async fn stale_github_precondition_returns_fresh_remote_snapshot_without_patch()
 
 #[tokio::test]
 async fn matching_github_precondition_reads_fresh_then_patches() {
+    let _guard = acquire_global_budget_test_lock().await;
     let (endpoint, captured, handle) = spawn_sequence_mock(vec![
         issue_revision_response("provider-revision-1"),
         issue_response("Base title", "Remote body", "open", "provider-revision-1"),

--- a/src/task_board/external/scopes.rs
+++ b/src/task_board/external/scopes.rs
@@ -16,6 +16,8 @@ impl ExternalProviderScopeIdentity {
         let resource_id = normalize_resource_id(provider, &client.scope_id());
         let role = if client.allows_push() {
             "write"
+        } else if client.authoritative_review_inbox() {
+            "authoritative_read"
         } else {
             "read"
         };
@@ -180,12 +182,16 @@ impl ExternalSyncScopeOutcome {
     }
 
     pub(crate) fn failed(provider: ExternalProvider, scope_id: String, error: &CliError) -> Self {
+        let message = error.details().map_or_else(
+            || error.message(),
+            |details| format!("{}; {details}", error.message()),
+        );
         Self {
             provider,
             scope_id,
             kind: ExternalSyncScopeOutcomeKind::Failed,
             error_code: Some(error.code().to_owned()),
-            error: Some(error.message()),
+            error: Some(message),
         }
     }
 
@@ -205,10 +211,14 @@ pub(crate) struct ExternalSyncBatch {
     pub(crate) operations: Vec<ExternalSyncOperation>,
     pub(crate) scope_outcomes: Vec<ExternalSyncScopeOutcome>,
     pub(crate) first_provider_failure: Option<CliError>,
+    pub(crate) terminal_error: Option<CliError>,
 }
 
 impl ExternalSyncBatch {
     pub(crate) fn into_completed(mut self) -> Result<Self, CliError> {
+        if let Some(error) = self.terminal_error.take() {
+            return Err(error);
+        }
         if self.succeeded_scope_count() == 0
             && let Some(error) = self.first_provider_failure.take()
         {
@@ -282,16 +292,19 @@ mod tests {
             provider: ExternalProvider::GitHub,
             scope_id: " Acme/Widgets ",
             allows_push: true,
+            authoritative_review_inbox: false,
         };
         let inbox = ScopeClient {
             provider: ExternalProvider::GitHub,
             scope_id: "acme/widgets",
             allows_push: false,
+            authoritative_review_inbox: false,
         };
         let todoist = ScopeClient {
             provider: ExternalProvider::Todoist,
             scope_id: "acme/widgets",
             allows_push: true,
+            authoritative_review_inbox: false,
         };
 
         let repository_scope = ExternalProviderScopeIdentity::for_client(&repository_sync);
@@ -305,6 +318,32 @@ mod tests {
         assert_eq!(inbox_scope.scope_id(), "v1:github:read:12:acme/widgets");
         assert_ne!(repository_scope, inbox_scope);
         assert_ne!(repository_scope, todoist_scope);
+    }
+
+    #[test]
+    fn authoritative_review_reader_has_distinct_scope_role() {
+        let shared_review = ScopeClient {
+            provider: ExternalProvider::GitHub,
+            scope_id: "org/repository",
+            allows_push: false,
+            authoritative_review_inbox: false,
+        };
+        let assigned_inbox = ScopeClient {
+            provider: ExternalProvider::GitHub,
+            scope_id: "org/repository",
+            allows_push: false,
+            authoritative_review_inbox: true,
+        };
+
+        let shared_scope = ExternalProviderScopeIdentity::for_client(&shared_review);
+        let assigned_scope = ExternalProviderScopeIdentity::for_client(&assigned_inbox);
+
+        assert_eq!(shared_scope.scope_id(), "v1:github:read:14:org/repository");
+        assert_eq!(
+            assigned_scope.scope_id(),
+            "v1:github:authoritative_read:14:org/repository"
+        );
+        assert_ne!(shared_scope, assigned_scope);
     }
 
     #[test]
@@ -330,6 +369,7 @@ mod tests {
         provider: ExternalProvider,
         scope_id: &'static str,
         allows_push: bool,
+        authoritative_review_inbox: bool,
     }
 
     #[async_trait]
@@ -344,6 +384,10 @@ mod tests {
 
         fn allows_push(&self) -> bool {
             self.allows_push
+        }
+
+        fn authoritative_review_inbox(&self) -> bool {
+            self.authoritative_review_inbox
         }
 
         async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {

--- a/src/task_board/external/scopes.rs
+++ b/src/task_board/external/scopes.rs
@@ -3,6 +3,7 @@ use chrono::DateTime;
 use crate::errors::{CliError, CliErrorKind};
 
 use super::{ExternalProvider, ExternalSyncClient, ExternalSyncOperation};
+use crate::task_board::TaskBoardExternalCreateIntent;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ExternalProviderScopeIdentity {
@@ -209,6 +210,7 @@ impl ExternalSyncScopeOutcome {
 #[derive(Debug)]
 pub(crate) struct ExternalSyncBatch {
     pub(crate) operations: Vec<ExternalSyncOperation>,
+    pub(crate) external_create_follow_ups: Vec<TaskBoardExternalCreateIntent>,
     pub(crate) scope_outcomes: Vec<ExternalSyncScopeOutcome>,
     pub(crate) first_provider_failure: Option<CliError>,
     pub(crate) terminal_error: Option<CliError>,

--- a/src/task_board/external/sync.rs
+++ b/src/task_board/external/sync.rs
@@ -19,6 +19,8 @@ mod conflicts;
 mod delete;
 mod import;
 #[cfg(test)]
+mod lease_tests;
+#[cfg(test)]
 mod legacy_store;
 mod lookup;
 mod merge;
@@ -36,7 +38,7 @@ use push::push_board_tasks;
 use reconcile::reconcile_existing_item;
 use scope::SyncClientError;
 use stale_reviews::reconcile_stale_github_review_requests;
-pub(crate) use store::TaskBoardSyncStore;
+pub(crate) use store::{TaskBoardSyncItemSnapshot, TaskBoardSyncStore};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 #[value(rename_all = "snake_case")]

--- a/src/task_board/external/sync.rs
+++ b/src/task_board/external/sync.rs
@@ -4,19 +4,20 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::CliError;
+use crate::task_board::TaskBoardExternalCreateIntent;
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 use crate::workspace::utc_now;
 
 use super::targeting::{board_project_id_for_task, execution_repository_for_task};
 use super::{
-    ExternalCreateOutcome, ExternalProvider, ExternalSyncClient, ExternalSyncConfig,
-    ExternalSyncConflictPolicy, ExternalSyncField, ExternalTask, ExternalTaskRef,
-    ExternalTaskUpdate, ExternalUpdateOutcome, GitHubInboxSyncClient, GitHubSyncClient,
-    TodoistSyncClient, canonical_external_status,
+    ExternalProvider, ExternalSyncClient, ExternalSyncConfig, ExternalSyncConflictPolicy,
+    ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome,
+    GitHubInboxSyncClient, GitHubSyncClient, TodoistSyncClient, canonical_external_status,
 };
 
 mod batch;
 mod conflicts;
+mod create_recovery;
 mod delete;
 #[cfg(test)]
 mod evidence_tests;
@@ -33,7 +34,14 @@ mod scope;
 mod stale_reviews;
 mod store;
 
-pub(crate) use batch::{sync_external_tasks, sync_external_tasks_scoped};
+#[cfg(test)]
+pub(crate) use batch::sync_external_tasks_scoped;
+pub(crate) use batch::{sync_external_tasks, sync_external_tasks_scoped_with_recovery};
+pub(crate) use create_recovery::{
+    assign_external_create_recovery, blocked_external_create_follow_ups,
+    blocked_external_create_recovery, load_external_create_recovery_work,
+    prepare_external_create_recovery,
+};
 use import::{external_item_id, imported_external_planning};
 use lookup::{OperationDraft, build_external_ref_index, item_for_ref, operation, provider_ref};
 use merge::{matching_ref, pull_create_fields, sync_state_from_task};
@@ -41,7 +49,9 @@ use push::push_board_tasks;
 use reconcile::reconcile_existing_item;
 use scope::SyncClientError;
 use stale_reviews::reconcile_stale_github_review_requests;
-pub(crate) use store::{TaskBoardSyncItemSnapshot, TaskBoardSyncStore};
+pub(crate) use store::{
+    TaskBoardExternalCreateStore, TaskBoardSyncItemSnapshot, TaskBoardSyncStore,
+};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 #[value(rename_all = "snake_case")]
@@ -208,7 +218,17 @@ async fn pull_provider_tasks(
     client: &dyn ExternalSyncClient,
     tasks: Vec<ExternalTask>,
     operations: &mut Vec<ExternalSyncOperation>,
-) -> Result<(), CliError> {
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<bool, CliError> {
+    let (tasks, recovered_create) = create_recovery::suppress_known_create_markers(
+        board,
+        client,
+        tasks,
+        operations,
+        follow_ups,
+        options.dry_run,
+    )
+    .await?;
     let board_items = board.list_items(None).await?;
     let item_index = build_external_ref_index(&board_items);
     for task in tasks.iter().cloned() {
@@ -273,7 +293,7 @@ async fn pull_provider_tasks(
         operations,
     )
     .await?;
-    Ok(())
+    Ok(recovered_create)
 }
 
 fn existing_pull_matches_status_filter(

--- a/src/task_board/external/sync.rs
+++ b/src/task_board/external/sync.rs
@@ -18,6 +18,8 @@ use super::{
 mod batch;
 mod conflicts;
 mod delete;
+#[cfg(test)]
+mod evidence_tests;
 mod import;
 #[cfg(test)]
 mod lease_tests;

--- a/src/task_board/external/sync.rs
+++ b/src/task_board/external/sync.rs
@@ -7,11 +7,12 @@ use crate::errors::CliError;
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 use crate::workspace::utc_now;
 
-use super::targeting::execution_repository_for_task;
+use super::targeting::{board_project_id_for_task, execution_repository_for_task};
 use super::{
-    ExternalProvider, ExternalSyncClient, ExternalSyncConfig, ExternalSyncConflictPolicy,
-    ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome,
-    GitHubInboxSyncClient, GitHubSyncClient, TodoistSyncClient, canonical_external_status,
+    ExternalCreateOutcome, ExternalProvider, ExternalSyncClient, ExternalSyncConfig,
+    ExternalSyncConflictPolicy, ExternalSyncField, ExternalTask, ExternalTaskRef,
+    ExternalTaskUpdate, ExternalUpdateOutcome, GitHubInboxSyncClient, GitHubSyncClient,
+    TodoistSyncClient, canonical_external_status,
 };
 
 mod batch;
@@ -314,7 +315,7 @@ fn create_item_from_external(task: &ExternalTask) -> TaskBoardItem {
         now,
     );
     item.status = canonical_external_status(task.status);
-    item.project_id.clone_from(&task.project_id);
+    item.project_id = board_project_id_for_task(task);
     item.execution_repository = execution_repository_for_task(task);
     let mut reference = task.reference.clone().into_core_ref();
     reference.sync_state = Some(sync_state_from_task(task));

--- a/src/task_board/external/sync/batch.rs
+++ b/src/task_board/external/sync/batch.rs
@@ -1,4 +1,5 @@
-use crate::errors::CliError;
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::TaskBoardExternalCreateIntent;
 use crate::task_board::external::{
     ExternalProvider, ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
     ExternalProviderScopeAvailability, ExternalProviderScopeIdentity, ExternalSyncBatch,
@@ -6,6 +7,9 @@ use crate::task_board::external::{
 };
 use crate::workspace::utc_now;
 
+use super::create_recovery::{
+    ExternalCreateRecoveryPlan, ExternalCreateScopeRecovery, recover_scope_intents,
+};
 use super::delete::delete_remote_tombstones;
 use super::lookup::provider_is_allowed;
 use super::{
@@ -32,17 +36,49 @@ pub(crate) async fn sync_external_tasks_scoped(
     options: ExternalSyncOptions,
     clients: &[Box<dyn ExternalSyncClient>],
 ) -> Result<ExternalSyncBatch, CliError> {
-    let mut batch = BatchAccumulator::default();
+    sync_external_tasks_scoped_with_recovery(
+        board,
+        options,
+        clients,
+        ExternalCreateRecoveryPlan::default(),
+    )
+    .await
+}
+
+pub(crate) async fn sync_external_tasks_scoped_with_recovery(
+    board: &dyn TaskBoardSyncStore,
+    options: ExternalSyncOptions,
+    clients: &[Box<dyn ExternalSyncClient>],
+    mut recovery: ExternalCreateRecoveryPlan,
+) -> Result<ExternalSyncBatch, CliError> {
+    let mut batch = BatchAccumulator {
+        operations: recovery.take_operations(),
+        external_create_follow_ups: recovery.take_follow_ups(),
+        ..BatchAccumulator::default()
+    };
     for client in clients {
         if provider_is_allowed(client.provider(), options.provider) {
-            sync_scope(board, options, client.as_ref(), &mut batch).await?;
+            let scope = ExternalProviderScopeIdentity::for_client(client.as_ref());
+            let recovery_scope = recovery.take_scope(scope.provider(), scope.scope_id());
+            sync_scope(board, options, client.as_ref(), &recovery_scope, &mut batch).await?;
             if batch.terminal_error.is_some() {
                 break;
             }
         }
     }
+    if batch.terminal_error.is_none() && recovery.has_recovery() {
+        let blocked = recovery.into_blocked(
+            CliErrorKind::workflow_io(
+                "provider create recovery has no configured client for its persisted scope",
+            )
+            .into(),
+        );
+        batch.scope_outcomes.extend(blocked.scope_outcomes);
+        batch.terminal_error = blocked.terminal_error;
+    }
     Ok(ExternalSyncBatch {
         operations: batch.operations,
+        external_create_follow_ups: batch.external_create_follow_ups,
         scope_outcomes: batch.scope_outcomes,
         first_provider_failure: batch.first_provider_failure,
         terminal_error: batch.terminal_error,
@@ -52,6 +88,7 @@ pub(crate) async fn sync_external_tasks_scoped(
 #[derive(Default)]
 struct BatchAccumulator {
     operations: Vec<ExternalSyncOperation>,
+    external_create_follow_ups: Vec<TaskBoardExternalCreateIntent>,
     scope_outcomes: Vec<ExternalSyncScopeOutcome>,
     first_provider_failure: Option<CliError>,
     terminal_error: Option<CliError>,
@@ -61,6 +98,7 @@ async fn sync_scope(
     board: &dyn TaskBoardSyncStore,
     options: ExternalSyncOptions,
     client: &dyn ExternalSyncClient,
+    recovery: &ExternalCreateScopeRecovery,
     batch: &mut BatchAccumulator,
 ) -> Result<(), CliError> {
     let scope = ExternalProviderScopeIdentity::for_client(client);
@@ -75,7 +113,16 @@ async fn sync_scope(
             return Ok(());
         }
     };
-    sync_admitted_scope(board, options, client, &scope, attempt.as_ref(), batch).await
+    sync_admitted_scope(
+        board,
+        options,
+        client,
+        &scope,
+        attempt.as_ref(),
+        recovery,
+        batch,
+    )
+    .await
 }
 
 async fn sync_admitted_scope(
@@ -84,12 +131,88 @@ async fn sync_admitted_scope(
     client: &dyn ExternalSyncClient,
     scope: &ExternalProviderScopeIdentity,
     attempt: Option<&ExternalProviderScopeAttempt>,
+    recovery: &ExternalCreateScopeRecovery,
     batch: &mut BatchAccumulator,
 ) -> Result<(), CliError> {
     let provider = scope.provider();
     let scope_id = scope.scope_id().to_owned();
-    match sync_client(board, options, client, attempt, &mut batch.operations).await {
-        Ok(base_revision) => {
+    let sync_result = run_scope_work(
+        board,
+        options,
+        client,
+        attempt,
+        &recovery.intents,
+        &mut batch.operations,
+        &mut batch.external_create_follow_ups,
+    )
+    .await?;
+    finish_scope_work(
+        board,
+        attempt,
+        provider,
+        scope_id,
+        recovery.touched,
+        sync_result,
+        batch,
+    )
+    .await
+}
+
+async fn run_scope_work(
+    board: &dyn TaskBoardSyncStore,
+    options: ExternalSyncOptions,
+    client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+    recovery_intents: &[TaskBoardExternalCreateIntent],
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<Result<SyncClientResult, SyncClientError>, CliError> {
+    if recovery_intents.is_empty() {
+        return Ok(sync_client(board, options, client, attempt, operations, follow_ups).await);
+    }
+    let Some(attempt) = attempt else {
+        return Err(CliErrorKind::workflow_io(
+            "provider create recovery requires a persisted scope attempt",
+        )
+        .into());
+    };
+    if let Err(error) = recover_scope_intents(
+        board,
+        client,
+        attempt,
+        recovery_intents,
+        operations,
+        follow_ups,
+    )
+    .await
+    {
+        return Ok(Err(error));
+    }
+    Ok(sync_client(
+        board,
+        options,
+        client,
+        Some(attempt),
+        operations,
+        follow_ups,
+    )
+    .await)
+}
+
+async fn finish_scope_work(
+    board: &dyn TaskBoardSyncStore,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+    provider: ExternalProvider,
+    scope_id: String,
+    recovery_touched: bool,
+    sync_result: Result<SyncClientResult, SyncClientError>,
+    batch: &mut BatchAccumulator,
+) -> Result<(), CliError> {
+    match sync_result {
+        Ok(result) => {
+            let base_revision = (!recovery_touched && !result.durable_create)
+                .then_some(result.base_revision)
+                .flatten();
             record_scope_success(
                 board,
                 attempt,
@@ -238,10 +361,25 @@ async fn sync_client(
     client: &dyn ExternalSyncClient,
     attempt: Option<&ExternalProviderScopeAttempt>,
     operations: &mut Vec<ExternalSyncOperation>,
-) -> Result<Option<String>, SyncClientError> {
-    let base_revision = pull_client_tasks(board, options, client, attempt, operations).await?;
-    push_client_tasks(board, options, client, attempt, operations).await?;
-    Ok(base_revision)
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<SyncClientResult, SyncClientError> {
+    let pull = pull_client_tasks(board, options, client, attempt, operations, follow_ups).await?;
+    let pushed_create =
+        push_client_tasks(board, options, client, attempt, operations, follow_ups).await?;
+    Ok(SyncClientResult {
+        base_revision: pull.base_revision,
+        durable_create: pull.recovered_create || pushed_create,
+    })
+}
+
+struct SyncClientResult {
+    base_revision: Option<String>,
+    durable_create: bool,
+}
+
+struct PullClientResult {
+    base_revision: Option<String>,
+    recovered_create: bool,
 }
 
 async fn pull_client_tasks(
@@ -250,9 +388,13 @@ async fn pull_client_tasks(
     client: &dyn ExternalSyncClient,
     attempt: Option<&ExternalProviderScopeAttempt>,
     operations: &mut Vec<ExternalSyncOperation>,
-) -> Result<Option<String>, SyncClientError> {
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<PullClientResult, SyncClientError> {
     if !direction_allows_pull(options.direction) || !client.allows_pull() {
-        return Ok(None);
+        return Ok(PullClientResult {
+            base_revision: None,
+            recovered_create: false,
+        });
     }
     super::scope::renew_scope_attempt(board, attempt).await?;
     let tasks = client
@@ -265,10 +407,14 @@ async fn pull_client_tasks(
         .filter_map(|task| task.updated_at.as_ref())
         .max()
         .cloned();
-    pull_provider_tasks(board, options, client, tasks, operations)
-        .await
-        .map_err(SyncClientError::Local)?;
-    Ok(base_revision)
+    let recovered_create =
+        pull_provider_tasks(board, options, client, tasks, operations, follow_ups)
+            .await
+            .map_err(SyncClientError::Local)?;
+    Ok(PullClientResult {
+        base_revision,
+        recovered_create,
+    })
 }
 
 async fn push_client_tasks(
@@ -277,12 +423,15 @@ async fn push_client_tasks(
     client: &dyn ExternalSyncClient,
     attempt: Option<&ExternalProviderScopeAttempt>,
     operations: &mut Vec<ExternalSyncOperation>,
-) -> Result<(), SyncClientError> {
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<bool, SyncClientError> {
     if direction_allows_push(options.direction) && client.allows_push() {
-        push_board_tasks(board, options, client, attempt, operations).await?;
+        let created =
+            push_board_tasks(board, options, client, attempt, operations, follow_ups).await?;
         delete_remote_tombstones(board, options, client, attempt, operations).await?;
+        return Ok(created);
     }
-    Ok(())
+    Ok(false)
 }
 
 fn direction_allows_pull(direction: ExternalSyncDirection) -> bool {

--- a/src/task_board/external/sync/batch.rs
+++ b/src/task_board/external/sync/batch.rs
@@ -83,7 +83,7 @@ async fn sync_admitted_scope(
 ) -> Result<(), CliError> {
     let provider = scope.provider();
     let scope_id = scope.scope_id().to_owned();
-    match sync_client(board, options, client, &mut batch.operations).await {
+    match sync_client(board, options, client, attempt, &mut batch.operations).await {
         Ok(base_revision) => {
             if let Some(attempt) = attempt {
                 board
@@ -151,28 +151,53 @@ async fn sync_client(
     board: &dyn TaskBoardSyncStore,
     options: ExternalSyncOptions,
     client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
     operations: &mut Vec<ExternalSyncOperation>,
 ) -> Result<Option<String>, SyncClientError> {
-    let mut base_revision = None;
-    if direction_allows_pull(options.direction) && client.allows_pull() {
-        let tasks = client
-            .pull_tasks()
-            .await
-            .map_err(SyncClientError::Provider)?;
-        base_revision = tasks
-            .iter()
-            .filter_map(|task| task.updated_at.as_ref())
-            .max()
-            .cloned();
-        pull_provider_tasks(board, options, client, tasks, operations)
-            .await
-            .map_err(SyncClientError::Local)?;
-    }
-    if direction_allows_push(options.direction) && client.allows_push() {
-        push_board_tasks(board, options, client, operations).await?;
-        delete_remote_tombstones(board, options, client, operations).await?;
-    }
+    let base_revision = pull_client_tasks(board, options, client, attempt, operations).await?;
+    push_client_tasks(board, options, client, attempt, operations).await?;
     Ok(base_revision)
+}
+
+async fn pull_client_tasks(
+    board: &dyn TaskBoardSyncStore,
+    options: ExternalSyncOptions,
+    client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+    operations: &mut Vec<ExternalSyncOperation>,
+) -> Result<Option<String>, SyncClientError> {
+    if !direction_allows_pull(options.direction) || !client.allows_pull() {
+        return Ok(None);
+    }
+    super::scope::renew_scope_attempt(board, attempt).await?;
+    let tasks = client
+        .pull_tasks()
+        .await
+        .map_err(SyncClientError::Provider)?;
+    super::scope::renew_scope_attempt(board, attempt).await?;
+    let base_revision = tasks
+        .iter()
+        .filter_map(|task| task.updated_at.as_ref())
+        .max()
+        .cloned();
+    pull_provider_tasks(board, options, client, tasks, operations)
+        .await
+        .map_err(SyncClientError::Local)?;
+    Ok(base_revision)
+}
+
+async fn push_client_tasks(
+    board: &dyn TaskBoardSyncStore,
+    options: ExternalSyncOptions,
+    client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+    operations: &mut Vec<ExternalSyncOperation>,
+) -> Result<(), SyncClientError> {
+    if direction_allows_push(options.direction) && client.allows_push() {
+        push_board_tasks(board, options, client, attempt, operations).await?;
+        delete_remote_tombstones(board, options, client, attempt, operations).await?;
+    }
+    Ok(())
 }
 
 fn direction_allows_pull(direction: ExternalSyncDirection) -> bool {

--- a/src/task_board/external/sync/batch.rs
+++ b/src/task_board/external/sync/batch.rs
@@ -1,6 +1,6 @@
 use crate::errors::CliError;
 use crate::task_board::external::{
-    ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
+    ExternalProvider, ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
     ExternalProviderScopeAvailability, ExternalProviderScopeIdentity, ExternalSyncBatch,
     ExternalSyncClient, ExternalSyncScopeOutcome,
 };
@@ -36,12 +36,16 @@ pub(crate) async fn sync_external_tasks_scoped(
     for client in clients {
         if provider_is_allowed(client.provider(), options.provider) {
             sync_scope(board, options, client.as_ref(), &mut batch).await?;
+            if batch.terminal_error.is_some() {
+                break;
+            }
         }
     }
     Ok(ExternalSyncBatch {
         operations: batch.operations,
         scope_outcomes: batch.scope_outcomes,
         first_provider_failure: batch.first_provider_failure,
+        terminal_error: batch.terminal_error,
     })
 }
 
@@ -50,6 +54,7 @@ struct BatchAccumulator {
     operations: Vec<ExternalSyncOperation>,
     scope_outcomes: Vec<ExternalSyncScopeOutcome>,
     first_provider_failure: Option<CliError>,
+    terminal_error: Option<CliError>,
 }
 
 async fn sync_scope(
@@ -85,31 +90,111 @@ async fn sync_admitted_scope(
     let scope_id = scope.scope_id().to_owned();
     match sync_client(board, options, client, attempt, &mut batch.operations).await {
         Ok(base_revision) => {
-            if let Some(attempt) = attempt {
-                board
-                    .complete_provider_scope_success(attempt, base_revision.as_deref(), &utc_now())
-                    .await?;
-            }
-            batch
-                .scope_outcomes
-                .push(ExternalSyncScopeOutcome::success(provider, scope_id));
+            record_scope_success(
+                board,
+                attempt,
+                provider,
+                scope_id,
+                base_revision.as_deref(),
+                batch,
+            )
+            .await?;
         }
         Err(SyncClientError::Provider(error)) => {
-            if let Some(attempt) = attempt {
-                board
-                    .complete_provider_scope_failure(attempt, &utc_now())
-                    .await?;
-            }
-            batch
-                .scope_outcomes
-                .push(ExternalSyncScopeOutcome::failed(provider, scope_id, &error));
-            if batch.first_provider_failure.is_none() {
-                batch.first_provider_failure = Some(error);
-            }
+            record_provider_failure(board, attempt, provider, scope_id, error, batch).await?;
         }
-        Err(SyncClientError::Local(error)) => return Err(error),
+        Err(SyncClientError::Local(error)) => {
+            record_terminal_local_failure(board, attempt, provider, scope_id, error, batch).await;
+        }
     }
     Ok(())
+}
+
+async fn record_scope_success(
+    board: &dyn TaskBoardSyncStore,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+    provider: ExternalProvider,
+    scope_id: String,
+    base_revision: Option<&str>,
+    batch: &mut BatchAccumulator,
+) -> Result<(), CliError> {
+    if let Some(attempt) = attempt {
+        board
+            .complete_provider_scope_success(attempt, base_revision, &utc_now())
+            .await?;
+    }
+    batch
+        .scope_outcomes
+        .push(ExternalSyncScopeOutcome::success(provider, scope_id));
+    Ok(())
+}
+
+async fn record_provider_failure(
+    board: &dyn TaskBoardSyncStore,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+    provider: ExternalProvider,
+    scope_id: String,
+    error: CliError,
+    batch: &mut BatchAccumulator,
+) -> Result<(), CliError> {
+    if let Some(attempt) = attempt {
+        board
+            .complete_provider_scope_failure(attempt, &utc_now())
+            .await?;
+    }
+    batch
+        .scope_outcomes
+        .push(ExternalSyncScopeOutcome::failed(provider, scope_id, &error));
+    if batch.first_provider_failure.is_none() {
+        batch.first_provider_failure = Some(error);
+    }
+    Ok(())
+}
+
+async fn record_terminal_local_failure(
+    board: &dyn TaskBoardSyncStore,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+    provider: ExternalProvider,
+    scope_id: String,
+    error: CliError,
+    batch: &mut BatchAccumulator,
+) {
+    let terminal_error = if let Some(attempt) = attempt {
+        match board
+            .complete_provider_scope_failure(attempt, &utc_now())
+            .await
+        {
+            Ok(_) => error,
+            Err(finalization_error) => combined_local_failure(error, &finalization_error),
+        }
+    } else {
+        error
+    };
+    batch.scope_outcomes.push(ExternalSyncScopeOutcome::failed(
+        provider,
+        scope_id,
+        &terminal_error,
+    ));
+    batch.terminal_error = Some(terminal_error);
+}
+
+fn combined_local_failure(local_error: CliError, finalization_error: &CliError) -> CliError {
+    let finalization_details = format!(
+        "provider scope failure finalization also failed with {}",
+        error_with_details(finalization_error)
+    );
+    let details = match local_error.details() {
+        Some(details) => format!("{details}; {finalization_details}"),
+        None => finalization_details,
+    };
+    local_error.with_details(details)
+}
+
+fn error_with_details(error: &CliError) -> String {
+    error.details().map_or_else(
+        || error.to_string(),
+        |details| format!("{error}; {details}"),
+    )
 }
 
 enum ScopeAdmission {

--- a/src/task_board/external/sync/create_recovery.rs
+++ b/src/task_board/external/sync/create_recovery.rs
@@ -1,0 +1,376 @@
+use std::mem;
+
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::external::{
+    ExternalProviderScopeIdentity, ExternalSyncBatch, ExternalSyncClient, ExternalSyncScopeOutcome,
+};
+use crate::task_board::{
+    ExternalProvider, ExternalSyncOperation, ExternalSyncOptions, TaskBoardExternalCreateIntent,
+    TaskBoardExternalCreateIntentState,
+};
+
+use super::TaskBoardSyncStore;
+
+mod execute;
+mod lease;
+pub(super) use execute::{
+    create_item_durably, recover_scope_intents, suppress_known_create_markers,
+};
+use execute::{finalize_intent, queue_attached_follow_up};
+
+pub(crate) struct ExternalCreateRecoveryWork {
+    created: Vec<TaskBoardExternalCreateIntent>,
+    in_flight: Vec<TaskBoardExternalCreateIntent>,
+}
+
+#[derive(Default)]
+pub(crate) struct PreparedExternalCreateRecovery {
+    operations: Vec<ExternalSyncOperation>,
+    in_flight: Vec<TaskBoardExternalCreateIntent>,
+    recovered: Vec<TaskBoardExternalCreateIntent>,
+    follow_ups: Vec<TaskBoardExternalCreateIntent>,
+}
+
+#[derive(Default)]
+pub(crate) struct ExternalCreateRecoveryPlan {
+    operations: Vec<ExternalSyncOperation>,
+    follow_ups: Vec<TaskBoardExternalCreateIntent>,
+    scopes: Vec<OwnedRecoveryScope>,
+}
+
+struct OwnedRecoveryScope {
+    provider: ExternalProvider,
+    scope_id: String,
+    intents: Vec<TaskBoardExternalCreateIntent>,
+    recovered: Vec<TaskBoardExternalCreateIntent>,
+}
+
+#[derive(Default)]
+pub(crate) struct ExternalCreateScopeRecovery {
+    pub(super) intents: Vec<TaskBoardExternalCreateIntent>,
+    pub(super) touched: bool,
+}
+
+pub(crate) async fn load_external_create_recovery_work(
+    board: &dyn TaskBoardSyncStore,
+    provider: Option<ExternalProvider>,
+) -> Result<ExternalCreateRecoveryWork, CliError> {
+    let created = board.list_created_external_create_intents().await?;
+    let providers = requested_providers(provider);
+    let mut filtered_created = Vec::new();
+    let mut in_flight = Vec::new();
+    for candidate in &providers {
+        filtered_created.extend(
+            created
+                .iter()
+                .filter(|intent| intent.provider == *candidate)
+                .cloned(),
+        );
+        in_flight.extend(
+            board
+                .list_in_flight_external_create_intents(*candidate)
+                .await?,
+        );
+    }
+    Ok(ExternalCreateRecoveryWork {
+        created: filtered_created,
+        in_flight,
+    })
+}
+
+pub(crate) async fn prepare_external_create_recovery(
+    board: &dyn TaskBoardSyncStore,
+    options: ExternalSyncOptions,
+    work: ExternalCreateRecoveryWork,
+) -> Result<PreparedExternalCreateRecovery, ExternalSyncBatch> {
+    if work.is_empty() {
+        return Ok(PreparedExternalCreateRecovery::default());
+    }
+    if options.dry_run {
+        let error =
+            CliErrorKind::workflow_io("pending provider create recovery blocks dry-run sync")
+                .into();
+        return Err(blocked_batch(
+            Vec::new(),
+            Vec::new(),
+            work.all_intents(),
+            error,
+        ));
+    }
+    let mut operations = Vec::new();
+    let mut in_flight = work.in_flight;
+    let mut recovered = Vec::new();
+    let mut follow_ups = Vec::new();
+    for listed in work.created {
+        let current = match reload_intent(board, &listed).await {
+            Ok(intent) => intent,
+            Err(error) => {
+                return Err(blocked_batch(operations, follow_ups, vec![listed], error));
+            }
+        };
+        match current.state {
+            TaskBoardExternalCreateIntentState::InFlight => in_flight.push(current),
+            TaskBoardExternalCreateIntentState::Created(_) => {
+                if let Err(error) =
+                    finalize_intent(board, &current, &mut operations, &mut follow_ups).await
+                {
+                    return Err(blocked_batch(operations, follow_ups, vec![current], error));
+                }
+                recovered.push(current);
+            }
+            TaskBoardExternalCreateIntentState::Attached(_) => {
+                if let Err(error) = queue_attached_follow_up(&current, &mut follow_ups) {
+                    return Err(blocked_batch(operations, follow_ups, vec![current], error));
+                }
+            }
+        }
+    }
+    Ok(PreparedExternalCreateRecovery {
+        operations,
+        in_flight,
+        recovered,
+        follow_ups,
+    })
+}
+
+#[expect(
+    clippy::result_large_err,
+    reason = "the blocked batch intentionally retains complete operation and scope evidence"
+)]
+pub(crate) fn assign_external_create_recovery(
+    prepared: PreparedExternalCreateRecovery,
+    clients: &[Box<dyn ExternalSyncClient>],
+) -> Result<ExternalCreateRecoveryPlan, ExternalSyncBatch> {
+    let mut scopes: Vec<OwnedRecoveryScope> = Vec::new();
+    for intent in &prepared.recovered {
+        let scope = recovery_scope(&mut scopes, intent);
+        scope.recovered.push(intent.clone());
+    }
+    for intent in &prepared.in_flight {
+        let owners = clients
+            .iter()
+            .filter(|client| client_owns_intent(client.as_ref(), intent))
+            .collect::<Vec<_>>();
+        if owners.len() != 1 {
+            let error = owner_error(intent, owners.len());
+            let intents = prepared
+                .in_flight
+                .iter()
+                .chain(&prepared.recovered)
+                .cloned()
+                .collect();
+            return Err(blocked_batch(
+                prepared.operations,
+                prepared.follow_ups,
+                intents,
+                error,
+            ));
+        }
+        recovery_scope(&mut scopes, intent)
+            .intents
+            .push(intent.clone());
+    }
+    Ok(ExternalCreateRecoveryPlan {
+        operations: prepared.operations,
+        follow_ups: prepared.follow_ups,
+        scopes,
+    })
+}
+
+pub(crate) fn blocked_external_create_recovery(
+    prepared: PreparedExternalCreateRecovery,
+    error: CliError,
+) -> ExternalSyncBatch {
+    let intents = prepared
+        .in_flight
+        .into_iter()
+        .chain(prepared.recovered)
+        .collect();
+    blocked_batch(prepared.operations, prepared.follow_ups, intents, error)
+}
+
+pub(crate) fn blocked_external_create_follow_ups(
+    intents: Vec<TaskBoardExternalCreateIntent>,
+    error: CliError,
+) -> ExternalSyncBatch {
+    blocked_batch(Vec::new(), intents.clone(), intents, error)
+}
+
+impl ExternalCreateRecoveryWork {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.created.is_empty() && self.in_flight.is_empty()
+    }
+
+    fn all_intents(self) -> Vec<TaskBoardExternalCreateIntent> {
+        self.created.into_iter().chain(self.in_flight).collect()
+    }
+}
+
+impl PreparedExternalCreateRecovery {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+            && self.in_flight.is_empty()
+            && self.recovered.is_empty()
+            && self.follow_ups.is_empty()
+    }
+
+    pub(crate) fn follow_ups(&self) -> &[TaskBoardExternalCreateIntent] {
+        &self.follow_ups
+    }
+
+    pub(crate) fn clear_follow_ups(&mut self) {
+        self.follow_ups.clear();
+    }
+}
+
+impl ExternalCreateRecoveryPlan {
+    pub(crate) fn take_operations(&mut self) -> Vec<ExternalSyncOperation> {
+        mem::take(&mut self.operations)
+    }
+
+    pub(crate) fn take_follow_ups(&mut self) -> Vec<TaskBoardExternalCreateIntent> {
+        mem::take(&mut self.follow_ups)
+    }
+
+    pub(crate) fn take_scope(
+        &mut self,
+        provider: ExternalProvider,
+        scope_id: &str,
+    ) -> ExternalCreateScopeRecovery {
+        let Some(index) = self
+            .scopes
+            .iter()
+            .position(|scope| scope.provider == provider && scope.scope_id == scope_id)
+        else {
+            return ExternalCreateScopeRecovery::default();
+        };
+        let scope = self.scopes.swap_remove(index);
+        ExternalCreateScopeRecovery {
+            intents: scope.intents,
+            touched: true,
+        }
+    }
+
+    pub(crate) fn has_recovery(&self) -> bool {
+        !self.scopes.is_empty()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.operations.is_empty() && self.follow_ups.is_empty() && self.scopes.is_empty()
+    }
+
+    pub(crate) fn into_blocked(self, error: CliError) -> ExternalSyncBatch {
+        let intents = self
+            .scopes
+            .into_iter()
+            .flat_map(|scope| scope.intents.into_iter().chain(scope.recovered))
+            .collect();
+        blocked_batch(self.operations, self.follow_ups, intents, error)
+    }
+}
+
+fn recovery_scope<'a>(
+    scopes: &'a mut Vec<OwnedRecoveryScope>,
+    intent: &TaskBoardExternalCreateIntent,
+) -> &'a mut OwnedRecoveryScope {
+    if let Some(index) = scopes
+        .iter()
+        .position(|scope| scope.provider == intent.provider && scope.scope_id == intent.scope_id)
+    {
+        return &mut scopes[index];
+    }
+    scopes.push(OwnedRecoveryScope {
+        provider: intent.provider,
+        scope_id: intent.scope_id.clone(),
+        intents: Vec::new(),
+        recovered: Vec::new(),
+    });
+    scopes.last_mut().expect("recovery scope was inserted")
+}
+
+fn client_owns_intent(
+    client: &dyn ExternalSyncClient,
+    intent: &TaskBoardExternalCreateIntent,
+) -> bool {
+    client.provider() == intent.provider
+        && client.allows_push()
+        && ExternalProviderScopeIdentity::for_client(client).scope_id() == intent.scope_id
+        && client.external_create_recovery().is_some_and(|capability| {
+            capability.provider() == intent.provider
+                && capability.supports_target(&intent.snapshot.provider_target)
+        })
+}
+
+pub(super) async fn reload_intent(
+    board: &dyn TaskBoardSyncStore,
+    expected: &TaskBoardExternalCreateIntent,
+) -> Result<TaskBoardExternalCreateIntent, CliError> {
+    let current = board
+        .external_create_intent_by_create_key(expected.provider, &expected.create_key)
+        .await?
+        .ok_or_else(|| {
+            CliErrorKind::concurrent_modification("provider create intent disappeared")
+        })?;
+    if current.intent_id == expected.intent_id && current.item_id == expected.item_id {
+        Ok(current)
+    } else {
+        Err(CliErrorKind::concurrent_modification(
+            "provider create key resolved to different intent evidence",
+        )
+        .into())
+    }
+}
+
+fn owner_error(intent: &TaskBoardExternalCreateIntent, owners: usize) -> CliError {
+    if owners == 0 {
+        CliErrorKind::workflow_io(format!(
+            "provider create for '{}' has no configured write owner for scope '{}'",
+            intent.item_id, intent.scope_id
+        ))
+        .into()
+    } else {
+        CliErrorKind::concurrent_modification(format!(
+            "provider create for '{}' has {owners} configured write owners for scope '{}'",
+            intent.item_id, intent.scope_id
+        ))
+        .into()
+    }
+}
+
+fn blocked_batch(
+    operations: Vec<ExternalSyncOperation>,
+    follow_ups: Vec<TaskBoardExternalCreateIntent>,
+    intents: Vec<TaskBoardExternalCreateIntent>,
+    error: CliError,
+) -> ExternalSyncBatch {
+    let mut scope_outcomes = Vec::new();
+    for intent in intents {
+        if scope_outcomes
+            .iter()
+            .any(|outcome: &ExternalSyncScopeOutcome| {
+                outcome.provider == intent.provider && outcome.scope_id == intent.scope_id
+            })
+        {
+            continue;
+        }
+        scope_outcomes.push(ExternalSyncScopeOutcome::failed(
+            intent.provider,
+            intent.scope_id,
+            &error,
+        ));
+    }
+    ExternalSyncBatch {
+        operations,
+        external_create_follow_ups: follow_ups,
+        scope_outcomes,
+        first_provider_failure: None,
+        terminal_error: Some(error),
+    }
+}
+
+fn requested_providers(provider: Option<ExternalProvider>) -> Vec<ExternalProvider> {
+    provider.map_or_else(
+        || vec![ExternalProvider::GitHub, ExternalProvider::Todoist],
+        |provider| vec![provider],
+    )
+}

--- a/src/task_board/external/sync/create_recovery/execute.rs
+++ b/src/task_board/external/sync/create_recovery/execute.rs
@@ -1,0 +1,513 @@
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::external::{
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
+    ExternalProviderScopeAttempt, ExternalProviderScopeIdentity, ExternalSyncClient,
+};
+use crate::task_board::{
+    ExternalCreateOutcome, ExternalProvider, ExternalSyncAction, ExternalSyncOperation,
+    ExternalTask, TaskBoardExternalCreateBegin, TaskBoardExternalCreateExisting,
+    TaskBoardExternalCreateFinalizeDisposition, TaskBoardExternalCreateIntent,
+    TaskBoardExternalCreateIntentState, TaskBoardItem,
+};
+
+use super::super::lookup::{OperationDraft, operation};
+use super::super::merge::sync_state_from_task;
+use super::super::{SyncClientError, TaskBoardSyncStore};
+use super::lease::ScopeCreateLease;
+use super::reload_intent;
+
+pub(crate) struct DurableCreateResult {
+    pub(crate) linked_item: Option<TaskBoardItem>,
+    pub(crate) durable_create: bool,
+}
+
+pub(crate) async fn recover_scope_intents(
+    board: &dyn TaskBoardSyncStore,
+    client: &dyn ExternalSyncClient,
+    attempt: &ExternalProviderScopeAttempt,
+    intents: &[TaskBoardExternalCreateIntent],
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<(), SyncClientError> {
+    let lease = ScopeCreateLease::new(board, attempt);
+    for listed in intents {
+        recover_scope_intent(board, client, &lease, listed, operations, follow_ups).await?;
+    }
+    Ok(())
+}
+
+async fn recover_scope_intent(
+    board: &dyn TaskBoardSyncStore,
+    client: &dyn ExternalSyncClient,
+    lease: &ScopeCreateLease<'_>,
+    listed: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<(), SyncClientError> {
+    lease.renew().await.map_err(SyncClientError::Local)?;
+    let current = reload_intent(board, listed)
+        .await
+        .map_err(SyncClientError::Local)?;
+    match current.state {
+        TaskBoardExternalCreateIntentState::InFlight => {
+            recover_remote_intent(board, client, lease, &current, operations, follow_ups).await
+        }
+        TaskBoardExternalCreateIntentState::Created(_) => {
+            finalize_intent(board, &current, operations, follow_ups)
+                .await
+                .map(|_| ())
+                .map_err(SyncClientError::Local)
+        }
+        TaskBoardExternalCreateIntentState::Attached(_) => {
+            queue_attached_follow_up(&current, follow_ups).map_err(SyncClientError::Local)
+        }
+    }
+}
+
+pub(crate) async fn create_item_durably(
+    board: &dyn TaskBoardSyncStore,
+    client: &dyn ExternalSyncClient,
+    attempt: &ExternalProviderScopeAttempt,
+    item: &TaskBoardItem,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<DurableCreateResult, SyncClientError> {
+    let capability = require_recovery_capability(client, item).map_err(SyncClientError::Local)?;
+    let provider_target = create_target(client, item);
+    let scope = ExternalProviderScopeIdentity::for_client(client);
+    let decision = board
+        .begin_external_create_intent(
+            &item.id,
+            client.provider(),
+            scope.scope_id(),
+            &provider_target,
+        )
+        .await
+        .map_err(SyncClientError::Local)?;
+    let lease = ScopeCreateLease::new(board, attempt);
+    let (linked_item, durable_create) = match decision {
+        TaskBoardExternalCreateBegin::Started(intent) => (
+            create_started(board, capability, &lease, &intent, operations, follow_ups).await?,
+            true,
+        ),
+        TaskBoardExternalCreateBegin::Existing(TaskBoardExternalCreateExisting::Recover(
+            intent,
+        )) => (
+            recover_existing(board, capability, &lease, &intent, operations, follow_ups).await?,
+            true,
+        ),
+        TaskBoardExternalCreateBegin::Existing(TaskBoardExternalCreateExisting::Finalize(
+            intent,
+        )) => (
+            finalize_intent(board, &intent, operations, follow_ups)
+                .await
+                .map_err(SyncClientError::Local)?,
+            true,
+        ),
+        TaskBoardExternalCreateBegin::Existing(TaskBoardExternalCreateExisting::Attached(
+            intent,
+        )) => {
+            queue_attached_follow_up(&intent, follow_ups).map_err(SyncClientError::Local)?;
+            (None, false)
+        }
+    };
+    Ok(DurableCreateResult {
+        linked_item,
+        durable_create,
+    })
+}
+
+pub(crate) async fn suppress_known_create_markers(
+    board: &dyn TaskBoardSyncStore,
+    client: &dyn ExternalSyncClient,
+    tasks: Vec<ExternalTask>,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+    dry_run: bool,
+) -> Result<(Vec<ExternalTask>, bool), CliError> {
+    let Some(capability) = client.external_create_recovery() else {
+        return Ok((tasks, false));
+    };
+    let scope = ExternalProviderScopeIdentity::for_client(client);
+    let mut clean = Vec::with_capacity(tasks.len());
+    let mut recovered = false;
+    for task in tasks {
+        let result = handle_create_marker(
+            board, client, capability, &scope, task, operations, follow_ups, dry_run,
+        )
+        .await?;
+        recovered |= result.recovered;
+        if let Some(task) = result.task {
+            clean.push(task);
+        }
+    }
+    Ok((clean, recovered))
+}
+
+struct MarkerTaskResult {
+    task: Option<ExternalTask>,
+    recovered: bool,
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "marker recovery needs the exact capability, scope, task, and durable effect sinks"
+)]
+async fn handle_create_marker(
+    board: &dyn TaskBoardSyncStore,
+    client: &dyn ExternalSyncClient,
+    capability: &dyn ExternalCreateRecoveryClient,
+    scope: &ExternalProviderScopeIdentity,
+    mut task: ExternalTask,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+    dry_run: bool,
+) -> Result<MarkerTaskResult, CliError> {
+    let Some(create_key) = capability.extract_create_key(&mut task)? else {
+        return Ok(MarkerTaskResult {
+            task: Some(task),
+            recovered: false,
+        });
+    };
+    let Some(intent) = board
+        .external_create_intent_by_create_key(client.provider(), &create_key)
+        .await?
+    else {
+        return Ok(MarkerTaskResult {
+            task: Some(task),
+            recovered: false,
+        });
+    };
+    require_marker_owner(client, capability, scope, &intent)?;
+    if matches!(
+        intent.state,
+        TaskBoardExternalCreateIntentState::Attached(_)
+    ) {
+        let linked = attached_marker_is_linked(board, &intent, &task).await?;
+        if !dry_run {
+            queue_attached_follow_up(&intent, follow_ups)?;
+        }
+        return Ok(MarkerTaskResult {
+            task: linked.then_some(task),
+            recovered: false,
+        });
+    }
+    if !dry_run {
+        persist_exact_task(board, &intent, task, operations, follow_ups).await?;
+    }
+    Ok(MarkerTaskResult {
+        task: None,
+        recovered: true,
+    })
+}
+
+async fn attached_marker_is_linked(
+    board: &dyn TaskBoardSyncStore,
+    intent: &TaskBoardExternalCreateIntent,
+    task: &ExternalTask,
+) -> Result<bool, CliError> {
+    let TaskBoardExternalCreateIntentState::Attached(receipt) = &intent.state else {
+        return Err(CliErrorKind::concurrent_modification(
+            "provider create marker receipt is not attached",
+        )
+        .into());
+    };
+    let recorded = &receipt.evidence.outcome.reference;
+    let baseline = &receipt.evidence.provider_baseline;
+    if task.reference.provider != intent.provider
+        || task.reference.provider != recorded.provider
+        || task.reference.external_id != recorded.external_id
+        || ExternalProvider::from(baseline.provider) != recorded.provider
+        || baseline.external_id != recorded.external_id
+    {
+        return Err(CliErrorKind::concurrent_modification(format!(
+            "attached provider create marker '{}' does not match its receipt identity",
+            intent.create_key
+        ))
+        .into());
+    }
+    let snapshot = board.item_snapshot(&intent.item_id).await?;
+    Ok(!snapshot.item.is_deleted()
+        && snapshot.item.external_refs.iter().any(|reference| {
+            ExternalProvider::from(reference.provider) == intent.provider
+                && reference.external_id == recorded.external_id
+        }))
+}
+
+async fn create_started(
+    board: &dyn TaskBoardSyncStore,
+    capability: &dyn ExternalCreateRecoveryClient,
+    lease: &ScopeCreateLease<'_>,
+    intent: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<Option<TaskBoardItem>, SyncClientError> {
+    lease.renew().await.map_err(SyncClientError::Local)?;
+    let current = reload_intent(board, intent)
+        .await
+        .map_err(SyncClientError::Local)?;
+    if !matches!(current.state, TaskBoardExternalCreateIntentState::InFlight) {
+        return finish_reloaded_intent(board, &current, operations, follow_ups)
+            .await
+            .map_err(SyncClientError::Local);
+    }
+    lease.begin_provider_call();
+    let task = capability
+        .create_started(&request_from_intent(&current), lease)
+        .await
+        .map_err(|error| lease.classify_provider_call(error).into_sync_client_error())?;
+    persist_exact_task(board, &current, task, operations, follow_ups)
+        .await
+        .map_err(SyncClientError::Local)
+}
+
+async fn recover_existing(
+    board: &dyn TaskBoardSyncStore,
+    capability: &dyn ExternalCreateRecoveryClient,
+    lease: &ScopeCreateLease<'_>,
+    intent: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<Option<TaskBoardItem>, SyncClientError> {
+    lease.renew().await.map_err(SyncClientError::Local)?;
+    let current = reload_intent(board, intent)
+        .await
+        .map_err(SyncClientError::Local)?;
+    if !matches!(current.state, TaskBoardExternalCreateIntentState::InFlight) {
+        return finish_reloaded_intent(board, &current, operations, follow_ups)
+            .await
+            .map_err(SyncClientError::Local);
+    }
+    lease.begin_provider_call();
+    let probe = capability
+        .recover_existing(&request_from_intent(&current), lease)
+        .await
+        .map_err(|error| lease.classify_provider_call(error).into_sync_client_error())?;
+    let ExternalCreateProbe::Found(task) = probe else {
+        return Err(SyncClientError::Provider(
+            CliErrorKind::workflow_io(format!(
+                "provider create recovery found no task for '{}'",
+                current.item_id
+            ))
+            .into(),
+        ));
+    };
+    persist_exact_task(board, &current, task, operations, follow_ups)
+        .await
+        .map_err(SyncClientError::Local)
+}
+
+async fn recover_remote_intent(
+    board: &dyn TaskBoardSyncStore,
+    client: &dyn ExternalSyncClient,
+    lease: &ScopeCreateLease<'_>,
+    intent: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<(), SyncClientError> {
+    let capability = require_intent_capability(client, intent).map_err(SyncClientError::Local)?;
+    recover_existing(board, capability, lease, intent, operations, follow_ups)
+        .await
+        .map(|_| ())
+}
+
+async fn finish_reloaded_intent(
+    board: &dyn TaskBoardSyncStore,
+    intent: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<Option<TaskBoardItem>, CliError> {
+    match intent.state {
+        TaskBoardExternalCreateIntentState::InFlight => Err(CliErrorKind::concurrent_modification(
+            "provider create intent remained in-flight after reload",
+        )
+        .into()),
+        TaskBoardExternalCreateIntentState::Created(_) => {
+            finalize_intent(board, intent, operations, follow_ups).await
+        }
+        TaskBoardExternalCreateIntentState::Attached(_) => {
+            queue_attached_follow_up(intent, follow_ups)?;
+            Ok(None)
+        }
+    }
+}
+
+async fn persist_exact_task(
+    board: &dyn TaskBoardSyncStore,
+    intent: &TaskBoardExternalCreateIntent,
+    task: ExternalTask,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<Option<TaskBoardItem>, CliError> {
+    let outcome = ExternalCreateOutcome {
+        reference: task.reference.clone(),
+        provider_revision: task.updated_at.clone(),
+        provider_project_id: task.project_id.clone(),
+    };
+    let sync_state = sync_state_from_task(&task);
+    let mut baseline = task.reference.into_core_ref();
+    baseline.sync_state = Some(sync_state);
+    let recorded = board
+        .record_external_create_outcome(intent, &outcome, &baseline)
+        .await?;
+    finish_reloaded_intent(board, &recorded, operations, follow_ups).await
+}
+
+pub(super) async fn finalize_intent(
+    board: &dyn TaskBoardSyncStore,
+    intent: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<Option<TaskBoardItem>, CliError> {
+    let finalized = board.finalize_external_create_intent(intent).await?;
+    match finalized.disposition {
+        TaskBoardExternalCreateFinalizeDisposition::RetainedMissingItem => {
+            Err(CliErrorKind::workflow_io(format!(
+                "provider create for missing item '{}' remains unresolved",
+                intent.item_id
+            ))
+            .into())
+        }
+        TaskBoardExternalCreateFinalizeDisposition::AlreadyAttached => {
+            queue_attached_follow_up(&finalized.intent, follow_ups)?;
+            Ok(finalized.item)
+        }
+        TaskBoardExternalCreateFinalizeDisposition::Attached
+        | TaskBoardExternalCreateFinalizeDisposition::AlreadyLinked => {
+            report_newly_attached_intent(&finalized.intent, operations, follow_ups);
+            Ok(finalized.item)
+        }
+    }
+}
+
+fn report_newly_attached_intent(
+    intent: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) {
+    let evidence = intent
+        .created_evidence()
+        .expect("attached create intent always retains evidence");
+    let already_reported = operations.iter().any(|operation| {
+        operation.provider == intent.provider
+            && operation.action == ExternalSyncAction::Push
+            && operation.board_item_id.as_deref() == Some(&intent.item_id)
+            && operation.external_id.as_deref() == Some(&evidence.outcome.reference.external_id)
+            && operation.applied
+    });
+    if !already_reported {
+        operations.push(create_operation(intent));
+    }
+    queue_attached_follow_up(intent, follow_ups).expect("finalized intent is attached");
+}
+
+pub(super) fn queue_attached_follow_up(
+    intent: &TaskBoardExternalCreateIntent,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<(), CliError> {
+    if !matches!(
+        intent.state,
+        TaskBoardExternalCreateIntentState::Attached(_)
+    ) {
+        return Err(CliErrorKind::concurrent_modification(
+            "provider create follow-up is not attached",
+        )
+        .into());
+    }
+    if !follow_ups
+        .iter()
+        .any(|candidate| candidate.intent_id == intent.intent_id)
+    {
+        follow_ups.push(intent.clone());
+    }
+    Ok(())
+}
+
+fn create_operation(intent: &TaskBoardExternalCreateIntent) -> ExternalSyncOperation {
+    let evidence = intent
+        .created_evidence()
+        .expect("attached create intent always retains evidence");
+    operation(OperationDraft {
+        provider: intent.provider,
+        action: ExternalSyncAction::Push,
+        board_item_id: Some(intent.item_id.clone()),
+        reference: evidence.outcome.reference.clone(),
+        dry_run: false,
+        applied: true,
+        changed_fields: intent.changed_fields.clone(),
+        unsupported_fields: Vec::new(),
+    })
+}
+
+fn request_from_intent(intent: &TaskBoardExternalCreateIntent) -> ExternalCreateRequest {
+    ExternalCreateRequest::new(
+        &intent.item_id,
+        &intent.create_key,
+        &intent.snapshot.title,
+        &intent.snapshot.body,
+        &intent.snapshot.provider_target,
+    )
+}
+
+fn require_recovery_capability<'a>(
+    client: &'a dyn ExternalSyncClient,
+    item: &TaskBoardItem,
+) -> Result<&'a dyn ExternalCreateRecoveryClient, CliError> {
+    let target = create_target(client, item);
+    let capability = client.external_create_recovery().ok_or_else(|| {
+        CliErrorKind::workflow_io("provider does not support durable create recovery")
+    })?;
+    if capability.provider() != client.provider() || !capability.supports_target(&target) {
+        return Err(CliErrorKind::workflow_io(
+            "provider create recovery does not support the immutable target",
+        )
+        .into());
+    }
+    Ok(capability)
+}
+
+fn create_target(client: &dyn ExternalSyncClient, item: &TaskBoardItem) -> String {
+    if client.provider() == ExternalProvider::Todoist
+        && let Some(project_id) = &item.project_id
+    {
+        return project_id.clone();
+    }
+    client.scope_for_item(item)
+}
+
+fn require_intent_capability<'a>(
+    client: &'a dyn ExternalSyncClient,
+    intent: &TaskBoardExternalCreateIntent,
+) -> Result<&'a dyn ExternalCreateRecoveryClient, CliError> {
+    let capability = client.external_create_recovery().ok_or_else(|| {
+        CliErrorKind::workflow_io("provider does not support durable create recovery")
+    })?;
+    if capability.provider() != intent.provider
+        || !capability.supports_target(&intent.snapshot.provider_target)
+    {
+        return Err(CliErrorKind::workflow_io(
+            "provider create recovery does not support the persisted target",
+        )
+        .into());
+    }
+    Ok(capability)
+}
+
+fn require_marker_owner(
+    client: &dyn ExternalSyncClient,
+    capability: &dyn ExternalCreateRecoveryClient,
+    scope: &ExternalProviderScopeIdentity,
+    intent: &TaskBoardExternalCreateIntent,
+) -> Result<(), CliError> {
+    if client.allows_push()
+        && intent.scope_id == scope.scope_id()
+        && capability.provider() == intent.provider
+        && capability.supports_target(&intent.snapshot.provider_target)
+    {
+        return Ok(());
+    }
+    Err(CliErrorKind::concurrent_modification(
+        "provider create marker does not match the configured write owner",
+    )
+    .into())
+}

--- a/src/task_board/external/sync/create_recovery/lease.rs
+++ b/src/task_board/external/sync/create_recovery/lease.rs
@@ -1,0 +1,68 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+
+use crate::errors::CliError;
+use crate::task_board::external::{ExternalCreateLease, ExternalProviderScopeAttempt};
+use crate::workspace::utc_now;
+
+use super::super::{SyncClientError, TaskBoardSyncStore};
+
+pub(super) struct ScopeCreateLease<'a> {
+    board: &'a dyn TaskBoardSyncStore,
+    attempt: &'a ExternalProviderScopeAttempt,
+    local_failure: AtomicBool,
+}
+
+pub(super) enum RecoveryCallError {
+    Local(CliError),
+    Provider(CliError),
+}
+
+impl<'a> ScopeCreateLease<'a> {
+    pub(super) fn new(
+        board: &'a dyn TaskBoardSyncStore,
+        attempt: &'a ExternalProviderScopeAttempt,
+    ) -> Self {
+        Self {
+            board,
+            attempt,
+            local_failure: AtomicBool::new(false),
+        }
+    }
+
+    pub(super) fn begin_provider_call(&self) {
+        self.local_failure.store(false, Ordering::SeqCst);
+    }
+
+    pub(super) fn classify_provider_call(&self, error: CliError) -> RecoveryCallError {
+        if self.local_failure.swap(false, Ordering::SeqCst) {
+            RecoveryCallError::Local(error)
+        } else {
+            RecoveryCallError::Provider(error)
+        }
+    }
+}
+
+impl RecoveryCallError {
+    pub(super) fn into_sync_client_error(self) -> SyncClientError {
+        match self {
+            Self::Local(error) => SyncClientError::Local(error),
+            Self::Provider(error) => SyncClientError::Provider(error),
+        }
+    }
+}
+
+#[async_trait]
+impl ExternalCreateLease for ScopeCreateLease<'_> {
+    async fn renew(&self) -> Result<(), CliError> {
+        let result = self
+            .board
+            .renew_provider_scope_attempt(self.attempt, &utc_now())
+            .await;
+        if result.is_err() {
+            self.local_failure.store(true, Ordering::SeqCst);
+        }
+        result
+    }
+}

--- a/src/task_board/external/sync/delete.rs
+++ b/src/task_board/external/sync/delete.rs
@@ -1,5 +1,6 @@
 use crate::task_board::external::{
-    ExternalProvider, ExternalSyncClient, ExternalSyncField, ExternalTaskRef,
+    ExternalProvider, ExternalProviderScopeAttempt, ExternalSyncClient, ExternalSyncField,
+    ExternalTaskRef,
 };
 use crate::task_board::types::TaskBoardItem;
 
@@ -12,6 +13,7 @@ pub(super) async fn delete_remote_tombstones(
     board: &dyn TaskBoardSyncStore,
     options: ExternalSyncOptions,
     client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
     operations: &mut Vec<ExternalSyncOperation>,
 ) -> Result<(), SyncClientError> {
     if !client.allows_delete() {
@@ -40,6 +42,7 @@ pub(super) async fn delete_remote_tombstones(
             )));
             continue;
         }
+        super::scope::renew_scope_attempt(board, attempt).await?;
         client
             .delete_task(&item, &reference)
             .await

--- a/src/task_board/external/sync/evidence_tests.rs
+++ b/src/task_board/external/sync/evidence_tests.rs
@@ -1,0 +1,502 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::errors::CliErrorKind;
+use crate::task_board::external::{
+    ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
+    TaskBoardSyncItemSnapshot,
+};
+use crate::task_board::store::{TaskBoardItemPatch, apply_patch};
+use crate::task_board::{ExternalRefProvider, ExternalRefSyncState, TaskBoardSyncConflict};
+
+#[tokio::test]
+async fn local_failure_preserves_partial_batch_and_stops_later_scopes() {
+    let store = EvidenceStore::with_create_limit(1);
+    let first_calls = Arc::new(AtomicUsize::new(0));
+    let later_calls = Arc::new(AtomicUsize::new(0));
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![
+        Box::new(PullClient::new(
+            "scope/primary",
+            vec![
+                pulled_task("remote-first", "First"),
+                pulled_task("remote-failing", "Failing"),
+            ],
+            Arc::clone(&first_calls),
+        )),
+        Box::new(PullClient::new(
+            "scope/later",
+            vec![pulled_task("remote-later", "Later")],
+            Arc::clone(&later_calls),
+        )),
+    ];
+
+    let batch = sync_external_tasks_scoped(&store, pull_options(), &clients)
+        .await
+        .expect("local failure should return batch evidence");
+
+    assert_eq!(first_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(later_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(store.failure_completions.load(Ordering::SeqCst), 1);
+    assert_eq!(batch.operations.len(), 1);
+    assert!(batch.operations[0].applied);
+    assert_eq!(batch.scope_outcomes.len(), 1);
+    assert_eq!(
+        batch.scope_outcomes[0].error_code.as_deref(),
+        Some("WORKFLOW_IO")
+    );
+    let error = batch
+        .into_completed()
+        .expect_err("terminal local failure must fail completion");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+    assert!(error.message().contains("local create persistence failed"));
+}
+
+#[tokio::test]
+async fn local_and_finalization_failures_are_both_preserved() {
+    let mut store = EvidenceStore::with_create_limit(0);
+    store.completion_error = Some("scope finalization failed");
+    store.completion_details = Some("scope finalization detail");
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(PullClient::new(
+        "scope/failing",
+        vec![pulled_task("remote-failing", "Failing")],
+        Arc::new(AtomicUsize::new(0)),
+    ))];
+
+    let batch = sync_external_tasks_scoped(&store, pull_options(), &clients)
+        .await
+        .expect("combined failure should return batch evidence");
+
+    assert_eq!(store.failure_completions.load(Ordering::SeqCst), 1);
+    let evidence = batch.scope_outcomes[0]
+        .error
+        .as_deref()
+        .expect("failed scope evidence");
+    assert!(evidence.contains("local create persistence failed"));
+    assert!(evidence.contains("scope finalization failed"));
+    assert!(evidence.contains("scope finalization detail"));
+    let error = batch
+        .into_completed()
+        .expect_err("combined terminal failure");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+    assert!(error.message().contains("local create persistence failed"));
+    assert!(
+        error
+            .details()
+            .is_some_and(|details| details.contains("scope finalization failed"))
+    );
+    assert!(
+        error
+            .details()
+            .is_some_and(|details| details.contains("scope finalization detail"))
+    );
+}
+
+#[tokio::test]
+async fn applied_pull_evidence_survives_conflict_cleanup_failure() {
+    let item = linked_item("task-cleanup", "Local title");
+    let mut store = EvidenceStore::with_items(vec![item.clone()]);
+    store.update_behavior = UpdateBehavior::Apply;
+    store.conflict_error = Some("conflict cleanup failed");
+    let task = remote_task("Remote title");
+    let mut operations = Vec::new();
+
+    let error = reconcile_existing_item(
+        &store,
+        ExternalSyncOptions {
+            direction: ExternalSyncDirection::Pull,
+            conflict_policy: ExternalSyncConflictPolicy::PreferRemote,
+            dry_run: false,
+            ..ExternalSyncOptions::default()
+        },
+        ExternalProvider::Todoist,
+        &item,
+        task,
+        &mut operations,
+    )
+    .await
+    .expect_err("cleanup failure");
+
+    assert!(error.message().contains("conflict cleanup failed"));
+    assert_eq!(operations.len(), 1);
+    assert_eq!(operations[0].action, ExternalSyncAction::Pull);
+    assert!(operations[0].applied);
+}
+
+#[tokio::test]
+async fn converged_concurrent_pull_emits_no_applied_evidence() {
+    let expected = linked_item("task-converged", "Local title");
+    let task = remote_task("Remote title");
+    let mut latest = expected.clone();
+    latest.title.clone_from(&task.title);
+    latest.external_refs[0].sync_state = Some(sync_state(&task));
+    let mut store = EvidenceStore::with_items(vec![latest]);
+    store.update_behavior = UpdateBehavior::Concurrent;
+    let mut operations = Vec::new();
+
+    reconcile_existing_item(
+        &store,
+        ExternalSyncOptions {
+            direction: ExternalSyncDirection::Pull,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            ..ExternalSyncOptions::default()
+        },
+        ExternalProvider::Todoist,
+        &expected,
+        task,
+        &mut operations,
+    )
+    .await
+    .expect("latest item already converged");
+
+    assert!(operations.is_empty());
+}
+
+#[tokio::test]
+async fn stale_review_failure_emits_no_applied_evidence() {
+    let item = stale_review_item();
+    let mut store = EvidenceStore::with_items(vec![item.clone()]);
+    store.update_behavior = UpdateBehavior::Fail("stale review persistence failed");
+    let client = ReviewClient;
+    let mut operations = Vec::new();
+
+    let error = reconcile_stale_github_review_requests(
+        &store,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::GitHub),
+            direction: ExternalSyncDirection::Pull,
+            dry_run: false,
+            ..ExternalSyncOptions::default()
+        },
+        &client,
+        &[item],
+        &[],
+        &mut operations,
+    )
+    .await
+    .expect_err("stale review persistence failure");
+
+    assert!(error.message().contains("stale review persistence failed"));
+    assert!(operations.is_empty());
+}
+
+#[derive(Clone, Copy)]
+enum UpdateBehavior {
+    Apply,
+    Concurrent,
+    Fail(&'static str),
+}
+
+struct EvidenceStore {
+    items: Mutex<Vec<TaskBoardItem>>,
+    successful_creates: usize,
+    create_calls: AtomicUsize,
+    update_behavior: UpdateBehavior,
+    conflict_error: Option<&'static str>,
+    completion_error: Option<&'static str>,
+    completion_details: Option<&'static str>,
+    failure_completions: AtomicUsize,
+}
+
+impl EvidenceStore {
+    fn with_create_limit(successful_creates: usize) -> Self {
+        Self {
+            items: Mutex::new(Vec::new()),
+            successful_creates,
+            create_calls: AtomicUsize::new(0),
+            update_behavior: UpdateBehavior::Apply,
+            conflict_error: None,
+            completion_error: None,
+            completion_details: None,
+            failure_completions: AtomicUsize::new(0),
+        }
+    }
+
+    fn with_items(items: Vec<TaskBoardItem>) -> Self {
+        Self {
+            items: Mutex::new(items),
+            successful_creates: usize::MAX,
+            create_calls: AtomicUsize::new(0),
+            update_behavior: UpdateBehavior::Apply,
+            conflict_error: None,
+            completion_error: None,
+            completion_details: None,
+            failure_completions: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl TaskBoardSyncStore for EvidenceStore {
+    async fn list_items(
+        &self,
+        _status: Option<TaskBoardStatus>,
+    ) -> Result<Vec<TaskBoardItem>, CliError> {
+        Ok(self.items.lock().expect("items").clone())
+    }
+
+    async fn list_items_including_deleted(&self) -> Result<Vec<TaskBoardItem>, CliError> {
+        Ok(self.items.lock().expect("items").clone())
+    }
+
+    async fn create_item(&self, item: TaskBoardItem) -> Result<TaskBoardItem, CliError> {
+        let call = self.create_calls.fetch_add(1, Ordering::SeqCst);
+        if call >= self.successful_creates {
+            return Err(CliErrorKind::workflow_io("local create persistence failed").into());
+        }
+        self.items.lock().expect("items").push(item.clone());
+        Ok(item)
+    }
+
+    async fn update_item(
+        &self,
+        expected_item: &TaskBoardItem,
+        patch: TaskBoardItemPatch,
+    ) -> Result<TaskBoardItem, CliError> {
+        match self.update_behavior {
+            UpdateBehavior::Apply => {
+                let mut updated = expected_item.clone();
+                apply_patch(&mut updated, patch);
+                let mut items = self.items.lock().expect("items");
+                if let Some(item) = items.iter_mut().find(|item| item.id == updated.id) {
+                    item.clone_from(&updated);
+                }
+                Ok(updated)
+            }
+            UpdateBehavior::Concurrent => {
+                Err(CliErrorKind::concurrent_modification("concurrent test update").into())
+            }
+            UpdateBehavior::Fail(message) => Err(CliErrorKind::workflow_io(message).into()),
+        }
+    }
+
+    async fn item_snapshot(&self, item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
+        self.items
+            .lock()
+            .expect("items")
+            .iter()
+            .find(|item| item.id == item_id)
+            .cloned()
+            .map(|item| TaskBoardSyncItemSnapshot::new(item, 1))
+            .ok_or_else(|| CliErrorKind::workflow_io("missing test item").into())
+    }
+
+    async fn provider_scope_state(
+        &self,
+        _provider: ExternalProvider,
+        _scope_id: &str,
+    ) -> Result<ExternalProviderScopeState, CliError> {
+        Ok(ExternalProviderScopeState::default())
+    }
+
+    async fn begin_provider_scope_attempt(
+        &self,
+        provider: ExternalProvider,
+        scope_id: &str,
+        _now: &str,
+    ) -> Result<ExternalProviderScopeAttemptDecision, CliError> {
+        Ok(ExternalProviderScopeAttemptDecision::Started(
+            ExternalProviderScopeAttempt::new(
+                provider,
+                scope_id.to_owned(),
+                format!("test:{scope_id}"),
+                true,
+            ),
+        ))
+    }
+
+    async fn renew_provider_scope_attempt(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _now: &str,
+    ) -> Result<(), CliError> {
+        Ok(())
+    }
+
+    async fn complete_provider_scope_success(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _base_revision: Option<&str>,
+        _completed_at: &str,
+    ) -> Result<(), CliError> {
+        Ok(())
+    }
+
+    async fn complete_provider_scope_failure(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _completed_at: &str,
+    ) -> Result<ExternalProviderScopeState, CliError> {
+        self.failure_completions.fetch_add(1, Ordering::SeqCst);
+        if let Some(message) = self.completion_error {
+            let mut error: CliError = CliErrorKind::workflow_io(message).into();
+            if let Some(details) = self.completion_details {
+                error = error.with_details(details);
+            }
+            return Err(error);
+        }
+        Ok(ExternalProviderScopeState::default())
+    }
+
+    async fn replace_open_sync_conflicts(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _external_ref: &str,
+        _item_revision: i64,
+        _conflicts: &[TaskBoardSyncConflict],
+    ) -> Result<(), CliError> {
+        self.conflict_error.map_or(Ok(()), |message| {
+            Err(CliErrorKind::workflow_io(message).into())
+        })
+    }
+}
+
+struct PullClient {
+    scope_id: &'static str,
+    tasks: Vec<ExternalTask>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl PullClient {
+    fn new(scope_id: &'static str, tasks: Vec<ExternalTask>, calls: Arc<AtomicUsize>) -> Self {
+        Self {
+            scope_id,
+            tasks,
+            calls,
+        }
+    }
+}
+
+#[async_trait]
+impl ExternalSyncClient for PullClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    fn scope_id(&self) -> String {
+        self.scope_id.into()
+    }
+
+    fn allows_push(&self) -> bool {
+        false
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self.tasks.clone())
+    }
+
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        unreachable!("pull-only test client")
+    }
+}
+
+struct ReviewClient;
+
+#[async_trait]
+impl ExternalSyncClient for ReviewClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::GitHub
+    }
+
+    fn allows_push(&self) -> bool {
+        false
+    }
+
+    fn authoritative_review_inbox(&self) -> bool {
+        true
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        unreachable!("direct stale-review test")
+    }
+
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        unreachable!("pull-only review client")
+    }
+}
+
+fn pull_options() -> ExternalSyncOptions {
+    ExternalSyncOptions {
+        direction: ExternalSyncDirection::Pull,
+        dry_run: false,
+        ..ExternalSyncOptions::default()
+    }
+}
+
+fn pulled_task(external_id: &str, title: &str) -> ExternalTask {
+    ExternalTask {
+        reference: ExternalTaskRef::new(ExternalProvider::Todoist, external_id),
+        title: title.into(),
+        body: String::new(),
+        status: TaskBoardStatus::Backlog,
+        project_id: None,
+        updated_at: Some("2026-07-16T10:00:00Z".into()),
+    }
+}
+
+fn linked_item(id: &str, title: &str) -> TaskBoardItem {
+    let mut item = TaskBoardItem::new(
+        id.into(),
+        title.into(),
+        "Body".into(),
+        "2026-07-16T10:00:00Z".into(),
+    );
+    let mut reference =
+        ExternalTaskRef::new(ExternalProvider::Todoist, "remote-linked").into_core_ref();
+    reference.sync_state = Some(ExternalRefSyncState {
+        title: Some("Base title".into()),
+        body: Some("Body".into()),
+        status: Some(TaskBoardStatus::Backlog),
+        project_id: None,
+        updated_at: Some("2026-07-16T10:00:00Z".into()),
+        synced_at: Some("2026-07-16T10:00:00Z".into()),
+    });
+    item.external_refs = vec![reference];
+    item
+}
+
+fn remote_task(title: &str) -> ExternalTask {
+    ExternalTask {
+        reference: ExternalTaskRef::new(ExternalProvider::Todoist, "remote-linked"),
+        title: title.into(),
+        body: "Body".into(),
+        status: TaskBoardStatus::Backlog,
+        project_id: None,
+        updated_at: Some("2026-07-16T10:05:00Z".into()),
+    }
+}
+
+fn sync_state(task: &ExternalTask) -> ExternalRefSyncState {
+    ExternalRefSyncState {
+        title: Some(task.title.clone()),
+        body: Some(task.body.clone()),
+        status: Some(task.status),
+        project_id: task.project_id.clone(),
+        updated_at: task.updated_at.clone(),
+        synced_at: Some("2026-07-16T10:05:00Z".into()),
+    }
+}
+
+fn stale_review_item() -> TaskBoardItem {
+    let mut item = TaskBoardItem::new(
+        "task-stale-review".into(),
+        "Review".into(),
+        String::new(),
+        "2026-07-16T10:00:00Z".into(),
+    );
+    item.imported_from_provider = Some(ExternalRefProvider::GitHub);
+    let mut reference = ExternalTaskRef::new(ExternalProvider::GitHub, "org/repository#17")
+        .with_url("https://example.test/org/repository/pull/17")
+        .into_core_ref();
+    reference.sync_state = Some(ExternalRefSyncState {
+        status: Some(TaskBoardStatus::Backlog),
+        ..ExternalRefSyncState::default()
+    });
+    item.external_refs = vec![reference];
+    item
+}

--- a/src/task_board/external/sync/evidence_tests.rs
+++ b/src/task_board/external/sync/evidence_tests.rs
@@ -201,6 +201,8 @@ struct EvidenceStore {
     failure_completions: AtomicUsize,
 }
 
+impl TaskBoardExternalCreateStore for EvidenceStore {}
+
 impl EvidenceStore {
     fn with_create_limit(successful_creates: usize) -> Self {
         Self {
@@ -348,6 +350,19 @@ impl TaskBoardSyncStore for EvidenceStore {
         _external_ref: &str,
         _item_revision: i64,
         _conflicts: &[TaskBoardSyncConflict],
+    ) -> Result<(), CliError> {
+        self.conflict_error.map_or(Ok(()), |message| {
+            Err(CliErrorKind::workflow_io(message).into())
+        })
+    }
+
+    async fn supersede_open_sync_conflicts(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _external_ref: &str,
+        _item_revision: i64,
+        _resolved_fields: &[ExternalSyncField],
     ) -> Result<(), CliError> {
         self.conflict_error.map_or(Ok(()), |message| {
             Err(CliErrorKind::workflow_io(message).into())

--- a/src/task_board/external/sync/lease_tests.rs
+++ b/src/task_board/external/sync/lease_tests.rs
@@ -22,11 +22,12 @@ async fn stale_lease_stops_before_remote_create() {
             String::new(),
             "2026-07-16T10:00:00Z".into(),
         ),
+        failure_completions: AtomicUsize::new(0),
     };
     let clients: Vec<Box<dyn ExternalSyncClient>> =
         vec![Box::new(CountingCreateClient(Arc::clone(&calls)))];
 
-    let error = sync_external_tasks_scoped(
+    let batch = sync_external_tasks_scoped(
         &store,
         ExternalSyncOptions {
             provider: Some(ExternalProvider::GitHub),
@@ -37,9 +38,28 @@ async fn stale_lease_stops_before_remote_create() {
         &clients,
     )
     .await
-    .expect_err("stale lease must stop the scope");
+    .expect("stale lease must retain scope evidence");
 
+    assert_eq!(store.failure_completions.load(Ordering::SeqCst), 1);
+    let evidence = batch.scope_outcomes[0]
+        .error
+        .as_deref()
+        .expect("stale lease failure evidence");
+    assert_eq!(
+        batch.scope_outcomes[0].error_code.as_deref(),
+        Some("WORKFLOW_CONCURRENT")
+    );
+    assert!(evidence.contains("provider scope lease was replaced"));
+    assert!(evidence.contains("stale provider scope cannot be finalized"));
+    let error = batch
+        .into_completed()
+        .expect_err("stale lease must stop the scope");
     assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert!(
+        error
+            .details()
+            .is_some_and(|details| details.contains("stale provider scope cannot be finalized"))
+    );
     assert_eq!(calls.load(Ordering::SeqCst), 0);
 }
 
@@ -70,6 +90,7 @@ impl ExternalSyncClient for CountingCreateClient {
 
 struct StaleLeaseStore {
     item: TaskBoardItem,
+    failure_completions: AtomicUsize,
 }
 
 #[async_trait]
@@ -147,7 +168,11 @@ impl TaskBoardSyncStore for StaleLeaseStore {
         _attempt: &ExternalProviderScopeAttempt,
         _completed_at: &str,
     ) -> Result<ExternalProviderScopeState, CliError> {
-        unreachable!("stale lease is not a provider failure")
+        self.failure_completions.fetch_add(1, Ordering::SeqCst);
+        Err(
+            CliErrorKind::concurrent_modification("stale provider scope cannot be finalized")
+                .into(),
+        )
     }
 
     async fn replace_open_sync_conflicts(

--- a/src/task_board/external/sync/lease_tests.rs
+++ b/src/task_board/external/sync/lease_tests.rs
@@ -1,0 +1,163 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::errors::CliErrorKind;
+use crate::task_board::TaskBoardSyncConflict;
+use crate::task_board::external::{
+    ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
+    TaskBoardSyncItemSnapshot,
+};
+use crate::task_board::store::TaskBoardItemPatch;
+
+#[tokio::test]
+async fn stale_lease_stops_before_remote_create() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let store = StaleLeaseStore {
+        item: TaskBoardItem::new(
+            "task-lease".into(),
+            "Task".into(),
+            String::new(),
+            "2026-07-16T10:00:00Z".into(),
+        ),
+    };
+    let clients: Vec<Box<dyn ExternalSyncClient>> =
+        vec![Box::new(CountingCreateClient(Arc::clone(&calls)))];
+
+    let error = sync_external_tasks_scoped(
+        &store,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::GitHub),
+            direction: ExternalSyncDirection::Push,
+            dry_run: false,
+            ..ExternalSyncOptions::default()
+        },
+        &clients,
+    )
+    .await
+    .expect_err("stale lease must stop the scope");
+
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+struct CountingCreateClient(Arc<AtomicUsize>);
+
+#[async_trait]
+impl ExternalSyncClient for CountingCreateClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::GitHub
+    }
+
+    fn scope_id(&self) -> String {
+        "acme/widgets".into()
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        unreachable!("push-only test")
+    }
+
+    async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(ExternalTaskRef::new(
+            ExternalProvider::GitHub,
+            format!("acme/widgets#{}", item.id),
+        ))
+    }
+}
+
+struct StaleLeaseStore {
+    item: TaskBoardItem,
+}
+
+#[async_trait]
+impl TaskBoardSyncStore for StaleLeaseStore {
+    async fn list_items(
+        &self,
+        _status: Option<TaskBoardStatus>,
+    ) -> Result<Vec<TaskBoardItem>, CliError> {
+        Ok(vec![self.item.clone()])
+    }
+
+    async fn list_items_including_deleted(&self) -> Result<Vec<TaskBoardItem>, CliError> {
+        Ok(vec![self.item.clone()])
+    }
+
+    async fn create_item(&self, _item: TaskBoardItem) -> Result<TaskBoardItem, CliError> {
+        unreachable!("push-only test")
+    }
+
+    async fn update_item(
+        &self,
+        _expected_item: &TaskBoardItem,
+        _patch: TaskBoardItemPatch,
+    ) -> Result<TaskBoardItem, CliError> {
+        unreachable!("lease fails before local persistence")
+    }
+
+    async fn item_snapshot(&self, _item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
+        Ok(TaskBoardSyncItemSnapshot::new(self.item.clone(), 1))
+    }
+
+    async fn provider_scope_state(
+        &self,
+        _provider: ExternalProvider,
+        _scope_id: &str,
+    ) -> Result<ExternalProviderScopeState, CliError> {
+        Ok(ExternalProviderScopeState::default())
+    }
+
+    async fn begin_provider_scope_attempt(
+        &self,
+        provider: ExternalProvider,
+        scope_id: &str,
+        _now: &str,
+    ) -> Result<ExternalProviderScopeAttemptDecision, CliError> {
+        Ok(ExternalProviderScopeAttemptDecision::Started(
+            ExternalProviderScopeAttempt::new(
+                provider,
+                scope_id.to_owned(),
+                "stale-fence".into(),
+                true,
+            ),
+        ))
+    }
+
+    async fn renew_provider_scope_attempt(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _now: &str,
+    ) -> Result<(), CliError> {
+        Err(CliErrorKind::concurrent_modification("provider scope lease was replaced").into())
+    }
+
+    async fn complete_provider_scope_success(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _base_revision: Option<&str>,
+        _completed_at: &str,
+    ) -> Result<(), CliError> {
+        unreachable!("stale lease never completes")
+    }
+
+    async fn complete_provider_scope_failure(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _completed_at: &str,
+    ) -> Result<ExternalProviderScopeState, CliError> {
+        unreachable!("stale lease is not a provider failure")
+    }
+
+    async fn replace_open_sync_conflicts(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _external_ref: &str,
+        _item_revision: i64,
+        _conflicts: &[TaskBoardSyncConflict],
+    ) -> Result<(), CliError> {
+        unreachable!("lease fails before conflict persistence")
+    }
+}

--- a/src/task_board/external/sync/lease_tests.rs
+++ b/src/task_board/external/sync/lease_tests.rs
@@ -1,44 +1,36 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use async_trait::async_trait;
-
 use super::*;
-use crate::errors::CliErrorKind;
-use crate::task_board::TaskBoardSyncConflict;
 use crate::task_board::external::{
-    ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
-    TaskBoardSyncItemSnapshot,
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
+    ExternalProviderScopeIdentity,
 };
-use crate::task_board::store::TaskBoardItemPatch;
+use crate::task_board::{
+    ExternalCreateOutcome, ExternalRefSyncState, TaskBoardExternalCreateBegin,
+    TaskBoardExternalCreateIntentState, TaskBoardExternalCreateStore,
+};
+
+mod client;
+mod marker;
+mod support;
+use client::DurableCreateClient;
+use support::DurableCreateStore;
 
 #[tokio::test]
 async fn stale_lease_stops_before_remote_create() {
     let calls = Arc::new(AtomicUsize::new(0));
-    let store = StaleLeaseStore {
-        item: TaskBoardItem::new(
-            "task-lease".into(),
-            "Task".into(),
-            String::new(),
-            "2026-07-16T10:00:00Z".into(),
-        ),
-        failure_completions: AtomicUsize::new(0),
-    };
-    let clients: Vec<Box<dyn ExternalSyncClient>> =
-        vec![Box::new(CountingCreateClient(Arc::clone(&calls)))];
+    let store = DurableCreateStore::stale_lease(unlinked_item("task-lease"));
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(DurableCreateClient::new(
+        ExternalProvider::GitHub,
+        "acme/widgets",
+        Arc::clone(&calls),
+    ))];
 
-    let batch = sync_external_tasks_scoped(
-        &store,
-        ExternalSyncOptions {
-            provider: Some(ExternalProvider::GitHub),
-            direction: ExternalSyncDirection::Push,
-            dry_run: false,
-            ..ExternalSyncOptions::default()
-        },
-        &clients,
-    )
-    .await
-    .expect("stale lease must retain scope evidence");
+    let batch =
+        sync_external_tasks_scoped(&store, push_options(ExternalProvider::GitHub), &clients)
+            .await
+            .expect("stale lease must retain scope evidence");
 
     assert_eq!(store.failure_completions.load(Ordering::SeqCst), 1);
     let evidence = batch.scope_outcomes[0]
@@ -63,126 +55,340 @@ async fn stale_lease_stops_before_remote_create() {
     assert_eq!(calls.load(Ordering::SeqCst), 0);
 }
 
-struct CountingCreateClient(Arc<AtomicUsize>);
+#[tokio::test]
+async fn capability_lease_io_failure_remains_a_terminal_local_error() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut item = unlinked_item("task-lease-io");
+    item.project_id = Some("provider-project".into());
+    let store = DurableCreateStore::io_lease_failure(item);
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(&calls),
+    ))];
 
-#[async_trait]
-impl ExternalSyncClient for CountingCreateClient {
+    let batch =
+        sync_external_tasks_scoped(&store, push_options(ExternalProvider::Todoist), &clients)
+            .await
+            .expect("local lease failure must retain scope evidence");
+
+    assert!(batch.terminal_error.is_some());
+    assert!(batch.first_provider_failure.is_none());
+    assert_eq!(
+        batch.scope_outcomes[0].error_code.as_deref(),
+        Some("WORKFLOW_IO")
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert!(matches!(
+        store.intent().state,
+        TaskBoardExternalCreateIntentState::InFlight
+    ));
+}
+
+#[tokio::test]
+async fn create_then_close_uses_the_finalized_current_item_status() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut item = unlinked_item("task-finalized-done");
+    item.project_id = Some("provider-project".into());
+    let store = DurableCreateStore::done_during_finalize(item);
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(&calls),
+    ))];
+
+    let operations = sync_external_tasks(&store, push_options(ExternalProvider::Todoist), &clients)
+        .await
+        .expect("finalized Done item");
+
+    assert_eq!(operations.len(), 2);
+    assert!(operations[0].applied);
+    assert_eq!(
+        operations[1].unsupported_fields,
+        vec![ExternalSyncField::Status]
+    );
+}
+
+#[tokio::test]
+async fn conflict_cleanup_failure_keeps_exact_create_evidence_unattached() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut item = unlinked_item("task-create-cleanup");
+    item.project_id = Some("provider-project".into());
+    let store = DurableCreateStore::cleanup_failure(item);
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(&calls),
+    ))];
+
+    let batch =
+        sync_external_tasks_scoped(&store, push_options(ExternalProvider::Todoist), &clients)
+            .await
+            .expect("cleanup failure must retain exact create evidence");
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(batch.operations.is_empty());
+    assert!(batch.external_create_follow_ups.is_empty());
+    assert!(matches!(
+        store.intent().state,
+        TaskBoardExternalCreateIntentState::Created(_)
+    ));
+    let error = batch
+        .into_completed()
+        .expect_err("conflict cleanup must remain visible");
+    assert!(error.message().contains("conflict cleanup failed"));
+}
+
+#[tokio::test]
+async fn remote_create_with_failed_local_link_retains_created_reference_evidence() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut item = unlinked_item("task-create-cas");
+    item.project_id = Some("provider-project".into());
+    let store = DurableCreateStore::finalize_failure(item);
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(&calls),
+    ))];
+
+    let batch =
+        sync_external_tasks_scoped(&store, push_options(ExternalProvider::Todoist), &clients)
+            .await
+            .expect("finalization failure must retain recorded provider evidence");
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(batch.operations.is_empty());
+    let intent = store.intent();
+    let TaskBoardExternalCreateIntentState::Created(evidence) = intent.state else {
+        panic!("provider evidence must remain Created");
+    };
+    assert_eq!(evidence.outcome.reference.external_id, "remote-created");
+    assert_eq!(
+        evidence.outcome.provider_revision.as_deref(),
+        Some("provider-revision-1")
+    );
+    assert_eq!(
+        evidence.outcome.provider_project_id.as_deref(),
+        Some("provider-project")
+    );
+    let baseline = evidence
+        .provider_baseline
+        .sync_state
+        .as_ref()
+        .expect("exact provider baseline");
+    assert_eq!(baseline.title.as_deref(), Some("Task"));
+    assert_eq!(baseline.body.as_deref(), Some(""));
+    assert_eq!(baseline.status, Some(TaskBoardStatus::Backlog));
+    assert_eq!(baseline.project_id.as_deref(), Some("provider-project"));
+    assert_eq!(baseline.updated_at.as_deref(), Some("provider-revision-1"));
+    let error = batch
+        .into_completed()
+        .expect_err("local finalization failure must stop the scope");
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+}
+
+#[tokio::test]
+async fn attached_receipt_causes_no_preflight_scan_or_repeat_create_operation() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut item = unlinked_item("task-attached-retry");
+    item.project_id = Some("provider-project".into());
+    let store = successful_store(item);
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(&calls),
+    ))];
+    let first = sync_external_tasks(&store, push_options(ExternalProvider::Todoist), &clients)
+        .await
+        .expect("attach provider create");
+    assert_eq!(first.len(), 1);
+    assert!(first[0].applied);
+    let before_record = store.record_calls.load(Ordering::SeqCst);
+    let before_finalize = store.finalize_calls.load(Ordering::SeqCst);
+    let before_cleanup = store.supersede_calls.load(Ordering::SeqCst);
+    let work = super::create_recovery::load_external_create_recovery_work(
+        &store,
+        Some(ExternalProvider::Todoist),
+    )
+    .await
+    .expect("load active recovery");
+    assert!(work.is_empty());
+    assert_eq!(store.tombstone_list_calls.load(Ordering::SeqCst), 0);
+    let prepared = super::create_recovery::prepare_external_create_recovery(
+        &store,
+        pull_options(ExternalProvider::Todoist),
+        work,
+    )
+    .await
+    .expect("prepare active recovery");
+    assert!(prepared.is_empty());
+
+    let second = sync_external_tasks(&store, push_options(ExternalProvider::Todoist), &clients)
+        .await
+        .expect("repeat sync");
+
+    assert!(second.is_empty());
+    assert_eq!(store.record_calls.load(Ordering::SeqCst), before_record);
+    assert_eq!(store.finalize_calls.load(Ordering::SeqCst), before_finalize);
+    assert_eq!(store.supersede_calls.load(Ordering::SeqCst), before_cleanup);
+}
+
+#[tokio::test]
+async fn created_preflight_suppresses_pull_base_revision_persistence() {
+    let mut item = unlinked_item("task-recovery-base");
+    item.project_id = Some("provider-project".into());
+    let store = successful_store(item);
+    let client = RecoveryPullClient;
+    let scope = ExternalProviderScopeIdentity::for_client(&client);
+    let started = store
+        .begin_external_create_intent(
+            "task-recovery-base",
+            ExternalProvider::Todoist,
+            scope.scope_id(),
+            "provider-project",
+        )
+        .await
+        .expect("begin create");
+    let TaskBoardExternalCreateBegin::Started(intent) = started else {
+        panic!("expected started intent");
+    };
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-created");
+    let outcome = ExternalCreateOutcome {
+        reference: reference.clone(),
+        provider_revision: Some("provider-revision-1".into()),
+        provider_project_id: Some("provider-project".into()),
+    };
+    let mut baseline = reference.into_core_ref();
+    baseline.sync_state = Some(ExternalRefSyncState {
+        title: Some("Task".into()),
+        body: Some(String::new()),
+        status: Some(TaskBoardStatus::Backlog),
+        project_id: Some("provider-project".into()),
+        updated_at: Some("provider-revision-1".into()),
+        synced_at: Some("2026-07-16T10:00:00Z".into()),
+    });
+    store
+        .record_external_create_outcome(&intent, &outcome, &baseline)
+        .await
+        .expect("record create outcome");
+    let work = super::create_recovery::load_external_create_recovery_work(
+        &store,
+        Some(ExternalProvider::Todoist),
+    )
+    .await
+    .expect("load created receipt");
+    let prepared = super::create_recovery::prepare_external_create_recovery(
+        &store,
+        pull_options(ExternalProvider::Todoist),
+        work,
+    )
+    .await
+    .expect("prepare created receipt");
+    let recovery_clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(RecoveryPullClient)];
+    let plan = super::create_recovery::assign_external_create_recovery(prepared, &recovery_clients)
+        .expect("assign created receipt");
+
+    sync_external_tasks_scoped_with_recovery(
+        &store,
+        pull_options(ExternalProvider::Todoist),
+        &recovery_clients,
+        plan,
+    )
+    .await
+    .expect("pull after Created recovery");
+
+    assert_eq!(
+        *store.success_base_revision.lock().expect("base revision"),
+        Some(None)
+    );
+}
+
+struct RecoveryPullClient;
+
+#[async_trait::async_trait]
+impl ExternalSyncClient for RecoveryPullClient {
     fn provider(&self) -> ExternalProvider {
-        ExternalProvider::GitHub
+        ExternalProvider::Todoist
+    }
+
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        Some(self)
     }
 
     fn scope_id(&self) -> String {
-        "acme/widgets".into()
+        "provider-project".into()
     }
 
     async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
-        unreachable!("push-only test")
+        Ok(vec![ExternalTask {
+            reference: ExternalTaskRef::new(ExternalProvider::Todoist, "remote-created"),
+            title: "Task".into(),
+            body: String::new(),
+            status: TaskBoardStatus::Backlog,
+            project_id: Some("provider-project".into()),
+            updated_at: Some("provider-revision-1".into()),
+        }])
     }
 
-    async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
-        self.0.fetch_add(1, Ordering::SeqCst);
-        Ok(ExternalTaskRef::new(
-            ExternalProvider::GitHub,
-            format!("acme/widgets#{}", item.id),
-        ))
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        unreachable!("pull-only recovery test")
     }
 }
 
-struct StaleLeaseStore {
-    item: TaskBoardItem,
-    failure_completions: AtomicUsize,
+#[async_trait::async_trait]
+impl ExternalCreateRecoveryClient for RecoveryPullClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    fn supports_target(&self, provider_target: &str) -> bool {
+        provider_target == "provider-project"
+    }
+
+    async fn create_started(
+        &self,
+        _request: &ExternalCreateRequest,
+        _lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError> {
+        unreachable!("attached recovery test")
+    }
+
+    async fn recover_existing(
+        &self,
+        _request: &ExternalCreateRequest,
+        _lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError> {
+        unreachable!("attached recovery test")
+    }
 }
 
-#[async_trait]
-impl TaskBoardSyncStore for StaleLeaseStore {
-    async fn list_items(
-        &self,
-        _status: Option<TaskBoardStatus>,
-    ) -> Result<Vec<TaskBoardItem>, CliError> {
-        Ok(vec![self.item.clone()])
-    }
+fn unlinked_item(id: &str) -> TaskBoardItem {
+    TaskBoardItem::new(
+        id.into(),
+        "Task".into(),
+        String::new(),
+        "2026-07-16T10:00:00Z".into(),
+    )
+}
 
-    async fn list_items_including_deleted(&self) -> Result<Vec<TaskBoardItem>, CliError> {
-        Ok(vec![self.item.clone()])
-    }
+fn successful_store(item: TaskBoardItem) -> DurableCreateStore {
+    DurableCreateStore::new(item, None, None, None, None, None)
+}
 
-    async fn create_item(&self, _item: TaskBoardItem) -> Result<TaskBoardItem, CliError> {
-        unreachable!("push-only test")
+fn push_options(provider: ExternalProvider) -> ExternalSyncOptions {
+    ExternalSyncOptions {
+        provider: Some(provider),
+        direction: ExternalSyncDirection::Push,
+        dry_run: false,
+        ..ExternalSyncOptions::default()
     }
+}
 
-    async fn update_item(
-        &self,
-        _expected_item: &TaskBoardItem,
-        _patch: TaskBoardItemPatch,
-    ) -> Result<TaskBoardItem, CliError> {
-        unreachable!("lease fails before local persistence")
-    }
-
-    async fn item_snapshot(&self, _item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
-        Ok(TaskBoardSyncItemSnapshot::new(self.item.clone(), 1))
-    }
-
-    async fn provider_scope_state(
-        &self,
-        _provider: ExternalProvider,
-        _scope_id: &str,
-    ) -> Result<ExternalProviderScopeState, CliError> {
-        Ok(ExternalProviderScopeState::default())
-    }
-
-    async fn begin_provider_scope_attempt(
-        &self,
-        provider: ExternalProvider,
-        scope_id: &str,
-        _now: &str,
-    ) -> Result<ExternalProviderScopeAttemptDecision, CliError> {
-        Ok(ExternalProviderScopeAttemptDecision::Started(
-            ExternalProviderScopeAttempt::new(
-                provider,
-                scope_id.to_owned(),
-                "stale-fence".into(),
-                true,
-            ),
-        ))
-    }
-
-    async fn renew_provider_scope_attempt(
-        &self,
-        _attempt: &ExternalProviderScopeAttempt,
-        _now: &str,
-    ) -> Result<(), CliError> {
-        Err(CliErrorKind::concurrent_modification("provider scope lease was replaced").into())
-    }
-
-    async fn complete_provider_scope_success(
-        &self,
-        _attempt: &ExternalProviderScopeAttempt,
-        _base_revision: Option<&str>,
-        _completed_at: &str,
-    ) -> Result<(), CliError> {
-        unreachable!("stale lease never completes")
-    }
-
-    async fn complete_provider_scope_failure(
-        &self,
-        _attempt: &ExternalProviderScopeAttempt,
-        _completed_at: &str,
-    ) -> Result<ExternalProviderScopeState, CliError> {
-        self.failure_completions.fetch_add(1, Ordering::SeqCst);
-        Err(
-            CliErrorKind::concurrent_modification("stale provider scope cannot be finalized")
-                .into(),
-        )
-    }
-
-    async fn replace_open_sync_conflicts(
-        &self,
-        _item_id: &str,
-        _provider: ExternalProvider,
-        _external_ref: &str,
-        _item_revision: i64,
-        _conflicts: &[TaskBoardSyncConflict],
-    ) -> Result<(), CliError> {
-        unreachable!("lease fails before conflict persistence")
+fn pull_options(provider: ExternalProvider) -> ExternalSyncOptions {
+    ExternalSyncOptions {
+        provider: Some(provider),
+        direction: ExternalSyncDirection::Pull,
+        dry_run: false,
+        ..ExternalSyncOptions::default()
     }
 }

--- a/src/task_board/external/sync/lease_tests/client.rs
+++ b/src/task_board/external/sync/lease_tests/client.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+
+use crate::errors::CliError;
+use crate::task_board::external::{
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
+};
+use crate::task_board::{
+    ExternalProvider, ExternalSyncClient, ExternalTask, ExternalTaskRef, TaskBoardItem,
+    TaskBoardStatus,
+};
+
+pub(super) struct DurableCreateClient {
+    provider: ExternalProvider,
+    target: &'static str,
+    calls: Arc<AtomicUsize>,
+}
+
+impl DurableCreateClient {
+    pub(super) fn new(
+        provider: ExternalProvider,
+        target: &'static str,
+        calls: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            provider,
+            target,
+            calls,
+        }
+    }
+}
+
+#[async_trait]
+impl ExternalSyncClient for DurableCreateClient {
+    fn provider(&self) -> ExternalProvider {
+        self.provider
+    }
+
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        Some(self)
+    }
+
+    fn scope_id(&self) -> String {
+        self.target.into()
+    }
+
+    fn scope_for_item(&self, _item: &TaskBoardItem) -> String {
+        self.target.into()
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        Ok(Vec::new())
+    }
+
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        unreachable!("durable creation uses the recovery capability")
+    }
+}
+
+#[async_trait]
+impl ExternalCreateRecoveryClient for DurableCreateClient {
+    fn provider(&self) -> ExternalProvider {
+        self.provider
+    }
+
+    fn supports_target(&self, provider_target: &str) -> bool {
+        provider_target == self.target
+    }
+
+    async fn create_started(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError> {
+        lease.renew().await?;
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let external_id = match self.provider {
+            ExternalProvider::GitHub => format!("{}#17", request.provider_target()),
+            ExternalProvider::Todoist => "remote-created".into(),
+        };
+        Ok(ExternalTask {
+            reference: ExternalTaskRef::new(self.provider, external_id),
+            title: request.title().into(),
+            body: request.body().into(),
+            status: TaskBoardStatus::Backlog,
+            project_id: (self.provider == ExternalProvider::Todoist)
+                .then(|| request.provider_target().into()),
+            updated_at: Some("provider-revision-1".into()),
+        })
+    }
+
+    async fn recover_existing(
+        &self,
+        _request: &ExternalCreateRequest,
+        _lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError> {
+        unreachable!("newly admitted create test")
+    }
+
+    fn extract_create_key(&self, task: &mut ExternalTask) -> Result<Option<String>, CliError> {
+        let Some((body, create_key)) = task.body.rsplit_once("\ncreate-key:") else {
+            return Ok(None);
+        };
+        let body = body.to_owned();
+        let create_key = create_key.to_owned();
+        task.body = body;
+        Ok(Some(create_key))
+    }
+}

--- a/src/task_board/external/sync/lease_tests/marker.rs
+++ b/src/task_board/external/sync/lease_tests/marker.rs
@@ -1,0 +1,335 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+
+use super::client::DurableCreateClient;
+use super::support::DurableCreateStore;
+use super::*;
+
+#[tokio::test]
+async fn attached_marker_is_cleaned_and_retained_for_normal_reconciliation() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (store, client) = attached_marker_fixture("task-marker-attached", &calls).await;
+    let mut operations = Vec::new();
+    let mut follow_ups = Vec::new();
+
+    let (tasks, recovered) = super::super::create_recovery::suppress_known_create_markers(
+        &store,
+        &client,
+        vec![marked_task("task-marker-attached", "Provider edit")],
+        &mut operations,
+        &mut follow_ups,
+        false,
+    )
+    .await
+    .expect("attached marker handling");
+
+    assert!(!recovered);
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].title, "Provider edit");
+    assert_eq!(tasks[0].body, "Provider body");
+    assert!(operations.is_empty());
+    assert_eq!(follow_ups, vec![store.intent()]);
+}
+
+#[tokio::test]
+async fn attached_marker_reconciles_provider_edits_once_without_recreating() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (store, _) = attached_marker_fixture("task-marker-reconcile", &calls).await;
+    let before_record = store.record_calls.load(Ordering::SeqCst);
+    let before_finalize = store.finalize_calls.load(Ordering::SeqCst);
+    let mut task = marked_task("task-marker-reconcile", "Provider edit");
+    task.reference = task
+        .reference
+        .with_url("https://todoist.com/showTask?id=remote-created");
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(MarkerPullClient::new(task))];
+
+    let first =
+        sync_external_tasks_scoped(&store, pull_options(ExternalProvider::Todoist), &clients)
+            .await
+            .expect("reconcile linked attached marker");
+
+    assert_eq!(first.operations.len(), 1);
+    assert_eq!(first.operations[0].action, ExternalSyncAction::Pull);
+    assert!(first.operations[0].applied);
+    assert_eq!(store.update_calls.load(Ordering::SeqCst), 1);
+    let updated = store.item.lock().expect("item").clone();
+    assert_eq!(updated.title, "Provider edit");
+    assert_eq!(updated.body, "Provider body");
+    assert_eq!(
+        updated.external_refs[0].url.as_deref(),
+        Some("https://todoist.com/showTask?id=remote-created")
+    );
+
+    let second =
+        sync_external_tasks_scoped(&store, pull_options(ExternalProvider::Todoist), &clients)
+            .await
+            .expect("repeat linked marker reconciliation");
+
+    assert!(second.operations.is_empty());
+    assert_eq!(store.update_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(store.record_calls.load(Ordering::SeqCst), before_record);
+    assert_eq!(store.finalize_calls.load(Ordering::SeqCst), before_finalize);
+}
+
+#[tokio::test]
+async fn attached_marker_without_its_local_reference_is_suppressed() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (store, client) = attached_marker_fixture("task-marker-unlinked", &calls).await;
+    store.item.lock().expect("item").external_refs.clear();
+    let mut operations = Vec::new();
+    let mut follow_ups = Vec::new();
+
+    let (tasks, recovered) = super::super::create_recovery::suppress_known_create_markers(
+        &store,
+        &client,
+        vec![marked_task("task-marker-unlinked", "Provider edit")],
+        &mut operations,
+        &mut follow_ups,
+        false,
+    )
+    .await
+    .expect("matching attached marker remains suppressed after unlink");
+
+    assert!(!recovered);
+    assert!(tasks.is_empty());
+    assert!(operations.is_empty());
+    assert_eq!(follow_ups, vec![store.intent()]);
+    assert!(store.item.lock().expect("item").external_refs.is_empty());
+
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(MarkerPullClient::new(
+        marked_task("task-marker-unlinked", "Provider edit"),
+    ))];
+    let options = ExternalSyncOptions {
+        provider: Some(ExternalProvider::Todoist),
+        direction: ExternalSyncDirection::Both,
+        dry_run: false,
+        ..ExternalSyncOptions::default()
+    };
+    for _ in 0..2 {
+        let batch = sync_external_tasks_scoped(&store, options, &clients)
+            .await
+            .expect("repeat sync after unlink");
+        assert!(batch.operations.is_empty());
+        assert_eq!(batch.external_create_follow_ups, vec![store.intent()]);
+        assert!(store.item.lock().expect("item").external_refs.is_empty());
+        assert_eq!(
+            *store.success_base_revision.lock().expect("base revision"),
+            Some(Some("provider-revision-2".into()))
+        );
+    }
+}
+
+#[tokio::test]
+async fn attached_marker_for_a_tombstone_is_suppressed_without_removing_its_ref() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (store, client) = attached_marker_fixture("task-marker-tombstone", &calls).await;
+    store.item.lock().expect("item").deleted_at = Some("2026-07-16T12:00:00Z".into());
+    let original_refs = store.item.lock().expect("item").external_refs.clone();
+    let mut operations = Vec::new();
+    let mut follow_ups = Vec::new();
+
+    let (tasks, recovered) = super::super::create_recovery::suppress_known_create_markers(
+        &store,
+        &client,
+        vec![marked_task("task-marker-tombstone", "Provider edit")],
+        &mut operations,
+        &mut follow_ups,
+        false,
+    )
+    .await
+    .expect("tombstoned attached marker remains recovery-owned");
+
+    assert!(!recovered);
+    assert!(tasks.is_empty());
+    assert!(operations.is_empty());
+    assert_eq!(follow_ups, vec![store.intent()]);
+    assert_eq!(
+        store.item.lock().expect("item").external_refs,
+        original_refs
+    );
+}
+
+#[tokio::test]
+async fn attached_marker_with_a_different_remote_identity_fails_closed() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (store, client) = attached_marker_fixture("task-marker-mismatch", &calls).await;
+    let mut task = marked_task("task-marker-mismatch", "Provider edit");
+    task.reference.external_id = "different-remote".into();
+    let mut operations = Vec::new();
+    let mut follow_ups = Vec::new();
+
+    let error = super::super::create_recovery::suppress_known_create_markers(
+        &store,
+        &client,
+        vec![task],
+        &mut operations,
+        &mut follow_ups,
+        false,
+    )
+    .await
+    .expect_err("mismatched attached marker identity must fail closed");
+
+    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
+    assert!(operations.is_empty());
+    assert!(follow_ups.is_empty());
+}
+
+#[tokio::test]
+async fn marker_preview_suppresses_pending_create_without_durable_writes() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut item = unlinked_item("task-marker-preview");
+    item.project_id = Some("provider-project".into());
+    let store = successful_store(item);
+    let client = DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(&calls),
+    );
+    let scope = ExternalProviderScopeIdentity::for_client(&client);
+    let decision = store
+        .begin_external_create_intent(
+            "task-marker-preview",
+            ExternalProvider::Todoist,
+            scope.scope_id(),
+            "provider-project",
+        )
+        .await
+        .expect("begin intent");
+    assert!(matches!(decision, TaskBoardExternalCreateBegin::Started(_)));
+    let mut operations = Vec::new();
+    let mut follow_ups = Vec::new();
+
+    let (tasks, recovered) = super::super::create_recovery::suppress_known_create_markers(
+        &store,
+        &client,
+        vec![marked_task("task-marker-preview", "Provider edit")],
+        &mut operations,
+        &mut follow_ups,
+        true,
+    )
+    .await
+    .expect("dry-run marker handling");
+
+    assert!(recovered);
+    assert!(tasks.is_empty());
+    assert!(operations.is_empty());
+    assert!(follow_ups.is_empty());
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(store.record_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(store.finalize_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(store.supersede_calls.load(Ordering::SeqCst), 0);
+    assert!(matches!(
+        store.intent().state,
+        TaskBoardExternalCreateIntentState::InFlight
+    ));
+}
+
+async fn attached_marker_fixture(
+    item_id: &str,
+    calls: &Arc<AtomicUsize>,
+) -> (DurableCreateStore, DurableCreateClient) {
+    let mut item = unlinked_item(item_id);
+    item.project_id = Some("provider-project".into());
+    let store = successful_store(item);
+    let client = DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(calls),
+    );
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(calls),
+    ))];
+    sync_external_tasks(&store, push_options(ExternalProvider::Todoist), &clients)
+        .await
+        .expect("attach provider create");
+    (store, client)
+}
+
+fn marked_task(item_id: &str, title: &str) -> ExternalTask {
+    ExternalTask {
+        reference: ExternalTaskRef::new(ExternalProvider::Todoist, "remote-created"),
+        title: title.into(),
+        body: format!("Provider body\ncreate-key:create-key-{item_id}"),
+        status: TaskBoardStatus::Backlog,
+        project_id: Some("provider-project".into()),
+        updated_at: Some("provider-revision-2".into()),
+    }
+}
+
+struct MarkerPullClient {
+    task: ExternalTask,
+}
+
+impl MarkerPullClient {
+    fn new(task: ExternalTask) -> Self {
+        Self { task }
+    }
+}
+
+#[async_trait]
+impl ExternalSyncClient for MarkerPullClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        Some(self)
+    }
+
+    fn scope_id(&self) -> String {
+        "provider-project".into()
+    }
+
+    fn scope_for_item(&self, _item: &TaskBoardItem) -> String {
+        self.scope_id()
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        Ok(vec![self.task.clone()])
+    }
+
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        unreachable!("marker regression is pull-only")
+    }
+}
+
+#[async_trait]
+impl ExternalCreateRecoveryClient for MarkerPullClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    fn supports_target(&self, provider_target: &str) -> bool {
+        provider_target == "provider-project"
+    }
+
+    async fn create_started(
+        &self,
+        _request: &ExternalCreateRequest,
+        _lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError> {
+        unreachable!("attached marker must not create")
+    }
+
+    async fn recover_existing(
+        &self,
+        _request: &ExternalCreateRequest,
+        _lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError> {
+        unreachable!("attached marker must not recover")
+    }
+
+    fn extract_create_key(&self, task: &mut ExternalTask) -> Result<Option<String>, CliError> {
+        let Some((body, create_key)) = task.body.rsplit_once("\ncreate-key:") else {
+            return Ok(None);
+        };
+        let body = body.to_owned();
+        let create_key = create_key.to_owned();
+        task.body = body;
+        Ok(Some(create_key))
+    }
+}

--- a/src/task_board/external/sync/lease_tests/support.rs
+++ b/src/task_board/external/sync/lease_tests/support.rs
@@ -1,0 +1,446 @@
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::external::{
+    ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
+    TaskBoardExternalCreateStore, TaskBoardSyncItemSnapshot, TaskBoardSyncStore,
+};
+use crate::task_board::store::{TaskBoardItemPatch, apply_patch};
+use crate::task_board::{
+    ExternalCreateOutcome, ExternalProvider, ExternalRef, ExternalSyncField,
+    TaskBoardExternalCreateBegin, TaskBoardExternalCreateEvidence, TaskBoardExternalCreateExisting,
+    TaskBoardExternalCreateFinalizeDisposition, TaskBoardExternalCreateFinalizeResult,
+    TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState,
+    TaskBoardExternalCreateReceipt, TaskBoardExternalCreateSnapshot, TaskBoardItem,
+    TaskBoardStatus, TaskBoardSyncConflict,
+};
+
+pub(super) struct DurableCreateStore {
+    pub(super) item: Mutex<TaskBoardItem>,
+    intent: Mutex<Option<TaskBoardExternalCreateIntent>>,
+    renew_error: Option<(&'static str, bool, usize)>,
+    finalize_error: Option<&'static str>,
+    completion_error: Option<&'static str>,
+    conflict_error: Option<&'static str>,
+    status_on_finalize: Option<TaskBoardStatus>,
+    pub(super) failure_completions: AtomicUsize,
+    pub(super) record_calls: AtomicUsize,
+    pub(super) finalize_calls: AtomicUsize,
+    pub(super) supersede_calls: AtomicUsize,
+    pub(super) update_calls: AtomicUsize,
+    pub(super) tombstone_list_calls: AtomicUsize,
+    renew_calls: AtomicUsize,
+    pub(super) resolved_fields: Mutex<Vec<ExternalSyncField>>,
+    pub(super) success_base_revision: Mutex<Option<Option<String>>>,
+}
+
+impl DurableCreateStore {
+    pub(super) fn stale_lease(item: TaskBoardItem) -> Self {
+        Self::new(
+            item,
+            Some(("provider scope lease was replaced", false, 0)),
+            None,
+            Some("stale provider scope cannot be finalized"),
+            None,
+            None,
+        )
+    }
+
+    pub(super) fn io_lease_failure(item: TaskBoardItem) -> Self {
+        Self::new(
+            item,
+            Some(("lease storage unavailable", true, 1)),
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    pub(super) fn cleanup_failure(item: TaskBoardItem) -> Self {
+        Self::new(
+            item,
+            None,
+            None,
+            None,
+            Some("conflict cleanup failed"),
+            None,
+        )
+    }
+
+    pub(super) fn done_during_finalize(item: TaskBoardItem) -> Self {
+        Self::new(item, None, None, None, None, Some(TaskBoardStatus::Done))
+    }
+
+    pub(super) fn finalize_failure(item: TaskBoardItem) -> Self {
+        Self::new(item, None, Some("local CAS failed"), None, None, None)
+    }
+
+    pub(super) fn new(
+        item: TaskBoardItem,
+        renew_error: Option<(&'static str, bool, usize)>,
+        finalize_error: Option<&'static str>,
+        completion_error: Option<&'static str>,
+        conflict_error: Option<&'static str>,
+        status_on_finalize: Option<TaskBoardStatus>,
+    ) -> Self {
+        Self {
+            item: Mutex::new(item),
+            intent: Mutex::new(None),
+            renew_error,
+            finalize_error,
+            completion_error,
+            conflict_error,
+            status_on_finalize,
+            failure_completions: AtomicUsize::new(0),
+            record_calls: AtomicUsize::new(0),
+            finalize_calls: AtomicUsize::new(0),
+            supersede_calls: AtomicUsize::new(0),
+            update_calls: AtomicUsize::new(0),
+            tombstone_list_calls: AtomicUsize::new(0),
+            renew_calls: AtomicUsize::new(0),
+            resolved_fields: Mutex::new(Vec::new()),
+            success_base_revision: Mutex::new(None),
+        }
+    }
+
+    pub(super) fn intent(&self) -> TaskBoardExternalCreateIntent {
+        self.intent
+            .lock()
+            .expect("intent")
+            .clone()
+            .expect("persisted intent")
+    }
+}
+
+#[async_trait]
+impl TaskBoardExternalCreateStore for DurableCreateStore {
+    async fn begin_external_create_intent(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        scope_id: &str,
+        provider_target: &str,
+    ) -> Result<TaskBoardExternalCreateBegin, CliError> {
+        let item = self.item.lock().expect("item").clone();
+        let mut stored = self.intent.lock().expect("intent");
+        if let Some(intent) = stored.as_ref() {
+            let existing = match intent.state {
+                TaskBoardExternalCreateIntentState::InFlight => {
+                    TaskBoardExternalCreateExisting::Recover(intent.clone())
+                }
+                TaskBoardExternalCreateIntentState::Created(_) => {
+                    TaskBoardExternalCreateExisting::Finalize(intent.clone())
+                }
+                TaskBoardExternalCreateIntentState::Attached(_) => {
+                    TaskBoardExternalCreateExisting::Attached(intent.clone())
+                }
+            };
+            return Ok(TaskBoardExternalCreateBegin::Existing(existing));
+        }
+        assert_eq!(item_id, item.id);
+        let mut changed_fields = vec![
+            ExternalSyncField::Title,
+            ExternalSyncField::Body,
+            ExternalSyncField::Status,
+        ];
+        if provider != ExternalProvider::GitHub && item.project_id.is_some() {
+            changed_fields.push(ExternalSyncField::Project);
+        }
+        let intent = TaskBoardExternalCreateIntent {
+            intent_id: format!("intent-{item_id}"),
+            item_id: item_id.into(),
+            item_revision: 1,
+            provider,
+            scope_id: scope_id.into(),
+            create_key: format!("create-key-{item_id}"),
+            snapshot: TaskBoardExternalCreateSnapshot {
+                title: item.title,
+                body: item.body,
+                status: item.status,
+                project_id: item.project_id,
+                execution_repository: item.execution_repository,
+                provider_target: provider_target.into(),
+            },
+            changed_fields,
+            state: TaskBoardExternalCreateIntentState::InFlight,
+            created_at: "2026-07-16T10:00:00Z".into(),
+            updated_at: "2026-07-16T10:00:00Z".into(),
+        };
+        *stored = Some(intent.clone());
+        Ok(TaskBoardExternalCreateBegin::Started(intent))
+    }
+
+    async fn record_external_create_outcome(
+        &self,
+        intent: &TaskBoardExternalCreateIntent,
+        outcome: &ExternalCreateOutcome,
+        provider_baseline: &ExternalRef,
+    ) -> Result<TaskBoardExternalCreateIntent, CliError> {
+        self.record_calls.fetch_add(1, Ordering::SeqCst);
+        let mut stored = self.intent.lock().expect("intent");
+        let mut recorded = stored.clone().expect("persisted intent");
+        assert_eq!(recorded.intent_id, intent.intent_id);
+        recorded.state = TaskBoardExternalCreateIntentState::Created(Box::new(
+            TaskBoardExternalCreateEvidence {
+                outcome: outcome.clone(),
+                provider_baseline: provider_baseline.clone(),
+                recorded_at: "2026-07-16T10:00:00Z".into(),
+            },
+        ));
+        *stored = Some(recorded.clone());
+        Ok(recorded)
+    }
+
+    async fn finalize_external_create_intent(
+        &self,
+        intent: &TaskBoardExternalCreateIntent,
+    ) -> Result<TaskBoardExternalCreateFinalizeResult, CliError> {
+        self.finalize_calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(message) = self.finalize_error {
+            return Err(CliErrorKind::concurrent_modification(message).into());
+        }
+        let mut stored = self.intent.lock().expect("intent");
+        let current = stored.clone().expect("persisted intent");
+        assert_eq!(current.intent_id, intent.intent_id);
+        let evidence = current
+            .created_evidence()
+            .cloned()
+            .expect("created evidence");
+        let attached = TaskBoardExternalCreateIntent {
+            state: TaskBoardExternalCreateIntentState::Attached(Box::new(
+                TaskBoardExternalCreateReceipt {
+                    evidence: evidence.clone(),
+                    attached_at: "2026-07-16T10:00:00Z".into(),
+                    attached_item_revision: 2,
+                },
+            )),
+            updated_at: "2026-07-16T10:00:00Z".into(),
+            ..current
+        };
+        let mut linked = self.item.lock().expect("item").clone();
+        if let Some(status) = self.status_on_finalize {
+            linked.status = status;
+        }
+        linked.external_refs.push(evidence.provider_baseline);
+        self.supersede_calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(message) = self.conflict_error {
+            return Err(CliErrorKind::workflow_io(message).into());
+        }
+        self.resolved_fields
+            .lock()
+            .expect("resolved fields")
+            .clone_from(&intent.changed_fields);
+        self.item.lock().expect("item").clone_from(&linked);
+        *stored = Some(attached.clone());
+        Ok(TaskBoardExternalCreateFinalizeResult {
+            intent: attached,
+            item: Some(linked),
+            item_revision: Some(2),
+            disposition: TaskBoardExternalCreateFinalizeDisposition::Attached,
+        })
+    }
+
+    async fn external_create_intent_by_create_key(
+        &self,
+        provider: ExternalProvider,
+        create_key: &str,
+    ) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+        Ok(self
+            .intent
+            .lock()
+            .expect("intent")
+            .as_ref()
+            .filter(|intent| intent.provider == provider && intent.create_key == create_key)
+            .cloned())
+    }
+
+    async fn list_created_external_create_intents(
+        &self,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Ok(self
+            .intent
+            .lock()
+            .expect("intent")
+            .iter()
+            .filter(|intent| matches!(intent.state, TaskBoardExternalCreateIntentState::Created(_)))
+            .cloned()
+            .collect())
+    }
+
+    async fn list_in_flight_external_create_intents(
+        &self,
+        provider: ExternalProvider,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Ok(self
+            .intent
+            .lock()
+            .expect("intent")
+            .iter()
+            .filter(|intent| {
+                intent.provider == provider
+                    && matches!(intent.state, TaskBoardExternalCreateIntentState::InFlight)
+            })
+            .cloned()
+            .collect())
+    }
+
+    async fn list_pending_external_create_follow_ups(
+        &self,
+        provider: Option<ExternalProvider>,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Ok(self
+            .intent
+            .lock()
+            .expect("intent")
+            .iter()
+            .filter(|intent| {
+                provider.is_none_or(|provider| intent.provider == provider)
+                    && matches!(
+                        intent.state,
+                        TaskBoardExternalCreateIntentState::Attached(_)
+                    )
+            })
+            .cloned()
+            .collect())
+    }
+}
+
+#[async_trait]
+impl TaskBoardSyncStore for DurableCreateStore {
+    async fn list_items(
+        &self,
+        status: Option<TaskBoardStatus>,
+    ) -> Result<Vec<TaskBoardItem>, CliError> {
+        let item = self.item.lock().expect("item").clone();
+        Ok(
+            (!item.is_deleted() && status.is_none_or(|target| item.status == target))
+                .then_some(item)
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    async fn list_items_including_deleted(&self) -> Result<Vec<TaskBoardItem>, CliError> {
+        self.tombstone_list_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![self.item.lock().expect("item").clone()])
+    }
+
+    async fn create_item(&self, _item: TaskBoardItem) -> Result<TaskBoardItem, CliError> {
+        unreachable!("push-only create test")
+    }
+
+    async fn update_item(
+        &self,
+        expected_item: &TaskBoardItem,
+        patch: TaskBoardItemPatch,
+    ) -> Result<TaskBoardItem, CliError> {
+        let mut current = self.item.lock().expect("item");
+        if *current != *expected_item {
+            return Err(CliErrorKind::concurrent_modification(
+                "test item changed before provider reconciliation",
+            )
+            .into());
+        }
+        let mut updated = current.clone();
+        apply_patch(&mut updated, patch);
+        self.update_calls.fetch_add(1, Ordering::SeqCst);
+        current.clone_from(&updated);
+        Ok(updated)
+    }
+
+    async fn item_snapshot(&self, _item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
+        Ok(TaskBoardSyncItemSnapshot::new(
+            self.item.lock().expect("item").clone(),
+            2,
+        ))
+    }
+
+    async fn provider_scope_state(
+        &self,
+        _provider: ExternalProvider,
+        _scope_id: &str,
+    ) -> Result<ExternalProviderScopeState, CliError> {
+        Ok(ExternalProviderScopeState::default())
+    }
+
+    async fn begin_provider_scope_attempt(
+        &self,
+        provider: ExternalProvider,
+        scope_id: &str,
+        _now: &str,
+    ) -> Result<ExternalProviderScopeAttemptDecision, CliError> {
+        Ok(ExternalProviderScopeAttemptDecision::Started(
+            ExternalProviderScopeAttempt::new(provider, scope_id.into(), "test-fence".into(), true),
+        ))
+    }
+
+    async fn renew_provider_scope_attempt(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _now: &str,
+    ) -> Result<(), CliError> {
+        let call = self.renew_calls.fetch_add(1, Ordering::SeqCst);
+        match self.renew_error {
+            Some((message, true, fail_at)) if call == fail_at => {
+                Err(CliErrorKind::workflow_io(message).into())
+            }
+            Some((message, false, fail_at)) if call == fail_at => {
+                Err(CliErrorKind::concurrent_modification(message).into())
+            }
+            Some(_) | None => Ok(()),
+        }
+    }
+
+    async fn complete_provider_scope_success(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        base_revision: Option<&str>,
+        _completed_at: &str,
+    ) -> Result<(), CliError> {
+        *self.success_base_revision.lock().expect("base revision") =
+            Some(base_revision.map(str::to_owned));
+        Ok(())
+    }
+
+    async fn complete_provider_scope_failure(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _completed_at: &str,
+    ) -> Result<ExternalProviderScopeState, CliError> {
+        self.failure_completions.fetch_add(1, Ordering::SeqCst);
+        self.completion_error.map_or_else(
+            || Ok(ExternalProviderScopeState::default()),
+            |message| Err(CliErrorKind::concurrent_modification(message).into()),
+        )
+    }
+
+    async fn replace_open_sync_conflicts(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _external_ref: &str,
+        _item_revision: i64,
+        _conflicts: &[TaskBoardSyncConflict],
+    ) -> Result<(), CliError> {
+        unreachable!("create evidence is durable, not synthesized as a conflict")
+    }
+
+    async fn supersede_open_sync_conflicts(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _external_ref: &str,
+        _item_revision: i64,
+        resolved_fields: &[ExternalSyncField],
+    ) -> Result<(), CliError> {
+        self.supersede_calls.fetch_add(1, Ordering::SeqCst);
+        *self.resolved_fields.lock().expect("resolved fields") = resolved_fields.to_vec();
+        self.conflict_error.map_or(Ok(()), |message| {
+            Err(CliErrorKind::workflow_io(message).into())
+        })
+    }
+}

--- a/src/task_board/external/sync/legacy_store.rs
+++ b/src/task_board/external/sync/legacy_store.rs
@@ -8,7 +8,7 @@ use crate::task_board::store::{TaskBoardItemPatch, TaskBoardStore};
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 use crate::task_board::{ExternalProvider, TaskBoardSyncConflict};
 
-use super::TaskBoardSyncStore;
+use super::{TaskBoardSyncItemSnapshot, TaskBoardSyncStore};
 
 #[async_trait]
 impl TaskBoardSyncStore for TaskBoardStore {
@@ -63,8 +63,16 @@ impl TaskBoardSyncStore for TaskBoardStore {
         .map_err(|error| sync_join_error("update item", error))?
     }
 
-    async fn item_revision(&self, _item_id: &str) -> Result<i64, CliError> {
-        Ok(0)
+    async fn item_snapshot(&self, item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
+        let board = self.clone();
+        let item_id = item_id.to_owned();
+        tokio::task::spawn_blocking(move || {
+            board
+                .get(&item_id)
+                .map(|item| TaskBoardSyncItemSnapshot::new(item, 0))
+        })
+        .await
+        .map_err(|error| sync_join_error("load item snapshot", error))?
     }
 
     async fn provider_scope_state(
@@ -91,6 +99,14 @@ impl TaskBoardSyncStore for TaskBoardStore {
         ))
     }
 
+    async fn renew_provider_scope_attempt(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _now: &str,
+    ) -> Result<(), CliError> {
+        Ok(())
+    }
+
     async fn complete_provider_scope_success(
         &self,
         _attempt: &ExternalProviderScopeAttempt,
@@ -113,6 +129,7 @@ impl TaskBoardSyncStore for TaskBoardStore {
         _item_id: &str,
         _provider: ExternalProvider,
         _external_ref: &str,
+        _item_revision: i64,
         _conflicts: &[TaskBoardSyncConflict],
     ) -> Result<(), CliError> {
         Ok(())

--- a/src/task_board/external/sync/legacy_store.rs
+++ b/src/task_board/external/sync/legacy_store.rs
@@ -6,9 +6,42 @@ use crate::task_board::external::{
 };
 use crate::task_board::store::{TaskBoardItemPatch, TaskBoardStore};
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
-use crate::task_board::{ExternalProvider, TaskBoardSyncConflict};
+use crate::task_board::{
+    ExternalProvider, ExternalSyncField, TaskBoardExternalCreateIntent, TaskBoardSyncConflict,
+};
 
-use super::{TaskBoardSyncItemSnapshot, TaskBoardSyncStore};
+use super::{TaskBoardExternalCreateStore, TaskBoardSyncItemSnapshot, TaskBoardSyncStore};
+
+#[async_trait]
+impl TaskBoardExternalCreateStore for TaskBoardStore {
+    async fn list_created_external_create_intents(
+        &self,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Ok(Vec::new())
+    }
+
+    async fn list_in_flight_external_create_intents(
+        &self,
+        _provider: ExternalProvider,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Ok(Vec::new())
+    }
+
+    async fn external_create_intent_by_create_key(
+        &self,
+        _provider: ExternalProvider,
+        _create_key: &str,
+    ) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+        Ok(None)
+    }
+
+    async fn list_pending_external_create_follow_ups(
+        &self,
+        _provider: Option<ExternalProvider>,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Ok(Vec::new())
+    }
+}
 
 #[async_trait]
 impl TaskBoardSyncStore for TaskBoardStore {
@@ -134,6 +167,17 @@ impl TaskBoardSyncStore for TaskBoardStore {
     ) -> Result<(), CliError> {
         Ok(())
     }
+
+    async fn supersede_open_sync_conflicts(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _external_ref: &str,
+        _item_revision: i64,
+        _resolved_fields: &[ExternalSyncField],
+    ) -> Result<(), CliError> {
+        Ok(())
+    }
 }
 
 fn sync_join_error(operation: &str, error: tokio::task::JoinError) -> CliError {
@@ -141,4 +185,22 @@ fn sync_join_error(operation: &str, error: tokio::task::JoinError) -> CliError {
         "task-board external sync {operation} worker failed: {error}"
     ))
     .into()
+}
+
+#[tokio::test]
+async fn non_durable_store_rejects_external_create_admission() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+
+    let error = TaskBoardExternalCreateStore::begin_external_create_intent(
+        &board,
+        "task-create",
+        ExternalProvider::Todoist,
+        "todoist:scope",
+        "todoist-project",
+    )
+    .await
+    .expect_err("non-durable create admission must fail closed");
+
+    assert_eq!(error.code(), "WORKFLOW_IO");
 }

--- a/src/task_board/external/sync/merge.rs
+++ b/src/task_board/external/sync/merge.rs
@@ -89,21 +89,6 @@ pub(super) fn replace_synced_ref(
         .collect()
 }
 
-pub(super) fn synced_ref_from_item(
-    reference: ExternalTaskRef,
-    item: &TaskBoardItem,
-    provider_project_id: Option<&str>,
-    provider_revision: Option<&str>,
-) -> ExternalRef {
-    let mut reference = reference.into_core_ref();
-    reference.sync_state = Some(sync_state_from_created_item(
-        item,
-        provider_project_id,
-        provider_revision,
-    ));
-    reference
-}
-
 pub(super) fn sync_state_from_task(task: &ExternalTask) -> ExternalRefSyncState {
     ExternalRefSyncState {
         title: Some(task.title.clone()),
@@ -126,6 +111,19 @@ pub(super) fn pull_create_fields(task: &ExternalTask) -> Vec<ExternalSyncField> 
     }
     if task.reference.url.is_some() {
         fields.push(ExternalSyncField::Url);
+    }
+    fields
+}
+
+pub(super) fn pull_resolution_fields(task: &ExternalTask) -> Vec<ExternalSyncField> {
+    let mut fields = vec![
+        ExternalSyncField::Title,
+        ExternalSyncField::Body,
+        ExternalSyncField::Status,
+        ExternalSyncField::Url,
+    ];
+    if provider_project_maps_to_board(task.reference.provider) {
+        fields.push(ExternalSyncField::Project);
     }
     fields
 }
@@ -159,21 +157,6 @@ pub(super) fn changed_fields(patch: &TaskBoardItemPatch) -> Vec<ExternalSyncFiel
         ExternalSyncField::Project,
     );
     fields
-}
-
-fn sync_state_from_created_item(
-    item: &TaskBoardItem,
-    provider_project_id: Option<&str>,
-    provider_revision: Option<&str>,
-) -> ExternalRefSyncState {
-    ExternalRefSyncState {
-        title: Some(item.title.clone()),
-        body: Some(item.body.clone()),
-        status: Some(TaskBoardStatus::Backlog),
-        project_id: provider_project_id.map(ToOwned::to_owned),
-        updated_at: provider_revision.map(ToOwned::to_owned),
-        synced_at: Some(utc_now()),
-    }
 }
 
 fn synced_ref_from_update(

--- a/src/task_board/external/sync/merge.rs
+++ b/src/task_board/external/sync/merge.rs
@@ -4,6 +4,7 @@ use crate::task_board::types::{
 };
 use crate::workspace::utc_now;
 
+use crate::task_board::external::targeting::provider_project_maps_to_board;
 use crate::task_board::external::{
     ExternalProvider, ExternalProviderCapabilities, ExternalSyncAction, ExternalSyncField,
     ExternalSyncOperation, ExternalTask, ExternalTaskRef, canonical_external_status,
@@ -31,7 +32,7 @@ pub(super) fn pull_conflict_fields(
     };
     match &reference.sync_state {
         Some(state) => {
-            let local = local_fields_changed_since_sync(item, state);
+            let local = local_fields_changed_since_sync(item, state, task.reference.provider);
             let remote = remote_fields_changed_since_sync(task, state);
             intersect_fields(local, &remote)
         }
@@ -48,7 +49,7 @@ pub(super) fn local_update_fields(
         .and_then(|reference| reference.sync_state.as_ref())
         .map_or_else(
             || capabilities.update_fields.clone(),
-            |state| local_fields_changed_since_sync(item, state),
+            |state| local_fields_changed_since_sync(item, state, reference.provider),
         )
 }
 
@@ -91,10 +92,15 @@ pub(super) fn replace_synced_ref(
 pub(super) fn synced_ref_from_item(
     reference: ExternalTaskRef,
     item: &TaskBoardItem,
+    provider_project_id: Option<&str>,
     provider_revision: Option<&str>,
 ) -> ExternalRef {
     let mut reference = reference.into_core_ref();
-    reference.sync_state = Some(sync_state_from_created_item(item, provider_revision));
+    reference.sync_state = Some(sync_state_from_created_item(
+        item,
+        provider_project_id,
+        provider_revision,
+    ));
     reference
 }
 
@@ -115,7 +121,7 @@ pub(super) fn pull_create_fields(task: &ExternalTask) -> Vec<ExternalSyncField> 
         ExternalSyncField::Body,
         ExternalSyncField::Status,
     ];
-    if task.project_id.is_some() {
+    if provider_project_maps_to_board(task.reference.provider) && task.project_id.is_some() {
         fields.push(ExternalSyncField::Project);
     }
     if task.reference.url.is_some() {
@@ -124,12 +130,15 @@ pub(super) fn pull_create_fields(task: &ExternalTask) -> Vec<ExternalSyncField> 
     fields
 }
 
-pub(super) fn push_create_fields(item: &TaskBoardItem) -> Vec<ExternalSyncField> {
+pub(super) fn push_create_fields(
+    item: &TaskBoardItem,
+    provider: ExternalProvider,
+) -> Vec<ExternalSyncField> {
     let mut fields = vec![ExternalSyncField::Title, ExternalSyncField::Body];
     if canonical_external_status(item.status) != TaskBoardStatus::Done {
         fields.push(ExternalSyncField::Status);
     }
-    if item.project_id.is_some() {
+    if provider_project_maps_to_board(provider) && item.project_id.is_some() {
         fields.push(ExternalSyncField::Project);
     }
     fields
@@ -154,13 +163,14 @@ pub(super) fn changed_fields(patch: &TaskBoardItemPatch) -> Vec<ExternalSyncFiel
 
 fn sync_state_from_created_item(
     item: &TaskBoardItem,
+    provider_project_id: Option<&str>,
     provider_revision: Option<&str>,
 ) -> ExternalRefSyncState {
     ExternalRefSyncState {
         title: Some(item.title.clone()),
         body: Some(item.body.clone()),
         status: Some(TaskBoardStatus::Backlog),
-        project_id: item.project_id.clone(),
+        project_id: provider_project_id.map(ToOwned::to_owned),
         updated_at: provider_revision.map(ToOwned::to_owned),
         synced_at: Some(utc_now()),
     }
@@ -211,7 +221,8 @@ fn item_remote_diff_fields(item: &TaskBoardItem, task: &ExternalTask) -> Vec<Ext
     );
     push_if(
         &mut fields,
-        item.project_id != task.project_id,
+        provider_project_maps_to_board(task.reference.provider)
+            && item.project_id != task.project_id,
         ExternalSyncField::Project,
     );
     fields
@@ -220,6 +231,7 @@ fn item_remote_diff_fields(item: &TaskBoardItem, task: &ExternalTask) -> Vec<Ext
 fn local_fields_changed_since_sync(
     item: &TaskBoardItem,
     state: &ExternalRefSyncState,
+    provider: ExternalProvider,
 ) -> Vec<ExternalSyncField> {
     let mut fields = Vec::new();
     push_if(
@@ -239,7 +251,7 @@ fn local_fields_changed_since_sync(
     );
     push_if(
         &mut fields,
-        state.project_id != item.project_id,
+        provider_project_maps_to_board(provider) && state.project_id != item.project_id,
         ExternalSyncField::Project,
     );
     fields
@@ -267,7 +279,8 @@ fn remote_fields_changed_since_sync(
     );
     push_if(
         &mut fields,
-        state.project_id != task.project_id,
+        provider_project_maps_to_board(task.reference.provider)
+            && state.project_id != task.project_id,
         ExternalSyncField::Project,
     );
     fields
@@ -336,10 +349,14 @@ pub(super) fn external_ref_matches(
 }
 
 fn project_matches(item: &TaskBoardItem, candidate: &ExternalRef, project_id: &str) -> bool {
-    candidate
-        .sync_state
-        .as_ref()
-        .and_then(|state| state.project_id.as_deref())
+    item.execution_repository
+        .as_deref()
+        .or_else(|| {
+            candidate
+                .sync_state
+                .as_ref()
+                .and_then(|state| state.project_id.as_deref())
+        })
         .or(item.project_id.as_deref())
         .is_some_and(|candidate_project| candidate_project.eq_ignore_ascii_case(project_id))
 }

--- a/src/task_board/external/sync/push.rs
+++ b/src/task_board/external/sync/push.rs
@@ -1,7 +1,8 @@
 use crate::errors::CliError;
 use crate::github_api::republish_current_data_change;
 use crate::task_board::external::ExternalProviderScopeAttempt;
-use crate::task_board::store::TaskBoardItemPatch;
+use crate::task_board::external::targeting::provider_project_maps_to_board;
+use crate::task_board::store::{OptionalFieldPatch, TaskBoardItemPatch};
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 
 use super::conflicts::build_sync_conflicts;
@@ -11,9 +12,10 @@ use super::merge::{
     replace_synced_ref, split_supported_fields, synced_ref_from_item,
 };
 use super::{
-    ExternalProvider, ExternalSyncAction, ExternalSyncClient, ExternalSyncField,
-    ExternalSyncOperation, ExternalSyncOptions, ExternalTask, ExternalTaskRef, ExternalTaskUpdate,
-    ExternalUpdateOutcome, SyncClientError, TaskBoardSyncStore, canonical_external_status,
+    ExternalCreateOutcome, ExternalProvider, ExternalSyncAction, ExternalSyncClient,
+    ExternalSyncField, ExternalSyncOperation, ExternalSyncOptions, ExternalTask, ExternalTaskRef,
+    ExternalTaskUpdate, ExternalUpdateOutcome, SyncClientError, TaskBoardSyncStore,
+    canonical_external_status,
 };
 
 pub(super) async fn push_board_tasks(
@@ -63,7 +65,7 @@ async fn create_remote_item(
     item: &TaskBoardItem,
     operations: &mut Vec<ExternalSyncOperation>,
 ) -> Result<(), SyncClientError> {
-    let changed_fields = push_create_fields(item);
+    let changed_fields = push_create_fields(item, client.provider());
     if options.dry_run {
         operations.push(push_operation(
             client.provider(),
@@ -77,16 +79,31 @@ async fn create_remote_item(
         return Ok(());
     }
     super::scope::renew_scope_attempt(board, attempt).await?;
-    let reference = client
-        .push_task(item)
+    let ExternalCreateOutcome {
+        reference,
+        provider_revision,
+        provider_project_id,
+    } = client
+        .push_task_with_outcome(item)
         .await
         .map_err(SyncClientError::Provider)?;
     let mut refs = item.external_refs.clone();
-    refs.push(synced_ref_from_item(reference.clone(), item, None));
+    refs.push(synced_ref_from_item(
+        reference.clone(),
+        item,
+        provider_project_id.as_deref(),
+        provider_revision.as_deref(),
+    ));
+    let project_id =
+        provider_project_patch(item, client.provider(), provider_project_id.as_deref());
+    let execution_repository =
+        provider_repository_patch(item, client.provider(), provider_project_id.as_deref());
     let linked = match board
         .update_item(
             item,
             TaskBoardItemPatch {
+                project_id,
+                execution_repository,
                 external_refs: Some(refs),
                 ..TaskBoardItemPatch::default()
             },
@@ -95,7 +112,12 @@ async fn create_remote_item(
     {
         Ok(linked) => linked,
         Err(error) => {
-            let remote = created_remote_task(item, reference.clone());
+            let remote = created_remote_task(
+                item,
+                reference.clone(),
+                provider_project_id,
+                provider_revision,
+            );
             persist_push_conflicts(board, item, &remote, &changed_fields)
                 .await
                 .map_err(SyncClientError::Local)?;
@@ -128,6 +150,38 @@ async fn create_remote_item(
         .await?;
     }
     Ok(())
+}
+
+fn provider_project_patch(
+    item: &TaskBoardItem,
+    provider: ExternalProvider,
+    provider_project_id: Option<&str>,
+) -> OptionalFieldPatch<String> {
+    if !provider_project_maps_to_board(provider)
+        || item.project_id.as_deref() == provider_project_id
+    {
+        return OptionalFieldPatch::Unchanged;
+    }
+    provider_project_id
+        .map(ToOwned::to_owned)
+        .map_or(OptionalFieldPatch::Clear, OptionalFieldPatch::Set)
+}
+
+fn provider_repository_patch(
+    item: &TaskBoardItem,
+    provider: ExternalProvider,
+    provider_project_id: Option<&str>,
+) -> OptionalFieldPatch<String> {
+    if provider != ExternalProvider::GitHub {
+        return OptionalFieldPatch::Unchanged;
+    }
+    let Some(provider_project_id) = provider_project_id else {
+        return OptionalFieldPatch::Unchanged;
+    };
+    if item.execution_repository.as_deref() == Some(provider_project_id) {
+        return OptionalFieldPatch::Unchanged;
+    }
+    OptionalFieldPatch::Set(provider_project_id.to_owned())
 }
 
 async fn update_linked_remote(
@@ -328,14 +382,19 @@ async fn persist_push_conflicts(
         .await
 }
 
-fn created_remote_task(item: &TaskBoardItem, reference: ExternalTaskRef) -> ExternalTask {
+fn created_remote_task(
+    item: &TaskBoardItem,
+    reference: ExternalTaskRef,
+    provider_project_id: Option<String>,
+    provider_revision: Option<String>,
+) -> ExternalTask {
     ExternalTask {
         reference,
         title: item.title.clone(),
         body: item.body.clone(),
         status: TaskBoardStatus::Backlog,
-        project_id: item.project_id.clone(),
-        updated_at: None,
+        project_id: provider_project_id,
+        updated_at: provider_revision,
     }
 }
 

--- a/src/task_board/external/sync/push.rs
+++ b/src/task_board/external/sync/push.rs
@@ -1,20 +1,20 @@
-use crate::errors::CliError;
+use crate::errors::{CliError, CliErrorKind};
 use crate::github_api::republish_current_data_change;
 use crate::task_board::external::ExternalProviderScopeAttempt;
-use crate::task_board::external::targeting::provider_project_maps_to_board;
-use crate::task_board::store::{OptionalFieldPatch, TaskBoardItemPatch};
+use crate::task_board::store::TaskBoardItemPatch;
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 
 use super::conflicts::build_sync_conflicts;
+use super::create_recovery::create_item_durably;
 use super::lookup::{OperationDraft, operation, provider_ref};
 use super::merge::{
     has_reported_conflict, local_update_fields, matching_ref, push_create_fields,
-    replace_synced_ref, split_supported_fields, synced_ref_from_item,
+    replace_synced_ref, split_supported_fields,
 };
 use super::{
-    ExternalCreateOutcome, ExternalProvider, ExternalSyncAction, ExternalSyncClient,
-    ExternalSyncField, ExternalSyncOperation, ExternalSyncOptions, ExternalTask, ExternalTaskRef,
-    ExternalTaskUpdate, ExternalUpdateOutcome, SyncClientError, TaskBoardSyncStore,
+    ExternalProvider, ExternalSyncAction, ExternalSyncClient, ExternalSyncField,
+    ExternalSyncOperation, ExternalSyncOptions, ExternalTask, ExternalTaskRef, ExternalTaskUpdate,
+    ExternalUpdateOutcome, SyncClientError, TaskBoardExternalCreateIntent, TaskBoardSyncStore,
     canonical_external_status,
 };
 
@@ -24,18 +24,27 @@ pub(super) async fn push_board_tasks(
     client: &dyn ExternalSyncClient,
     attempt: Option<&ExternalProviderScopeAttempt>,
     operations: &mut Vec<ExternalSyncOperation>,
-) -> Result<(), SyncClientError> {
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<bool, SyncClientError> {
     let items = board
         .list_items(options.status)
         .await
         .map_err(SyncClientError::Local)?;
     let scope_id = client.scope_id();
+    let mut created = false;
     for item in &items {
-        push_board_item(board, options, client, attempt, item, &scope_id, operations).await?;
+        created |= push_board_item(
+            board, options, client, attempt, item, &scope_id, operations, follow_ups,
+        )
+        .await?;
     }
-    Ok(())
+    Ok(created)
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one item push needs the admitted scope plus operation and durable follow-up sinks"
+)]
 async fn push_board_item(
     board: &dyn TaskBoardSyncStore,
     options: ExternalSyncOptions,
@@ -44,16 +53,22 @@ async fn push_board_item(
     item: &TaskBoardItem,
     scope_id: &str,
     operations: &mut Vec<ExternalSyncOperation>,
-) -> Result<(), SyncClientError> {
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<bool, SyncClientError> {
     if !super::client_owns_item(client, item, scope_id)
         || has_reported_conflict(operations, client.provider(), &item.id)
     {
-        return Ok(());
+        return Ok(false);
     }
     if let Some(reference) = provider_ref(item, client.provider()) {
-        update_linked_remote(board, options, client, attempt, item, reference, operations).await
+        update_linked_remote(board, options, client, attempt, item, reference, operations)
+            .await
+            .map(|()| false)
     } else {
-        create_remote_item(board, options, client, attempt, item, operations).await
+        create_remote_item(
+            board, options, client, attempt, item, operations, follow_ups,
+        )
+        .await
     }
 }
 
@@ -64,7 +79,8 @@ async fn create_remote_item(
     attempt: Option<&ExternalProviderScopeAttempt>,
     item: &TaskBoardItem,
     operations: &mut Vec<ExternalSyncOperation>,
-) -> Result<(), SyncClientError> {
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<bool, SyncClientError> {
     let changed_fields = push_create_fields(item, client.provider());
     if options.dry_run {
         operations.push(push_operation(
@@ -76,112 +92,40 @@ async fn create_remote_item(
             changed_fields,
             Vec::new(),
         ));
-        return Ok(());
+        return Ok(false);
     }
-    super::scope::renew_scope_attempt(board, attempt).await?;
-    let ExternalCreateOutcome {
-        reference,
-        provider_revision,
-        provider_project_id,
-    } = client
-        .push_task_with_outcome(item)
-        .await
-        .map_err(SyncClientError::Provider)?;
-    let mut refs = item.external_refs.clone();
-    refs.push(synced_ref_from_item(
-        reference.clone(),
-        item,
-        provider_project_id.as_deref(),
-        provider_revision.as_deref(),
-    ));
-    let project_id =
-        provider_project_patch(item, client.provider(), provider_project_id.as_deref());
-    let execution_repository =
-        provider_repository_patch(item, client.provider(), provider_project_id.as_deref());
-    let linked = match board
-        .update_item(
-            item,
-            TaskBoardItemPatch {
-                project_id,
-                execution_repository,
-                external_refs: Some(refs),
-                ..TaskBoardItemPatch::default()
-            },
-        )
-        .await
-    {
-        Ok(linked) => linked,
-        Err(error) => {
-            let remote = created_remote_task(
-                item,
-                reference.clone(),
-                provider_project_id,
-                provider_revision,
-            );
-            operations.push(push_operation(
-                client.provider(),
-                item,
-                reference,
-                false,
-                false,
-                changed_fields.clone(),
-                Vec::new(),
-            ));
-            persist_push_conflicts(board, item, &remote, &changed_fields)
-                .await
-                .map_err(SyncClientError::Local)?;
-            return Err(SyncClientError::Local(error));
-        }
+    let Some(attempt) = attempt else {
+        return Err(SyncClientError::Local(
+            CliErrorKind::workflow_io("durable provider create requires a persisted scope attempt")
+                .into(),
+        ));
+    };
+    let result = create_item_durably(board, client, attempt, item, operations, follow_ups).await?;
+    let Some(linked) = result.linked_item else {
+        return Ok(result.durable_create);
     };
     republish_github_board_ready(client.provider());
-    operations.push(push_operation(
-        client.provider(),
-        item,
-        reference.clone(),
-        false,
-        true,
-        changed_fields,
-        Vec::new(),
-    ));
-    if canonical_external_status(item.status) == TaskBoardStatus::Done {
+    if linked.status == TaskBoardStatus::Done {
+        let reference = provider_ref(&linked, client.provider()).ok_or_else(|| {
+            SyncClientError::Local(
+                CliErrorKind::concurrent_modification(
+                    "finalized provider create has no linked reference",
+                )
+                .into(),
+            )
+        })?;
         update_linked_remote(
-            board, options, client, attempt, &linked, reference, operations,
+            board,
+            options,
+            client,
+            Some(attempt),
+            &linked,
+            reference,
+            operations,
         )
         .await?;
     }
-    Ok(())
-}
-
-fn provider_project_patch(
-    item: &TaskBoardItem,
-    provider: ExternalProvider,
-    provider_project_id: Option<&str>,
-) -> OptionalFieldPatch<String> {
-    if !provider_project_maps_to_board(provider)
-        || item.project_id.as_deref() == provider_project_id
-    {
-        return OptionalFieldPatch::Unchanged;
-    }
-    provider_project_id
-        .map(ToOwned::to_owned)
-        .map_or(OptionalFieldPatch::Clear, OptionalFieldPatch::Set)
-}
-
-fn provider_repository_patch(
-    item: &TaskBoardItem,
-    provider: ExternalProvider,
-    provider_project_id: Option<&str>,
-) -> OptionalFieldPatch<String> {
-    if provider != ExternalProvider::GitHub {
-        return OptionalFieldPatch::Unchanged;
-    }
-    let Some(provider_project_id) = provider_project_id else {
-        return OptionalFieldPatch::Unchanged;
-    };
-    if item.execution_repository.as_deref() == Some(provider_project_id) {
-        return OptionalFieldPatch::Unchanged;
-    }
-    OptionalFieldPatch::Set(provider_project_id.to_owned())
+    Ok(result.durable_create)
 }
 
 async fn update_linked_remote(
@@ -334,32 +278,29 @@ async fn persist_linked_update(
             .map_err(SyncClientError::Local)?;
         return Err(SyncClientError::Local(error));
     }
-    let clears_conflicts = unsupported.is_empty();
     operations.push(push_operation(
         client.provider(),
         item,
         updated_ref.clone(),
         false,
         true,
-        supported,
+        supported.clone(),
         unsupported,
     ));
-    if clears_conflicts {
-        let snapshot = board
-            .item_snapshot(&item.id)
-            .await
-            .map_err(SyncClientError::Local)?;
-        board
-            .replace_open_sync_conflicts(
-                &item.id,
-                client.provider(),
-                &updated_ref.external_id,
-                snapshot.item_revision,
-                &[],
-            )
-            .await
-            .map_err(SyncClientError::Local)?;
-    }
+    let snapshot = board
+        .item_snapshot(&item.id)
+        .await
+        .map_err(SyncClientError::Local)?;
+    board
+        .supersede_open_sync_conflicts(
+            &item.id,
+            client.provider(),
+            &updated_ref.external_id,
+            snapshot.item_revision,
+            &supported,
+        )
+        .await
+        .map_err(SyncClientError::Local)?;
     republish_github_board_ready(client.provider());
     Ok(())
 }
@@ -381,22 +322,6 @@ async fn persist_push_conflicts(
             &conflicts,
         )
         .await
-}
-
-fn created_remote_task(
-    item: &TaskBoardItem,
-    reference: ExternalTaskRef,
-    provider_project_id: Option<String>,
-    provider_revision: Option<String>,
-) -> ExternalTask {
-    ExternalTask {
-        reference,
-        title: item.title.clone(),
-        body: item.body.clone(),
-        status: TaskBoardStatus::Backlog,
-        project_id: provider_project_id,
-        updated_at: provider_revision,
-    }
 }
 
 fn updated_remote_task(

--- a/src/task_board/external/sync/push.rs
+++ b/src/task_board/external/sync/push.rs
@@ -118,18 +118,18 @@ async fn create_remote_item(
                 provider_project_id,
                 provider_revision,
             );
-            persist_push_conflicts(board, item, &remote, &changed_fields)
-                .await
-                .map_err(SyncClientError::Local)?;
             operations.push(push_operation(
                 client.provider(),
                 item,
                 reference,
                 false,
                 false,
-                changed_fields,
+                changed_fields.clone(),
                 Vec::new(),
             ));
+            persist_push_conflicts(board, item, &remote, &changed_fields)
+                .await
+                .map_err(SyncClientError::Local)?;
             return Err(SyncClientError::Local(error));
         }
     };
@@ -320,21 +320,31 @@ async fn persist_linked_update(
         )
         .await
     {
-        persist_push_conflicts(board, item, &remote, &supported)
-            .await
-            .map_err(SyncClientError::Local)?;
         operations.push(push_operation(
             client.provider(),
             item,
             updated_ref,
             false,
             false,
-            supported,
+            supported.clone(),
             unsupported,
         ));
+        persist_push_conflicts(board, item, &remote, &supported)
+            .await
+            .map_err(SyncClientError::Local)?;
         return Err(SyncClientError::Local(error));
     }
-    if unsupported.is_empty() {
+    let clears_conflicts = unsupported.is_empty();
+    operations.push(push_operation(
+        client.provider(),
+        item,
+        updated_ref.clone(),
+        false,
+        true,
+        supported,
+        unsupported,
+    ));
+    if clears_conflicts {
         let snapshot = board
             .item_snapshot(&item.id)
             .await
@@ -351,15 +361,6 @@ async fn persist_linked_update(
             .map_err(SyncClientError::Local)?;
     }
     republish_github_board_ready(client.provider());
-    operations.push(push_operation(
-        client.provider(),
-        item,
-        updated_ref,
-        false,
-        true,
-        supported,
-        unsupported,
-    ));
     Ok(())
 }
 
@@ -436,9 +437,7 @@ fn updated_remote_task(
                 .and_then(|state| state.project_id.clone())
                 .or_else(|| item.project_id.clone())
         },
-        updated_at: provider_revision
-            .map(ToOwned::to_owned)
-            .or_else(|| state.and_then(|state| state.updated_at.clone())),
+        updated_at: provider_revision.map(ToOwned::to_owned),
     }
 }
 

--- a/src/task_board/external/sync/push.rs
+++ b/src/task_board/external/sync/push.rs
@@ -1,5 +1,6 @@
 use crate::errors::CliError;
 use crate::github_api::republish_current_data_change;
+use crate::task_board::external::ExternalProviderScopeAttempt;
 use crate::task_board::store::TaskBoardItemPatch;
 use crate::task_board::types::{TaskBoardItem, TaskBoardStatus};
 
@@ -19,6 +20,7 @@ pub(super) async fn push_board_tasks(
     board: &dyn TaskBoardSyncStore,
     options: ExternalSyncOptions,
     client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
     operations: &mut Vec<ExternalSyncOperation>,
 ) -> Result<(), SyncClientError> {
     let items = board
@@ -27,7 +29,7 @@ pub(super) async fn push_board_tasks(
         .map_err(SyncClientError::Local)?;
     let scope_id = client.scope_id();
     for item in &items {
-        push_board_item(board, options, client, item, &scope_id, operations).await?;
+        push_board_item(board, options, client, attempt, item, &scope_id, operations).await?;
     }
     Ok(())
 }
@@ -36,6 +38,7 @@ async fn push_board_item(
     board: &dyn TaskBoardSyncStore,
     options: ExternalSyncOptions,
     client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
     item: &TaskBoardItem,
     scope_id: &str,
     operations: &mut Vec<ExternalSyncOperation>,
@@ -46,9 +49,9 @@ async fn push_board_item(
         return Ok(());
     }
     if let Some(reference) = provider_ref(item, client.provider()) {
-        update_linked_remote(board, options, client, item, reference, operations).await
+        update_linked_remote(board, options, client, attempt, item, reference, operations).await
     } else {
-        create_remote_item(board, options, client, item, operations).await
+        create_remote_item(board, options, client, attempt, item, operations).await
     }
 }
 
@@ -56,6 +59,7 @@ async fn create_remote_item(
     board: &dyn TaskBoardSyncStore,
     options: ExternalSyncOptions,
     client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
     item: &TaskBoardItem,
     operations: &mut Vec<ExternalSyncOperation>,
 ) -> Result<(), SyncClientError> {
@@ -72,6 +76,7 @@ async fn create_remote_item(
         ));
         return Ok(());
     }
+    super::scope::renew_scope_attempt(board, attempt).await?;
     let reference = client
         .push_task(item)
         .await
@@ -117,7 +122,10 @@ async fn create_remote_item(
         Vec::new(),
     ));
     if canonical_external_status(item.status) == TaskBoardStatus::Done {
-        update_linked_remote(board, options, client, &linked, reference, operations).await?;
+        update_linked_remote(
+            board, options, client, attempt, &linked, reference, operations,
+        )
+        .await?;
     }
     Ok(())
 }
@@ -126,6 +134,7 @@ async fn update_linked_remote(
     board: &dyn TaskBoardSyncStore,
     options: ExternalSyncOptions,
     client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
     item: &TaskBoardItem,
     reference: ExternalTaskRef,
     operations: &mut Vec<ExternalSyncOperation>,
@@ -148,8 +157,10 @@ async fn update_linked_remote(
         ));
         return Ok(());
     }
-    let Some(applied) =
-        execute_provider_update(board, client, item, &reference, &supported, operations).await?
+    let Some(applied) = execute_provider_update(
+        board, client, attempt, item, &reference, &supported, operations,
+    )
+    .await?
     else {
         return Ok(());
     };
@@ -174,6 +185,7 @@ struct AppliedRemoteUpdate {
 async fn execute_provider_update(
     board: &dyn TaskBoardSyncStore,
     client: &dyn ExternalSyncClient,
+    attempt: Option<&ExternalProviderScopeAttempt>,
     item: &TaskBoardItem,
     reference: &ExternalTaskRef,
     supported: &[ExternalSyncField],
@@ -182,6 +194,7 @@ async fn execute_provider_update(
     let precondition = remote_precondition(item, reference);
     let update =
         ExternalTaskUpdate::new(supported.to_vec()).with_precondition_updated_at(precondition);
+    super::scope::renew_scope_attempt(board, attempt).await?;
     let outcome = client
         .update_task(item, reference, update)
         .await
@@ -268,8 +281,18 @@ async fn persist_linked_update(
         return Err(SyncClientError::Local(error));
     }
     if unsupported.is_empty() {
+        let snapshot = board
+            .item_snapshot(&item.id)
+            .await
+            .map_err(SyncClientError::Local)?;
         board
-            .replace_open_sync_conflicts(&item.id, client.provider(), &updated_ref.external_id, &[])
+            .replace_open_sync_conflicts(
+                &item.id,
+                client.provider(),
+                &updated_ref.external_id,
+                snapshot.item_revision,
+                &[],
+            )
             .await
             .map_err(SyncClientError::Local)?;
     }
@@ -292,29 +315,17 @@ async fn persist_push_conflicts(
     remote: &ExternalTask,
     fields: &[ExternalSyncField],
 ) -> Result<(), CliError> {
-    let item = latest_item(board, expected_item).await?;
-    let item_revision = board.item_revision(&item.id).await?;
-    let conflicts = build_sync_conflicts(&item, remote, fields, item_revision);
+    let snapshot = board.item_snapshot(&expected_item.id).await?;
+    let conflicts = build_sync_conflicts(&snapshot.item, remote, fields, snapshot.item_revision);
     board
         .replace_open_sync_conflicts(
-            &item.id,
+            &snapshot.item.id,
             remote.reference.provider,
             &remote.reference.external_id,
+            snapshot.item_revision,
             &conflicts,
         )
         .await
-}
-
-async fn latest_item(
-    board: &dyn TaskBoardSyncStore,
-    expected_item: &TaskBoardItem,
-) -> Result<TaskBoardItem, CliError> {
-    Ok(board
-        .list_items_including_deleted()
-        .await?
-        .into_iter()
-        .find(|item| item.id == expected_item.id)
-        .unwrap_or_else(|| expected_item.clone()))
 }
 
 fn created_remote_task(item: &TaskBoardItem, reference: ExternalTaskRef) -> ExternalTask {

--- a/src/task_board/external/sync/push/tests.rs
+++ b/src/task_board/external/sync/push/tests.rs
@@ -6,14 +6,18 @@ use super::*;
 use crate::errors::CliErrorKind;
 use crate::task_board::external::{
     ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
+    TaskBoardSyncItemSnapshot,
 };
 use crate::task_board::{ExternalRefSyncState, TaskBoardSyncConflict};
 
 #[tokio::test]
 async fn linked_push_is_not_applied_when_required_local_persistence_fails() {
     let item = linked_item();
+    let mut listed_item = item.clone();
+    listed_item.title = "Stale local edit".into();
     let store = FailingStore {
         item: item.clone(),
+        listed_item,
         conflicts: Mutex::new(Vec::new()),
     };
     let client = UpdateClient;
@@ -40,7 +44,10 @@ async fn linked_push_is_not_applied_when_required_local_persistence_fails() {
     assert_eq!(operations.len(), 1);
     assert_eq!(operations[0].action, ExternalSyncAction::Push);
     assert!(!operations[0].applied);
-    assert_eq!(store.conflicts.lock().expect("conflicts").len(), 1);
+    let conflicts = store.conflicts.lock().expect("conflicts");
+    assert_eq!(conflicts.len(), 1);
+    assert_eq!(conflicts[0].local_value, serde_json::json!("Local edit"));
+    assert_eq!(conflicts[0].item_revision, 2);
 }
 
 fn linked_item() -> TaskBoardItem {
@@ -82,6 +89,7 @@ impl ExternalSyncClient for UpdateClient {
 
 struct FailingStore {
     item: TaskBoardItem,
+    listed_item: TaskBoardItem,
     conflicts: Mutex<Vec<TaskBoardSyncConflict>>,
 }
 
@@ -91,11 +99,11 @@ impl TaskBoardSyncStore for FailingStore {
         &self,
         _status: Option<TaskBoardStatus>,
     ) -> Result<Vec<TaskBoardItem>, CliError> {
-        Ok(vec![self.item.clone()])
+        Ok(vec![self.listed_item.clone()])
     }
 
     async fn list_items_including_deleted(&self) -> Result<Vec<TaskBoardItem>, CliError> {
-        Ok(vec![self.item.clone()])
+        Ok(vec![self.listed_item.clone()])
     }
 
     async fn create_item(&self, _item: TaskBoardItem) -> Result<TaskBoardItem, CliError> {
@@ -110,8 +118,8 @@ impl TaskBoardSyncStore for FailingStore {
         Err(CliErrorKind::concurrent_modification("local CAS failed").into())
     }
 
-    async fn item_revision(&self, _item_id: &str) -> Result<i64, CliError> {
-        Ok(2)
+    async fn item_snapshot(&self, _item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
+        Ok(TaskBoardSyncItemSnapshot::new(self.item.clone(), 2))
     }
 
     async fn provider_scope_state(
@@ -128,6 +136,14 @@ impl TaskBoardSyncStore for FailingStore {
         _scope_id: &str,
         _now: &str,
     ) -> Result<ExternalProviderScopeAttemptDecision, CliError> {
+        unreachable!("direct persistence test")
+    }
+
+    async fn renew_provider_scope_attempt(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _now: &str,
+    ) -> Result<(), CliError> {
         unreachable!("direct persistence test")
     }
 
@@ -153,6 +169,7 @@ impl TaskBoardSyncStore for FailingStore {
         _item_id: &str,
         _provider: ExternalProvider,
         _external_ref: &str,
+        _item_revision: i64,
         conflicts: &[TaskBoardSyncConflict],
     ) -> Result<(), CliError> {
         *self.conflicts.lock().expect("conflicts") = conflicts.to_vec();

--- a/src/task_board/external/sync/push/tests.rs
+++ b/src/task_board/external/sync/push/tests.rs
@@ -6,8 +6,9 @@ use super::*;
 use crate::errors::CliErrorKind;
 use crate::task_board::external::{
     ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
-    TaskBoardSyncItemSnapshot,
+    ExternalSyncDirection, TaskBoardSyncItemSnapshot,
 };
+use crate::task_board::store::apply_patch;
 use crate::task_board::{ExternalRefSyncState, TaskBoardSyncConflict};
 
 #[tokio::test]
@@ -19,6 +20,9 @@ async fn linked_push_is_not_applied_when_required_local_persistence_fails() {
         item: item.clone(),
         listed_item,
         conflicts: Mutex::new(Vec::new()),
+        updated_items: Mutex::new(Vec::new()),
+        update_succeeds: false,
+        conflict_error: None,
     };
     let client = UpdateClient;
     let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
@@ -48,6 +52,149 @@ async fn linked_push_is_not_applied_when_required_local_persistence_fails() {
     assert_eq!(conflicts.len(), 1);
     assert_eq!(conflicts[0].local_value, serde_json::json!("Local edit"));
     assert_eq!(conflicts[0].item_revision, 2);
+}
+
+#[tokio::test]
+async fn remote_create_evidence_survives_conflict_persistence_failure() {
+    let item = TaskBoardItem::new(
+        "task-create".into(),
+        "Create remotely".into(),
+        "Body".into(),
+        "2026-07-16T10:00:00Z".into(),
+    );
+    let store = failing_store(&item, false, Some("conflict persistence failed"));
+    let mut operations = Vec::new();
+
+    let error = create_remote_item(
+        &store,
+        push_options(),
+        &CreateClient,
+        None,
+        &item,
+        &mut operations,
+    )
+    .await
+    .expect_err("local link and conflict persistence must fail");
+
+    assert!(matches!(error, SyncClientError::Local(_)));
+    assert_eq!(operations.len(), 1);
+    assert_eq!(operations[0].external_id.as_deref(), Some("remote-created"));
+    assert!(!operations[0].applied);
+}
+
+#[tokio::test]
+async fn remote_update_evidence_survives_conflict_persistence_failure() {
+    let item = linked_item();
+    let store = failing_store(&item, false, Some("conflict persistence failed"));
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let mut operations = Vec::new();
+
+    let error = persist_linked_update(
+        &store,
+        &UpdateClient,
+        &item,
+        reference.clone(),
+        AppliedRemoteUpdate {
+            reference,
+            provider_revision: Some("provider-revision-2".into()),
+        },
+        vec![ExternalSyncField::Title],
+        Vec::new(),
+        &mut operations,
+    )
+    .await
+    .expect_err("local update and conflict persistence must fail");
+
+    assert!(matches!(error, SyncClientError::Local(_)));
+    assert_eq!(operations.len(), 1);
+    assert!(!operations[0].applied);
+}
+
+#[tokio::test]
+async fn applied_remote_update_evidence_survives_cleanup_failure() {
+    let item = linked_item();
+    let store = failing_store(&item, true, Some("conflict cleanup failed"));
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let mut operations = Vec::new();
+
+    let error = persist_linked_update(
+        &store,
+        &UpdateClient,
+        &item,
+        reference.clone(),
+        AppliedRemoteUpdate {
+            reference,
+            provider_revision: Some("provider-revision-2".into()),
+        },
+        vec![ExternalSyncField::Title],
+        Vec::new(),
+        &mut operations,
+    )
+    .await
+    .expect_err("conflict cleanup must fail");
+
+    assert!(matches!(error, SyncClientError::Local(_)));
+    assert_eq!(operations.len(), 1);
+    assert!(operations[0].applied);
+}
+
+#[tokio::test]
+async fn missing_provider_revision_stays_unknown_in_conflict_evidence() {
+    let item = linked_item();
+    let store = failing_store(&item, false, None);
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let mut operations = Vec::new();
+
+    persist_linked_update(
+        &store,
+        &UpdateClient,
+        &item,
+        reference.clone(),
+        AppliedRemoteUpdate {
+            reference,
+            provider_revision: None,
+        },
+        vec![ExternalSyncField::Title],
+        Vec::new(),
+        &mut operations,
+    )
+    .await
+    .expect_err("local persistence must fail");
+
+    let conflicts = store.conflicts.lock().expect("conflicts");
+    assert_eq!(conflicts.len(), 1);
+    assert_eq!(conflicts[0].provider_revision, None);
+}
+
+#[tokio::test]
+async fn successful_local_sync_retains_known_revision_when_provider_omits_one() {
+    let item = linked_item();
+    let store = failing_store(&item, true, None);
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let mut operations = Vec::new();
+
+    let result = persist_linked_update(
+        &store,
+        &UpdateClient,
+        &item,
+        reference.clone(),
+        AppliedRemoteUpdate {
+            reference,
+            provider_revision: None,
+        },
+        vec![ExternalSyncField::Title],
+        Vec::new(),
+        &mut operations,
+    )
+    .await;
+    assert!(result.is_ok(), "local sync persistence");
+
+    let updated_items = store.updated_items.lock().expect("updated items");
+    let state = updated_items[0].external_refs[0]
+        .sync_state
+        .as_ref()
+        .expect("updated sync state");
+    assert_eq!(state.updated_at.as_deref(), Some("provider-revision-1"));
 }
 
 fn linked_item() -> TaskBoardItem {
@@ -87,10 +234,33 @@ impl ExternalSyncClient for UpdateClient {
     }
 }
 
+struct CreateClient;
+
+#[async_trait]
+impl ExternalSyncClient for CreateClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        unreachable!("direct create test")
+    }
+
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        Ok(ExternalTaskRef::new(
+            ExternalProvider::Todoist,
+            "remote-created",
+        ))
+    }
+}
+
 struct FailingStore {
     item: TaskBoardItem,
     listed_item: TaskBoardItem,
     conflicts: Mutex<Vec<TaskBoardSyncConflict>>,
+    updated_items: Mutex<Vec<TaskBoardItem>>,
+    update_succeeds: bool,
+    conflict_error: Option<&'static str>,
 }
 
 #[async_trait]
@@ -112,9 +282,18 @@ impl TaskBoardSyncStore for FailingStore {
 
     async fn update_item(
         &self,
-        _expected_item: &TaskBoardItem,
-        _patch: TaskBoardItemPatch,
+        expected_item: &TaskBoardItem,
+        patch: TaskBoardItemPatch,
     ) -> Result<TaskBoardItem, CliError> {
+        if self.update_succeeds {
+            let mut updated = expected_item.clone();
+            apply_patch(&mut updated, patch);
+            self.updated_items
+                .lock()
+                .expect("updated items")
+                .push(updated.clone());
+            return Ok(updated);
+        }
         Err(CliErrorKind::concurrent_modification("local CAS failed").into())
     }
 
@@ -172,7 +351,33 @@ impl TaskBoardSyncStore for FailingStore {
         _item_revision: i64,
         conflicts: &[TaskBoardSyncConflict],
     ) -> Result<(), CliError> {
+        if let Some(message) = self.conflict_error {
+            return Err(CliErrorKind::workflow_io(message).into());
+        }
         *self.conflicts.lock().expect("conflicts") = conflicts.to_vec();
         Ok(())
+    }
+}
+
+fn failing_store(
+    item: &TaskBoardItem,
+    update_succeeds: bool,
+    conflict_error: Option<&'static str>,
+) -> FailingStore {
+    FailingStore {
+        item: item.clone(),
+        listed_item: item.clone(),
+        conflicts: Mutex::new(Vec::new()),
+        updated_items: Mutex::new(Vec::new()),
+        update_succeeds,
+        conflict_error,
+    }
+}
+
+fn push_options() -> ExternalSyncOptions {
+    ExternalSyncOptions {
+        direction: ExternalSyncDirection::Push,
+        dry_run: false,
+        ..ExternalSyncOptions::default()
     }
 }

--- a/src/task_board/external/sync/push/tests.rs
+++ b/src/task_board/external/sync/push/tests.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::errors::CliErrorKind;
 use crate::task_board::external::{
     ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
-    ExternalSyncDirection, TaskBoardSyncItemSnapshot,
+    TaskBoardSyncItemSnapshot,
 };
 use crate::task_board::store::apply_patch;
 use crate::task_board::{ExternalRefSyncState, TaskBoardSyncConflict};
@@ -52,34 +52,6 @@ async fn linked_push_is_not_applied_when_required_local_persistence_fails() {
     assert_eq!(conflicts.len(), 1);
     assert_eq!(conflicts[0].local_value, serde_json::json!("Local edit"));
     assert_eq!(conflicts[0].item_revision, 2);
-}
-
-#[tokio::test]
-async fn remote_create_evidence_survives_conflict_persistence_failure() {
-    let item = TaskBoardItem::new(
-        "task-create".into(),
-        "Create remotely".into(),
-        "Body".into(),
-        "2026-07-16T10:00:00Z".into(),
-    );
-    let store = failing_store(&item, false, Some("conflict persistence failed"));
-    let mut operations = Vec::new();
-
-    let error = create_remote_item(
-        &store,
-        push_options(),
-        &CreateClient,
-        None,
-        &item,
-        &mut operations,
-    )
-    .await
-    .expect_err("local link and conflict persistence must fail");
-
-    assert!(matches!(error, SyncClientError::Local(_)));
-    assert_eq!(operations.len(), 1);
-    assert_eq!(operations[0].external_id.as_deref(), Some("remote-created"));
-    assert!(!operations[0].applied);
 }
 
 #[tokio::test]
@@ -234,26 +206,6 @@ impl ExternalSyncClient for UpdateClient {
     }
 }
 
-struct CreateClient;
-
-#[async_trait]
-impl ExternalSyncClient for CreateClient {
-    fn provider(&self) -> ExternalProvider {
-        ExternalProvider::Todoist
-    }
-
-    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
-        unreachable!("direct create test")
-    }
-
-    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
-        Ok(ExternalTaskRef::new(
-            ExternalProvider::Todoist,
-            "remote-created",
-        ))
-    }
-}
-
 struct FailingStore {
     item: TaskBoardItem,
     listed_item: TaskBoardItem,
@@ -262,6 +214,8 @@ struct FailingStore {
     update_succeeds: bool,
     conflict_error: Option<&'static str>,
 }
+
+impl crate::task_board::TaskBoardExternalCreateStore for FailingStore {}
 
 #[async_trait]
 impl TaskBoardSyncStore for FailingStore {
@@ -357,6 +311,19 @@ impl TaskBoardSyncStore for FailingStore {
         *self.conflicts.lock().expect("conflicts") = conflicts.to_vec();
         Ok(())
     }
+
+    async fn supersede_open_sync_conflicts(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _external_ref: &str,
+        _item_revision: i64,
+        _resolved_fields: &[ExternalSyncField],
+    ) -> Result<(), CliError> {
+        self.conflict_error.map_or(Ok(()), |message| {
+            Err(CliErrorKind::workflow_io(message).into())
+        })
+    }
 }
 
 fn failing_store(
@@ -371,13 +338,5 @@ fn failing_store(
         updated_items: Mutex::new(Vec::new()),
         update_succeeds,
         conflict_error,
-    }
-}
-
-fn push_options() -> ExternalSyncOptions {
-    ExternalSyncOptions {
-        direction: ExternalSyncDirection::Push,
-        dry_run: false,
-        ..ExternalSyncOptions::default()
     }
 }

--- a/src/task_board/external/sync/reconcile.rs
+++ b/src/task_board/external/sync/reconcile.rs
@@ -1,5 +1,7 @@
 use crate::errors::CliError;
-use crate::task_board::external::targeting::execution_repository_for_task;
+use crate::task_board::external::targeting::{
+    execution_repository_for_task, provider_project_maps_to_board,
+};
 use crate::task_board::external::{
     ExternalProvider, ExternalSyncConflictPolicy, ExternalSyncField, ExternalTask, ExternalTaskRef,
 };
@@ -199,7 +201,8 @@ fn reconciliation_patch(
     if item.status != status {
         patch.status = Some(status);
     }
-    if item.project_id != task.project_id
+    if provider_project_maps_to_board(task.reference.provider)
+        && item.project_id != task.project_id
         && should_apply_remote(
             sync_state.map(|state| &state.project_id),
             &item.project_id,

--- a/src/task_board/external/sync/reconcile.rs
+++ b/src/task_board/external/sync/reconcile.rs
@@ -28,17 +28,23 @@ pub(super) async fn reconcile_existing_item(
     task: ExternalTask,
     operations: &mut Vec<ExternalSyncOperation>,
 ) -> Result<(), CliError> {
-    let conflict_fields = pull_conflict_fields(item, &task);
     let reports_conflicts = matches!(options.direction, ExternalSyncDirection::Both)
         && matches!(options.conflict_policy, ExternalSyncConflictPolicy::Report);
-    if reports_conflicts && !options.dry_run {
-        let item_revision = board.item_revision(&item.id).await?;
-        let conflicts = build_sync_conflicts(item, &task, &conflict_fields, item_revision);
+    let snapshot = if reports_conflicts && !options.dry_run {
+        Some(board.item_snapshot(&item.id).await?)
+    } else {
+        None
+    };
+    let item = snapshot.as_ref().map_or(item, |snapshot| &snapshot.item);
+    let conflict_fields = pull_conflict_fields(item, &task);
+    if let Some(snapshot) = &snapshot {
+        let conflicts = build_sync_conflicts(item, &task, &conflict_fields, snapshot.item_revision);
         board
             .replace_open_sync_conflicts(
                 &item.id,
                 provider,
                 &task.reference.external_id,
+                snapshot.item_revision,
                 &conflicts,
             )
             .await?;
@@ -122,8 +128,15 @@ async fn supersede_resolved_conflicts(
         ExternalSyncConflictPolicy::PreferLocal => conflict_fields.is_empty(),
     };
     if resolved && !options.dry_run {
+        let snapshot = board.item_snapshot(&item.id).await?;
         board
-            .replace_open_sync_conflicts(&item.id, provider, &task.reference.external_id, &[])
+            .replace_open_sync_conflicts(
+                &item.id,
+                provider,
+                &task.reference.external_id,
+                snapshot.item_revision,
+                &[],
+            )
             .await?;
     }
     Ok(())
@@ -285,7 +298,7 @@ mod tests {
     use crate::task_board::TaskBoardSyncConflict;
     use crate::task_board::external::{
         ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
-        ExternalProviderScopeState, ExternalSyncDirection,
+        ExternalProviderScopeState, ExternalSyncDirection, TaskBoardSyncItemSnapshot,
     };
 
     #[tokio::test]
@@ -348,8 +361,11 @@ mod tests {
             Err(CliErrorKind::concurrent_modification("concurrent test edit").into())
         }
 
-        async fn item_revision(&self, _item_id: &str) -> Result<i64, CliError> {
-            Ok(0)
+        async fn item_snapshot(
+            &self,
+            _item_id: &str,
+        ) -> Result<TaskBoardSyncItemSnapshot, CliError> {
+            Ok(TaskBoardSyncItemSnapshot::new(self.latest.clone(), 0))
         }
 
         async fn provider_scope_state(
@@ -367,6 +383,14 @@ mod tests {
             _now: &str,
         ) -> Result<ExternalProviderScopeAttemptDecision, CliError> {
             unreachable!("reconciliation test does not begin provider attempts")
+        }
+
+        async fn renew_provider_scope_attempt(
+            &self,
+            _attempt: &ExternalProviderScopeAttempt,
+            _now: &str,
+        ) -> Result<(), CliError> {
+            unreachable!("reconciliation test does not renew provider attempts")
         }
 
         async fn complete_provider_scope_success(
@@ -391,6 +415,7 @@ mod tests {
             _item_id: &str,
             _provider: ExternalProvider,
             _external_ref: &str,
+            _item_revision: i64,
             _conflicts: &[TaskBoardSyncConflict],
         ) -> Result<(), CliError> {
             Ok(())

--- a/src/task_board/external/sync/reconcile.rs
+++ b/src/task_board/external/sync/reconcile.rs
@@ -11,11 +11,12 @@ use crate::task_board::types::{ExternalRef, ExternalRefSyncState, TaskBoardItem,
 use super::super::github::reconciled_external_status;
 use super::conflicts::build_sync_conflicts;
 use super::merge::{
-    changed_fields, external_ref_matches, matching_ref, pull_conflict_fields, sync_state_from_task,
+    changed_fields, external_ref_matches, matching_ref, pull_conflict_fields,
+    pull_resolution_fields, sync_state_from_task,
 };
 use super::{
     ExternalSyncAction, ExternalSyncDirection, ExternalSyncOperation, ExternalSyncOptions,
-    OperationDraft, TaskBoardSyncStore, operation,
+    OperationDraft, TaskBoardSyncStore, canonical_external_status, operation,
 };
 
 #[expect(
@@ -139,24 +140,51 @@ async fn supersede_resolved_conflicts(
     task: &ExternalTask,
     conflict_fields: &[ExternalSyncField],
 ) -> Result<(), CliError> {
-    let resolved = match options.conflict_policy {
-        ExternalSyncConflictPolicy::Report => false,
+    if options.dry_run || !conflicts_are_resolved(options, conflict_fields) {
+        return Ok(());
+    }
+    let snapshot = board.item_snapshot(&item.id).await?;
+    let resolved_fields = converged_pull_fields(&snapshot.item, task);
+    board
+        .supersede_open_sync_conflicts(
+            &item.id,
+            provider,
+            &task.reference.external_id,
+            snapshot.item_revision,
+            &resolved_fields,
+        )
+        .await
+}
+
+fn conflicts_are_resolved(
+    options: ExternalSyncOptions,
+    conflict_fields: &[ExternalSyncField],
+) -> bool {
+    match options.conflict_policy {
+        ExternalSyncConflictPolicy::Report => {
+            matches!(options.direction, ExternalSyncDirection::Pull)
+        }
         ExternalSyncConflictPolicy::PreferRemote => true,
         ExternalSyncConflictPolicy::PreferLocal => conflict_fields.is_empty(),
-    };
-    if resolved && !options.dry_run {
-        let snapshot = board.item_snapshot(&item.id).await?;
-        board
-            .replace_open_sync_conflicts(
-                &item.id,
-                provider,
-                &task.reference.external_id,
-                snapshot.item_revision,
-                &[],
-            )
-            .await?;
     }
-    Ok(())
+}
+
+fn converged_pull_fields(item: &TaskBoardItem, task: &ExternalTask) -> Vec<ExternalSyncField> {
+    pull_resolution_fields(task)
+        .into_iter()
+        .filter(|field| match field {
+            ExternalSyncField::Title => item.title == task.title,
+            ExternalSyncField::Body => item.body == task.body,
+            ExternalSyncField::Status => {
+                canonical_external_status(item.status) == canonical_external_status(task.status)
+            }
+            ExternalSyncField::Project => item.project_id == task.project_id,
+            ExternalSyncField::Url => {
+                matching_ref(item, &task.reference, task.project_id.as_deref())
+                    .is_some_and(|reference| reference.url == task.reference.url)
+            }
+        })
+        .collect()
 }
 
 async fn latest_item_still_needs_reconciliation(
@@ -353,6 +381,8 @@ mod tests {
     struct ConcurrentEditStore {
         latest: TaskBoardItem,
     }
+
+    impl crate::task_board::TaskBoardExternalCreateStore for ConcurrentEditStore {}
 
     #[async_trait]
     impl TaskBoardSyncStore for ConcurrentEditStore {

--- a/src/task_board/external/sync/reconcile.rs
+++ b/src/task_board/external/sync/reconcile.rs
@@ -67,7 +67,8 @@ pub(super) async fn reconcile_existing_item(
     let prefer_remote = matches!(
         options.conflict_policy,
         ExternalSyncConflictPolicy::PreferRemote
-    );
+    ) || matches!(options.direction, ExternalSyncDirection::Pull)
+        && matches!(options.conflict_policy, ExternalSyncConflictPolicy::Report);
     let patch = reconciliation_patch(item, &task, prefer_remote);
     if !has_reconciliation_change(&patch) {
         supersede_resolved_conflicts(board, options, provider, item, &task, &conflict_fields)
@@ -88,32 +89,46 @@ pub(super) async fn reconcile_existing_item(
         }));
         return Ok(());
     }
-    if let Err(error) = board.update_item(item, patch).await
-        && (error.code() != "WORKFLOW_CONCURRENT"
-            || latest_item_still_needs_reconciliation(board, item, &task, prefer_remote).await?)
-    {
-        return Err(error);
+    let applied = apply_reconciliation(board, item, &task, prefer_remote, patch).await?;
+    let records_applied_operation = applied
+        && !(matches!(
+            options.conflict_policy,
+            ExternalSyncConflictPolicy::PreferLocal
+        ) && !conflict_fields.is_empty()
+            && changed_fields.is_empty());
+    if records_applied_operation {
+        operations.push(operation(OperationDraft {
+            provider,
+            action: ExternalSyncAction::Pull,
+            board_item_id: Some(item.id.clone()),
+            reference: task.reference.clone(),
+            dry_run: false,
+            applied: true,
+            changed_fields,
+            unsupported_fields: Vec::new(),
+        }));
     }
     supersede_resolved_conflicts(board, options, provider, item, &task, &conflict_fields).await?;
-    if matches!(
-        options.conflict_policy,
-        ExternalSyncConflictPolicy::PreferLocal
-    ) && !conflict_fields.is_empty()
-        && changed_fields.is_empty()
-    {
-        return Ok(());
-    }
-    operations.push(operation(OperationDraft {
-        provider,
-        action: ExternalSyncAction::Pull,
-        board_item_id: Some(item.id.clone()),
-        reference: task.reference.clone(),
-        dry_run: false,
-        applied: true,
-        changed_fields,
-        unsupported_fields: Vec::new(),
-    }));
     Ok(())
+}
+
+async fn apply_reconciliation(
+    board: &dyn TaskBoardSyncStore,
+    item: &TaskBoardItem,
+    task: &ExternalTask,
+    prefer_remote: bool,
+    patch: TaskBoardItemPatch,
+) -> Result<bool, CliError> {
+    match board.update_item(item, patch).await {
+        Ok(_) => Ok(true),
+        Err(error) if error.code() != "WORKFLOW_CONCURRENT" => Err(error),
+        Err(error) => {
+            if latest_item_still_needs_reconciliation(board, item, task, prefer_remote).await? {
+                return Err(error);
+            }
+            Ok(false)
+        }
+    }
 }
 
 async fn supersede_resolved_conflicts(

--- a/src/task_board/external/sync/scope.rs
+++ b/src/task_board/external/sync/scope.rs
@@ -1,6 +1,23 @@
 use crate::errors::CliError;
+use crate::task_board::external::ExternalProviderScopeAttempt;
+use crate::workspace::utc_now;
+
+use super::TaskBoardSyncStore;
 
 pub(super) enum SyncClientError {
     Provider(CliError),
     Local(CliError),
+}
+
+pub(super) async fn renew_scope_attempt(
+    board: &dyn TaskBoardSyncStore,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+) -> Result<(), SyncClientError> {
+    if let Some(attempt) = attempt {
+        board
+            .renew_provider_scope_attempt(attempt, &utc_now())
+            .await
+            .map_err(SyncClientError::Local)?;
+    }
+    Ok(())
 }

--- a/src/task_board/external/sync/stale_reviews.rs
+++ b/src/task_board/external/sync/stale_reviews.rs
@@ -42,14 +42,17 @@ pub(super) async fn reconcile_stale_github_review_requests(
         .collect::<Vec<_>>();
 
     for (item, reference) in stale_items {
-        operations.push(stale_review_request_operation(
-            provider, &item, &reference, options,
-        ));
         if options.dry_run {
+            operations.push(stale_review_request_operation(
+                provider, &item, &reference, options,
+            ));
             continue;
         }
         let patch = stale_review_request_patch(&item, &reference);
         board.update_item(&item, patch).await?;
+        operations.push(stale_review_request_operation(
+            provider, &item, &reference, options,
+        ));
     }
 
     Ok(())

--- a/src/task_board/external/sync/store.rs
+++ b/src/task_board/external/sync/store.rs
@@ -7,6 +7,21 @@ use crate::task_board::external::{
 use crate::task_board::store::TaskBoardItemPatch;
 use crate::task_board::{ExternalProvider, TaskBoardItem, TaskBoardStatus, TaskBoardSyncConflict};
 
+#[derive(Debug, Clone)]
+pub(crate) struct TaskBoardSyncItemSnapshot {
+    pub(crate) item: TaskBoardItem,
+    pub(crate) item_revision: i64,
+}
+
+impl TaskBoardSyncItemSnapshot {
+    pub(crate) const fn new(item: TaskBoardItem, item_revision: i64) -> Self {
+        Self {
+            item,
+            item_revision,
+        }
+    }
+}
+
 #[async_trait]
 pub(crate) trait TaskBoardSyncStore: Send + Sync {
     async fn list_items(
@@ -21,7 +36,7 @@ pub(crate) trait TaskBoardSyncStore: Send + Sync {
         patch: TaskBoardItemPatch,
     ) -> Result<TaskBoardItem, CliError>;
 
-    async fn item_revision(&self, item_id: &str) -> Result<i64, CliError>;
+    async fn item_snapshot(&self, item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError>;
 
     async fn provider_scope_state(
         &self,
@@ -35,6 +50,12 @@ pub(crate) trait TaskBoardSyncStore: Send + Sync {
         scope_id: &str,
         now: &str,
     ) -> Result<ExternalProviderScopeAttemptDecision, CliError>;
+
+    async fn renew_provider_scope_attempt(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        now: &str,
+    ) -> Result<(), CliError>;
 
     async fn complete_provider_scope_success(
         &self,
@@ -54,6 +75,7 @@ pub(crate) trait TaskBoardSyncStore: Send + Sync {
         item_id: &str,
         provider: ExternalProvider,
         external_ref: &str,
+        item_revision: i64,
         conflicts: &[TaskBoardSyncConflict],
     ) -> Result<(), CliError>;
 }

--- a/src/task_board/external/sync/store.rs
+++ b/src/task_board/external/sync/store.rs
@@ -1,11 +1,16 @@
 use async_trait::async_trait;
 
-use crate::errors::CliError;
+use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::external::{
-    ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
+    ExternalCreateOutcome, ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
+    ExternalProviderScopeState,
 };
 use crate::task_board::store::TaskBoardItemPatch;
-use crate::task_board::{ExternalProvider, TaskBoardItem, TaskBoardStatus, TaskBoardSyncConflict};
+use crate::task_board::{
+    ExternalProvider, ExternalRef, ExternalSyncField, TaskBoardExternalCreateBegin,
+    TaskBoardExternalCreateFinalizeResult, TaskBoardExternalCreateIntent, TaskBoardItem,
+    TaskBoardStatus, TaskBoardSyncConflict,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct TaskBoardSyncItemSnapshot {
@@ -23,7 +28,64 @@ impl TaskBoardSyncItemSnapshot {
 }
 
 #[async_trait]
-pub(crate) trait TaskBoardSyncStore: Send + Sync {
+pub(crate) trait TaskBoardExternalCreateStore: Send + Sync {
+    async fn begin_external_create_intent(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _scope_id: &str,
+        _provider_target: &str,
+    ) -> Result<TaskBoardExternalCreateBegin, CliError> {
+        Err(durable_external_create_store_required())
+    }
+
+    async fn record_external_create_outcome(
+        &self,
+        _intent: &TaskBoardExternalCreateIntent,
+        _outcome: &ExternalCreateOutcome,
+        _provider_baseline: &ExternalRef,
+    ) -> Result<TaskBoardExternalCreateIntent, CliError> {
+        Err(durable_external_create_store_required())
+    }
+
+    async fn finalize_external_create_intent(
+        &self,
+        _intent: &TaskBoardExternalCreateIntent,
+    ) -> Result<TaskBoardExternalCreateFinalizeResult, CliError> {
+        Err(durable_external_create_store_required())
+    }
+
+    async fn list_created_external_create_intents(
+        &self,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Err(durable_external_create_store_required())
+    }
+
+    async fn list_in_flight_external_create_intents(
+        &self,
+        _provider: ExternalProvider,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Err(durable_external_create_store_required())
+    }
+
+    async fn external_create_intent_by_create_key(
+        &self,
+        _provider: ExternalProvider,
+        _create_key: &str,
+    ) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+        Err(durable_external_create_store_required())
+    }
+
+    async fn list_pending_external_create_follow_ups(
+        &self,
+        _provider: Option<ExternalProvider>,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        Err(durable_external_create_store_required())
+    }
+}
+
+#[async_trait]
+pub(crate) trait TaskBoardSyncStore: TaskBoardExternalCreateStore {
     async fn list_items(
         &self,
         status: Option<TaskBoardStatus>,
@@ -78,4 +140,22 @@ pub(crate) trait TaskBoardSyncStore: Send + Sync {
         item_revision: i64,
         conflicts: &[TaskBoardSyncConflict],
     ) -> Result<(), CliError>;
+
+    async fn supersede_open_sync_conflicts(
+        &self,
+        _item_id: &str,
+        _provider: ExternalProvider,
+        _external_ref: &str,
+        _item_revision: i64,
+        _resolved_fields: &[ExternalSyncField],
+    ) -> Result<(), CliError> {
+        Err(CliErrorKind::workflow_io(
+            "field-scoped task-board conflict supersession is unavailable",
+        )
+        .into())
+    }
+}
+
+fn durable_external_create_store_required() -> CliError {
+    CliErrorKind::workflow_io("durable task-board external-create storage is unavailable").into()
 }

--- a/src/task_board/external/sync_tests.rs
+++ b/src/task_board/external/sync_tests.rs
@@ -8,6 +8,7 @@ use crate::task_board::store::TaskBoardStore;
 use crate::task_board::types::{ExternalRefSyncState, TaskBoardItem, TaskBoardStatus};
 
 mod conflict_correctness_tests;
+mod pull_policy_tests;
 mod status_roundtrip_tests;
 
 #[tokio::test]

--- a/src/task_board/external/sync_tests/conflict_correctness_tests.rs
+++ b/src/task_board/external/sync_tests/conflict_correctness_tests.rs
@@ -109,6 +109,51 @@ async fn prefer_remote_supersedes_existing_open_conflict() {
 }
 
 #[tokio::test]
+async fn pull_report_supersedes_only_converged_known_conflict_fields() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    let item = linked_item(
+        "task-pull-report",
+        "Local edit",
+        "Old body",
+        TaskBoardStatus::Todo,
+    );
+    db.create_task_board_item(item).await.expect("create item");
+    record_open_title_and_future_conflicts(&db, "task-pull-report").await;
+    let client = UpdateFakeSyncClient::new(
+        ExternalProvider::Todoist,
+        vec![ExternalSyncField::Title],
+        vec![remote_task(
+            "remote-1",
+            "Remote edit",
+            "Old body",
+            TaskBoardStatus::Backlog,
+        )],
+    );
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
+
+    sync_external_tasks(&db, pull_report_options(), &clients)
+        .await
+        .expect("pull report sync");
+
+    assert_eq!(
+        db.task_board_item("task-pull-report")
+            .await
+            .expect("item")
+            .title,
+        "Remote edit"
+    );
+    let open = db
+        .open_task_board_sync_conflicts()
+        .await
+        .expect("open conflicts");
+    assert_eq!(open.len(), 1);
+    assert_eq!(open[0].field, "future_field");
+}
+
+#[tokio::test]
 async fn prefer_local_supersedes_conflict_after_remote_and_local_state_converge() {
     let dir = tempdir().expect("tempdir");
     let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
@@ -202,37 +247,6 @@ async fn remote_update_with_failed_local_persistence_records_conflict_evidence()
     );
 }
 
-#[tokio::test]
-async fn remote_create_with_failed_local_link_persists_created_reference_evidence() {
-    let item = TaskBoardItem::new(
-        "task-create-cas".into(),
-        "Created remotely".into(),
-        "Body".into(),
-        "2026-07-16T10:00:00Z".into(),
-    );
-    let store = FailingPersistenceStore::new(item);
-    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(CreateSyncClient)];
-
-    let error = sync_external_tasks(&store, push_options(), &clients)
-        .await
-        .expect_err("local link persistence must fail");
-
-    assert_eq!(error.code(), "WORKFLOW_CONCURRENT");
-    let conflicts = store.conflicts.lock().expect("conflicts");
-    let title = conflicts
-        .iter()
-        .find(|conflict| conflict.field == "title")
-        .expect("title conflict");
-    assert_eq!(title.external_ref, "remote-created");
-    assert_eq!(title.base_value, serde_json::Value::Null);
-    assert_eq!(title.local_value, serde_json::json!("Created remotely"));
-    assert_eq!(title.remote_value, serde_json::json!("Created remotely"));
-    assert_eq!(
-        title.provider_revision.as_deref(),
-        Some("provider-revision-1")
-    );
-}
-
 fn push_options() -> ExternalSyncOptions {
     ExternalSyncOptions {
         provider: Some(ExternalProvider::Todoist),
@@ -253,33 +267,59 @@ fn both_options(conflict_policy: ExternalSyncConflictPolicy) -> ExternalSyncOpti
     }
 }
 
+fn pull_report_options() -> ExternalSyncOptions {
+    ExternalSyncOptions {
+        provider: Some(ExternalProvider::Todoist),
+        direction: ExternalSyncDirection::Pull,
+        conflict_policy: ExternalSyncConflictPolicy::Report,
+        dry_run: false,
+        status: None,
+    }
+}
+
 async fn record_open_title_conflict(db: &AsyncDaemonDb, item_id: &str) {
+    record_open_conflicts(db, item_id, &["title"]).await;
+}
+
+async fn record_open_title_and_future_conflicts(db: &AsyncDaemonDb, item_id: &str) {
+    record_open_conflicts(db, item_id, &["title", "future_field"]).await;
+}
+
+async fn record_open_conflicts(db: &AsyncDaemonDb, item_id: &str, fields: &[&str]) {
     let revision = db
         .task_board_item_snapshot(item_id)
         .await
         .expect("item snapshot")
         .item_revision;
+    let conflicts = fields
+        .iter()
+        .map(|field| open_conflict(item_id, field, revision))
+        .collect::<Vec<_>>();
     db.replace_open_task_board_sync_conflicts(
         item_id,
         ExternalProvider::Todoist,
         "remote-1",
         revision,
-        &[TaskBoardSyncConflict {
-            conflict_id: format!("conflict-{item_id}"),
-            item_id: item_id.into(),
-            provider: ExternalRefProvider::Todoist,
-            external_ref: "remote-1".into(),
-            field: "title".into(),
-            base_value: serde_json::json!("Old title"),
-            local_value: serde_json::json!("Local edit"),
-            remote_value: serde_json::json!("Remote edit"),
-            item_revision: revision,
-            provider_revision: Some("2026-05-14T01:00:00Z".into()),
-            state: TaskBoardConflictState::Open,
-        }],
+        &conflicts,
     )
     .await
     .expect("record conflict");
+}
+
+fn open_conflict(item_id: &str, field: &str, revision: i64) -> TaskBoardSyncConflict {
+    TaskBoardSyncConflict {
+        conflict_id: format!("conflict-{item_id}-{field}"),
+        item_id: item_id.into(),
+        provider: ExternalRefProvider::Todoist,
+        external_ref: "remote-1".into(),
+        field: field.into(),
+        base_value: serde_json::json!("Old value"),
+        local_value: serde_json::json!("Local value"),
+        remote_value: serde_json::json!("Remote value"),
+        item_revision: revision,
+        provider_revision: Some("2026-05-14T01:00:00Z".into()),
+        state: TaskBoardConflictState::Open,
+    }
 }
 
 struct FailingPersistenceStore {
@@ -296,36 +336,7 @@ impl FailingPersistenceStore {
     }
 }
 
-struct CreateSyncClient;
-
-#[async_trait]
-impl ExternalSyncClient for CreateSyncClient {
-    fn provider(&self) -> ExternalProvider {
-        ExternalProvider::Todoist
-    }
-
-    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
-        Ok(Vec::new())
-    }
-
-    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
-        Ok(ExternalTaskRef::new(
-            ExternalProvider::Todoist,
-            "remote-created",
-        ))
-    }
-
-    async fn push_task_with_outcome(
-        &self,
-        item: &TaskBoardItem,
-    ) -> Result<ExternalCreateOutcome, CliError> {
-        Ok(ExternalCreateOutcome {
-            reference: self.push_task(item).await?,
-            provider_revision: Some("provider-revision-1".into()),
-            provider_project_id: Some("provider-project".into()),
-        })
-    }
-}
+impl crate::task_board::TaskBoardExternalCreateStore for FailingPersistenceStore {}
 
 #[async_trait]
 impl TaskBoardSyncStore for FailingPersistenceStore {

--- a/src/task_board/external/sync_tests/conflict_correctness_tests.rs
+++ b/src/task_board/external/sync_tests/conflict_correctness_tests.rs
@@ -227,6 +227,10 @@ async fn remote_create_with_failed_local_link_persists_created_reference_evidenc
     assert_eq!(title.base_value, serde_json::Value::Null);
     assert_eq!(title.local_value, serde_json::json!("Created remotely"));
     assert_eq!(title.remote_value, serde_json::json!("Created remotely"));
+    assert_eq!(
+        title.provider_revision.as_deref(),
+        Some("provider-revision-1")
+    );
 }
 
 fn push_options() -> ExternalSyncOptions {
@@ -309,6 +313,17 @@ impl ExternalSyncClient for CreateSyncClient {
             ExternalProvider::Todoist,
             "remote-created",
         ))
+    }
+
+    async fn push_task_with_outcome(
+        &self,
+        item: &TaskBoardItem,
+    ) -> Result<ExternalCreateOutcome, CliError> {
+        Ok(ExternalCreateOutcome {
+            reference: self.push_task(item).await?,
+            provider_revision: Some("provider-revision-1".into()),
+            provider_project_id: Some("provider-project".into()),
+        })
     }
 }
 

--- a/src/task_board/external/sync_tests/conflict_correctness_tests.rs
+++ b/src/task_board/external/sync_tests/conflict_correctness_tests.rs
@@ -259,6 +259,7 @@ async fn record_open_title_conflict(db: &AsyncDaemonDb, item_id: &str) {
         item_id,
         ExternalProvider::Todoist,
         "remote-1",
+        revision,
         &[TaskBoardSyncConflict {
             conflict_id: format!("conflict-{item_id}"),
             item_id: item_id.into(),
@@ -336,8 +337,8 @@ impl TaskBoardSyncStore for FailingPersistenceStore {
         Err(CliErrorKind::concurrent_modification("local CAS failed").into())
     }
 
-    async fn item_revision(&self, _item_id: &str) -> Result<i64, CliError> {
-        Ok(2)
+    async fn item_snapshot(&self, _item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
+        Ok(TaskBoardSyncItemSnapshot::new(self.item.clone(), 2))
     }
 
     async fn provider_scope_state(
@@ -364,6 +365,14 @@ impl TaskBoardSyncStore for FailingPersistenceStore {
         ))
     }
 
+    async fn renew_provider_scope_attempt(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _now: &str,
+    ) -> Result<(), CliError> {
+        Ok(())
+    }
+
     async fn complete_provider_scope_success(
         &self,
         _attempt: &ExternalProviderScopeAttempt,
@@ -386,6 +395,7 @@ impl TaskBoardSyncStore for FailingPersistenceStore {
         _item_id: &str,
         _provider: ExternalProvider,
         _external_ref: &str,
+        _item_revision: i64,
         conflicts: &[TaskBoardSyncConflict],
     ) -> Result<(), CliError> {
         *self.conflicts.lock().expect("conflicts") = conflicts.to_vec();

--- a/src/task_board/external/sync_tests/pull_policy_tests.rs
+++ b/src/task_board/external/sync_tests/pull_policy_tests.rs
@@ -1,0 +1,83 @@
+use tempfile::tempdir;
+
+use super::*;
+use crate::daemon::db::AsyncDaemonDb;
+
+#[tokio::test]
+async fn pull_report_is_remote_authoritative_but_prefer_local_is_explicit() {
+    let cases = [
+        (
+            ExternalSyncConflictPolicy::Report,
+            "task-pull-report",
+            "Remote title",
+        ),
+        (
+            ExternalSyncConflictPolicy::PreferLocal,
+            "task-pull-prefer-local",
+            "Local title",
+        ),
+    ];
+
+    for (policy, item_id, expected_title) in cases {
+        let temp = tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("database");
+        db.create_task_board_item(linked_item(
+            item_id,
+            "Local title",
+            "Old body",
+            TaskBoardStatus::Todo,
+        ))
+        .await
+        .expect("create local task");
+        let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(UpdateFakeSyncClient::new(
+            ExternalProvider::Todoist,
+            vec![ExternalSyncField::Title],
+            vec![remote_task(
+                "remote-1",
+                "Remote title",
+                "Old body",
+                TaskBoardStatus::Backlog,
+            )],
+        ))];
+
+        let operations = sync_external_tasks(
+            &db,
+            ExternalSyncOptions {
+                provider: Some(ExternalProvider::Todoist),
+                direction: ExternalSyncDirection::Pull,
+                conflict_policy: policy,
+                dry_run: false,
+                status: None,
+            },
+            &clients,
+        )
+        .await
+        .expect("pull external task");
+
+        assert_eq!(
+            db.task_board_item(item_id)
+                .await
+                .expect("reconciled item")
+                .title,
+            expected_title
+        );
+        if policy == ExternalSyncConflictPolicy::Report {
+            assert_eq!(operations.len(), 1);
+            assert_eq!(operations[0].action, ExternalSyncAction::Pull);
+            assert!(operations[0].applied);
+            assert!(
+                operations[0]
+                    .changed_fields
+                    .contains(&ExternalSyncField::Title)
+            );
+            assert!(
+                db.open_task_board_sync_conflicts()
+                    .await
+                    .expect("open conflicts")
+                    .is_empty()
+            );
+        }
+    }
+}

--- a/src/task_board/external/targeting.rs
+++ b/src/task_board/external/targeting.rs
@@ -1,6 +1,16 @@
-use crate::task_board::{TaskBoardItem, normalize_repository_slug};
+use crate::task_board::{ExternalRefProvider, TaskBoardItem, normalize_repository_slug};
 
 use super::{ExternalProvider, ExternalTask};
+
+pub(super) fn provider_project_maps_to_board(provider: ExternalProvider) -> bool {
+    provider != ExternalProvider::GitHub
+}
+
+pub(super) fn board_project_id_for_task(task: &ExternalTask) -> Option<String> {
+    provider_project_maps_to_board(task.reference.provider)
+        .then(|| task.project_id.clone())
+        .flatten()
+}
 
 pub(super) fn execution_repository_for_task(task: &ExternalTask) -> Option<String> {
     (task.reference.provider == ExternalProvider::GitHub)
@@ -9,9 +19,13 @@ pub(super) fn execution_repository_for_task(task: &ExternalTask) -> Option<Strin
 }
 
 pub(super) fn github_repository_for_item(item: &TaskBoardItem) -> Option<&str> {
-    item.execution_repository
-        .as_deref()
-        .or(item.project_id.as_deref())
+    item.execution_repository.as_deref().or_else(|| {
+        item.external_refs
+            .iter()
+            .any(|reference| reference.provider == ExternalRefProvider::GitHub)
+            .then_some(item.project_id.as_deref())
+            .flatten()
+    })
 }
 
 #[cfg(test)]
@@ -50,6 +64,19 @@ mod tests {
         item.execution_repository = Some("acme/target".into());
 
         assert_eq!(github_repository_for_item(&item), Some("acme/target"));
+    }
+
+    #[test]
+    fn unlinked_project_identity_is_not_a_github_repository() {
+        let mut item = TaskBoardItem::new(
+            "task-1".into(),
+            "Task".into(),
+            String::new(),
+            "2026-07-15T00:00:00Z".into(),
+        );
+        item.project_id = Some("portfolio-a".into());
+
+        assert_eq!(github_repository_for_item(&item), None);
     }
 
     fn external_task(provider: ExternalProvider, project_id: Option<&str>) -> ExternalTask {

--- a/src/task_board/external/tests/create_done.rs
+++ b/src/task_board/external/tests/create_done.rs
@@ -6,10 +6,10 @@ use tempfile::tempdir;
 
 use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::{
-    ExternalProvider, ExternalProviderCapabilities, ExternalSyncAction, ExternalSyncClient,
-    ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncField, ExternalSyncOptions,
-    ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome, TaskBoardItem,
-    TaskBoardStatus, TaskBoardStore, sync_external_tasks,
+    ExternalCreateOutcome, ExternalProvider, ExternalProviderCapabilities, ExternalSyncAction,
+    ExternalSyncClient, ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncField,
+    ExternalSyncOptions, ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome,
+    TaskBoardItem, TaskBoardStatus, TaskBoardStore, sync_external_tasks,
 };
 
 #[tokio::test]
@@ -25,7 +25,10 @@ async fn newly_created_done_item_is_linked_then_closed() {
     assert_eq!(pushes.lock().expect("push log").as_slice(), ["done-1"]);
     assert_eq!(
         updates.lock().expect("update log").as_slice(),
-        [vec![ExternalSyncField::Status]]
+        [CapturedUpdate {
+            changed_fields: vec![ExternalSyncField::Status],
+            precondition_updated_at: Some("provider-revision-1".into()),
+        }]
     );
     assert_eq!(operations.len(), 2);
     assert_eq!(
@@ -36,7 +39,10 @@ async fn newly_created_done_item_is_linked_then_closed() {
         operations[1].changed_fields,
         vec![ExternalSyncField::Status]
     );
-    assert_eq!(stored_sync_status(&board), TaskBoardStatus::Done);
+    let state = stored_sync_state(&board);
+    assert_eq!(state.status, Some(TaskBoardStatus::Done));
+    assert_eq!(state.updated_at.as_deref(), Some("provider-revision-2"));
+    assert_eq!(state.project_id.as_deref(), Some("provider-project"));
 }
 
 #[tokio::test]
@@ -53,7 +59,9 @@ async fn failed_close_keeps_link_and_retry_does_not_create_duplicate() {
         .expect_err("first close should fail");
 
     assert_eq!(pushes.lock().expect("push log").as_slice(), ["done-1"]);
-    assert_eq!(stored_sync_status(&board), TaskBoardStatus::Backlog);
+    let state = stored_sync_state(&board);
+    assert_eq!(state.status, Some(TaskBoardStatus::Backlog));
+    assert_eq!(state.updated_at.as_deref(), Some("provider-revision-1"));
     assert_eq!(
         board
             .get("done-1")
@@ -68,8 +76,14 @@ async fn failed_close_keeps_link_and_retry_does_not_create_duplicate() {
         .expect("retry closes linked item");
 
     assert_eq!(pushes.lock().expect("push log").as_slice(), ["done-1"]);
-    assert_eq!(updates.lock().expect("update log").len(), 2);
-    assert_eq!(stored_sync_status(&board), TaskBoardStatus::Done);
+    let updates = updates.lock().expect("update log");
+    assert_eq!(updates.len(), 2);
+    assert!(updates.iter().all(|update| {
+        update.precondition_updated_at.as_deref() == Some("provider-revision-1")
+    }));
+    let state = stored_sync_state(&board);
+    assert_eq!(state.status, Some(TaskBoardStatus::Done));
+    assert_eq!(state.updated_at.as_deref(), Some("provider-revision-2"));
 }
 
 #[tokio::test]
@@ -92,7 +106,10 @@ async fn create_only_provider_reports_done_status_as_unsupported() {
         vec![ExternalSyncField::Status]
     );
     assert!(!operations[1].applied);
-    assert_eq!(stored_sync_status(&board), TaskBoardStatus::Backlog);
+    let state = stored_sync_state(&board);
+    assert_eq!(state.status, Some(TaskBoardStatus::Backlog));
+    assert_eq!(state.updated_at.as_deref(), Some("provider-revision-1"));
+    assert_eq!(state.project_id.as_deref(), Some("provider-project"));
 }
 
 async fn sync(
@@ -128,7 +145,7 @@ fn board_with_done_item(path: &std::path::Path) -> TaskBoardStore {
     board
 }
 
-fn stored_sync_status(board: &TaskBoardStore) -> TaskBoardStatus {
+fn stored_sync_state(board: &TaskBoardStore) -> crate::task_board::ExternalRefSyncState {
     board
         .get("done-1")
         .expect("stored item")
@@ -136,16 +153,20 @@ fn stored_sync_status(board: &TaskBoardStore) -> TaskBoardStatus {
         .first()
         .expect("external reference")
         .sync_state
-        .as_ref()
+        .clone()
         .expect("sync state")
-        .status
-        .expect("sync status")
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CapturedUpdate {
+    changed_fields: Vec<ExternalSyncField>,
+    precondition_updated_at: Option<String>,
 }
 
 struct CreateDoneClient {
     capabilities: ExternalProviderCapabilities,
     pushes: Arc<Mutex<Vec<String>>>,
-    updates: Arc<Mutex<Vec<Vec<ExternalSyncField>>>>,
+    updates: Arc<Mutex<Vec<CapturedUpdate>>>,
     fail_next_update: AtomicBool,
 }
 
@@ -197,6 +218,17 @@ impl ExternalSyncClient for CreateDoneClient {
         ))
     }
 
+    async fn push_task_with_outcome(
+        &self,
+        item: &TaskBoardItem,
+    ) -> Result<ExternalCreateOutcome, CliError> {
+        Ok(ExternalCreateOutcome {
+            reference: self.push_task(item).await?,
+            provider_revision: Some("provider-revision-1".into()),
+            provider_project_id: Some("provider-project".into()),
+        })
+    }
+
     async fn update_task(
         &self,
         _item: &TaskBoardItem,
@@ -206,13 +238,16 @@ impl ExternalSyncClient for CreateDoneClient {
         self.updates
             .lock()
             .expect("update log")
-            .push(update.changed_fields);
+            .push(CapturedUpdate {
+                changed_fields: update.changed_fields,
+                precondition_updated_at: update.precondition_updated_at,
+            });
         if self.fail_next_update.swap(false, Ordering::SeqCst) {
             return Err(CliErrorKind::workflow_io("simulated status update failure").into());
         }
         Ok(ExternalUpdateOutcome::Applied {
             reference: reference.clone(),
-            provider_revision: None,
+            provider_revision: Some("provider-revision-2".into()),
         })
     }
 }

--- a/src/task_board/external/tests/create_done.rs
+++ b/src/task_board/external/tests/create_done.rs
@@ -4,18 +4,22 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use tempfile::tempdir;
 
+use crate::daemon::db::AsyncDaemonDb;
 use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::external::{
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
+    ExternalProviderScopeIdentity,
+};
 use crate::task_board::{
-    ExternalCreateOutcome, ExternalProvider, ExternalProviderCapabilities, ExternalSyncAction,
+    ExternalProvider, ExternalProviderCapabilities, ExternalRefSyncState, ExternalSyncAction,
     ExternalSyncClient, ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncField,
     ExternalSyncOptions, ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome,
-    TaskBoardItem, TaskBoardStatus, TaskBoardStore, sync_external_tasks,
+    TaskBoardExternalCreateIntentState, TaskBoardItem, TaskBoardStatus, sync_external_tasks,
 };
 
 #[tokio::test]
 async fn newly_created_done_item_is_linked_then_closed() {
-    let temp = tempdir().expect("tempdir");
-    let board = board_with_done_item(temp.path());
+    let (_temp, board) = board_with_done_item().await;
     let client = CreateDoneClient::with_status_updates();
     let pushes = client.pushes.clone();
     let updates = client.updates.clone();
@@ -33,22 +37,25 @@ async fn newly_created_done_item_is_linked_then_closed() {
     assert_eq!(operations.len(), 2);
     assert_eq!(
         operations[0].changed_fields,
-        vec![ExternalSyncField::Title, ExternalSyncField::Body]
+        vec![
+            ExternalSyncField::Title,
+            ExternalSyncField::Body,
+            ExternalSyncField::Project,
+        ]
     );
     assert_eq!(
         operations[1].changed_fields,
         vec![ExternalSyncField::Status]
     );
-    let state = stored_sync_state(&board);
+    let state = stored_sync_state(&board).await;
     assert_eq!(state.status, Some(TaskBoardStatus::Done));
     assert_eq!(state.updated_at.as_deref(), Some("provider-revision-2"));
     assert_eq!(state.project_id.as_deref(), Some("provider-project"));
 }
 
 #[tokio::test]
-async fn failed_close_keeps_link_and_retry_does_not_create_duplicate() {
-    let temp = tempdir().expect("tempdir");
-    let board = board_with_done_item(temp.path());
+async fn failed_close_keeps_link_and_backoff_does_not_create_duplicate() {
+    let (_temp, board) = board_with_done_item().await;
     let client = CreateDoneClient::with_status_updates().fail_next_update();
     let pushes = client.pushes.clone();
     let updates = client.updates.clone();
@@ -59,37 +66,38 @@ async fn failed_close_keeps_link_and_retry_does_not_create_duplicate() {
         .expect_err("first close should fail");
 
     assert_eq!(pushes.lock().expect("push log").as_slice(), ["done-1"]);
-    let state = stored_sync_state(&board);
+    let state = stored_sync_state(&board).await;
     assert_eq!(state.status, Some(TaskBoardStatus::Backlog));
     assert_eq!(state.updated_at.as_deref(), Some("provider-revision-1"));
     assert_eq!(
         board
-            .get("done-1")
+            .task_board_item("done-1")
+            .await
             .expect("linked item after failure")
             .external_refs
             .len(),
         1
     );
 
-    sync_external_tasks(&board, push_options(), &clients)
+    let operations = sync_external_tasks(&board, push_options(), &clients)
         .await
-        .expect("retry closes linked item");
+        .expect("backoff skips the linked retry");
 
     assert_eq!(pushes.lock().expect("push log").as_slice(), ["done-1"]);
+    assert!(operations.is_empty());
     let updates = updates.lock().expect("update log");
-    assert_eq!(updates.len(), 2);
+    assert_eq!(updates.len(), 1);
     assert!(updates.iter().all(|update| {
         update.precondition_updated_at.as_deref() == Some("provider-revision-1")
     }));
-    let state = stored_sync_state(&board);
-    assert_eq!(state.status, Some(TaskBoardStatus::Done));
-    assert_eq!(state.updated_at.as_deref(), Some("provider-revision-2"));
+    let state = stored_sync_state(&board).await;
+    assert_eq!(state.status, Some(TaskBoardStatus::Backlog));
+    assert_eq!(state.updated_at.as_deref(), Some("provider-revision-1"));
 }
 
 #[tokio::test]
 async fn create_only_provider_reports_done_status_as_unsupported() {
-    let temp = tempdir().expect("tempdir");
-    let board = board_with_done_item(temp.path());
+    let (_temp, board) = board_with_done_item().await;
 
     let operations = sync(&board, CreateDoneClient::creates_only())
         .await
@@ -99,21 +107,79 @@ async fn create_only_provider_reports_done_status_as_unsupported() {
     assert_eq!(operations[0].action, ExternalSyncAction::Push);
     assert_eq!(
         operations[0].changed_fields,
-        vec![ExternalSyncField::Title, ExternalSyncField::Body]
+        vec![
+            ExternalSyncField::Title,
+            ExternalSyncField::Body,
+            ExternalSyncField::Project,
+        ]
     );
     assert_eq!(
         operations[1].unsupported_fields,
         vec![ExternalSyncField::Status]
     );
     assert!(!operations[1].applied);
-    let state = stored_sync_state(&board);
+    let state = stored_sync_state(&board).await;
     assert_eq!(state.status, Some(TaskBoardStatus::Backlog));
     assert_eq!(state.updated_at.as_deref(), Some("provider-revision-1"));
     assert_eq!(state.project_id.as_deref(), Some("provider-project"));
 }
 
+#[tokio::test]
+async fn done_create_and_close_preserve_exact_unknown_provider_revisions() {
+    let (_temp, board) = board_with_done_item().await;
+    let client = CreateDoneClient::with_status_updates().without_revisions();
+    let scope_id = ExternalProviderScopeIdentity::for_client(&client)
+        .scope_id()
+        .to_owned();
+    let updates = client.updates.clone();
+
+    let operations = sync(&board, client)
+        .await
+        .expect("push Done item with unknown revisions");
+
+    assert_eq!(operations.len(), 2);
+    assert!(operations.iter().all(|operation| operation.applied));
+    assert_eq!(
+        updates.lock().expect("update log").as_slice(),
+        [CapturedUpdate {
+            changed_fields: vec![ExternalSyncField::Status],
+            precondition_updated_at: None,
+        }]
+    );
+    let state = stored_sync_state(&board).await;
+    assert_eq!(state.status, Some(TaskBoardStatus::Done));
+    assert_eq!(state.updated_at, None);
+    let receipt = board
+        .task_board_external_create_receipt("done-1", ExternalProvider::Todoist)
+        .await
+        .expect("create receipt")
+        .expect("attached create receipt");
+    let TaskBoardExternalCreateIntentState::Attached(receipt) = receipt.state else {
+        panic!("create receipt must be attached");
+    };
+    assert_eq!(receipt.evidence.outcome.provider_revision, None);
+    assert_eq!(
+        receipt
+            .evidence
+            .provider_baseline
+            .sync_state
+            .as_ref()
+            .expect("provider baseline")
+            .updated_at,
+        None
+    );
+    assert_eq!(
+        board
+            .task_board_provider_scope_state(ExternalProvider::Todoist, &scope_id)
+            .await
+            .expect("scope state")
+            .base_revision,
+        None
+    );
+}
+
 async fn sync(
-    board: &TaskBoardStore,
+    board: &AsyncDaemonDb,
     client: CreateDoneClient,
 ) -> Result<Vec<crate::task_board::ExternalSyncOperation>, CliError> {
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(client)];
@@ -130,8 +196,11 @@ fn push_options() -> ExternalSyncOptions {
     }
 }
 
-fn board_with_done_item(path: &std::path::Path) -> TaskBoardStore {
-    let board = TaskBoardStore::new(path.join("board"));
+async fn board_with_done_item() -> (tempfile::TempDir, AsyncDaemonDb) {
+    let temp = tempdir().expect("tempdir");
+    let board = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+        .await
+        .expect("database");
     let mut item = TaskBoardItem::new(
         "done-1".to_owned(),
         "Finished task".to_owned(),
@@ -139,15 +208,18 @@ fn board_with_done_item(path: &std::path::Path) -> TaskBoardStore {
         "2026-07-16T00:00:00Z".to_owned(),
     );
     item.status = TaskBoardStatus::Done;
+    item.project_id = Some("provider-project".into());
     board
-        .create("Finished task", "Completed locally.", item)
+        .create_task_board_item(item)
+        .await
         .expect("create Done item");
-    board
+    (temp, board)
 }
 
-fn stored_sync_state(board: &TaskBoardStore) -> crate::task_board::ExternalRefSyncState {
+async fn stored_sync_state(board: &AsyncDaemonDb) -> ExternalRefSyncState {
     board
-        .get("done-1")
+        .task_board_item("done-1")
+        .await
         .expect("stored item")
         .external_refs
         .first()
@@ -168,6 +240,8 @@ struct CreateDoneClient {
     pushes: Arc<Mutex<Vec<String>>>,
     updates: Arc<Mutex<Vec<CapturedUpdate>>>,
     fail_next_update: AtomicBool,
+    create_revision: Option<String>,
+    update_revision: Option<String>,
 }
 
 impl CreateDoneClient {
@@ -187,11 +261,19 @@ impl CreateDoneClient {
             pushes: Arc::new(Mutex::new(Vec::new())),
             updates: Arc::new(Mutex::new(Vec::new())),
             fail_next_update: AtomicBool::new(false),
+            create_revision: Some("provider-revision-1".into()),
+            update_revision: Some("provider-revision-2".into()),
         }
     }
 
     fn fail_next_update(self) -> Self {
         self.fail_next_update.store(true, Ordering::SeqCst);
+        self
+    }
+
+    fn without_revisions(mut self) -> Self {
+        self.create_revision = None;
+        self.update_revision = None;
         self
     }
 }
@@ -202,6 +284,14 @@ impl ExternalSyncClient for CreateDoneClient {
         ExternalProvider::Todoist
     }
 
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        Some(self)
+    }
+
+    fn scope_id(&self) -> String {
+        "provider-project".into()
+    }
+
     fn capabilities(&self) -> ExternalProviderCapabilities {
         self.capabilities.clone()
     }
@@ -210,23 +300,8 @@ impl ExternalSyncClient for CreateDoneClient {
         Ok(Vec::new())
     }
 
-    async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
-        self.pushes.lock().expect("push log").push(item.id.clone());
-        Ok(ExternalTaskRef::new(
-            ExternalProvider::Todoist,
-            format!("remote-{}", item.id),
-        ))
-    }
-
-    async fn push_task_with_outcome(
-        &self,
-        item: &TaskBoardItem,
-    ) -> Result<ExternalCreateOutcome, CliError> {
-        Ok(ExternalCreateOutcome {
-            reference: self.push_task(item).await?,
-            provider_revision: Some("provider-revision-1".into()),
-            provider_project_id: Some("provider-project".into()),
-        })
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        unreachable!("durable create admission must use create_started")
     }
 
     async fn update_task(
@@ -247,7 +322,57 @@ impl ExternalSyncClient for CreateDoneClient {
         }
         Ok(ExternalUpdateOutcome::Applied {
             reference: reference.clone(),
-            provider_revision: Some("provider-revision-2".into()),
+            provider_revision: self.update_revision.clone(),
         })
+    }
+}
+
+#[async_trait]
+impl ExternalCreateRecoveryClient for CreateDoneClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    fn supports_target(&self, provider_target: &str) -> bool {
+        provider_target == "provider-project"
+    }
+
+    async fn create_started(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError> {
+        lease.renew().await?;
+        self.pushes
+            .lock()
+            .expect("push log")
+            .push(request.item_id().into());
+        Ok(task_from_request(request, self.create_revision.clone()))
+    }
+
+    async fn recover_existing(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError> {
+        lease.renew().await?;
+        Ok(ExternalCreateProbe::Found(task_from_request(
+            request,
+            self.create_revision.clone(),
+        )))
+    }
+}
+
+fn task_from_request(request: &ExternalCreateRequest, updated_at: Option<String>) -> ExternalTask {
+    ExternalTask {
+        reference: ExternalTaskRef::new(
+            ExternalProvider::Todoist,
+            format!("remote-{}", request.item_id()),
+        ),
+        title: request.title().into(),
+        body: request.body().into(),
+        status: TaskBoardStatus::Backlog,
+        project_id: Some(request.provider_target().into()),
+        updated_at,
     }
 }

--- a/src/task_board/external/tests/github.rs
+++ b/src/task_board/external/tests/github.rs
@@ -2,9 +2,9 @@ use tempfile::tempdir;
 
 use super::support::{FakeSyncClient, github_external_task, github_external_task_with_status};
 use crate::task_board::{
-    ExternalProvider, ExternalRefProvider, ExternalSyncClient, ExternalSyncConflictPolicy,
-    ExternalSyncDirection, ExternalSyncOptions, ExternalTaskRef, TaskBoardItem, TaskBoardStatus,
-    TaskBoardStore, build_dispatch_plan, sync_external_tasks,
+    ExternalProvider, ExternalRef, ExternalRefProvider, ExternalRefSyncState, ExternalSyncClient,
+    ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncOptions, ExternalTaskRef,
+    TaskBoardItem, TaskBoardStatus, TaskBoardStore, build_dispatch_plan, sync_external_tasks,
 };
 
 #[tokio::test]
@@ -35,7 +35,8 @@ async fn sync_external_tasks_imports_github_tasks_with_plan_pending_approval() {
         .get("github-7-7902699be42c8a8e46fbbb4501726517")
         .expect("load imported github task");
     assert_eq!(item.status, TaskBoardStatus::Backlog);
-    assert_eq!(item.project_id.as_deref(), Some("owner/repo"));
+    assert_eq!(item.project_id, None);
+    assert_eq!(item.execution_repository.as_deref(), Some("owner/repo"));
     assert!(item.planning.approved_by.is_none());
     assert!(item.planning.approved_at.is_none());
     assert!(
@@ -82,7 +83,8 @@ async fn sync_external_tasks_imports_github_inbox_items_as_backlog_with_plan_pen
         .get("github-owner-repo-19-983c1507241b6007ac5729cfcea78b64")
         .expect("load imported github inbox task");
     assert_eq!(item.status, TaskBoardStatus::Backlog);
-    assert_eq!(item.project_id.as_deref(), Some("owner/repo"));
+    assert_eq!(item.project_id, None);
+    assert_eq!(item.execution_repository.as_deref(), Some("owner/repo"));
     assert!(item.planning.summary.is_some());
     assert!(item.planning.approved_by.is_none());
     assert!(item.planning.approved_at.is_none());
@@ -145,9 +147,9 @@ async fn sync_external_tasks_reconciles_legacy_github_refs_by_project_scope() {
         "2026-05-14T00:00:00Z".to_owned(),
     );
     primary.status = TaskBoardStatus::Todo;
-    primary.project_id = Some("owner/repo".to_owned());
-    primary.external_refs =
-        vec![ExternalTaskRef::new(ExternalProvider::GitHub, "7").into_core_ref()];
+    primary.project_id = Some("portfolio-primary".to_owned());
+    primary.execution_repository = Some("owner/repo".to_owned());
+    primary.external_refs = vec![legacy_github_ref("7", "portfolio-primary")];
     board
         .create("Old title", "Body", primary)
         .expect("create primary task");
@@ -159,9 +161,9 @@ async fn sync_external_tasks_reconciles_legacy_github_refs_by_project_scope() {
         "2026-05-14T00:00:00Z".to_owned(),
     );
     secondary.status = TaskBoardStatus::Todo;
-    secondary.project_id = Some("other/repo".to_owned());
-    secondary.external_refs =
-        vec![ExternalTaskRef::new(ExternalProvider::GitHub, "7").into_core_ref()];
+    secondary.project_id = Some("portfolio-secondary".to_owned());
+    secondary.execution_repository = Some("other/repo".to_owned());
+    secondary.external_refs = vec![legacy_github_ref("7", "portfolio-secondary")];
     board
         .create("Other title", "Body", secondary)
         .expect("create secondary task");
@@ -196,6 +198,8 @@ async fn sync_external_tasks_reconciles_legacy_github_refs_by_project_scope() {
         .get("legacy-owner-repo")
         .expect("load reconciled legacy task");
     assert_eq!(updated.title, "Updated title");
+    assert_eq!(updated.project_id.as_deref(), Some("portfolio-primary"));
+    assert_eq!(updated.execution_repository.as_deref(), Some("owner/repo"));
     assert!(updated.external_refs.iter().any(|reference| {
         reference.provider == ExternalRefProvider::GitHub && reference.external_id == "owner/repo#7"
     }));
@@ -204,7 +208,21 @@ async fn sync_external_tasks_reconciles_legacy_github_refs_by_project_scope() {
         .get("legacy-other-repo")
         .expect("load other repo task");
     assert_eq!(untouched.title, "Other title");
+    assert_eq!(untouched.project_id.as_deref(), Some("portfolio-secondary"));
+    assert_eq!(
+        untouched.execution_repository.as_deref(),
+        Some("other/repo")
+    );
     assert!(untouched.external_refs.iter().any(|reference| {
         reference.provider == ExternalRefProvider::GitHub && reference.external_id == "7"
     }));
+}
+
+fn legacy_github_ref(external_id: &str, stale_project_id: &str) -> ExternalRef {
+    let mut reference = ExternalTaskRef::new(ExternalProvider::GitHub, external_id).into_core_ref();
+    reference.sync_state = Some(ExternalRefSyncState {
+        project_id: Some(stale_project_id.to_owned()),
+        ..ExternalRefSyncState::default()
+    });
+    reference
 }

--- a/src/task_board/external/tests/support.rs
+++ b/src/task_board/external/tests/support.rs
@@ -3,6 +3,9 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 
 use crate::errors::CliError;
+use crate::task_board::external::{
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
+};
 use crate::task_board::{
     ExternalProvider, ExternalRef, ExternalRefProvider, ExternalRefSyncState, ExternalSyncClient,
     ExternalTask, ExternalTaskRef, PlanningState, TaskBoardItem, TaskBoardStatus,
@@ -57,6 +60,10 @@ impl ExternalSyncClient for FakeSyncClient {
         self.provider
     }
 
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        Some(self)
+    }
+
     fn allows_delete(&self) -> bool {
         self.allows_delete
     }
@@ -87,6 +94,56 @@ impl ExternalSyncClient for FakeSyncClient {
             .expect("delete log should not be poisoned")
             .push(reference.external_id.clone());
         Ok(())
+    }
+}
+
+#[async_trait]
+impl ExternalCreateRecoveryClient for FakeSyncClient {
+    fn provider(&self) -> ExternalProvider {
+        self.provider
+    }
+
+    fn supports_target(&self, provider_target: &str) -> bool {
+        provider_target == self.scope_id()
+    }
+
+    async fn create_started(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError> {
+        lease.renew().await?;
+        self.pushed
+            .lock()
+            .expect("push log should not be poisoned")
+            .push(request.item_id().into());
+        Ok(task_from_create_request(self.provider, request))
+    }
+
+    async fn recover_existing(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError> {
+        lease.renew().await?;
+        Ok(ExternalCreateProbe::Found(task_from_create_request(
+            self.provider,
+            request,
+        )))
+    }
+}
+
+fn task_from_create_request(
+    provider: ExternalProvider,
+    request: &ExternalCreateRequest,
+) -> ExternalTask {
+    ExternalTask {
+        reference: ExternalTaskRef::new(provider, request.item_id()),
+        title: request.title().into(),
+        body: request.body().into(),
+        status: TaskBoardStatus::Backlog,
+        project_id: None,
+        updated_at: None,
     }
 }
 

--- a/src/task_board/external/tests/sync.rs
+++ b/src/task_board/external/tests/sync.rs
@@ -3,6 +3,7 @@ mod execution_repository_tests;
 use tempfile::tempdir;
 
 use super::support::{FakeSyncClient, external_task};
+use crate::daemon::db::AsyncDaemonDb;
 use crate::task_board::{
     ExternalProvider, ExternalRefProvider, ExternalRefSyncState, ExternalSyncAction,
     ExternalSyncClient, ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncField,
@@ -49,7 +50,9 @@ async fn fake_client_pushes_task_without_network() {
 #[tokio::test]
 async fn sync_external_tasks_uses_injected_clients_without_network() {
     let temp = tempdir().expect("tempdir");
-    let board = TaskBoardStore::new(temp.path().join("board"));
+    let board = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+        .await
+        .expect("database");
     let mut local = TaskBoardItem::new(
         "local-1".to_owned(),
         "Local task".to_owned(),
@@ -58,7 +61,8 @@ async fn sync_external_tasks_uses_injected_clients_without_network() {
     );
     local.status = TaskBoardStatus::Todo;
     board
-        .create("Local task", "Body", local)
+        .create_task_board_item(local)
+        .await
         .expect("create local task");
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FakeSyncClient::new(
         ExternalProvider::Todoist,
@@ -91,9 +95,15 @@ async fn sync_external_tasks_uses_injected_clients_without_network() {
             && operation.external_id.as_deref() == Some("local-1")
             && operation.applied
     }));
-    let pulled = board.get("todoist-remote-1").expect("load pulled task");
+    let pulled = board
+        .task_board_item("todoist-remote-1")
+        .await
+        .expect("load pulled task");
     assert_eq!(pulled.title, "Remote task");
-    let pushed = board.get("local-1").expect("load pushed task");
+    let pushed = board
+        .task_board_item("local-1")
+        .await
+        .expect("load pushed task");
     assert!(pushed.external_refs.iter().any(|reference| {
         reference.provider == ExternalRefProvider::Todoist && reference.external_id == "local-1"
     }));

--- a/src/task_board/external/tests/sync/execution_repository_tests.rs
+++ b/src/task_board/external/tests/sync/execution_repository_tests.rs
@@ -1,14 +1,59 @@
+use async_trait::async_trait;
 use tempfile::tempdir;
 
 use super::super::support::{FakeSyncClient, github_review_request_item};
+use crate::errors::CliError;
 use crate::task_board::{
-    ExternalProvider, ExternalSyncAction, ExternalSyncClient, ExternalSyncConflictPolicy,
-    ExternalSyncDirection, ExternalSyncOptions, ExternalTask, ExternalTaskRef, TaskBoardStatus,
-    TaskBoardStore, sync_external_tasks,
+    ExternalCreateOutcome, ExternalProvider, ExternalSyncAction, ExternalSyncClient,
+    ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncOptions, ExternalTask,
+    ExternalTaskRef, TaskBoardItem, TaskBoardStatus, TaskBoardStore, sync_external_tasks,
 };
 
 #[tokio::test]
-async fn sync_external_tasks_backfills_execution_repository_for_existing_github_items() {
+async fn github_create_persists_repository_without_replacing_project_identity() {
+    let temp = tempdir().expect("tempdir");
+    let board = TaskBoardStore::new(temp.path().join("board"));
+    let mut item = TaskBoardItem::new(
+        "local-1".to_owned(),
+        "Local issue".to_owned(),
+        "Body".to_owned(),
+        "2026-07-16T00:00:00Z".to_owned(),
+    );
+    item.project_id = Some("portfolio-primary".to_owned());
+    board
+        .create("Local issue", "Body", item)
+        .expect("create local task");
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(GitHubCreateClient)];
+
+    let operations = sync_external_tasks(
+        &board,
+        ExternalSyncOptions {
+            provider: Some(ExternalProvider::GitHub),
+            direction: ExternalSyncDirection::Push,
+            conflict_policy: ExternalSyncConflictPolicy::Report,
+            dry_run: false,
+            status: None,
+        },
+        &clients,
+    )
+    .await
+    .expect("create GitHub issue");
+
+    assert_eq!(operations.len(), 1);
+    assert!(operations[0].applied);
+    let linked = board.get("local-1").expect("load linked task");
+    assert_eq!(linked.project_id.as_deref(), Some("portfolio-primary"));
+    assert_eq!(linked.execution_repository.as_deref(), Some("owner/repo"));
+    let state = linked.external_refs[0]
+        .sync_state
+        .as_ref()
+        .expect("created sync state");
+    assert_eq!(state.project_id.as_deref(), Some("owner/repo"));
+    assert_eq!(state.updated_at.as_deref(), Some("provider-revision-1"));
+}
+
+#[tokio::test]
+async fn github_pull_preserves_project_identity_while_backfilling_execution_repository() {
     let temp = tempdir().expect("tempdir");
     let board = TaskBoardStore::new(temp.path().join("board"));
     let mut item = github_review_request_item(
@@ -16,7 +61,13 @@ async fn sync_external_tasks_backfills_execution_repository_for_existing_github_
         "owner/repo#18",
         TaskBoardStatus::Backlog,
     );
+    item.project_id = Some("portfolio-primary".to_owned());
     item.execution_repository = None;
+    item.external_refs[0]
+        .sync_state
+        .as_mut()
+        .expect("existing sync state")
+        .project_id = Some("portfolio-primary".to_owned());
     board
         .create("Review requested", "Please review the pull request.", item)
         .expect("create existing GitHub item");
@@ -36,7 +87,7 @@ async fn sync_external_tasks_backfills_execution_repository_for_existing_github_
     let options = ExternalSyncOptions {
         provider: Some(ExternalProvider::GitHub),
         direction: ExternalSyncDirection::Pull,
-        conflict_policy: ExternalSyncConflictPolicy::Report,
+        conflict_policy: ExternalSyncConflictPolicy::PreferRemote,
         dry_run: false,
         status: None,
     };
@@ -48,12 +99,16 @@ async fn sync_external_tasks_backfills_execution_repository_for_existing_github_
     assert_eq!(operations.len(), 1);
     assert_eq!(operations[0].action, ExternalSyncAction::Pull);
     assert!(operations[0].applied);
+    let updated = board
+        .get("github-owner-repo-18")
+        .expect("load backfilled item");
+    assert_eq!(updated.project_id.as_deref(), Some("portfolio-primary"));
+    assert_eq!(updated.execution_repository.as_deref(), Some("owner/repo"));
     assert_eq!(
-        board
-            .get("github-owner-repo-18")
-            .expect("load backfilled item")
-            .execution_repository
-            .as_deref(),
+        updated.external_refs[0]
+            .sync_state
+            .as_ref()
+            .and_then(|state| state.project_id.as_deref()),
         Some("owner/repo")
     );
     assert!(
@@ -62,4 +117,39 @@ async fn sync_external_tasks_backfills_execution_repository_for_existing_github_
             .expect("repeat sync")
             .is_empty()
     );
+}
+
+struct GitHubCreateClient;
+
+#[async_trait]
+impl ExternalSyncClient for GitHubCreateClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::GitHub
+    }
+
+    fn scope_id(&self) -> String {
+        "owner/repo".to_owned()
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        Ok(Vec::new())
+    }
+
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        Ok(ExternalTaskRef::new(
+            ExternalProvider::GitHub,
+            "owner/repo#17",
+        ))
+    }
+
+    async fn push_task_with_outcome(
+        &self,
+        item: &TaskBoardItem,
+    ) -> Result<ExternalCreateOutcome, CliError> {
+        Ok(ExternalCreateOutcome {
+            reference: self.push_task(item).await?,
+            provider_revision: Some("provider-revision-1".to_owned()),
+            provider_project_id: Some("owner/repo".to_owned()),
+        })
+    }
 }

--- a/src/task_board/external/tests/sync/execution_repository_tests.rs
+++ b/src/task_board/external/tests/sync/execution_repository_tests.rs
@@ -2,17 +2,23 @@ use async_trait::async_trait;
 use tempfile::tempdir;
 
 use super::super::support::{FakeSyncClient, github_review_request_item};
+use crate::daemon::db::AsyncDaemonDb;
 use crate::errors::CliError;
+use crate::task_board::external::{
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
+};
 use crate::task_board::{
-    ExternalCreateOutcome, ExternalProvider, ExternalSyncAction, ExternalSyncClient,
-    ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncOptions, ExternalTask,
-    ExternalTaskRef, TaskBoardItem, TaskBoardStatus, TaskBoardStore, sync_external_tasks,
+    ExternalProvider, ExternalSyncAction, ExternalSyncClient, ExternalSyncConflictPolicy,
+    ExternalSyncDirection, ExternalSyncOptions, ExternalTask, ExternalTaskRef, TaskBoardItem,
+    TaskBoardStatus, TaskBoardStore, sync_external_tasks,
 };
 
 #[tokio::test]
 async fn github_create_persists_repository_without_replacing_project_identity() {
     let temp = tempdir().expect("tempdir");
-    let board = TaskBoardStore::new(temp.path().join("board"));
+    let board = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+        .await
+        .expect("database");
     let mut item = TaskBoardItem::new(
         "local-1".to_owned(),
         "Local issue".to_owned(),
@@ -21,7 +27,8 @@ async fn github_create_persists_repository_without_replacing_project_identity() 
     );
     item.project_id = Some("portfolio-primary".to_owned());
     board
-        .create("Local issue", "Body", item)
+        .create_task_board_item(item)
+        .await
         .expect("create local task");
     let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(GitHubCreateClient)];
 
@@ -41,7 +48,10 @@ async fn github_create_persists_repository_without_replacing_project_identity() 
 
     assert_eq!(operations.len(), 1);
     assert!(operations[0].applied);
-    let linked = board.get("local-1").expect("load linked task");
+    let linked = board
+        .task_board_item("local-1")
+        .await
+        .expect("load linked task");
     assert_eq!(linked.project_id.as_deref(), Some("portfolio-primary"));
     assert_eq!(linked.execution_repository.as_deref(), Some("owner/repo"));
     let state = linked.external_refs[0]
@@ -127,6 +137,10 @@ impl ExternalSyncClient for GitHubCreateClient {
         ExternalProvider::GitHub
     }
 
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        Some(self)
+    }
+
     fn scope_id(&self) -> String {
         "owner/repo".to_owned()
     }
@@ -136,20 +150,46 @@ impl ExternalSyncClient for GitHubCreateClient {
     }
 
     async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
-        Ok(ExternalTaskRef::new(
-            ExternalProvider::GitHub,
-            "owner/repo#17",
-        ))
+        unreachable!("durable create admission must use create_started")
+    }
+}
+
+#[async_trait]
+impl ExternalCreateRecoveryClient for GitHubCreateClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::GitHub
     }
 
-    async fn push_task_with_outcome(
+    fn supports_target(&self, provider_target: &str) -> bool {
+        provider_target == "owner/repo"
+    }
+
+    async fn create_started(
         &self,
-        item: &TaskBoardItem,
-    ) -> Result<ExternalCreateOutcome, CliError> {
-        Ok(ExternalCreateOutcome {
-            reference: self.push_task(item).await?,
-            provider_revision: Some("provider-revision-1".to_owned()),
-            provider_project_id: Some("owner/repo".to_owned()),
-        })
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError> {
+        lease.renew().await?;
+        Ok(created_github_task(request))
+    }
+
+    async fn recover_existing(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError> {
+        lease.renew().await?;
+        Ok(ExternalCreateProbe::Found(created_github_task(request)))
+    }
+}
+
+fn created_github_task(request: &ExternalCreateRequest) -> ExternalTask {
+    ExternalTask {
+        reference: ExternalTaskRef::new(ExternalProvider::GitHub, "owner/repo#17"),
+        title: request.title().into(),
+        body: request.body().into(),
+        status: TaskBoardStatus::Backlog,
+        project_id: Some("owner/repo".into()),
+        updated_at: Some("provider-revision-1".into()),
     }
 }

--- a/src/task_board/external/todoist.rs
+++ b/src/task_board/external/todoist.rs
@@ -7,15 +7,18 @@ use crate::errors::{CliError, CliErrorKind};
 
 use super::super::types::{ExternalRefProvider, TaskBoardItem, TaskBoardStatus};
 use super::{
-    ExternalCreateOutcome, ExternalProvider, ExternalProviderCapabilities, ExternalSyncClient,
-    ExternalSyncConfig, ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate,
-    ExternalUpdateOutcome, non_empty_body, normalize_token,
+    ExternalCreateOutcome, ExternalCreateRecoveryClient, ExternalProvider,
+    ExternalProviderCapabilities, ExternalSyncClient, ExternalSyncConfig, ExternalSyncField,
+    ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome, non_empty_body,
+    normalize_token,
 };
 
 #[cfg(test)]
 use move_task::TodoistMoveTaskRequest;
 use request_id::{TodoistRequestIntent, TodoistStatusAction};
 
+#[path = "todoist/create_recovery.rs"]
+mod create_recovery;
 #[path = "todoist/move_task.rs"]
 mod move_task;
 #[path = "todoist/pagination.rs"]
@@ -24,6 +27,7 @@ mod pagination;
 mod request_id;
 
 const TODOIST_API_BASE: &str = "https://api.todoist.com/api/v1";
+const TODOIST_ALL_SCOPE: &str = "all";
 const TODOIST_TASK_URL_BASE: &str = "https://app.todoist.com/app/task";
 
 #[derive(Clone)]
@@ -105,10 +109,18 @@ impl ExternalSyncClient for TodoistSyncClient {
         ExternalProvider::Todoist
     }
 
+    #[allow(
+        private_interfaces,
+        reason = "provider-create recovery is intentionally crate-private"
+    )]
+    fn external_create_recovery(&self) -> Option<&dyn ExternalCreateRecoveryClient> {
+        Some(self)
+    }
+
     fn scope_id(&self) -> String {
         match self.import_project_ids.as_slice() {
             [project_id] => project_id.clone(),
-            _ => "all".into(),
+            _ => TODOIST_ALL_SCOPE.into(),
         }
     }
 
@@ -159,17 +171,7 @@ impl ExternalSyncClient for TodoistSyncClient {
             request: &request,
         }
         .request_id();
-        let task = self
-            .write_request(self.client.post(self.endpoint("tasks")), &request_id)
-            .json(&request)
-            .send()
-            .await
-            .map_err(todoist_sync_error)?
-            .error_for_status()
-            .map_err(todoist_sync_error)?
-            .json::<TodoistTask>()
-            .await
-            .map_err(todoist_sync_error)?;
+        let task = self.create_task(&request, &request_id).await?;
         Ok(ExternalCreateOutcome {
             reference: task.reference(),
             provider_revision: task.updated_at,
@@ -263,6 +265,23 @@ impl ExternalSyncClient for TodoistSyncClient {
 }
 
 impl TodoistSyncClient {
+    async fn create_task(
+        &self,
+        request: &TodoistCreateTaskRequest,
+        request_id: &str,
+    ) -> Result<TodoistTask, CliError> {
+        self.write_request(self.client.post(self.endpoint("tasks")), request_id)
+            .json(request)
+            .send()
+            .await
+            .map_err(todoist_sync_error)?
+            .error_for_status()
+            .map_err(todoist_sync_error)?
+            .json::<TodoistTask>()
+            .await
+            .map_err(todoist_sync_error)
+    }
+
     fn write_request(
         &self,
         request: reqwest::RequestBuilder,

--- a/src/task_board/external/todoist.rs
+++ b/src/task_board/external/todoist.rs
@@ -9,9 +9,9 @@ use crate::errors::{CliError, CliErrorKind};
 
 use super::super::types::{ExternalRefProvider, TaskBoardItem, TaskBoardStatus};
 use super::{
-    ExternalProvider, ExternalProviderCapabilities, ExternalSyncClient, ExternalSyncConfig,
-    ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate, ExternalUpdateOutcome,
-    non_empty_body, normalize_token,
+    ExternalCreateOutcome, ExternalProvider, ExternalProviderCapabilities, ExternalSyncClient,
+    ExternalSyncConfig, ExternalSyncField, ExternalTask, ExternalTaskRef, ExternalTaskUpdate,
+    ExternalUpdateOutcome, non_empty_body, normalize_token,
 };
 
 const TODOIST_API_BASE: &str = "https://api.todoist.com/rest/v2";
@@ -151,6 +151,13 @@ impl ExternalSyncClient for TodoistSyncClient {
     }
 
     async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        Ok(self.push_task_with_outcome(item).await?.reference)
+    }
+
+    async fn push_task_with_outcome(
+        &self,
+        item: &TaskBoardItem,
+    ) -> Result<ExternalCreateOutcome, CliError> {
         let request = TodoistCreateTaskRequest {
             content: item.title.clone(),
             description: non_empty_body(&item.body),
@@ -168,7 +175,11 @@ impl ExternalSyncClient for TodoistSyncClient {
             .json::<TodoistTask>()
             .await
             .map_err(todoist_sync_error)?;
-        Ok(task.reference())
+        Ok(ExternalCreateOutcome {
+            reference: task.reference(),
+            provider_revision: task.updated_at,
+            provider_project_id: task.project_id,
+        })
     }
 
     async fn update_task(
@@ -187,15 +198,27 @@ impl ExternalSyncClient for TodoistSyncClient {
                 });
             }
         }
+        let changes_metadata = update.changes_metadata();
+        let changes_status = update.changes_status();
+        let closes_task = changes_status && item.status == TaskBoardStatus::Done;
         let mut updated_reference = reference.clone();
-        let mut provider_revision = update.precondition_updated_at.clone();
-        if update.changes_metadata() {
+        let mut provider_revision = None;
+        if changes_status && changes_metadata && !closes_task {
+            self.update_task_status(item, reference).await?;
+        }
+        if changes_metadata {
             let updated = self.update_task_metadata(item, reference, &update).await?;
             updated_reference = updated.reference();
-            provider_revision = updated.updated_at.or(provider_revision);
+            provider_revision = updated.updated_at;
         }
-        if update.changes_status() {
+        if changes_status && (!changes_metadata || closes_task) {
             self.update_task_status(item, reference).await?;
+        }
+        if changes_metadata && closes_task {
+            // Todoist close returns no task and archived tasks are not available
+            // through the active-task read endpoint. Never report the metadata
+            // revision as though it followed the close mutation.
+            provider_revision = None;
         }
         Ok(ExternalUpdateOutcome::Applied {
             reference: updated_reference,

--- a/src/task_board/external/todoist.rs
+++ b/src/task_board/external/todoist.rs
@@ -2,8 +2,6 @@ use std::fmt;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use uuid::Uuid;
 
 use crate::errors::{CliError, CliErrorKind};
 
@@ -14,7 +12,19 @@ use super::{
     ExternalUpdateOutcome, non_empty_body, normalize_token,
 };
 
-const TODOIST_API_BASE: &str = "https://api.todoist.com/rest/v2";
+#[cfg(test)]
+use move_task::TodoistMoveTaskRequest;
+use request_id::{TodoistRequestIntent, TodoistStatusAction};
+
+#[path = "todoist/move_task.rs"]
+mod move_task;
+#[path = "todoist/pagination.rs"]
+mod pagination;
+#[path = "todoist/request_id.rs"]
+mod request_id;
+
+const TODOIST_API_BASE: &str = "https://api.todoist.com/api/v1";
+const TODOIST_TASK_URL_BASE: &str = "https://app.todoist.com/app/task";
 
 #[derive(Clone)]
 pub struct TodoistSyncClient {
@@ -128,26 +138,7 @@ impl ExternalSyncClient for TodoistSyncClient {
     }
 
     async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
-        let tasks = self
-            .client
-            .get(self.endpoint("tasks"))
-            .bearer_auth(&self.token)
-            .send()
-            .await
-            .map_err(todoist_sync_error)?
-            .error_for_status()
-            .map_err(todoist_sync_error)?
-            .json::<Vec<TodoistTask>>()
-            .await
-            .map_err(todoist_sync_error)?;
-        let project_filter = self.import_project_ids.as_slice();
-        Ok(tasks
-            .into_iter()
-            .filter(|task| {
-                todoist_project_matches_filter(task.project_id.as_deref(), project_filter)
-            })
-            .map(ExternalTask::from)
-            .collect())
+        pagination::pull_tasks(self).await
     }
 
     async fn push_task(&self, item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
@@ -163,7 +154,11 @@ impl ExternalSyncClient for TodoistSyncClient {
             description: non_empty_body(&item.body),
             project_id: item.project_id.clone(),
         };
-        let request_id = todoist_request_id("create", item, None);
+        let request_id = TodoistRequestIntent::Create {
+            item,
+            request: &request,
+        }
+        .request_id();
         let task = self
             .write_request(self.client.post(self.endpoint("tasks")), &request_id)
             .json(&request)
@@ -188,6 +183,7 @@ impl ExternalSyncClient for TodoistSyncClient {
         reference: &ExternalTaskRef,
         update: ExternalTaskUpdate,
     ) -> Result<ExternalUpdateOutcome, CliError> {
+        let project_destination = update.project_destination(item)?;
         if let Some(precondition) = update.precondition_updated_at.as_deref() {
             // Todoist exposes task revisions but no conditional mutation header.
             // A fresh task read is the strongest available preflight.
@@ -200,24 +196,36 @@ impl ExternalSyncClient for TodoistSyncClient {
         }
         let changes_metadata = update.changes_metadata();
         let changes_status = update.changes_status();
-        let closes_task = changes_status && item.status == TaskBoardStatus::Done;
-        let mut updated_reference = reference.clone();
+        let has_task_mutation = changes_metadata || project_destination.is_some();
+        let status_action = changes_status.then(|| TodoistStatusAction::for_status(item.status));
+        let closes_task = status_action == Some(TodoistStatusAction::Close);
+        let mut updated_reference = todoist_task_reference(&reference.external_id);
         let mut provider_revision = None;
-        if changes_status && changes_metadata && !closes_task {
-            self.update_task_status(item, reference).await?;
+        if let Some(action) = status_action
+            .filter(|action| *action == TodoistStatusAction::Reopen && has_task_mutation)
+        {
+            self.update_task_status(item, reference, action).await?;
         }
+        let mut latest_task = None;
         if changes_metadata {
-            let updated = self.update_task_metadata(item, reference, &update).await?;
-            updated_reference = updated.reference();
-            provider_revision = updated.updated_at;
+            latest_task = Some(self.update_task_metadata(item, reference, &update).await?);
         }
-        if changes_status && (!changes_metadata || closes_task) {
-            self.update_task_status(item, reference).await?;
+        if let Some(project_id) = project_destination {
+            latest_task = Some(move_task::move_task(self, item, reference, project_id).await?);
         }
-        if changes_metadata && closes_task {
+        if let Some(action) = status_action
+            .filter(|action| *action == TodoistStatusAction::Close || !has_task_mutation)
+        {
+            self.update_task_status(item, reference, action).await?;
+        }
+        if let Some(task) = latest_task {
+            updated_reference = task.reference();
+            provider_revision = task.updated_at;
+        }
+        if has_task_mutation && closes_task {
             // Todoist close returns no task and archived tasks are not available
-            // through the active-task read endpoint. Never report the metadata
-            // revision as though it followed the close mutation.
+            // through the active-task read endpoint. Never report a pre-close
+            // mutation revision as though it followed the close mutation.
             provider_revision = None;
         }
         Ok(ExternalUpdateOutcome::Applied {
@@ -235,10 +243,14 @@ impl ExternalSyncClient for TodoistSyncClient {
         item: &TaskBoardItem,
         reference: &ExternalTaskRef,
     ) -> Result<(), CliError> {
-        let request_id = todoist_request_id("delete", item, Some(&reference.external_id));
+        let request_id = TodoistRequestIntent::Delete {
+            item,
+            external_id: &reference.external_id,
+        }
+        .request_id();
         self.write_request(
             self.client
-                .post(self.endpoint(format!("tasks/{}/close", reference.external_id).as_str())),
+                .delete(self.endpoint(format!("tasks/{}", reference.external_id).as_str())),
             &request_id,
         )
         .send()
@@ -290,13 +302,13 @@ impl TodoistSyncClient {
                 .changed_fields
                 .contains(&ExternalSyncField::Body)
                 .then(|| item.body.clone()),
-            project_id: update
-                .changed_fields
-                .contains(&ExternalSyncField::Project)
-                .then(|| item.project_id.clone())
-                .flatten(),
         };
-        let request_id = todoist_request_id("update-metadata", item, Some(&reference.external_id));
+        let request_id = TodoistRequestIntent::Metadata {
+            item,
+            external_id: &reference.external_id,
+            request: &request,
+        }
+        .request_id();
         let task = self
             .write_request(
                 self.client
@@ -319,10 +331,16 @@ impl TodoistSyncClient {
         &self,
         item: &TaskBoardItem,
         reference: &ExternalTaskRef,
+        action: TodoistStatusAction,
     ) -> Result<(), CliError> {
-        let action = status_endpoint(&reference.external_id, item.status);
-        let request_id = todoist_request_id(&action, item, Some(&reference.external_id));
-        self.write_request(self.client.post(self.endpoint(&action)), &request_id)
+        let endpoint = action.endpoint(&reference.external_id);
+        let request_id = TodoistRequestIntent::Status {
+            item,
+            external_id: &reference.external_id,
+            action,
+        }
+        .request_id();
+        self.write_request(self.client.post(self.endpoint(&endpoint)), &request_id)
             .send()
             .await
             .map_err(todoist_sync_error)?
@@ -334,68 +352,33 @@ impl TodoistSyncClient {
 
 impl ExternalTaskUpdate {
     fn changes_metadata(&self) -> bool {
-        self.changed_fields.iter().any(|field| {
-            matches!(
-                field,
-                ExternalSyncField::Title | ExternalSyncField::Body | ExternalSyncField::Project
+        self.changed_fields
+            .iter()
+            .any(|field| matches!(field, ExternalSyncField::Title | ExternalSyncField::Body))
+    }
+
+    fn project_destination<'a>(
+        &self,
+        item: &'a TaskBoardItem,
+    ) -> Result<Option<&'a str>, CliError> {
+        if !self.changed_fields.contains(&ExternalSyncField::Project) {
+            return Ok(None);
+        }
+        let Some(project_id) = item
+            .project_id
+            .as_deref()
+            .filter(|project_id| !project_id.trim().is_empty())
+        else {
+            return Err(CliErrorKind::workflow_io(
+                "task-board todoist project move requires a destination project ID",
             )
-        })
+            .into());
+        };
+        Ok(Some(project_id))
     }
 
     fn changes_status(&self) -> bool {
         self.changed_fields.contains(&ExternalSyncField::Status)
-    }
-}
-
-fn status_endpoint(external_id: &str, status: TaskBoardStatus) -> String {
-    let action = if status == TaskBoardStatus::Done {
-        "close"
-    } else {
-        "reopen"
-    };
-    format!("tasks/{external_id}/{action}")
-}
-
-fn todoist_request_id(operation: &str, item: &TaskBoardItem, external_id: Option<&str>) -> String {
-    let mut hasher = Sha256::new();
-    for part in [
-        operation,
-        item.id.as_str(),
-        item.updated_at.as_str(),
-        external_id.unwrap_or_default(),
-        item.title.as_str(),
-        item.body.as_str(),
-        item.project_id.as_deref().unwrap_or_default(),
-    ] {
-        hasher.update(part.len().to_be_bytes());
-        hasher.update(part.as_bytes());
-    }
-    hasher.update(todoist_request_id_status(item.status));
-    let digest = hasher.finalize();
-    let mut bytes = [0_u8; 16];
-    bytes.copy_from_slice(&digest[..16]);
-    bytes[6] = (bytes[6] & 0x0f) | 0x40;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    Uuid::from_bytes(bytes).to_string()
-}
-
-fn todoist_request_id_status(status: TaskBoardStatus) -> &'static str {
-    match status {
-        TaskBoardStatus::Backlog => "backlog",
-        TaskBoardStatus::Todo => "todo",
-        TaskBoardStatus::Planning => "planning",
-        TaskBoardStatus::InProgress => "in_progress",
-        TaskBoardStatus::AgenticReview => "agentic_review",
-        TaskBoardStatus::Testing => "testing",
-        TaskBoardStatus::InReview => "in_review",
-        TaskBoardStatus::ToReview => "to_review",
-        TaskBoardStatus::HumanRequired => "human_required",
-        TaskBoardStatus::Failed => "failed",
-        TaskBoardStatus::Done => "done",
-        TaskBoardStatus::New => "new",
-        TaskBoardStatus::PlanReview => "plan_review",
-        TaskBoardStatus::NeedsYou => "needs_you",
-        TaskBoardStatus::Blocked => "blocked",
     }
 }
 
@@ -414,8 +397,6 @@ struct TodoistUpdateTaskRequest {
     content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    project_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -425,8 +406,6 @@ struct TodoistTask {
     #[serde(default)]
     description: String,
     #[serde(default)]
-    url: Option<String>,
-    #[serde(default)]
     project_id: Option<String>,
     #[serde(default, alias = "checked")]
     is_completed: bool,
@@ -434,13 +413,14 @@ struct TodoistTask {
     updated_at: Option<String>,
 }
 
+fn todoist_task_reference(external_id: &str) -> ExternalTaskRef {
+    ExternalTaskRef::new(ExternalProvider::Todoist, external_id)
+        .with_url(format!("{TODOIST_TASK_URL_BASE}/{external_id}"))
+}
+
 impl TodoistTask {
     fn reference(&self) -> ExternalTaskRef {
-        let mut reference = ExternalTaskRef::new(ExternalProvider::Todoist, self.id.clone());
-        if let Some(url) = &self.url {
-            reference = reference.with_url(url.clone());
-        }
-        reference
+        todoist_task_reference(&self.id)
     }
 }
 

--- a/src/task_board/external/todoist/create_recovery.rs
+++ b/src/task_board/external/todoist/create_recovery.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+
+use crate::errors::CliError;
+
+use super::{TODOIST_ALL_SCOPE, TodoistCreateTaskRequest, TodoistSyncClient, non_empty_body};
+use crate::task_board::external::{
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
+    ExternalProvider, ExternalTask,
+};
+
+#[async_trait]
+impl ExternalCreateRecoveryClient for TodoistSyncClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    fn supports_target(&self, provider_target: &str) -> bool {
+        let provider_target = provider_target.trim();
+        !provider_target.is_empty()
+            && (self.project_filter().is_empty()
+                || self
+                    .project_filter()
+                    .iter()
+                    .any(|project_id| project_id.trim() == provider_target))
+    }
+
+    async fn create_started(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalTask, CliError> {
+        lease.renew().await?;
+        self.replay_create(request).await
+    }
+
+    async fn recover_existing(
+        &self,
+        request: &ExternalCreateRequest,
+        lease: &dyn ExternalCreateLease,
+    ) -> Result<ExternalCreateProbe, CliError> {
+        lease.renew().await?;
+        self.replay_create(request)
+            .await
+            .map(ExternalCreateProbe::Found)
+    }
+}
+
+impl TodoistSyncClient {
+    async fn replay_create(
+        &self,
+        request: &ExternalCreateRequest,
+    ) -> Result<ExternalTask, CliError> {
+        let provider_request = TodoistCreateTaskRequest {
+            content: request.title().to_owned(),
+            description: non_empty_body(request.body()),
+            project_id: self.recovery_project_id(request.provider_target()),
+        };
+        self.create_task(&provider_request, request.create_key())
+            .await
+            .map(Into::into)
+    }
+
+    fn recovery_project_id(&self, provider_target: &str) -> Option<String> {
+        (!self.project_filter().is_empty() || provider_target != TODOIST_ALL_SCOPE)
+            .then(|| provider_target.to_owned())
+    }
+}

--- a/src/task_board/external/todoist/move_task.rs
+++ b/src/task_board/external/todoist/move_task.rs
@@ -1,0 +1,46 @@
+use serde::Serialize;
+
+use crate::errors::CliError;
+
+use super::{
+    ExternalTaskRef, TaskBoardItem, TodoistRequestIntent, TodoistSyncClient, TodoistTask,
+    todoist_sync_error,
+};
+
+#[derive(Debug, Serialize)]
+pub(super) struct TodoistMoveTaskRequest {
+    pub(super) project_id: String,
+}
+
+pub(super) async fn move_task(
+    client: &TodoistSyncClient,
+    item: &TaskBoardItem,
+    reference: &ExternalTaskRef,
+    project_id: &str,
+) -> Result<TodoistTask, CliError> {
+    let request = TodoistMoveTaskRequest {
+        project_id: project_id.to_owned(),
+    };
+    let request_id = TodoistRequestIntent::Move {
+        item,
+        external_id: &reference.external_id,
+        request: &request,
+    }
+    .request_id();
+    client
+        .write_request(
+            client
+                .client
+                .post(client.endpoint(format!("tasks/{}/move", reference.external_id).as_str())),
+            &request_id,
+        )
+        .json(&request)
+        .send()
+        .await
+        .map_err(todoist_sync_error)?
+        .error_for_status()
+        .map_err(todoist_sync_error)?
+        .json::<TodoistTask>()
+        .await
+        .map_err(todoist_sync_error)
+}

--- a/src/task_board/external/todoist/pagination.rs
+++ b/src/task_board/external/todoist/pagination.rs
@@ -1,0 +1,90 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Deserializer};
+
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::external::ExternalTask;
+
+use super::{TodoistSyncClient, TodoistTask, todoist_project_matches_filter, todoist_sync_error};
+
+#[derive(Debug, Deserialize)]
+struct TodoistTaskPage {
+    results: Vec<TodoistTask>,
+    #[serde(default)]
+    next_cursor: TodoistNextCursor,
+}
+
+#[derive(Debug, Default)]
+enum TodoistNextCursor {
+    #[default]
+    Missing,
+    Present(Option<String>),
+}
+
+impl<'de> Deserialize<'de> for TodoistNextCursor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer).map(Self::Present)
+    }
+}
+
+pub(super) async fn pull_tasks(client: &TodoistSyncClient) -> Result<Vec<ExternalTask>, CliError> {
+    let mut tasks = Vec::new();
+    let mut cursor = None;
+    let mut seen_cursors = HashSet::new();
+    loop {
+        let page = pull_page(client, cursor.as_deref()).await?;
+        let project_filter = client.import_project_ids.as_slice();
+        tasks.extend(
+            page.results
+                .into_iter()
+                .filter(|task| {
+                    todoist_project_matches_filter(task.project_id.as_deref(), project_filter)
+                })
+                .map(ExternalTask::from),
+        );
+        let next_cursor = match page.next_cursor {
+            TodoistNextCursor::Missing => {
+                return Err(pagination_error("missing pagination cursor"));
+            }
+            TodoistNextCursor::Present(None) => break,
+            TodoistNextCursor::Present(Some(next_cursor)) => next_cursor,
+        };
+        if next_cursor.trim().is_empty() {
+            return Err(pagination_error("empty pagination cursor"));
+        }
+        if !seen_cursors.insert(next_cursor.clone()) {
+            return Err(pagination_error("repeated pagination cursor"));
+        }
+        cursor = Some(next_cursor);
+    }
+    Ok(tasks)
+}
+
+async fn pull_page(
+    client: &TodoistSyncClient,
+    cursor: Option<&str>,
+) -> Result<TodoistTaskPage, CliError> {
+    let mut request = client
+        .client
+        .get(client.endpoint("tasks"))
+        .bearer_auth(&client.token);
+    if let Some(cursor) = cursor {
+        request = request.query(&[("cursor", cursor)]);
+    }
+    request
+        .send()
+        .await
+        .map_err(todoist_sync_error)?
+        .error_for_status()
+        .map_err(todoist_sync_error)?
+        .json::<TodoistTaskPage>()
+        .await
+        .map_err(todoist_sync_error)
+}
+
+fn pagination_error(detail: &str) -> CliError {
+    CliErrorKind::workflow_io(format!("task-board todoist sync failed: {detail}")).into()
+}

--- a/src/task_board/external/todoist/request_id.rs
+++ b/src/task_board/external/todoist/request_id.rs
@@ -1,0 +1,146 @@
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::move_task::TodoistMoveTaskRequest;
+use super::{TaskBoardItem, TaskBoardStatus, TodoistCreateTaskRequest, TodoistUpdateTaskRequest};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum TodoistStatusAction {
+    Close,
+    Reopen,
+}
+
+impl TodoistStatusAction {
+    pub(super) const fn for_status(status: TaskBoardStatus) -> Self {
+        if matches!(status, TaskBoardStatus::Done) {
+            Self::Close
+        } else {
+            Self::Reopen
+        }
+    }
+
+    pub(super) fn endpoint(self, external_id: &str) -> String {
+        format!("tasks/{external_id}/{}", self.identity())
+    }
+
+    const fn identity(self) -> &'static str {
+        match self {
+            Self::Close => "close",
+            Self::Reopen => "reopen",
+        }
+    }
+}
+
+pub(super) enum TodoistRequestIntent<'a> {
+    Create {
+        item: &'a TaskBoardItem,
+        request: &'a TodoistCreateTaskRequest,
+    },
+    Metadata {
+        item: &'a TaskBoardItem,
+        external_id: &'a str,
+        request: &'a TodoistUpdateTaskRequest,
+    },
+    Move {
+        item: &'a TaskBoardItem,
+        external_id: &'a str,
+        request: &'a TodoistMoveTaskRequest,
+    },
+    Status {
+        item: &'a TaskBoardItem,
+        external_id: &'a str,
+        action: TodoistStatusAction,
+    },
+    Delete {
+        item: &'a TaskBoardItem,
+        external_id: &'a str,
+    },
+}
+
+impl TodoistRequestIntent<'_> {
+    pub(super) fn request_id(&self) -> String {
+        let mut hash = RequestIdHash::default();
+        match self {
+            Self::Create { item, request } => {
+                hash.required("create");
+                // Preserve the current local item revision as the create retry
+                // boundary until durable provider create keys are wired.
+                hash.item_revision(item);
+                hash.required(&request.content);
+                hash.optional(request.description.as_deref());
+                hash.optional(request.project_id.as_deref());
+            }
+            Self::Move {
+                item,
+                external_id,
+                request,
+            } => {
+                hash.required("move");
+                hash.item_revision(item);
+                hash.required(external_id);
+                hash.required(&request.project_id);
+            }
+            Self::Metadata {
+                item,
+                external_id,
+                request,
+            } => {
+                hash.required("metadata");
+                hash.item_revision(item);
+                hash.required(external_id);
+                hash.optional(request.content.as_deref());
+                hash.optional(request.description.as_deref());
+            }
+            Self::Status {
+                item,
+                external_id,
+                action,
+            } => {
+                hash.required("status");
+                hash.item_revision(item);
+                hash.required(external_id);
+                hash.required(action.identity());
+            }
+            Self::Delete { item, external_id } => {
+                hash.required("delete");
+                hash.item_revision(item);
+                hash.required(external_id);
+            }
+        }
+        hash.finish()
+    }
+}
+
+#[derive(Default)]
+struct RequestIdHash {
+    hasher: Sha256,
+}
+
+impl RequestIdHash {
+    fn item_revision(&mut self, item: &TaskBoardItem) {
+        self.required(&item.id);
+        self.required(&item.updated_at);
+    }
+
+    fn required(&mut self, value: &str) {
+        self.hasher.update([1]);
+        self.hasher.update((value.len() as u64).to_be_bytes());
+        self.hasher.update(value.as_bytes());
+    }
+
+    fn optional(&mut self, value: Option<&str>) {
+        match value {
+            Some(value) => self.required(value),
+            None => self.hasher.update([0]),
+        }
+    }
+
+    fn finish(self) -> String {
+        let digest = self.hasher.finalize();
+        let mut bytes = [0_u8; 16];
+        bytes.copy_from_slice(&digest[..16]);
+        bytes[6] = (bytes[6] & 0x0f) | 0x50;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        Uuid::from_bytes(bytes).to_string()
+    }
+}

--- a/src/task_board/external/todoist/todoist_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests.rs
@@ -7,6 +7,8 @@ use serde_json::Value;
 
 use super::*;
 
+mod revision_tests;
+
 #[derive(Debug, Default)]
 struct CapturedRequest {
     path: String,
@@ -92,14 +94,25 @@ async fn todoist_update_task_reopens_remote_when_local_status_is_not_done() {
 #[tokio::test]
 async fn todoist_push_task_posts_metadata_payload() {
     let (endpoint, captured, handle) = spawn_json_mock(
-        r#"{"id":"remote-1","content":"Remote title","description":"Remote body"}"#,
+        r#"{"id":"remote-1","content":"Remote title","description":"Remote body","project_id":"provider-project","updated_at":"provider-revision-1"}"#,
     );
     let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
     let item = local_item("Local title", "Local body", Some("project-1"));
 
-    let reference = client.push_task(&item).await.expect("push task");
+    let outcome = client
+        .push_task_with_outcome(&item)
+        .await
+        .expect("push task");
 
-    assert_eq!(reference.external_id, "remote-1");
+    assert_eq!(outcome.reference.external_id, "remote-1");
+    assert_eq!(
+        outcome.provider_revision.as_deref(),
+        Some("provider-revision-1")
+    );
+    assert_eq!(
+        outcome.provider_project_id.as_deref(),
+        Some("provider-project")
+    );
     handle.join().expect("mock server");
     let captured = captured.lock().expect("captured request");
     assert_eq!(captured.path, "/tasks");
@@ -140,45 +153,6 @@ async fn todoist_update_task_posts_changed_metadata_payload() {
     assert_eq!(body["content"], "Updated title");
     assert_eq!(body["description"], "Updated body");
     assert_eq!(body["project_id"], "project-2");
-}
-
-#[tokio::test]
-async fn todoist_status_write_preserves_metadata_provider_revision() {
-    let (endpoint, captured, handle) = spawn_sequence_mock(vec![
-        (
-            "200 OK",
-            r#"{"id":"remote-1","content":"Updated title","description":"Body","updated_at":"provider-revision-2"}"#,
-        ),
-        ("204 No Content", ""),
-    ]);
-    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
-    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
-    let mut item = local_item("Updated title", "Body", None);
-    item.status = TaskBoardStatus::Done;
-
-    let outcome = client
-        .update_task(
-            &item,
-            &reference,
-            ExternalTaskUpdate::new(vec![ExternalSyncField::Title, ExternalSyncField::Status]),
-        )
-        .await
-        .expect("update metadata and status");
-
-    handle.join().expect("mock server");
-    let ExternalUpdateOutcome::Applied {
-        provider_revision, ..
-    } = outcome
-    else {
-        panic!("update must be applied");
-    };
-    assert_eq!(provider_revision.as_deref(), Some("provider-revision-2"));
-    let captured = captured.lock().expect("captured requests");
-    assert_eq!(captured.len(), 2);
-    assert_eq!(captured[0].path, "/tasks/remote-1");
-    assert_eq!(captured[1].path, "/tasks/remote-1/close");
-    assert!(captured.iter().all(|request| request.request_id.is_some()));
-    assert_ne!(captured[0].request_id, captured[1].request_id);
 }
 
 #[tokio::test]

--- a/src/task_board/external/todoist/todoist_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests.rs
@@ -7,14 +7,23 @@ use serde_json::Value;
 
 use super::*;
 
+mod move_tests;
+mod pagination_tests;
+mod request_id_tests;
 mod revision_tests;
 
 #[derive(Debug, Default)]
 struct CapturedRequest {
+    method: String,
     path: String,
     authorization: Option<String>,
     request_id: Option<String>,
     body: String,
+}
+
+#[test]
+fn todoist_production_base_uses_official_v1_api() {
+    assert_eq!(TODOIST_API_BASE, "https://api.todoist.com/api/v1");
 }
 
 #[test]
@@ -29,30 +38,14 @@ fn todoist_capabilities_include_status_updates() {
     );
 }
 
-#[test]
-fn todoist_status_endpoint_closes_done_and_reopens_other_statuses() {
-    assert_eq!(
-        status_endpoint("task-1", TaskBoardStatus::Done),
-        "tasks/task-1/close"
-    );
-    assert_eq!(
-        status_endpoint("task-1", TaskBoardStatus::Todo),
-        "tasks/task-1/reopen"
-    );
-    assert_eq!(
-        status_endpoint("task-1", TaskBoardStatus::Backlog),
-        "tasks/task-1/reopen"
-    );
-}
-
 #[tokio::test]
-async fn todoist_update_task_closes_remote_when_local_status_is_done() {
+async fn todoist_status_only_close_canonicalizes_missing_reference_url() {
     let (endpoint, captured, handle) = spawn_status_mock();
     let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
     let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
     let item = local_item_with_status(TaskBoardStatus::Done);
 
-    client
+    let outcome = client
         .update_task(
             &item,
             &reference,
@@ -61,6 +54,7 @@ async fn todoist_update_task_closes_remote_when_local_status_is_done() {
         .await
         .expect("update task status");
 
+    assert_status_update_reference(outcome);
     handle.join().expect("mock server");
     let captured = captured.lock().expect("captured request");
     assert_eq!(captured.path, "/tasks/remote-1/close");
@@ -69,13 +63,14 @@ async fn todoist_update_task_closes_remote_when_local_status_is_done() {
 }
 
 #[tokio::test]
-async fn todoist_update_task_reopens_remote_when_local_status_is_not_done() {
+async fn todoist_status_only_reopen_replaces_legacy_reference_url() {
     let (endpoint, captured, handle) = spawn_status_mock();
     let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
-    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1")
+        .with_url("https://legacy.todoist.invalid/task/remote-1");
     let item = local_item_with_status(TaskBoardStatus::InProgress);
 
-    client
+    let outcome = client
         .update_task(
             &item,
             &reference,
@@ -84,11 +79,27 @@ async fn todoist_update_task_reopens_remote_when_local_status_is_not_done() {
         .await
         .expect("update task status");
 
+    assert_status_update_reference(outcome);
     handle.join().expect("mock server");
     let captured = captured.lock().expect("captured request");
     assert_eq!(captured.path, "/tasks/remote-1/reopen");
     assert_eq!(captured.authorization.as_deref(), Some("Bearer token"));
     assert!(captured.body.is_empty());
+}
+
+fn assert_status_update_reference(outcome: ExternalUpdateOutcome) {
+    let ExternalUpdateOutcome::Applied {
+        reference,
+        provider_revision,
+    } = outcome
+    else {
+        panic!("status update must be applied");
+    };
+    assert_eq!(
+        reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/remote-1")
+    );
+    assert_eq!(provider_revision, None);
 }
 
 #[tokio::test]
@@ -113,6 +124,10 @@ async fn todoist_push_task_posts_metadata_payload() {
         outcome.provider_project_id.as_deref(),
         Some("provider-project")
     );
+    assert_eq!(
+        outcome.reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/remote-1")
+    );
     handle.join().expect("mock server");
     let captured = captured.lock().expect("captured request");
     assert_eq!(captured.path, "/tasks");
@@ -126,25 +141,33 @@ async fn todoist_push_task_posts_metadata_payload() {
 #[tokio::test]
 async fn todoist_update_task_posts_changed_metadata_payload() {
     let (endpoint, captured, handle) = spawn_json_mock(
-        r#"{"id":"remote-1","content":"Remote title","description":"Remote body"}"#,
+        r#"{"id":"remote-1","content":"Remote title","description":"Remote body","project_id":"project-2","updated_at":null}"#,
     );
     let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
     let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
     let item = local_item("Updated title", "Updated body", Some("project-2"));
 
-    client
+    let outcome = client
         .update_task(
             &item,
             &reference,
-            ExternalTaskUpdate::new(vec![
-                ExternalSyncField::Title,
-                ExternalSyncField::Body,
-                ExternalSyncField::Project,
-            ]),
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Title, ExternalSyncField::Body]),
         )
         .await
         .expect("update task metadata");
 
+    let ExternalUpdateOutcome::Applied {
+        reference,
+        provider_revision,
+    } = outcome
+    else {
+        panic!("metadata update must be applied");
+    };
+    assert_eq!(
+        reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/remote-1")
+    );
+    assert_eq!(provider_revision, None);
     handle.join().expect("mock server");
     let captured = captured.lock().expect("captured request");
     assert_eq!(captured.path, "/tasks/remote-1");
@@ -152,7 +175,7 @@ async fn todoist_update_task_posts_changed_metadata_payload() {
     let body = body_json(&captured.body);
     assert_eq!(body["content"], "Updated title");
     assert_eq!(body["description"], "Updated body");
-    assert_eq!(body["project_id"], "project-2");
+    assert!(body.get("project_id").is_none());
 }
 
 #[tokio::test]
@@ -183,6 +206,10 @@ async fn todoist_precondition_failure_returns_current_remote_snapshot() {
     assert_eq!(current.project_id.as_deref(), Some("project-1"));
     assert_eq!(current.updated_at.as_deref(), Some("provider-revision-2"));
     assert_eq!(
+        current.reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/remote-1")
+    );
+    assert_eq!(
         captured.lock().expect("captured request").path,
         "/tasks/remote-1"
     );
@@ -197,41 +224,6 @@ fn todoist_update_classifies_metadata_and_status_changes() {
     assert!(!metadata.changes_status());
     assert!(!status.changes_metadata());
     assert!(status.changes_status());
-}
-
-#[test]
-fn todoist_request_ids_are_stable_for_safe_retries_and_change_with_intent() {
-    let item = local_item("Title", "Body", Some("project-1"));
-
-    assert_eq!(
-        todoist_request_id("create", &item, None),
-        todoist_request_id("create", &item, None)
-    );
-    assert_ne!(
-        todoist_request_id("create", &item, None),
-        todoist_request_id("update-metadata", &item, Some("remote-1"))
-    );
-    let edited = local_item("Edited title", "Body", Some("project-1"));
-    assert_ne!(
-        todoist_request_id("create", &item, None),
-        todoist_request_id("create", &edited, None)
-    );
-}
-
-#[test]
-fn todoist_request_id_status_uses_stable_wire_values() {
-    assert_eq!(
-        todoist_request_id_status(TaskBoardStatus::InProgress),
-        "in_progress"
-    );
-    assert_eq!(
-        todoist_request_id_status(TaskBoardStatus::HumanRequired),
-        "human_required"
-    );
-    assert_eq!(
-        todoist_request_id_status(TaskBoardStatus::NeedsYou),
-        "needs_you"
-    );
 }
 
 #[test]
@@ -255,11 +247,14 @@ fn todoist_project_filter_admits_only_matching_project_ids() {
 
 #[tokio::test]
 async fn todoist_pull_drops_tasks_outside_project_filter() {
-    let body = r#"[
-        {"id":"a","content":"In scope","description":"","project_id":"proj-keep"},
-        {"id":"b","content":"Out of scope","description":"","project_id":"proj-skip"},
-        {"id":"c","content":"No project","description":""}
-    ]"#;
+    let body = r#"{
+        "results": [
+            {"id":"a","content":"In scope","description":"","project_id":"proj-keep"},
+            {"id":"b","content":"Out of scope","description":"","project_id":"proj-skip"},
+            {"id":"c","content":"No project","description":""}
+        ],
+        "next_cursor": null
+    }"#;
     let (endpoint, _captured, handle) = spawn_json_mock_response(body);
     let mut config = ExternalSyncConfig::default()
         .with_todoist_token_override(Some("token"))
@@ -275,6 +270,10 @@ async fn todoist_pull_drops_tasks_outside_project_filter() {
     assert_eq!(tasks[0].reference.external_id, "a");
     assert_eq!(tasks[0].status, TaskBoardStatus::Backlog);
     assert_eq!(tasks[0].project_id.as_deref(), Some("proj-keep"));
+    assert_eq!(
+        tasks[0].reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/a")
+    );
 }
 
 fn spawn_json_mock_response(
@@ -320,7 +319,7 @@ fn spawn_status_mock() -> (String, Arc<Mutex<CapturedRequest>>, thread::JoinHand
         let (mut stream, _) = listener.accept().expect("accept");
         let request = read_http_request(&mut stream);
         *captured_clone.lock().expect("captured request") = capture_request(&request);
-        write_http_response(&mut stream, "204 No Content", "");
+        write_json_response(&mut stream, "{}");
     });
     (endpoint, captured, handle)
 }
@@ -367,10 +366,15 @@ fn spawn_sequence_mock(
 }
 
 fn capture_request(request: &str) -> CapturedRequest {
-    let path = request
-        .lines()
+    let request_line = request.lines().next().unwrap_or_default();
+    let method = request_line
+        .split_whitespace()
         .next()
-        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or_default()
+        .to_string();
+    let path = request_line
+        .split_whitespace()
+        .nth(1)
         .unwrap_or_default()
         .to_string();
     let authorization = request.lines().find_map(|line| {
@@ -391,6 +395,7 @@ fn capture_request(request: &str) -> CapturedRequest {
         .unwrap_or_default()
         .to_string();
     CapturedRequest {
+        method,
         path,
         authorization,
         request_id,

--- a/src/task_board/external/todoist/todoist_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 
 use super::*;
 
+mod create_recovery_tests;
 mod move_tests;
 mod pagination_tests;
 mod request_id_tests;

--- a/src/task_board/external/todoist/todoist_tests/create_recovery_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests/create_recovery_tests.rs
@@ -1,0 +1,174 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::external::{
+    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRequest,
+};
+
+#[tokio::test]
+async fn todoist_create_recovery_replays_exact_persisted_request() {
+    let response = r#"{"id":"remote-1","content":"Provider title","description":"Provider body","project_id":null,"is_completed":true,"updated_at":null}"#;
+    let (endpoint, captured, handle) =
+        spawn_sequence_mock(vec![("200 OK", response), ("200 OK", response)]);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let recovery = client
+        .external_create_recovery()
+        .expect("Todoist create recovery");
+    let request = ExternalCreateRequest::new(
+        "task-1",
+        "persisted-create-key",
+        "Persisted title",
+        "Persisted body",
+        "provider-project",
+    );
+    let lease = CountingLease::default();
+
+    let created = recovery
+        .create_started(&request, &lease)
+        .await
+        .expect("create started");
+    let recovered = recovery
+        .recover_existing(&request, &lease)
+        .await
+        .expect("recover existing");
+
+    assert_exact_provider_task(&created);
+    assert_eq!(recovered, ExternalCreateProbe::Found(created));
+    assert_eq!(lease.renewals.load(Ordering::SeqCst), 2);
+    handle.join().expect("mock server");
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].body, captured[1].body);
+    for request in captured.iter() {
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/tasks");
+        assert_eq!(request.authorization.as_deref(), Some("Bearer token"));
+        assert_eq!(request.request_id.as_deref(), Some("persisted-create-key"));
+        let body = body_json(&request.body);
+        assert_eq!(body["content"], "Persisted title");
+        assert_eq!(body["description"], "Persisted body");
+        assert_eq!(body["project_id"], "provider-project");
+    }
+}
+
+#[tokio::test]
+async fn todoist_unfiltered_create_recovery_omits_all_scope_sentinel() {
+    let response =
+        r#"{"id":"remote-1","content":"Provider title","description":"","project_id":null}"#;
+    let (endpoint, captured, handle) = spawn_json_mock(response);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let recovery = client
+        .external_create_recovery()
+        .expect("Todoist create recovery");
+    let request = ExternalCreateRequest::new(
+        "task-1",
+        "persisted-create-key",
+        "Persisted title",
+        "",
+        TODOIST_ALL_SCOPE,
+    );
+    let lease = CountingLease::default();
+
+    recovery
+        .create_started(&request, &lease)
+        .await
+        .expect("create unfiltered task");
+
+    handle.join().expect("mock server");
+    let captured = captured.lock().expect("captured request");
+    assert_eq!(captured.request_id.as_deref(), Some("persisted-create-key"));
+    let body = body_json(&captured.body);
+    assert_eq!(body["content"], "Persisted title");
+    assert!(body.get("description").is_none());
+    assert!(body.get("project_id").is_none());
+}
+
+#[test]
+fn todoist_create_recovery_supports_only_configured_targets() {
+    let mut scoped =
+        TodoistSyncClient::new_with_api_base("token", "https://todoist.invalid").expect("client");
+    scoped.import_project_ids = vec!["project-1".into()];
+    let scoped_recovery = scoped.external_create_recovery().expect("scoped recovery");
+
+    assert!(scoped_recovery.supports_target("project-1"));
+    assert!(!scoped_recovery.supports_target("project-2"));
+    assert!(!scoped_recovery.supports_target(""));
+
+    let unscoped =
+        TodoistSyncClient::new_with_api_base("token", "https://todoist.invalid").expect("client");
+    let unscoped_recovery = unscoped
+        .external_create_recovery()
+        .expect("unscoped recovery");
+
+    assert_eq!(unscoped_recovery.provider(), ExternalProvider::Todoist);
+    assert!(unscoped_recovery.supports_target("project-2"));
+    assert!(!unscoped_recovery.supports_target(" "));
+}
+
+#[tokio::test]
+async fn todoist_create_recovery_renews_before_remote_io() {
+    let client =
+        TodoistSyncClient::new_with_api_base("token", "http://127.0.0.1:1").expect("client");
+    let recovery = client
+        .external_create_recovery()
+        .expect("Todoist create recovery");
+    let request = ExternalCreateRequest::new(
+        "task-1",
+        "persisted-create-key",
+        "Persisted title",
+        "Persisted body",
+        "provider-project",
+    );
+    let lease = RejectingLease;
+
+    let create_error = recovery
+        .create_started(&request, &lease)
+        .await
+        .expect_err("stale create lease");
+    let recover_error = recovery
+        .recover_existing(&request, &lease)
+        .await
+        .expect_err("stale recovery lease");
+
+    assert_eq!(create_error.code(), "WORKFLOW_CONCURRENT");
+    assert_eq!(recover_error.code(), "WORKFLOW_CONCURRENT");
+}
+
+fn assert_exact_provider_task(task: &ExternalTask) {
+    assert_eq!(task.reference.provider, ExternalProvider::Todoist);
+    assert_eq!(task.reference.external_id, "remote-1");
+    assert_eq!(
+        task.reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/remote-1")
+    );
+    assert_eq!(task.title, "Provider title");
+    assert_eq!(task.body, "Provider body");
+    assert_eq!(task.status, TaskBoardStatus::Done);
+    assert_eq!(task.project_id, None);
+    assert_eq!(task.updated_at, None);
+}
+
+#[derive(Default)]
+struct CountingLease {
+    renewals: AtomicUsize,
+}
+
+#[async_trait]
+impl ExternalCreateLease for CountingLease {
+    async fn renew(&self) -> Result<(), CliError> {
+        self.renewals.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+struct RejectingLease;
+
+#[async_trait]
+impl ExternalCreateLease for RejectingLease {
+    async fn renew(&self) -> Result<(), CliError> {
+        Err(CliErrorKind::concurrent_modification("stale create lease").into())
+    }
+}

--- a/src/task_board/external/todoist/todoist_tests/move_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests/move_tests.rs
@@ -1,0 +1,224 @@
+use std::io::ErrorKind;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+
+use super::*;
+
+#[tokio::test]
+async fn todoist_project_only_update_uses_move_endpoint_and_response() {
+    let (endpoint, captured, handle) = spawn_json_mock(
+        r#"{"id":"remote-1","content":"Title","description":"Body","project_id":"project-destination","updated_at":"revision-move"}"#,
+    );
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let item = local_item("Title", "Body", Some("project-destination"));
+    let move_request = TodoistMoveTaskRequest {
+        project_id: "project-destination".into(),
+    };
+    let expected_request_id = TodoistRequestIntent::Move {
+        item: &item,
+        external_id: "remote-1",
+        request: &move_request,
+    }
+    .request_id();
+
+    let outcome = client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Project]),
+        )
+        .await
+        .expect("move task");
+
+    handle.join().expect("mock server");
+    let ExternalUpdateOutcome::Applied {
+        reference,
+        provider_revision,
+    } = outcome
+    else {
+        panic!("move must be applied");
+    };
+    assert_eq!(provider_revision.as_deref(), Some("revision-move"));
+    assert_eq!(
+        reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/remote-1")
+    );
+    let captured = captured.lock().expect("captured request");
+    assert_eq!(captured.method, "POST");
+    assert_eq!(captured.path, "/tasks/remote-1/move");
+    assert_eq!(
+        body_json(&captured.body),
+        json!({"project_id": "project-destination"})
+    );
+    assert_eq!(captured.authorization.as_deref(), Some("Bearer token"));
+    assert_eq!(
+        captured.request_id.as_deref(),
+        Some(expected_request_id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn todoist_combined_metadata_then_move_returns_move_truth() {
+    let (endpoint, captured, handle) = spawn_sequence_mock(vec![
+        (
+            "200 OK",
+            r#"{"id":"remote-1","content":"Updated","description":"Body","project_id":"project-source","updated_at":"revision-metadata"}"#,
+        ),
+        (
+            "200 OK",
+            r#"{"id":"remote-1","content":"Updated","description":"Body","project_id":"project-destination","updated_at":"revision-move"}"#,
+        ),
+    ]);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let item = local_item("Updated", "Body", Some("project-destination"));
+
+    let outcome = client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Title, ExternalSyncField::Project]),
+        )
+        .await
+        .expect("update metadata and move task");
+
+    handle.join().expect("mock server");
+    let ExternalUpdateOutcome::Applied {
+        reference,
+        provider_revision,
+    } = outcome
+    else {
+        panic!("combined update must be applied");
+    };
+    assert_eq!(provider_revision.as_deref(), Some("revision-move"));
+    assert_eq!(
+        reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/remote-1")
+    );
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].path, "/tasks/remote-1");
+    assert_eq!(body_json(&captured[0].body), json!({"content": "Updated"}));
+    assert_eq!(captured[1].path, "/tasks/remote-1/move");
+    assert_eq!(
+        body_json(&captured[1].body),
+        json!({"project_id": "project-destination"})
+    );
+    assert!(captured.iter().all(|request| request.request_id.is_some()));
+    assert_ne!(captured[0].request_id, captured[1].request_id);
+}
+
+#[tokio::test]
+async fn todoist_reopen_then_metadata_then_move_preserves_final_truth() {
+    let (endpoint, captured, handle) = spawn_sequence_mock(vec![
+        ("200 OK", "{}"),
+        (
+            "200 OK",
+            r#"{"id":"remote-1","content":"Updated","description":"Body","project_id":"project-source","updated_at":"revision-metadata"}"#,
+        ),
+        (
+            "200 OK",
+            r#"{"id":"remote-1","content":"Updated","description":"Body","project_id":"project-destination","updated_at":"revision-move"}"#,
+        ),
+    ]);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let mut item = local_item("Updated", "Body", Some("project-destination"));
+    item.status = TaskBoardStatus::InProgress;
+
+    let outcome = client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![
+                ExternalSyncField::Status,
+                ExternalSyncField::Title,
+                ExternalSyncField::Project,
+            ]),
+        )
+        .await
+        .expect("reopen, update metadata, and move task");
+
+    handle.join().expect("mock server");
+    let ExternalUpdateOutcome::Applied {
+        reference,
+        provider_revision,
+    } = outcome
+    else {
+        panic!("combined update must be applied");
+    };
+    assert_eq!(provider_revision.as_deref(), Some("revision-move"));
+    assert_eq!(
+        reference.url.as_deref(),
+        Some("https://app.todoist.com/app/task/remote-1")
+    );
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(
+        captured
+            .iter()
+            .map(|request| request.path.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "/tasks/remote-1/reopen",
+            "/tasks/remote-1",
+            "/tasks/remote-1/move",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn todoist_project_update_without_destination_fails_before_remote_call() {
+    let (endpoint, captured, handle) = spawn_optional_json_mock();
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let item = local_item("Title", "Body", None);
+
+    let error = client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Project]),
+        )
+        .await
+        .expect_err("missing project destination must fail");
+
+    handle.join().expect("mock server");
+    assert!(error.to_string().contains("destination project ID"));
+    assert!(captured.lock().expect("captured request").is_none());
+}
+
+fn spawn_optional_json_mock() -> (
+    String,
+    Arc<Mutex<Option<CapturedRequest>>>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    listener.set_nonblocking(true).expect("nonblocking");
+    let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
+    let captured = Arc::new(Mutex::new(None));
+    let captured_clone = Arc::clone(&captured);
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_millis(200);
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let request = read_http_request(&mut stream);
+                    *captured_clone.lock().expect("captured request") =
+                        Some(capture_request(&request));
+                    write_json_response(
+                        &mut stream,
+                        r#"{"id":"remote-1","content":"Title","project_id":"project-destination"}"#,
+                    );
+                    return;
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Err(error) => panic!("accept request: {error}"),
+            }
+        }
+    });
+    (endpoint, captured, handle)
+}

--- a/src/task_board/external/todoist/todoist_tests/pagination_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests/pagination_tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+#[tokio::test]
+async fn todoist_pull_follows_encoded_cursor_and_filters_every_page() {
+    let cursor = "page/2?token=alpha+beta=";
+    let (endpoint, captured, handle) = spawn_sequence_mock(vec![
+        (
+            "200 OK",
+            r#"{
+                "results": [
+                    {"id":"first","content":"First match","project_id":"project-keep"},
+                    {"id":"skip","content":"Skip","project_id":"project-skip"}
+                ],
+                "next_cursor":"page/2?token=alpha+beta="
+            }"#,
+        ),
+        (
+            "200 OK",
+            r#"{
+                "results": [
+                    {"id":"second","content":"Second match","project_id":"project-keep"}
+                ],
+                "next_cursor":null
+            }"#,
+        ),
+    ]);
+    let mut client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    client.import_project_ids = vec!["project-keep".into()];
+
+    let tasks = client.pull_tasks().await.expect("pull every page");
+
+    handle.join().expect("mock server");
+    assert_eq!(
+        tasks
+            .iter()
+            .map(|task| task.reference.external_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["first", "second"]
+    );
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].path, "/tasks");
+    let page_url =
+        reqwest::Url::parse(&format!("http://localhost{}", captured[1].path)).expect("page URL");
+    assert_eq!(
+        page_url
+            .query_pairs()
+            .find(|(name, _)| name == "cursor")
+            .map(|(_, value)| value.into_owned())
+            .as_deref(),
+        Some(cursor)
+    );
+    assert!(captured[1].path.contains("%2F"));
+    assert!(
+        captured
+            .iter()
+            .all(|request| request.authorization.as_deref() == Some("Bearer token"))
+    );
+}
+
+#[tokio::test]
+async fn todoist_pull_rejects_repeated_cursor() {
+    let (endpoint, captured, handle) = spawn_sequence_mock(vec![
+        ("200 OK", r#"{"results":[],"next_cursor":"repeat-cursor"}"#),
+        ("200 OK", r#"{"results":[],"next_cursor":"repeat-cursor"}"#),
+    ]);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+
+    let error = client
+        .pull_tasks()
+        .await
+        .expect_err("repeated cursor must fail closed");
+
+    handle.join().expect("mock server");
+    assert!(error.to_string().contains("repeated pagination cursor"));
+    assert_eq!(captured.lock().expect("captured requests").len(), 2);
+}
+
+#[tokio::test]
+async fn todoist_pull_rejects_missing_required_next_cursor() {
+    let (endpoint, _captured, handle) =
+        spawn_json_mock_response(r#"{"results":[{"id":"task-1","content":"Task"}]}"#);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+
+    let result = client.pull_tasks().await;
+
+    handle.join().expect("mock server");
+    result.expect_err("missing next_cursor must fail closed");
+}
+
+#[tokio::test]
+async fn todoist_pull_rejects_empty_next_cursor() {
+    let (endpoint, _captured, handle) =
+        spawn_json_mock_response(r#"{"results":[],"next_cursor":""}"#);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+
+    let error = client
+        .pull_tasks()
+        .await
+        .expect_err("empty next_cursor must fail closed");
+
+    handle.join().expect("mock server");
+    assert!(error.to_string().contains("empty pagination cursor"));
+}
+
+#[tokio::test]
+async fn todoist_pull_rejects_malformed_next_cursor() {
+    let (endpoint, _captured, handle) =
+        spawn_json_mock_response(r#"{"results":[],"next_cursor":42}"#);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+
+    let result = client.pull_tasks().await;
+
+    handle.join().expect("mock server");
+    result.expect_err("malformed next_cursor must fail closed");
+}

--- a/src/task_board/external/todoist/todoist_tests/request_id_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests/request_id_tests.rs
@@ -1,0 +1,394 @@
+use uuid::Uuid;
+
+use super::*;
+
+#[test]
+fn todoist_status_intents_share_explicit_close_and_reopen_identities() {
+    let base_item = local_item("Title", "Body", None);
+    let non_done_statuses = [
+        TaskBoardStatus::Backlog,
+        TaskBoardStatus::Todo,
+        TaskBoardStatus::Planning,
+        TaskBoardStatus::InProgress,
+        TaskBoardStatus::AgenticReview,
+        TaskBoardStatus::Testing,
+        TaskBoardStatus::InReview,
+        TaskBoardStatus::ToReview,
+        TaskBoardStatus::HumanRequired,
+        TaskBoardStatus::Failed,
+        TaskBoardStatus::New,
+        TaskBoardStatus::PlanReview,
+        TaskBoardStatus::NeedsYou,
+        TaskBoardStatus::Blocked,
+    ];
+    let reopen_ids = non_done_statuses.map(|status| {
+        let mut item = base_item.clone();
+        item.status = status;
+        let action = TodoistStatusAction::for_status(status);
+        assert!(action == TodoistStatusAction::Reopen);
+        assert_eq!(action.endpoint("remote-1"), "tasks/remote-1/reopen");
+        TodoistRequestIntent::Status {
+            item: &item,
+            external_id: "remote-1",
+            action,
+        }
+        .request_id()
+    });
+    assert!(reopen_ids.windows(2).all(|ids| ids[0] == ids[1]));
+
+    let close = TodoistStatusAction::for_status(TaskBoardStatus::Done);
+    let mut done_item = base_item;
+    done_item.status = TaskBoardStatus::Done;
+    assert!(close == TodoistStatusAction::Close);
+    assert_eq!(close.endpoint("remote-1"), "tasks/remote-1/close");
+    let close_id = TodoistRequestIntent::Status {
+        item: &done_item,
+        external_id: "remote-1",
+        action: close,
+    }
+    .request_id();
+    assert_ne!(reopen_ids[0], close_id);
+}
+
+#[test]
+fn todoist_request_ids_hash_only_explicit_intent_inputs() {
+    let item = local_item("Title", "Body", Some("project-1"));
+    let create_request = TodoistCreateTaskRequest {
+        content: item.title.clone(),
+        description: non_empty_body(&item.body),
+        project_id: item.project_id.clone(),
+    };
+    let create_id = TodoistRequestIntent::Create {
+        item: &item,
+        request: &create_request,
+    }
+    .request_id();
+    assert_eq!(
+        create_id,
+        TodoistRequestIntent::Create {
+            item: &item,
+            request: &create_request,
+        }
+        .request_id()
+    );
+    assert_v5_rfc4122(&create_id);
+
+    let edited = local_item("Edited title", "Body", Some("project-1"));
+    let edited_request = TodoistCreateTaskRequest {
+        content: edited.title.clone(),
+        description: non_empty_body(&edited.body),
+        project_id: edited.project_id.clone(),
+    };
+    assert_ne!(
+        create_id,
+        TodoistRequestIntent::Create {
+            item: &edited,
+            request: &edited_request,
+        }
+        .request_id()
+    );
+
+    let metadata = TodoistUpdateTaskRequest {
+        content: Some("Updated".into()),
+        description: None,
+    };
+    let metadata_id = TodoistRequestIntent::Metadata {
+        item: &item,
+        external_id: "remote-1",
+        request: &metadata,
+    }
+    .request_id();
+    assert_v5_rfc4122(&metadata_id);
+    assert_ne!(create_id, metadata_id);
+
+    let move_request = TodoistMoveTaskRequest {
+        project_id: "project-2".into(),
+    };
+    let move_id = TodoistRequestIntent::Move {
+        item: &item,
+        external_id: "remote-1",
+        request: &move_request,
+    }
+    .request_id();
+    assert_v5_rfc4122(&move_id);
+    assert_ne!(move_id, metadata_id);
+
+    let delete_id = TodoistRequestIntent::Delete {
+        item: &item,
+        external_id: "remote-1",
+    }
+    .request_id();
+    assert_v5_rfc4122(&delete_id);
+    assert_ne!(delete_id, metadata_id);
+}
+
+#[test]
+fn todoist_metadata_and_move_request_ids_advance_with_local_revision() {
+    let item = local_item("Title", "Body", None);
+    let mut later = item.clone();
+    later.updated_at = "2026-05-15T00:01:00Z".into();
+    let metadata = TodoistUpdateTaskRequest {
+        content: Some("Updated".into()),
+        description: None,
+    };
+
+    let metadata_id = TodoistRequestIntent::Metadata {
+        item: &item,
+        external_id: "remote-1",
+        request: &metadata,
+    }
+    .request_id();
+    assert_eq!(
+        metadata_id,
+        TodoistRequestIntent::Metadata {
+            item: &item,
+            external_id: "remote-1",
+            request: &metadata,
+        }
+        .request_id()
+    );
+    assert_ne!(
+        metadata_id,
+        TodoistRequestIntent::Metadata {
+            item: &later,
+            external_id: "remote-1",
+            request: &metadata,
+        }
+        .request_id()
+    );
+
+    let move_request = TodoistMoveTaskRequest {
+        project_id: "project-2".into(),
+    };
+    let move_id = TodoistRequestIntent::Move {
+        item: &item,
+        external_id: "remote-1",
+        request: &move_request,
+    }
+    .request_id();
+    assert_eq!(
+        move_id,
+        TodoistRequestIntent::Move {
+            item: &item,
+            external_id: "remote-1",
+            request: &move_request,
+        }
+        .request_id()
+    );
+    assert_ne!(
+        move_id,
+        TodoistRequestIntent::Move {
+            item: &later,
+            external_id: "remote-1",
+            request: &move_request,
+        }
+        .request_id()
+    );
+}
+
+#[test]
+fn todoist_status_and_delete_request_ids_advance_with_local_revision() {
+    let item = local_item("Title", "Body", None);
+    let mut later = item.clone();
+    later.updated_at = "2026-05-15T00:01:00Z".into();
+    let close_id = TodoistRequestIntent::Status {
+        item: &item,
+        external_id: "remote-1",
+        action: TodoistStatusAction::Close,
+    }
+    .request_id();
+    assert_eq!(
+        close_id,
+        TodoistRequestIntent::Status {
+            item: &item,
+            external_id: "remote-1",
+            action: TodoistStatusAction::Close,
+        }
+        .request_id()
+    );
+    assert_ne!(
+        close_id,
+        TodoistRequestIntent::Status {
+            item: &later,
+            external_id: "remote-1",
+            action: TodoistStatusAction::Close,
+        }
+        .request_id()
+    );
+
+    let delete_id = TodoistRequestIntent::Delete {
+        item: &item,
+        external_id: "remote-1",
+    }
+    .request_id();
+    assert_eq!(
+        delete_id,
+        TodoistRequestIntent::Delete {
+            item: &item,
+            external_id: "remote-1",
+        }
+        .request_id()
+    );
+    assert_ne!(
+        delete_id,
+        TodoistRequestIntent::Delete {
+            item: &later,
+            external_id: "remote-1",
+        }
+        .request_id()
+    );
+}
+
+#[tokio::test]
+async fn todoist_write_requests_send_intent_request_ids() {
+    assert_create_headers().await;
+    assert_metadata_headers().await;
+    assert_move_headers().await;
+    assert_status_headers().await;
+    assert_delete_headers().await;
+}
+
+async fn assert_create_headers() {
+    let (endpoint, captured, handle) = spawn_json_mock(
+        r#"{"id":"remote-1","content":"Title","description":"Body","project_id":"project-1"}"#,
+    );
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let item = local_item("Title", "Body", Some("project-1"));
+    let request = TodoistCreateTaskRequest {
+        content: item.title.clone(),
+        description: non_empty_body(&item.body),
+        project_id: item.project_id.clone(),
+    };
+    let expected = TodoistRequestIntent::Create {
+        item: &item,
+        request: &request,
+    }
+    .request_id();
+
+    client.push_task(&item).await.expect("create task");
+
+    handle.join().expect("mock server");
+    assert_headers(&captured.lock().expect("captured request"), &expected);
+}
+
+async fn assert_metadata_headers() {
+    let (endpoint, captured, handle) = spawn_json_mock(
+        r#"{"id":"remote-1","content":"Updated","description":"Body","project_id":"project-1","updated_at":null}"#,
+    );
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let item = local_item("Updated", "Body", None);
+    let request = TodoistUpdateTaskRequest {
+        content: Some("Updated".into()),
+        description: None,
+    };
+    let expected = TodoistRequestIntent::Metadata {
+        item: &item,
+        external_id: "remote-1",
+        request: &request,
+    }
+    .request_id();
+
+    client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Title]),
+        )
+        .await
+        .expect("update metadata");
+
+    handle.join().expect("mock server");
+    assert_headers(&captured.lock().expect("captured request"), &expected);
+}
+
+async fn assert_move_headers() {
+    let (endpoint, captured, handle) = spawn_json_mock(
+        r#"{"id":"remote-1","content":"Title","project_id":"project-2","updated_at":"revision-move"}"#,
+    );
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let item = local_item("Title", "Body", Some("project-2"));
+    let request = TodoistMoveTaskRequest {
+        project_id: "project-2".into(),
+    };
+    let expected = TodoistRequestIntent::Move {
+        item: &item,
+        external_id: "remote-1",
+        request: &request,
+    }
+    .request_id();
+
+    client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Project]),
+        )
+        .await
+        .expect("move task");
+
+    handle.join().expect("mock server");
+    let captured = captured.lock().expect("captured request");
+    assert_eq!(captured.path, "/tasks/remote-1/move");
+    assert_headers(&captured, &expected);
+}
+
+async fn assert_status_headers() {
+    let (endpoint, captured, handle) = spawn_status_mock();
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let item = local_item_with_status(TaskBoardStatus::InProgress);
+    let expected = TodoistRequestIntent::Status {
+        item: &item,
+        external_id: "remote-1",
+        action: TodoistStatusAction::Reopen,
+    }
+    .request_id();
+
+    client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Status]),
+        )
+        .await
+        .expect("update status");
+
+    handle.join().expect("mock server");
+    assert_headers(&captured.lock().expect("captured request"), &expected);
+}
+
+async fn assert_delete_headers() {
+    let (endpoint, captured, handle) = spawn_status_mock();
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let item = local_item("Title", "Body", None);
+    let expected = TodoistRequestIntent::Delete {
+        item: &item,
+        external_id: "remote-1",
+    }
+    .request_id();
+
+    client
+        .delete_task(&item, &reference)
+        .await
+        .expect("delete task");
+
+    handle.join().expect("mock server");
+    let captured = captured.lock().expect("captured request");
+    assert_eq!(captured.method, "DELETE");
+    assert_eq!(captured.path, "/tasks/remote-1");
+    assert_headers(&captured, &expected);
+}
+
+fn assert_headers(captured: &CapturedRequest, expected_request_id: &str) {
+    assert_eq!(captured.authorization.as_deref(), Some("Bearer token"));
+    assert_eq!(captured.request_id.as_deref(), Some(expected_request_id));
+}
+
+fn assert_v5_rfc4122(request_id: &str) {
+    let parsed = Uuid::parse_str(request_id).expect("request id UUID");
+    assert_eq!(parsed.as_bytes()[6] >> 4, 5);
+    assert_eq!(parsed.as_bytes()[8] & 0xc0, 0x80);
+}

--- a/src/task_board/external/todoist/todoist_tests/revision_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests/revision_tests.rs
@@ -1,0 +1,144 @@
+use super::*;
+
+#[tokio::test]
+async fn todoist_combined_close_does_not_report_pre_close_revision() {
+    let (endpoint, captured, handle) = spawn_sequence_mock(vec![
+        (
+            "200 OK",
+            r#"{"id":"remote-1","content":"Updated title","description":"Body","updated_at":"provider-revision-2"}"#,
+        ),
+        ("204 No Content", ""),
+    ]);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let mut item = local_item("Updated title", "Body", None);
+    item.status = TaskBoardStatus::Done;
+
+    let outcome = client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Title, ExternalSyncField::Status]),
+        )
+        .await
+        .expect("update metadata and close task");
+
+    handle.join().expect("mock server");
+    let ExternalUpdateOutcome::Applied {
+        provider_revision, ..
+    } = outcome
+    else {
+        panic!("update must be applied");
+    };
+    assert_eq!(provider_revision, None);
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].path, "/tasks/remote-1");
+    assert_eq!(captured[1].path, "/tasks/remote-1/close");
+    assert!(captured.iter().all(|request| request.request_id.is_some()));
+    assert_ne!(captured[0].request_id, captured[1].request_id);
+}
+
+#[tokio::test]
+async fn todoist_combined_reopen_returns_final_metadata_revision() {
+    let (endpoint, captured, handle) = spawn_reopen_metadata_mock();
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let mut item = local_item("Updated title", "Body", None);
+    item.status = TaskBoardStatus::Todo;
+
+    let outcome = client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Title, ExternalSyncField::Status]),
+        )
+        .await
+        .expect("reopen and update metadata");
+
+    handle.join().expect("mock server");
+    let ExternalUpdateOutcome::Applied {
+        provider_revision, ..
+    } = outcome
+    else {
+        panic!("update must be applied");
+    };
+    assert_eq!(provider_revision.as_deref(), Some("provider-revision-3"));
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].path, "/tasks/remote-1/reopen");
+    assert_eq!(captured[1].path, "/tasks/remote-1");
+}
+
+#[tokio::test]
+async fn todoist_metadata_write_without_revision_does_not_reuse_precondition() {
+    let (endpoint, captured, handle) = spawn_sequence_mock(vec![
+        (
+            "200 OK",
+            r#"{"id":"remote-1","content":"Base title","description":"Body","updated_at":"provider-revision-1"}"#,
+        ),
+        (
+            "200 OK",
+            r#"{"id":"remote-1","content":"Updated title","description":"Body"}"#,
+        ),
+    ]);
+    let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-1");
+    let item = local_item("Updated title", "Body", None);
+
+    let outcome = client
+        .update_task(
+            &item,
+            &reference,
+            ExternalTaskUpdate::new(vec![ExternalSyncField::Title])
+                .with_precondition_updated_at(Some("provider-revision-1".into())),
+        )
+        .await
+        .expect("update metadata");
+
+    handle.join().expect("mock server");
+    let ExternalUpdateOutcome::Applied {
+        provider_revision, ..
+    } = outcome
+    else {
+        panic!("update must be applied");
+    };
+    assert_eq!(provider_revision, None);
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].path, "/tasks/remote-1");
+    assert_eq!(captured[1].path, "/tasks/remote-1");
+}
+
+fn spawn_reopen_metadata_mock() -> (
+    String,
+    Arc<Mutex<Vec<CapturedRequest>>>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let captured_clone = Arc::clone(&captured);
+    let handle = thread::spawn(move || {
+        for _ in 0..2 {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let request = read_http_request(&mut stream);
+            let captured_request = capture_request(&request);
+            let is_reopen = captured_request.path.ends_with("/reopen");
+            captured_clone
+                .lock()
+                .expect("captured requests")
+                .push(captured_request);
+            if is_reopen {
+                write_http_response(&mut stream, "204 No Content", "");
+            } else {
+                write_http_response(
+                    &mut stream,
+                    "200 OK",
+                    r#"{"id":"remote-1","content":"Updated title","description":"Body","updated_at":"provider-revision-3"}"#,
+                );
+            }
+        }
+    });
+    (endpoint, captured, handle)
+}

--- a/src/task_board/external/todoist/todoist_tests/revision_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests/revision_tests.rs
@@ -79,7 +79,7 @@ async fn todoist_metadata_write_without_revision_does_not_reuse_precondition() {
         ),
         (
             "200 OK",
-            r#"{"id":"remote-1","content":"Updated title","description":"Body"}"#,
+            r#"{"id":"remote-1","content":"Updated title","description":"Body","project_id":"project-1","updated_at":null}"#,
         ),
     ]);
     let client = TodoistSyncClient::new_with_api_base("token", endpoint).expect("client");

--- a/src/task_board/external_create_intents.rs
+++ b/src/task_board/external_create_intents.rs
@@ -1,0 +1,95 @@
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ExternalCreateOutcome, ExternalProvider, ExternalRef, ExternalSyncField, TaskBoardItem,
+    TaskBoardStatus,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TaskBoardExternalCreateSnapshot {
+    pub(crate) title: String,
+    pub(crate) body: String,
+    pub(crate) status: TaskBoardStatus,
+    pub(crate) project_id: Option<String>,
+    pub(crate) execution_repository: Option<String>,
+    pub(crate) provider_target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskBoardExternalCreateIntent {
+    pub(crate) intent_id: String,
+    pub(crate) item_id: String,
+    pub(crate) item_revision: i64,
+    pub(crate) provider: ExternalProvider,
+    pub(crate) scope_id: String,
+    pub(crate) create_key: String,
+    pub(crate) snapshot: TaskBoardExternalCreateSnapshot,
+    pub(crate) changed_fields: Vec<ExternalSyncField>,
+    pub(crate) state: TaskBoardExternalCreateIntentState,
+    pub(crate) created_at: String,
+    pub(crate) updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskBoardExternalCreateEvidence {
+    pub(crate) outcome: ExternalCreateOutcome,
+    pub(crate) provider_baseline: ExternalRef,
+    pub(crate) recorded_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskBoardExternalCreateReceipt {
+    pub(crate) evidence: TaskBoardExternalCreateEvidence,
+    pub(crate) attached_at: String,
+    pub(crate) attached_item_revision: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskBoardExternalCreateIntentState {
+    InFlight,
+    Created(Box<TaskBoardExternalCreateEvidence>),
+    Attached(Box<TaskBoardExternalCreateReceipt>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskBoardExternalCreateExisting {
+    Recover(TaskBoardExternalCreateIntent),
+    Finalize(TaskBoardExternalCreateIntent),
+    Attached(TaskBoardExternalCreateIntent),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskBoardExternalCreateBegin {
+    Started(TaskBoardExternalCreateIntent),
+    Existing(TaskBoardExternalCreateExisting),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskBoardExternalCreateFinalizeDisposition {
+    Attached,
+    AlreadyLinked,
+    AlreadyAttached,
+    RetainedMissingItem,
+}
+
+#[derive(Debug, Clone)]
+#[allow(
+    dead_code,
+    reason = "the storage contract is consumed by the follow-up provider-create worker"
+)]
+pub(crate) struct TaskBoardExternalCreateFinalizeResult {
+    pub(crate) intent: TaskBoardExternalCreateIntent,
+    pub(crate) item: Option<TaskBoardItem>,
+    pub(crate) item_revision: Option<i64>,
+    pub(crate) disposition: TaskBoardExternalCreateFinalizeDisposition,
+}
+
+impl TaskBoardExternalCreateIntent {
+    pub(crate) fn created_evidence(&self) -> Option<&TaskBoardExternalCreateEvidence> {
+        match &self.state {
+            TaskBoardExternalCreateIntentState::InFlight => None,
+            TaskBoardExternalCreateIntentState::Created(evidence) => Some(evidence),
+            TaskBoardExternalCreateIntentState::Attached(receipt) => Some(&receipt.evidence),
+        }
+    }
+}

--- a/src/task_board/mod.rs
+++ b/src/task_board/mod.rs
@@ -55,9 +55,9 @@ pub use external::{
 };
 #[cfg(any(test, feature = "daemon-runtime"))]
 pub(crate) use external::{
-    TaskBoardSyncStore, configured_sync_clients_without_review_requests,
-    imported_review_references_from_items, reconcile_review_item_from_snapshots,
-    sync_external_tasks,
+    TaskBoardExternalCreateStore, TaskBoardSyncStore,
+    configured_sync_clients_without_review_requests, imported_review_references_from_items,
+    reconcile_review_item_from_snapshots, sync_external_tasks,
 };
 pub(crate) use external_create_intents::{
     TaskBoardExternalCreateBegin, TaskBoardExternalCreateEvidence, TaskBoardExternalCreateExisting,

--- a/src/task_board/mod.rs
+++ b/src/task_board/mod.rs
@@ -44,12 +44,13 @@ pub use evaluation::{
     skipped_unlinked_record,
 };
 pub use external::{
-    ExternalProvider, ExternalProviderCapabilities, ExternalSyncAction, ExternalSyncClient,
-    ExternalSyncConfig, ExternalSyncConflictPolicy, ExternalSyncDirection, ExternalSyncField,
-    ExternalSyncOperation, ExternalSyncOptions, ExternalTask, ExternalTaskRef, ExternalTaskUpdate,
-    ExternalUpdateOutcome, GH_TOKEN_ENV, GITHUB_REPOSITORY_ENV, GitHubInboxSyncClient,
-    GitHubSyncClient, HARNESS_GITHUB_REPOSITORY_ENV, HARNESS_GITHUB_TOKEN_ENV,
-    HARNESS_TODOIST_TOKEN_ENV, TodoistSyncClient, configured_sync_clients,
+    ExternalCreateOutcome, ExternalProvider, ExternalProviderCapabilities, ExternalSyncAction,
+    ExternalSyncClient, ExternalSyncConfig, ExternalSyncConflictPolicy, ExternalSyncDirection,
+    ExternalSyncField, ExternalSyncOperation, ExternalSyncOptions, ExternalTask, ExternalTaskRef,
+    ExternalTaskUpdate, ExternalUpdateOutcome, GH_TOKEN_ENV, GITHUB_REPOSITORY_ENV,
+    GitHubInboxSyncClient, GitHubSyncClient, HARNESS_GITHUB_REPOSITORY_ENV,
+    HARNESS_GITHUB_TOKEN_ENV, HARNESS_TODOIST_TOKEN_ENV, TodoistSyncClient,
+    configured_sync_clients,
 };
 #[cfg(any(test, feature = "daemon-runtime"))]
 pub(crate) use external::{

--- a/src/task_board/mod.rs
+++ b/src/task_board/mod.rs
@@ -2,6 +2,7 @@ pub mod automation;
 pub mod dispatch;
 pub mod evaluation;
 pub mod external;
+mod external_create_intents;
 pub mod git_identity_defaults;
 pub mod github;
 #[allow(dead_code)]
@@ -57,6 +58,12 @@ pub(crate) use external::{
     TaskBoardSyncStore, configured_sync_clients_without_review_requests,
     imported_review_references_from_items, reconcile_review_item_from_snapshots,
     sync_external_tasks,
+};
+pub(crate) use external_create_intents::{
+    TaskBoardExternalCreateBegin, TaskBoardExternalCreateEvidence, TaskBoardExternalCreateExisting,
+    TaskBoardExternalCreateFinalizeDisposition, TaskBoardExternalCreateFinalizeResult,
+    TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState,
+    TaskBoardExternalCreateReceipt, TaskBoardExternalCreateSnapshot,
 };
 pub use git_identity_defaults::{
     TaskBoardEnvDefaults, TaskBoardGhCliDefaults, TaskBoardGitConfigDefaults,

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-testkit"
-version = "48.1.0"
+version = "48.1.1"
 edition = "2024"
 rust-version = "1.94"
 publish = false


### PR DESCRIPTION
## Motivation
Provider task creation could lose exact remote evidence across crashes or retries, allowing duplicate creates and stale local reconciliation. Recovery also needed durable, auditable ownership so provider and local state remain consistent without replaying historical work.

## Implementation
- Fence provider scopes and persist exact provider revisions, identities, failures, backoff, and audit outcomes.
- Add durable create intents, receipts, transactional conflict supersession, and one-time audit follow-up acknowledgement.
- Add idempotent Todoist v1 pagination, move, delete, request-key, and create recovery behavior.
- Add canonical GitHub terminal markers and exhaustive fresh recovery scans without automatic re-POST.
- Wire recovery for currently configured provider scopes while preserving dry-run, unlink, tombstone, and exact-identity behavior.
- Validate provider, storage, migration, conflict, audit, and external-sync paths and synchronize version 48.1.1.