### PR TITLE
feat(task-board): add durable coordinator run envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "aff"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "harness-bridge"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "harness-command"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "tempfile",
  "uzers",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "harness-daemon"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "harness-daemon-client"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "fs2",
  "reqwest",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "harness-hook"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "harness-mcp"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "clap",
  "serde",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "harness-systemd"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "harness-systemd-protocol"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "nix 0.31.3",
  "temp-env",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "harness-telemetry"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "harness-testkit"
-version = "48.1.1"
+version = "48.2.0"
 dependencies = [
  "temp-env",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 
 [package]
 name = "harness"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 autoexamples = false
@@ -38,11 +38,11 @@ include = [
 ]
 
 [dependencies]
-harness-command = { path = "crates/harness-command", version = "48.1.1" }
-harness-mcp = { path = "crates/harness-mcp", version = "48.1.1", optional = true }
-harness-protocol = { path = "crates/harness-protocol", version = "48.1.1" }
-harness-systemd-protocol = { path = "crates/harness-systemd-protocol", version = "48.1.1", optional = true }
-harness-telemetry = { path = "crates/harness-telemetry", version = "48.1.1" }
+harness-command = { path = "crates/harness-command", version = "48.2.0" }
+harness-mcp = { path = "crates/harness-mcp", version = "48.2.0", optional = true }
+harness-protocol = { path = "crates/harness-protocol", version = "48.2.0" }
+harness-systemd-protocol = { path = "crates/harness-systemd-protocol", version = "48.2.0", optional = true }
+harness-telemetry = { path = "crates/harness-telemetry", version = "48.2.0" }
 arc-swap = "1.9.1"
 bollard = "0.21.0"
 bytes = "1.10.1"

--- a/aff/Cargo.toml
+++ b/aff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aff"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 

--- a/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
+++ b/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>48.1.1</string>
+	<string>48.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>48.1.1</string>
+	<string>48.2.0</string>
 	<key>LSBackgroundOnly</key>
 	<true/>
 </dict>

--- a/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
+++ b/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
@@ -32,7 +32,7 @@ public enum BuildSettings {
         "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS": .string(
             compilationCacheDiagnosticRemarksSetting
         ),
-        "CURRENT_PROJECT_VERSION": "48.1.1", // VERSION_MARKER_CURRENT
+        "CURRENT_PROJECT_VERSION": "48.2.0", // VERSION_MARKER_CURRENT
         "DEVELOPMENT_TEAM": "Q498EB36N4",
         "DEAD_CODE_STRIPPING": "YES",
         "ENABLE_HARDENED_RUNTIME": "YES",
@@ -61,7 +61,7 @@ public enum BuildSettings {
         "HARNESS_MONITOR_BUILD_GIT_COMMIT": "local-dev",
         "HARNESS_MONITOR_BUILD_GIT_DIRTY": "false",
         "HARNESS_MONITOR_BUILD_WORKSPACE_FINGERPRINT": "local-dev",
-        "MARKETING_VERSION": "48.1.1" // VERSION_MARKER_MARKETING
+        "MARKETING_VERSION": "48.2.0" // VERSION_MARKER_MARKETING
     ]
 
     public static let previewOverrides: SettingsDictionary = [

--- a/crates/harness-bridge/Cargo.toml
+++ b/crates/harness-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-bridge"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -21,9 +21,9 @@ clap = { version = "4.6.0", features = ["derive", "env"] }
 crossterm = "0.29.0"
 fs2 = "0.4.3"
 fs-err = "3.3.0"
-harness-hook = { path = "../harness-hook", version = "48.1.1" }
-harness-protocol = { path = "../harness-protocol", version = "48.1.1" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.1.1" }
+harness-hook = { path = "../harness-hook", version = "48.2.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.2.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.2.0" }
 hex = "0.4.3"
 nix = { version = "0.31", features = ["signal"] }
 notify = "8.2.0"

--- a/crates/harness-command/Cargo.toml
+++ b/crates/harness-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-command"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 

--- a/crates/harness-daemon-client/Cargo.toml
+++ b/crates/harness-daemon-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-daemon-client"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-daemon/Cargo.toml
+++ b/crates/harness-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-daemon"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -28,11 +28,11 @@ fs-err = "3.3.0"
 futures-util = "0.3.31"
 gix = { version = "0.83.0", features = ["status", "worktree-mutation", "index", "blocking-http-transport-reqwest-rust-tls"] }
 gray_matter = { version = "0.3.2", default-features = false, features = ["yaml"] }
-harness-command = { path = "../harness-command", version = "48.1.1" }
-harness-hook = { path = "../harness-hook", version = "48.1.1" }
-harness-protocol = { path = "../harness-protocol", version = "48.1.1" }
-harness-systemd-protocol = { path = "../harness-systemd-protocol", version = "48.1.1", optional = true }
-harness-telemetry = { path = "../harness-telemetry", version = "48.1.1" }
+harness-command = { path = "../harness-command", version = "48.2.0" }
+harness-hook = { path = "../harness-hook", version = "48.2.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.2.0" }
+harness-systemd-protocol = { path = "../harness-systemd-protocol", version = "48.2.0", optional = true }
+harness-telemetry = { path = "../harness-telemetry", version = "48.2.0" }
 hex = "0.4.3"
 hickory-resolver = "0.26.1"
 hmac = "0.13.0"

--- a/crates/harness-hook/Cargo.toml
+++ b/crates/harness-hook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-hook"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -14,9 +14,9 @@ test = false
 
 [dependencies]
 clap = { version = "4.6.0", features = ["derive", "env"] }
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.1" }
-harness-protocol = { path = "../harness-protocol", version = "48.1.1" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.1.1" }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.2.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.2.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.2.0" }
 chrono = { version = "0.4.44", features = ["serde"] }
 fs-err = "3.3.0"
 fs2 = "0.4.3"

--- a/crates/harness-mcp/Cargo.toml
+++ b/crates/harness-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-mcp"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -13,9 +13,9 @@ async-trait = "0.1.83"
 base64 = "0.22.1"
 clap = { version = "4.6.0", features = ["derive", "env"] }
 futures-util = "0.3.31"
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.1" }
-harness-protocol = { path = "../harness-protocol", version = "48.1.1" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.1.1" }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.2.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.2.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.2.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
@@ -26,7 +26,7 @@ uuid = { version = "1.18.1", features = ["v4"] }
 
 [dev-dependencies]
 axum = { version = "0.8.7", features = ["ws"] }
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.1.1", features = ["test-support"] }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.2.0", features = ["test-support"] }
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tempfile = "3.27.0"
 

--- a/crates/harness-protocol/Cargo.toml
+++ b/crates/harness-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-protocol"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-systemd-protocol/Cargo.toml
+++ b/crates/harness-systemd-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-systemd-protocol"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-systemd/Cargo.toml
+++ b/crates/harness-systemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-systemd"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 build = "build.rs"
@@ -14,7 +14,7 @@ chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive"] }
 fs-err = "3.3.0"
 fs2 = "0.4.3"
-harness-command = { path = "../harness-command", version = "48.1.1" }
+harness-command = { path = "../harness-command", version = "48.2.0" }
 hex = "0.4.3"
 libc = "0.2"
 nix = { version = "0.31", features = ["fs", "signal", "user"] }

--- a/crates/harness-telemetry/Cargo.toml
+++ b/crates/harness-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-telemetry"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/src/daemon/audit_events.rs
+++ b/src/daemon/audit_events.rs
@@ -117,7 +117,7 @@ async fn persist_audit_event(async_db: &AsyncDaemonDb, event: &HarnessMonitorAud
     clippy::cognitive_complexity,
     reason = "audit push broadcasting has explicit early returns for each failure mode"
 )]
-fn broadcast_audit_event(event: &HarnessMonitorAuditEvent) {
+pub(crate) fn broadcast_audit_event(event: &HarnessMonitorAuditEvent) {
     let Some(sender) = observe_sender() else {
         return;
     };

--- a/src/daemon/db/audit.rs
+++ b/src/daemon/db/audit.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use sqlx::{QueryBuilder, Sqlite, query};
+use sqlx::{QueryBuilder, Sqlite, Transaction, query};
 
 use crate::daemon::protocol::{
     HarnessMonitorAuditEvent, HarnessMonitorAuditEventsRequest, HarnessMonitorAuditEventsResponse,
@@ -85,6 +85,36 @@ impl AsyncDaemonDb {
             .map_err(|error| db_error(format!("query audit events: {error}")))?;
         audit_response(rows, limit)
     }
+}
+
+pub(in crate::daemon::db) async fn upsert_audit_event_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    event: &HarnessMonitorAuditEvent,
+) -> Result<(), CliError> {
+    let payload_json = event.payload_json.as_ref().map(Value::to_string);
+    let related_urls_json = serde_json::to_string(&event.related_urls)
+        .map_err(|error| db_error(format!("serialize audit related urls: {error}")))?;
+    query(UPSERT_AUDIT_EVENT_SQL)
+        .bind(&event.id)
+        .bind(&event.recorded_at)
+        .bind(&event.source)
+        .bind(&event.category)
+        .bind(&event.kind)
+        .bind(&event.severity)
+        .bind(&event.outcome)
+        .bind(&event.title)
+        .bind(&event.summary)
+        .bind(event.subject.as_deref())
+        .bind(event.actor.as_deref())
+        .bind(event.correlation_id.as_deref())
+        .bind(event.action_key.as_deref())
+        .bind(payload_json.as_deref())
+        .bind(event.legacy_message.as_deref())
+        .bind(&related_urls_json)
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("upsert audit event {}: {error}", event.id)))?;
+    Ok(())
 }
 
 #[derive(Debug, sqlx::FromRow)]

--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -103,7 +103,9 @@ mod task_board;
 #[allow(unused_imports)]
 pub(crate) use task_board::{
     ClaimedTaskBoardDispatch, ClaimedTaskBoardDispatchPreparation, ReservedTaskBoardDispatch,
-    TaskBoardImportMarker, TaskBoardItemSnapshot,
+    TaskBoardAutomationControlRecord, TaskBoardAutomationRunAdmission, TaskBoardAutomationRunFence,
+    TaskBoardAutomationRunLease, TaskBoardAutomationRunStage, TaskBoardImportMarker,
+    TaskBoardItemSnapshot, TaskBoardRunAcquireRequest,
 };
 mod session_data;
 mod signals;

--- a/src/daemon/db/task_board/mod.rs
+++ b/src/daemon/db/task_board/mod.rs
@@ -18,6 +18,7 @@ mod provider_external_creates;
 mod provider_sync;
 mod provider_sync_conflicts;
 mod rows;
+mod scheduler;
 
 #[cfg(test)]
 mod provider_external_create_finalize_tests;
@@ -52,6 +53,10 @@ pub(crate) use dispatch_preparations::{
 pub(crate) use imports::{TaskBoardImportMarker, TaskBoardImportResult};
 #[allow(unused_imports)]
 pub(crate) use items::{TaskBoardItemSnapshot, TaskBoardMutation};
+pub(crate) use scheduler::{
+    TaskBoardAutomationControlRecord, TaskBoardAutomationRunAdmission, TaskBoardAutomationRunFence,
+    TaskBoardAutomationRunLease, TaskBoardAutomationRunStage, TaskBoardRunAcquireRequest,
+};
 
 pub(crate) const ITEMS_CHANGE_SCOPE: &str = "task_board:items";
 pub(crate) const MACHINES_CHANGE_SCOPE: &str = "task_board:machines";

--- a/src/daemon/db/task_board/provider_sync.rs
+++ b/src/daemon/db/task_board/provider_sync.rs
@@ -141,6 +141,55 @@ impl AsyncDaemonDb {
         }
     }
 
+    pub(crate) async fn release_task_board_provider_scope_attempt(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        released_at: &str,
+    ) -> Result<(), CliError> {
+        parse_timestamp(released_at)?;
+        let mut transaction = self
+            .begin_immediate_transaction("task board provider scope release")
+            .await?;
+        let updated = if attempt.created_scope() {
+            query(
+                "DELETE FROM task_board_provider_scope_state
+                 WHERE provider = ?1 AND scope_id = ?2 AND health = ?3",
+            )
+            .bind(provider_label(attempt.provider()))
+            .bind(attempt.scope_id())
+            .bind(attempt.fence_marker())
+            .execute(transaction.as_mut())
+            .await
+            .map_err(|error| db_error(format!("release new task-board provider attempt: {error}")))?
+            .rows_affected()
+        } else {
+            query(
+                "UPDATE task_board_provider_scope_state SET
+                    health = 'healthy', backoff_until = NULL, updated_at = ?4
+                 WHERE provider = ?1 AND scope_id = ?2 AND health = ?3",
+            )
+            .bind(provider_label(attempt.provider()))
+            .bind(attempt.scope_id())
+            .bind(attempt.fence_marker())
+            .bind(released_at)
+            .execute(transaction.as_mut())
+            .await
+            .map_err(|error| db_error(format!("release task-board provider attempt: {error}")))?
+            .rows_affected()
+        };
+        if updated != 1 {
+            return Err(stale_attempt_error(attempt));
+        }
+        if !attempt.created_scope() {
+            bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        }
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task-board provider attempt release: {error}"
+            ))
+        })
+    }
+
     pub(crate) async fn complete_task_board_provider_scope_success(
         &self,
         attempt: &ExternalProviderScopeAttempt,

--- a/src/daemon/db/task_board/provider_sync_fencing_tests.rs
+++ b/src/daemon/db/task_board/provider_sync_fencing_tests.rs
@@ -10,7 +10,7 @@ use crate::daemon::db::AsyncDaemonDb;
 use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::external::{
     ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
-    ExternalProviderScopeIdentity,
+    ExternalProviderScopeHealth, ExternalProviderScopeIdentity,
 };
 use crate::task_board::{
     ExternalProvider, ExternalSyncClient, ExternalSyncConflictPolicy, ExternalSyncDirection,
@@ -222,6 +222,93 @@ async fn dry_run_success_and_failure_leave_provider_state_unchanged() {
     assert_eq!(calls.load(Ordering::SeqCst), 2);
 }
 
+#[tokio::test]
+async fn neutral_release_preserves_failure_count_without_backoff() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    let scope_id = "v1:todoist:write:7:scope-a";
+    let initial = start_attempt_for(
+        &db,
+        ExternalProvider::Todoist,
+        scope_id,
+        "2026-07-16T13:00:00Z",
+    )
+    .await;
+    db.complete_task_board_provider_scope_failure(&initial, "2026-07-16T13:00:00Z")
+        .await
+        .expect("seed failure");
+    query(
+        "UPDATE task_board_provider_scope_state
+         SET backoff_until = '2000-01-01T00:00:00Z'
+         WHERE provider = 'todoist' AND scope_id = ?1",
+    )
+    .bind(scope_id)
+    .execute(db.pool())
+    .await
+    .expect("expire backoff");
+    let current = start_attempt_for(
+        &db,
+        ExternalProvider::Todoist,
+        scope_id,
+        "2026-07-16T13:10:01Z",
+    )
+    .await;
+    let revision_before = db
+        .task_board_revision()
+        .await
+        .expect("revision before release");
+
+    db.release_task_board_provider_scope_attempt(&current, "2026-07-16T13:10:02Z")
+        .await
+        .expect("release attempt");
+
+    let state = db
+        .task_board_provider_scope_state(ExternalProvider::Todoist, scope_id)
+        .await
+        .expect("scope state");
+    assert_eq!(state.health, ExternalProviderScopeHealth::Healthy);
+    assert_eq!(state.failure_count, 1);
+    assert_eq!(state.backoff_until, None);
+    assert!(
+        db.task_board_revision()
+            .await
+            .expect("revision after release")
+            > revision_before
+    );
+}
+
+#[tokio::test]
+async fn neutral_release_removes_a_new_attempt_row() {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("database");
+    let scope_id = "v1:todoist:write:7:scope-b";
+    let attempt = start_attempt_for(
+        &db,
+        ExternalProvider::Todoist,
+        scope_id,
+        "2026-07-16T14:00:00Z",
+    )
+    .await;
+
+    db.release_task_board_provider_scope_attempt(&attempt, "2026-07-16T14:00:01Z")
+        .await
+        .expect("release attempt");
+
+    let rows = query_as::<_, (i64,)>(
+        "SELECT COUNT(*) FROM task_board_provider_scope_state
+         WHERE provider = 'todoist' AND scope_id = ?1",
+    )
+    .bind(scope_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("count scope rows");
+    assert_eq!(rows.0, 0);
+}
+
 async fn start_attempt(
     db: &AsyncDaemonDb,
     scope_id: &str,
@@ -229,6 +316,22 @@ async fn start_attempt(
 ) -> ExternalProviderScopeAttempt {
     match db
         .begin_task_board_provider_scope_attempt(ExternalProvider::GitHub, scope_id, now)
+        .await
+        .expect("begin provider attempt")
+    {
+        ExternalProviderScopeAttemptDecision::Started(attempt) => attempt,
+        other => panic!("expected started attempt, got {other:?}"),
+    }
+}
+
+async fn start_attempt_for(
+    db: &AsyncDaemonDb,
+    provider: ExternalProvider,
+    scope_id: &str,
+    now: &str,
+) -> ExternalProviderScopeAttempt {
+    match db
+        .begin_task_board_provider_scope_attempt(provider, scope_id, now)
         .await
         .expect("begin provider attempt")
     {

--- a/src/daemon/db/task_board/scheduler.rs
+++ b/src/daemon/db/task_board/scheduler.rs
@@ -1,0 +1,25 @@
+//! Durable scheduler state for Task Board automation.
+
+mod audit;
+mod control;
+mod recovery;
+mod runs;
+mod stages;
+
+#[cfg(test)]
+mod control_tests;
+#[cfg(test)]
+mod recovery_tests;
+#[cfg(test)]
+mod runs_tests;
+#[cfg(test)]
+mod stages_tests;
+#[cfg(test)]
+mod test_support;
+
+pub(crate) use control::TaskBoardAutomationControlRecord;
+pub(crate) use runs::{
+    TaskBoardAutomationRunAdmission, TaskBoardAutomationRunFence, TaskBoardAutomationRunLease,
+    TaskBoardRunAcquireRequest,
+};
+pub(crate) use stages::TaskBoardAutomationRunStage;

--- a/src/daemon/db/task_board/scheduler/audit.rs
+++ b/src/daemon/db/task_board/scheduler/audit.rs
@@ -109,6 +109,12 @@ impl AuditDescriptor {
                 outcome: "cancelled",
             };
         }
+        if event_type.ends_with(".partial") {
+            return Self {
+                severity: "warning",
+                outcome: "partial",
+            };
+        }
         if event_type.contains("defer") || event_type.contains("retry") {
             return Self {
                 severity: "info",
@@ -157,5 +163,13 @@ mod tests {
         assert_eq!(failure.severity, "error");
         assert_eq!(failure.outcome, "failure");
         assert_eq!(retry.outcome, "deferred");
+    }
+
+    #[test]
+    fn partial_run_has_warning_partial_audit_outcome() {
+        let partial = AuditDescriptor::from_event_type("task_board.automation.run.partial");
+
+        assert_eq!(partial.severity, "warning");
+        assert_eq!(partial.outcome, "partial");
     }
 }

--- a/src/daemon/db/task_board/scheduler/audit.rs
+++ b/src/daemon/db/task_board/scheduler/audit.rs
@@ -1,0 +1,161 @@
+use serde_json::{Value, json};
+use sqlx::{Sqlite, Transaction};
+use uuid::Uuid;
+
+use crate::daemon::db::audit::upsert_audit_event_in_tx;
+use crate::daemon::db::{CliError, db_error};
+use crate::daemon::protocol::HarnessMonitorAuditEvent;
+use crate::task_board::{TaskBoardAutomationRunOutcome, TaskBoardAutomationScope};
+
+pub(super) async fn insert_automation_audit(
+    transaction: &mut Transaction<'_, Sqlite>,
+    event_type: &str,
+    run_id: &str,
+    scope: &TaskBoardAutomationScope,
+    recorded_at: &str,
+    payload: Value,
+) -> Result<HarnessMonitorAuditEvent, CliError> {
+    let event = automation_event(event_type, run_id, scope, recorded_at, payload);
+    upsert_audit_event_in_tx(transaction, &event).await?;
+    Ok(event)
+}
+
+pub(super) fn parse_scope(value: &str, run_id: &str) -> Result<TaskBoardAutomationScope, CliError> {
+    serde_json::from_str(value).map_err(|error| {
+        db_error(format!(
+            "parse task board automation run scope '{run_id}': {error}"
+        ))
+    })
+}
+
+pub(super) fn broadcast_automation_audits(events: &[HarnessMonitorAuditEvent]) {
+    for event in events {
+        crate::daemon::audit_events::broadcast_audit_event(event);
+    }
+}
+
+pub(super) const fn terminal_event_type(outcome: TaskBoardAutomationRunOutcome) -> &'static str {
+    match outcome {
+        TaskBoardAutomationRunOutcome::Completed => "task_board.automation.run.completed",
+        TaskBoardAutomationRunOutcome::Noop => "task_board.automation.run.noop",
+        TaskBoardAutomationRunOutcome::Partial => "task_board.automation.run.partial",
+        TaskBoardAutomationRunOutcome::Failed => "task_board.automation.run.failed",
+        TaskBoardAutomationRunOutcome::Cancelled => "task_board.automation.run.cancelled",
+    }
+}
+
+fn automation_event(
+    event_type: &str,
+    run_id: &str,
+    scope: &TaskBoardAutomationScope,
+    recorded_at: &str,
+    payload: Value,
+) -> HarnessMonitorAuditEvent {
+    let descriptor = AuditDescriptor::from_event_type(event_type);
+    let details = payload;
+    HarnessMonitorAuditEvent {
+        id: format!("audit-{}", Uuid::new_v4().simple()),
+        recorded_at: recorded_at.to_owned(),
+        source: "taskBoard".into(),
+        category: "automation".into(),
+        kind: event_type.to_owned(),
+        severity: descriptor.severity.into(),
+        outcome: descriptor.outcome.into(),
+        title: format!("Task Board automation: {event_type}"),
+        summary: format!("Automation run {run_id} emitted {event_type}"),
+        subject: audit_subject(scope),
+        actor: Some("Task Board orchestrator".into()),
+        correlation_id: Some(run_id.to_owned()),
+        action_key: Some(event_type.to_owned()),
+        payload_json: Some(json!({
+            "run_id": run_id,
+            "scope": scope,
+            "details": details,
+        })),
+        legacy_message: None,
+        related_urls: Vec::new(),
+    }
+}
+
+fn audit_subject(scope: &TaskBoardAutomationScope) -> Option<String> {
+    scope
+        .item_id
+        .clone()
+        .or_else(|| scope.repository.clone())
+        .or_else(|| scope.provider_scope.clone())
+        .or_else(|| {
+            scope
+                .provider
+                .map(|provider| format!("{provider:?}").to_lowercase())
+        })
+}
+
+struct AuditDescriptor {
+    severity: &'static str,
+    outcome: &'static str,
+}
+
+impl AuditDescriptor {
+    fn from_event_type(event_type: &str) -> Self {
+        if event_type.contains("fail") || event_type.contains("error") {
+            return Self {
+                severity: "error",
+                outcome: "failure",
+            };
+        }
+        if event_type.contains("cancel") {
+            return Self {
+                severity: "warning",
+                outcome: "cancelled",
+            };
+        }
+        if event_type.contains("defer") || event_type.contains("retry") {
+            return Self {
+                severity: "info",
+                outcome: "deferred",
+            };
+        }
+        Self {
+            severity: "info",
+            outcome: "success",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_keeps_run_correlation_and_scope() {
+        let event = automation_event(
+            "task_board.automation.run.completed",
+            "run-42",
+            &TaskBoardAutomationScope {
+                item_id: Some("task-17".into()),
+                repository: Some("example/widgets".into()),
+                ..TaskBoardAutomationScope::default()
+            },
+            "2026-07-16T12:00:00Z",
+            json!({"mutated": false}),
+        );
+
+        assert_eq!(event.correlation_id.as_deref(), Some("run-42"));
+        assert_eq!(event.subject.as_deref(), Some("task-17"));
+        assert_eq!(event.outcome, "success");
+        assert_eq!(
+            event.payload_json.unwrap()["scope"]["repository"],
+            "example/widgets"
+        );
+    }
+
+    #[test]
+    fn failure_and_retry_events_have_distinct_outcomes() {
+        let failure = AuditDescriptor::from_event_type("task_board.automation.phase.failed");
+        let retry = AuditDescriptor::from_event_type("task_board.automation.phase.retry");
+
+        assert_eq!(failure.severity, "error");
+        assert_eq!(failure.outcome, "failure");
+        assert_eq!(retry.outcome, "deferred");
+    }
+}

--- a/src/daemon/db/task_board/scheduler/control.rs
+++ b/src/daemon/db/task_board/scheduler/control.rs
@@ -1,0 +1,283 @@
+use chrono::{DateTime, Utc};
+use sqlx::{Sqlite, Transaction, query, query_as};
+
+use super::super::ORCHESTRATOR_CHANGE_SCOPE;
+use super::super::items::bump_change_in_tx;
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
+use crate::task_board::{TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskBoardAutomationControlRecord {
+    pub(crate) desired_mode: TaskBoardAutomationDesiredMode,
+    pub(crate) admission_state: TaskBoardAutomationAdmissionState,
+    pub(crate) stop_generation: u64,
+    pub(crate) updated_at: String,
+}
+
+impl Default for TaskBoardAutomationControlRecord {
+    fn default() -> Self {
+        Self {
+            desired_mode: TaskBoardAutomationDesiredMode::Off,
+            admission_state: TaskBoardAutomationAdmissionState::Stopped,
+            stop_generation: 0,
+            updated_at: String::new(),
+        }
+    }
+}
+
+impl AsyncDaemonDb {
+    pub(crate) async fn initialize_task_board_automation_control_from_legacy_intent(
+        &self,
+        desired_mode: TaskBoardAutomationDesiredMode,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationControlRecord, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation control initialization")
+            .await?;
+        let admission_state = admission_state_for_mode(desired_mode);
+        query(
+            "INSERT INTO task_board_orchestrator_control (
+                singleton, desired_mode, admission_state, stop_generation, updated_at
+             ) VALUES (1, ?1, ?2, 0, ?3)
+             ON CONFLICT(singleton) DO UPDATE SET
+                 desired_mode = excluded.desired_mode,
+                 admission_state = excluded.admission_state,
+                 updated_at = excluded.updated_at
+             WHERE task_board_orchestrator_control.desired_mode = 'off'
+               AND task_board_orchestrator_control.admission_state = 'stopped'
+               AND task_board_orchestrator_control.stop_generation = 0
+               AND excluded.desired_mode != 'off'",
+        )
+        .bind(desired_mode_label(desired_mode))
+        .bind(admission_state)
+        .bind(now.to_rfc3339())
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| {
+            db_error(format!(
+                "initialize task board automation control from legacy intent: {error}"
+            ))
+        })?;
+        let control = load_control_in_tx(&mut transaction).await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board automation control initialization: {error}"
+            ))
+        })?;
+        Ok(control)
+    }
+
+    pub(crate) async fn task_board_automation_control(
+        &self,
+    ) -> Result<TaskBoardAutomationControlRecord, CliError> {
+        let row = query_as::<_, (String, String, i64, String)>(
+            "SELECT desired_mode, admission_state, stop_generation, updated_at
+             FROM task_board_orchestrator_control WHERE singleton = 1",
+        )
+        .fetch_optional(self.pool())
+        .await
+        .map_err(|error| db_error(format!("load task board automation control: {error}")))?;
+        row.map(control_from_row)
+            .transpose()
+            .map(Option::unwrap_or_default)
+    }
+
+    pub(crate) async fn start_task_board_automation(
+        &self,
+        desired_mode: TaskBoardAutomationDesiredMode,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationControlRecord, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation start")
+            .await?;
+        ensure_control_row(&mut transaction, now).await?;
+        query(
+            "UPDATE task_board_orchestrator_control
+             SET desired_mode = ?1, admission_state = 'accepting', updated_at = ?2
+             WHERE singleton = 1",
+        )
+        .bind(desired_mode_label(desired_mode))
+        .bind(now.to_rfc3339())
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("start task board automation: {error}")))?;
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        let control = load_control_in_tx(&mut transaction).await?;
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit task board automation start: {error}")))?;
+        Ok(control)
+    }
+
+    pub(crate) async fn stop_task_board_automation(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationControlRecord, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation stop")
+            .await?;
+        ensure_control_row(&mut transaction, now).await?;
+        query(
+            "UPDATE task_board_orchestrator_control
+             SET desired_mode = 'off', admission_state = 'draining',
+                 stop_generation = stop_generation + 1, updated_at = ?1
+             WHERE singleton = 1",
+        )
+        .bind(now.to_rfc3339())
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("stop task board automation: {error}")))?;
+        query(
+            "UPDATE task_board_orchestrator_runs
+             SET state = 'cancelling', revision = revision + 1
+             WHERE state = 'running'",
+        )
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("cancel active task board automation run: {error}")))?;
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        let control = load_control_in_tx(&mut transaction).await?;
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit task board automation stop: {error}")))?;
+        Ok(control)
+    }
+
+    pub(crate) async fn finish_task_board_automation_drain_if_idle(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationControlRecord, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation drain completion")
+            .await?;
+        ensure_control_row(&mut transaction, now).await?;
+        let active = active_automation_count(&mut transaction).await?;
+        let changed = finish_drain_if_idle(&mut transaction, active, now).await?;
+        if changed > 0 {
+            bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        }
+        let control = load_control_in_tx(&mut transaction).await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board automation drain completion: {error}"
+            ))
+        })?;
+        Ok(control)
+    }
+}
+
+pub(super) async fn ensure_control_row(
+    transaction: &mut Transaction<'_, Sqlite>,
+    now: DateTime<Utc>,
+) -> Result<(), CliError> {
+    query(
+        "INSERT INTO task_board_orchestrator_control (
+            singleton, desired_mode, admission_state, stop_generation, updated_at
+         ) VALUES (1, 'off', 'stopped', 0, ?1)
+         ON CONFLICT(singleton) DO NOTHING",
+    )
+    .bind(now.to_rfc3339())
+    .execute(transaction.as_mut())
+    .await
+    .map(|_| ())
+    .map_err(|error| db_error(format!("initialize task board automation control: {error}")))
+}
+
+pub(super) async fn load_control_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+) -> Result<TaskBoardAutomationControlRecord, CliError> {
+    let row = query_as::<_, (String, String, i64, String)>(
+        "SELECT desired_mode, admission_state, stop_generation, updated_at
+         FROM task_board_orchestrator_control WHERE singleton = 1",
+    )
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load task board automation control: {error}")))?;
+    control_from_row(row)
+}
+
+async fn active_automation_count(
+    transaction: &mut Transaction<'_, Sqlite>,
+) -> Result<i64, CliError> {
+    query_as::<_, (i64,)>(
+        "SELECT COUNT(*) FROM task_board_orchestrator_runs
+         WHERE state IN ('running', 'cancelling')",
+    )
+    .fetch_one(transaction.as_mut())
+    .await
+    .map(|row| row.0)
+    .map_err(|error| db_error(format!("count active task board automation: {error}")))
+}
+
+async fn finish_drain_if_idle(
+    transaction: &mut Transaction<'_, Sqlite>,
+    active: i64,
+    now: DateTime<Utc>,
+) -> Result<u64, CliError> {
+    if active != 0 {
+        return Ok(0);
+    }
+    query(
+        "UPDATE task_board_orchestrator_control
+         SET admission_state = 'stopped', updated_at = ?1
+         WHERE singleton = 1 AND desired_mode = 'off' AND admission_state = 'draining'",
+    )
+    .bind(now.to_rfc3339())
+    .execute(transaction.as_mut())
+    .await
+    .map(|result| result.rows_affected())
+    .map_err(|error| db_error(format!("finish task board automation drain: {error}")))
+}
+
+fn control_from_row(
+    (desired_mode, admission_state, stop_generation, updated_at): (String, String, i64, String),
+) -> Result<TaskBoardAutomationControlRecord, CliError> {
+    Ok(TaskBoardAutomationControlRecord {
+        desired_mode: parse_desired_mode(&desired_mode)?,
+        admission_state: parse_admission_state(&admission_state)?,
+        stop_generation: u64::try_from(stop_generation)
+            .map_err(|error| db_error(format!("parse task board stop generation: {error}")))?,
+        updated_at,
+    })
+}
+
+pub(super) const fn desired_mode_label(mode: TaskBoardAutomationDesiredMode) -> &'static str {
+    match mode {
+        TaskBoardAutomationDesiredMode::Off => "off",
+        TaskBoardAutomationDesiredMode::Continuous => "continuous",
+        TaskBoardAutomationDesiredMode::Step => "step",
+    }
+}
+
+const fn admission_state_for_mode(mode: TaskBoardAutomationDesiredMode) -> &'static str {
+    match mode {
+        TaskBoardAutomationDesiredMode::Off => "stopped",
+        TaskBoardAutomationDesiredMode::Continuous | TaskBoardAutomationDesiredMode::Step => {
+            "accepting"
+        }
+    }
+}
+
+fn parse_desired_mode(value: &str) -> Result<TaskBoardAutomationDesiredMode, CliError> {
+    match value {
+        "off" => Ok(TaskBoardAutomationDesiredMode::Off),
+        "continuous" => Ok(TaskBoardAutomationDesiredMode::Continuous),
+        "step" => Ok(TaskBoardAutomationDesiredMode::Step),
+        value => Err(db_error(format!(
+            "invalid task board automation desired mode '{value}'"
+        ))),
+    }
+}
+
+fn parse_admission_state(value: &str) -> Result<TaskBoardAutomationAdmissionState, CliError> {
+    match value {
+        "accepting" => Ok(TaskBoardAutomationAdmissionState::Accepting),
+        "draining" => Ok(TaskBoardAutomationAdmissionState::Draining),
+        "stopped" => Ok(TaskBoardAutomationAdmissionState::Stopped),
+        value => Err(db_error(format!(
+            "invalid task board automation admission state '{value}'"
+        ))),
+    }
+}

--- a/src/daemon/db/task_board/scheduler/control_tests.rs
+++ b/src/daemon/db/task_board/scheduler/control_tests.rs
@@ -1,0 +1,100 @@
+use chrono::Duration;
+
+use super::test_support::{database, instant};
+use crate::task_board::{TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode};
+
+#[tokio::test]
+async fn control_defaults_without_persisted_intent() {
+    let db = database().await;
+
+    let control = db
+        .task_board_automation_control()
+        .await
+        .expect("load default control");
+
+    assert_eq!(control.desired_mode, TaskBoardAutomationDesiredMode::Off);
+    assert_eq!(
+        control.admission_state,
+        TaskBoardAutomationAdmissionState::Stopped
+    );
+    assert_eq!(control.stop_generation, 0);
+    assert!(control.updated_at.is_empty());
+}
+
+#[tokio::test]
+async fn legacy_intent_initializes_only_pristine_control() {
+    let db = database().await;
+    let now = instant("2026-07-15T07:00:00Z");
+
+    let initialized = db
+        .initialize_task_board_automation_control_from_legacy_intent(
+            TaskBoardAutomationDesiredMode::Continuous,
+            now,
+        )
+        .await
+        .expect("initialize legacy intent");
+    assert_eq!(
+        initialized.desired_mode,
+        TaskBoardAutomationDesiredMode::Continuous
+    );
+    assert_eq!(
+        initialized.admission_state,
+        TaskBoardAutomationAdmissionState::Accepting
+    );
+
+    let stopped = db
+        .stop_task_board_automation(now + Duration::seconds(1))
+        .await
+        .expect("stop initialized control");
+    assert_eq!(stopped.stop_generation, 1);
+    let retained = db
+        .initialize_task_board_automation_control_from_legacy_intent(
+            TaskBoardAutomationDesiredMode::Step,
+            now + Duration::seconds(2),
+        )
+        .await
+        .expect("retain explicit control");
+    assert_eq!(retained.desired_mode, TaskBoardAutomationDesiredMode::Off);
+    assert_eq!(
+        retained.admission_state,
+        TaskBoardAutomationAdmissionState::Draining
+    );
+    assert_eq!(retained.stop_generation, 1);
+}
+
+#[tokio::test]
+async fn idle_drain_transitions_to_stopped_once() {
+    let db = database().await;
+    let now = instant("2026-07-15T07:30:00Z");
+
+    db.stop_task_board_automation(now)
+        .await
+        .expect("start drain");
+    let revision_before = db
+        .task_board_revision()
+        .await
+        .expect("revision before drain completion");
+    let stopped = db
+        .finish_task_board_automation_drain_if_idle(now + Duration::seconds(1))
+        .await
+        .expect("finish idle drain");
+    assert_eq!(
+        stopped.admission_state,
+        TaskBoardAutomationAdmissionState::Stopped
+    );
+    let revision_after = db
+        .task_board_revision()
+        .await
+        .expect("revision after drain completion");
+    assert!(revision_after > revision_before);
+
+    db.finish_task_board_automation_drain_if_idle(now + Duration::seconds(2))
+        .await
+        .expect("repeat drain completion");
+    assert_eq!(
+        db.task_board_revision()
+            .await
+            .expect("revision after repeated completion"),
+        revision_after
+    );
+}

--- a/src/daemon/db/task_board/scheduler/recovery.rs
+++ b/src/daemon/db/task_board/scheduler/recovery.rs
@@ -1,0 +1,138 @@
+use chrono::{DateTime, Utc};
+use serde_json::json;
+use sqlx::{FromRow, Sqlite, Transaction, query, query_as};
+
+use super::audit::{
+    broadcast_automation_audits, insert_automation_audit, parse_scope, terminal_event_type,
+};
+use super::control::{ensure_control_row, load_control_in_tx};
+use super::runs::run_outcome_label;
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
+use crate::daemon::protocol::HarnessMonitorAuditEvent;
+use crate::task_board::TaskBoardAutomationRunOutcome;
+
+const LEASE_EXPIRED_ERROR: &str = "coordinator lease expired before run completion";
+
+#[derive(FromRow)]
+struct StaleRunRow {
+    run_id: String,
+    scope_json: String,
+    state: String,
+    stop_generation: i64,
+}
+
+impl AsyncDaemonDb {
+    /// Expire coordinator runs left stale across daemon startup.
+    pub(crate) async fn recover_stale_task_board_automation_runs(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<u64, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation startup recovery")
+            .await?;
+        ensure_control_row(&mut transaction, now).await?;
+        let events = expire_stale_runs(&mut transaction, now).await?;
+        if !events.is_empty() {
+            super::super::items::bump_change_in_tx(
+                &mut transaction,
+                super::super::ORCHESTRATOR_CHANGE_SCOPE,
+            )
+            .await?;
+        }
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board automation startup recovery: {error}"
+            ))
+        })?;
+        broadcast_automation_audits(&events);
+        u64::try_from(events.len())
+            .map_err(|error| db_error(format!("count recovered automation runs: {error}")))
+    }
+}
+
+pub(super) async fn expire_stale_runs(
+    transaction: &mut Transaction<'_, Sqlite>,
+    now: DateTime<Utc>,
+) -> Result<Vec<HarnessMonitorAuditEvent>, CliError> {
+    let control = load_control_in_tx(transaction).await?;
+    let rows = stale_run_rows(transaction, now).await?;
+    let mut events = Vec::with_capacity(rows.len());
+    for row in rows {
+        let outcome = stale_outcome(&row, control.stop_generation);
+        expire_stale_row(transaction, &row, outcome, now).await?;
+        let scope = parse_scope(&row.scope_json, &row.run_id)?;
+        events.push(
+            insert_automation_audit(
+                transaction,
+                terminal_event_type(outcome),
+                &row.run_id,
+                &scope,
+                &now.to_rfc3339(),
+                json!({
+                    "outcome": outcome,
+                    "error_kind": "lease_expired",
+                    "error": LEASE_EXPIRED_ERROR,
+                }),
+            )
+            .await?,
+        );
+    }
+    Ok(events)
+}
+
+async fn stale_run_rows(
+    transaction: &mut Transaction<'_, Sqlite>,
+    now: DateTime<Utc>,
+) -> Result<Vec<StaleRunRow>, CliError> {
+    query_as::<_, StaleRunRow>(
+        "SELECT run_id, scope_json, state, stop_generation
+         FROM task_board_orchestrator_runs
+         WHERE state IN ('running', 'cancelling') AND lease_expires_at <= ?1
+         ORDER BY run_id",
+    )
+    .bind(now.to_rfc3339())
+    .fetch_all(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load stale task board automation runs: {error}")))
+}
+
+async fn expire_stale_row(
+    transaction: &mut Transaction<'_, Sqlite>,
+    row: &StaleRunRow,
+    outcome: TaskBoardAutomationRunOutcome,
+    now: DateTime<Utc>,
+) -> Result<(), CliError> {
+    let changed = query(
+        "UPDATE task_board_orchestrator_runs
+         SET state = 'terminal', outcome = ?2, completed_at = ?3,
+             heartbeat_at = ?3, error_kind = 'lease_expired',
+             error = ?4, revision = revision + 1
+         WHERE run_id = ?1 AND state = ?5 AND lease_expires_at <= ?3",
+    )
+    .bind(&row.run_id)
+    .bind(run_outcome_label(outcome))
+    .bind(now.to_rfc3339())
+    .bind(LEASE_EXPIRED_ERROR)
+    .bind(&row.state)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("expire task board automation run: {error}")))?
+    .rows_affected();
+    if changed == 1 {
+        Ok(())
+    } else {
+        Err(db_error(format!(
+            "task board automation run '{}' changed during stale recovery",
+            row.run_id
+        )))
+    }
+}
+
+fn stale_outcome(row: &StaleRunRow, current_stop_generation: u64) -> TaskBoardAutomationRunOutcome {
+    let stop_generation = u64::try_from(row.stop_generation).unwrap_or(u64::MAX);
+    if row.state == "cancelling" || stop_generation != current_stop_generation {
+        TaskBoardAutomationRunOutcome::Cancelled
+    } else {
+        TaskBoardAutomationRunOutcome::Failed
+    }
+}

--- a/src/daemon/db/task_board/scheduler/recovery_tests.rs
+++ b/src/daemon/db/task_board/scheduler/recovery_tests.rs
@@ -1,0 +1,246 @@
+use chrono::Duration;
+use sqlx::{query, query_as};
+
+use super::TaskBoardAutomationRunAdmission;
+use super::test_support::{
+    acquire_request, automation_audit_count, database, fail_automation_audit_inserts, instant,
+};
+use crate::task_board::{TaskBoardAutomationDesiredMode, TaskBoardAutomationRunTrigger};
+
+#[tokio::test]
+async fn startup_recovery_expires_stale_run_and_publishes_revision() {
+    let db = database().await;
+    let started_at = instant("2026-07-15T15:00:00.900Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, started_at)
+        .await
+        .expect("start automation");
+    let admission = db
+        .try_acquire_task_board_automation_run(&acquire_request(
+            "run-startup-stale",
+            TaskBoardAutomationRunTrigger::Scheduled,
+            started_at,
+        ))
+        .await
+        .expect("acquire stale run");
+    assert!(matches!(
+        admission,
+        TaskBoardAutomationRunAdmission::Acquired(_)
+    ));
+    let revision_before = db
+        .task_board_revision()
+        .await
+        .expect("revision before recovery");
+    let recovered_at = started_at + Duration::seconds(30);
+
+    assert_eq!(
+        db.recover_stale_task_board_automation_runs(started_at + Duration::milliseconds(29_200))
+            .await
+            .expect("recover before fractional expiry"),
+        0
+    );
+    assert_eq!(active_run_count(&db).await, 1);
+    assert_eq!(
+        db.task_board_revision()
+            .await
+            .expect("revision before fractional expiry"),
+        revision_before
+    );
+
+    assert_eq!(
+        db.recover_stale_task_board_automation_runs(recovered_at)
+            .await
+            .expect("recover stale runs"),
+        1
+    );
+    assert_eq!(active_run_count(&db).await, 0);
+    let row = query_as::<_, (String, String, String, String)>(
+        "SELECT state, outcome, error_kind, completed_at
+         FROM task_board_orchestrator_runs WHERE run_id = 'run-startup-stale'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("load recovered run");
+    assert_eq!(
+        row,
+        (
+            "terminal".into(),
+            "failed".into(),
+            "lease_expired".into(),
+            "2026-07-15T15:00:30.900+00:00".into(),
+        )
+    );
+    let revision_after = db
+        .task_board_revision()
+        .await
+        .expect("revision after recovery");
+    assert!(revision_after > revision_before);
+    assert_eq!(run_count(&db).await, 1, "recovery starts no replacement");
+    assert_eq!(automation_audit_count(&db, "run-startup-stale").await, 2);
+
+    assert_eq!(
+        db.recover_stale_task_board_automation_runs(recovered_at + Duration::seconds(1))
+            .await
+            .expect("repeat recovery"),
+        0
+    );
+    assert_eq!(
+        db.task_board_revision()
+            .await
+            .expect("revision after repeat recovery"),
+        revision_after
+    );
+}
+
+#[tokio::test]
+async fn stale_cancelling_run_is_cancelled_and_audited() {
+    let db = database().await;
+    let started_at = instant("2026-07-15T16:00:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, started_at)
+        .await
+        .expect("start automation");
+    db.try_acquire_task_board_automation_run(&acquire_request(
+        "run-stale-cancelling",
+        TaskBoardAutomationRunTrigger::Scheduled,
+        started_at,
+    ))
+    .await
+    .expect("acquire run");
+    db.stop_task_board_automation(started_at + Duration::seconds(1))
+        .await
+        .expect("stop automation");
+
+    assert_eq!(
+        db.recover_stale_task_board_automation_runs(started_at + Duration::seconds(30))
+            .await
+            .expect("recover cancelling run"),
+        1
+    );
+
+    let row = query_as::<_, (String, String)>(
+        "SELECT state, outcome FROM task_board_orchestrator_runs WHERE run_id = ?1",
+    )
+    .bind("run-stale-cancelling")
+    .fetch_one(db.pool())
+    .await
+    .expect("load cancelled run");
+    assert_eq!(row, ("terminal".into(), "cancelled".into()));
+    assert_eq!(
+        terminal_audit_outcome(&db, "run-stale-cancelling").await,
+        "cancelled"
+    );
+}
+
+#[tokio::test]
+async fn stale_stop_generation_mismatch_is_cancelled() {
+    let db = database().await;
+    let started_at = instant("2026-07-15T16:30:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, started_at)
+        .await
+        .expect("start automation");
+    db.try_acquire_task_board_automation_run(&acquire_request(
+        "run-stale-stop-generation",
+        TaskBoardAutomationRunTrigger::Scheduled,
+        started_at,
+    ))
+    .await
+    .expect("acquire run");
+    query(
+        "UPDATE task_board_orchestrator_control
+         SET stop_generation = stop_generation + 1 WHERE singleton = 1",
+    )
+    .execute(db.pool())
+    .await
+    .expect("advance stop generation");
+
+    db.recover_stale_task_board_automation_runs(started_at + Duration::seconds(30))
+        .await
+        .expect("recover mismatched run");
+
+    assert_eq!(
+        terminal_audit_outcome(&db, "run-stale-stop-generation").await,
+        "cancelled"
+    );
+}
+
+#[tokio::test]
+async fn stale_recovery_rolls_back_when_audit_insert_fails() {
+    let db = database().await;
+    let started_at = instant("2026-07-15T17:00:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, started_at)
+        .await
+        .expect("start automation");
+    db.try_acquire_task_board_automation_run(&acquire_request(
+        "run-stale-audit-failure",
+        TaskBoardAutomationRunTrigger::Scheduled,
+        started_at,
+    ))
+    .await
+    .expect("acquire run");
+    let revision = db
+        .task_board_revision()
+        .await
+        .expect("revision before recovery");
+    fail_automation_audit_inserts(&db).await;
+
+    let error = db
+        .recover_stale_task_board_automation_runs(started_at + Duration::seconds(30))
+        .await
+        .expect_err("audit failure must roll back stale recovery");
+
+    assert!(
+        error
+            .to_string()
+            .contains("simulated automation audit failure")
+    );
+    let row = query_as::<_, (String, Option<String>, i64)>(
+        "SELECT state, outcome, revision
+         FROM task_board_orchestrator_runs WHERE run_id = ?1",
+    )
+    .bind("run-stale-audit-failure")
+    .fetch_one(db.pool())
+    .await
+    .expect("load run after failed recovery");
+    assert_eq!(row, ("running".into(), None, 1));
+    assert_eq!(
+        automation_audit_count(&db, "run-stale-audit-failure").await,
+        1
+    );
+    assert_eq!(
+        db.task_board_revision()
+            .await
+            .expect("revision after failed recovery"),
+        revision
+    );
+}
+
+async fn active_run_count(db: &crate::daemon::db::AsyncDaemonDb) -> i64 {
+    query_as::<_, (i64,)>(
+        "SELECT COUNT(*) FROM task_board_orchestrator_runs
+         WHERE state IN ('running', 'cancelling')",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("count active automation runs")
+    .0
+}
+
+async fn run_count(db: &crate::daemon::db::AsyncDaemonDb) -> i64 {
+    query_as::<_, (i64,)>("SELECT COUNT(*) FROM task_board_orchestrator_runs")
+        .fetch_one(db.pool())
+        .await
+        .expect("count automation runs")
+        .0
+}
+
+async fn terminal_audit_outcome(db: &crate::daemon::db::AsyncDaemonDb, run_id: &str) -> String {
+    query_as::<_, (String,)>(
+        "SELECT outcome FROM audit_events
+         WHERE correlation_id = ?1 AND kind != 'task_board.automation.run.started'
+         ORDER BY recorded_at DESC, id DESC LIMIT 1",
+    )
+    .bind(run_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load terminal automation audit")
+    .0
+}

--- a/src/daemon/db/task_board/scheduler/runs.rs
+++ b/src/daemon/db/task_board/scheduler/runs.rs
@@ -1,0 +1,441 @@
+use chrono::{DateTime, Duration, Utc};
+use serde_json::json;
+use sqlx::{Sqlite, Transaction, query, query_as};
+
+use super::super::ORCHESTRATOR_CHANGE_SCOPE;
+use super::super::items::bump_change_in_tx;
+use super::audit::{
+    broadcast_automation_audits, insert_automation_audit, parse_scope, terminal_event_type,
+};
+use super::control::{TaskBoardAutomationControlRecord, ensure_control_row, load_control_in_tx};
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
+use crate::daemon::protocol::HarnessMonitorAuditEvent;
+use crate::task_board::{
+    TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode,
+    TaskBoardAutomationRunOutcome, TaskBoardAutomationRunTrigger, TaskBoardAutomationScope,
+};
+
+const RUN_LEASE_SECONDS: i64 = 30;
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskBoardRunAcquireRequest {
+    pub(crate) run_id: String,
+    pub(crate) trigger: TaskBoardAutomationRunTrigger,
+    pub(crate) actor: Option<String>,
+    pub(crate) dry_run: bool,
+    pub(crate) scope: TaskBoardAutomationScope,
+    pub(crate) lease_owner: String,
+    pub(crate) now: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskBoardAutomationRunLease {
+    pub(crate) run_id: String,
+    pub(crate) trigger: TaskBoardAutomationRunTrigger,
+    pub(crate) lease_owner: String,
+    pub(crate) lease_epoch: u64,
+    pub(crate) stop_generation: u64,
+    pub(crate) started_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskBoardAutomationRunAdmission {
+    Acquired(TaskBoardAutomationRunLease),
+    Busy { run_id: String },
+    Disabled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskBoardAutomationRunFence {
+    Active,
+    Draining,
+}
+
+struct RunFenceRow {
+    state: String,
+    lease_expires_at: DateTime<Utc>,
+    scope: TaskBoardAutomationScope,
+}
+
+impl AsyncDaemonDb {
+    pub(crate) async fn try_acquire_task_board_automation_run(
+        &self,
+        request: &TaskBoardRunAcquireRequest,
+    ) -> Result<TaskBoardAutomationRunAdmission, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation run acquire")
+            .await?;
+        ensure_control_row(&mut transaction, request.now).await?;
+        let expired_events =
+            super::recovery::expire_stale_runs(&mut transaction, request.now).await?;
+        if let Some(run_id) = active_run_id(&mut transaction).await? {
+            return commit_non_acquired_run(
+                transaction,
+                expired_events,
+                TaskBoardAutomationRunAdmission::Busy { run_id },
+                "busy",
+            )
+            .await;
+        }
+        let control = load_control_in_tx(&mut transaction).await?;
+        if !trigger_is_enabled(request.trigger, &control) {
+            return commit_non_acquired_run(
+                transaction,
+                expired_events,
+                TaskBoardAutomationRunAdmission::Disabled,
+                "disabled",
+            )
+            .await;
+        }
+        let lease_epoch = next_lease_epoch(&mut transaction).await?;
+        insert_run(&mut transaction, request, &control, lease_epoch).await?;
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        let started_event = insert_automation_audit(
+            &mut transaction,
+            "task_board.automation.run.started",
+            &request.run_id,
+            &request.scope,
+            &request.now.to_rfc3339(),
+            json!({ "trigger": request.trigger, "dry_run": request.dry_run }),
+        )
+        .await?;
+        let mut events = expired_events;
+        events.push(started_event);
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit task board automation run: {error}")))?;
+        broadcast_automation_audits(&events);
+        Ok(TaskBoardAutomationRunAdmission::Acquired(run_lease(
+            request,
+            &control,
+            lease_epoch,
+        )))
+    }
+
+    pub(crate) async fn heartbeat_task_board_automation_run(
+        &self,
+        lease: &TaskBoardAutomationRunLease,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationRunFence, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation run heartbeat")
+            .await?;
+        let row = load_run_fence(&mut transaction, lease).await?;
+        if row.lease_expires_at <= now {
+            return Err(expired_lease(&lease.run_id));
+        }
+        let control = load_control_in_tx(&mut transaction).await?;
+        let fence = run_fence(lease, &control, &row.state);
+        renew_run_lease(&mut transaction, lease, now).await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!("commit task board automation heartbeat: {error}"))
+        })?;
+        Ok(fence)
+    }
+
+    pub(crate) async fn finalize_task_board_automation_run(
+        &self,
+        lease: &TaskBoardAutomationRunLease,
+        outcome: TaskBoardAutomationRunOutcome,
+        error_kind: Option<&str>,
+        error: Option<&str>,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationRunOutcome, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation run finalize")
+            .await?;
+        let row = load_run_fence(&mut transaction, lease).await?;
+        if row.lease_expires_at <= now {
+            return Err(lost_lease(&lease.run_id));
+        }
+        let control = load_control_in_tx(&mut transaction).await?;
+        let outcome = final_outcome(lease, &control, &row.state, outcome);
+        finalize_run_row(&mut transaction, lease, outcome, error_kind, error, now).await?;
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        let event = insert_automation_audit(
+            &mut transaction,
+            terminal_event_type(outcome),
+            &lease.run_id,
+            &row.scope,
+            &now.to_rfc3339(),
+            json!({
+                "outcome": outcome,
+                "error_kind": error_kind,
+                "error": error,
+            }),
+        )
+        .await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board automation run finalization: {error}"
+            ))
+        })?;
+        broadcast_automation_audits(std::slice::from_ref(&event));
+        Ok(outcome)
+    }
+}
+
+async fn commit_non_acquired_run(
+    mut transaction: Transaction<'_, Sqlite>,
+    events: Vec<HarnessMonitorAuditEvent>,
+    admission: TaskBoardAutomationRunAdmission,
+    context: &str,
+) -> Result<TaskBoardAutomationRunAdmission, CliError> {
+    if !events.is_empty() {
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+    }
+    transaction.commit().await.map_err(|error| {
+        db_error(format!(
+            "commit {context} task board automation run: {error}"
+        ))
+    })?;
+    broadcast_automation_audits(&events);
+    Ok(admission)
+}
+
+async fn active_run_id(
+    transaction: &mut Transaction<'_, Sqlite>,
+) -> Result<Option<String>, CliError> {
+    query_as::<_, (String,)>(
+        "SELECT run_id FROM task_board_orchestrator_runs
+         WHERE state IN ('running', 'cancelling') LIMIT 1",
+    )
+    .fetch_optional(transaction.as_mut())
+    .await
+    .map(|row| row.map(|row| row.0))
+    .map_err(|error| db_error(format!("load active task board automation run: {error}")))
+}
+
+async fn next_lease_epoch(transaction: &mut Transaction<'_, Sqlite>) -> Result<u64, CliError> {
+    let value = query_as::<_, (i64,)>(
+        "SELECT COALESCE(MAX(lease_epoch), 0) + 1 FROM task_board_orchestrator_runs",
+    )
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("allocate task board run lease epoch: {error}")))?
+    .0;
+    u64::try_from(value)
+        .map_err(|error| db_error(format!("parse task board run lease epoch: {error}")))
+}
+
+async fn insert_run(
+    transaction: &mut Transaction<'_, Sqlite>,
+    request: &TaskBoardRunAcquireRequest,
+    control: &TaskBoardAutomationControlRecord,
+    lease_epoch: u64,
+) -> Result<(), CliError> {
+    let scope_json = serde_json::to_string(&request.scope)
+        .map_err(|error| db_error(format!("serialize task board run scope: {error}")))?;
+    let lease_expires_at = request.now + Duration::seconds(RUN_LEASE_SECONDS);
+    query(
+        "INSERT INTO task_board_orchestrator_runs (
+            run_id, trigger, actor, dry_run, scope_json, state, lease_owner, lease_epoch,
+            lease_expires_at, stop_generation, started_at, heartbeat_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, 'running', ?6, ?7, ?8, ?9, ?10, ?10)",
+    )
+    .bind(&request.run_id)
+    .bind(run_trigger_label(request.trigger))
+    .bind(&request.actor)
+    .bind(request.dry_run)
+    .bind(scope_json)
+    .bind(&request.lease_owner)
+    .bind(to_db_integer(lease_epoch))
+    .bind(lease_expires_at.to_rfc3339())
+    .bind(to_db_integer(control.stop_generation))
+    .bind(request.now.to_rfc3339())
+    .execute(transaction.as_mut())
+    .await
+    .map(|_| ())
+    .map_err(|error| db_error(format!("insert task board automation run: {error}")))
+}
+
+async fn load_run_fence(
+    transaction: &mut Transaction<'_, Sqlite>,
+    lease: &TaskBoardAutomationRunLease,
+) -> Result<RunFenceRow, CliError> {
+    let row = query_as::<_, (String, String, String)>(
+        "SELECT state, lease_expires_at, scope_json FROM task_board_orchestrator_runs
+         WHERE run_id = ?1 AND lease_owner = ?2 AND lease_epoch = ?3
+           AND state IN ('running', 'cancelling')",
+    )
+    .bind(&lease.run_id)
+    .bind(&lease.lease_owner)
+    .bind(to_db_integer(lease.lease_epoch))
+    .fetch_optional(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load task board run fence: {error}")))?
+    .ok_or_else(|| lost_lease(&lease.run_id))?;
+    let expires_at = DateTime::parse_from_rfc3339(&row.1)
+        .map_err(|error| db_error(format!("parse task board run lease expiry: {error}")))?
+        .with_timezone(&Utc);
+    Ok(RunFenceRow {
+        state: row.0,
+        lease_expires_at: expires_at,
+        scope: parse_scope(&row.2, &lease.run_id)?,
+    })
+}
+
+async fn renew_run_lease(
+    transaction: &mut Transaction<'_, Sqlite>,
+    lease: &TaskBoardAutomationRunLease,
+    now: DateTime<Utc>,
+) -> Result<(), CliError> {
+    let expires_at = now + Duration::seconds(RUN_LEASE_SECONDS);
+    let changed = query(
+        "UPDATE task_board_orchestrator_runs
+         SET heartbeat_at = ?4, lease_expires_at = ?5, revision = revision + 1
+         WHERE run_id = ?1 AND lease_owner = ?2 AND lease_epoch = ?3
+           AND state IN ('running', 'cancelling')",
+    )
+    .bind(&lease.run_id)
+    .bind(&lease.lease_owner)
+    .bind(to_db_integer(lease.lease_epoch))
+    .bind(now.to_rfc3339())
+    .bind(expires_at.to_rfc3339())
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("heartbeat task board automation run: {error}")))?
+    .rows_affected();
+    ensure_single_run_changed(changed, &lease.run_id)
+}
+
+async fn finalize_run_row(
+    transaction: &mut Transaction<'_, Sqlite>,
+    lease: &TaskBoardAutomationRunLease,
+    outcome: TaskBoardAutomationRunOutcome,
+    error_kind: Option<&str>,
+    error: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<(), CliError> {
+    let changed = query(
+        "UPDATE task_board_orchestrator_runs
+         SET state = 'terminal', outcome = ?4, completed_at = ?5,
+             heartbeat_at = ?5, error_kind = ?6, error = ?7, revision = revision + 1
+         WHERE run_id = ?1 AND lease_owner = ?2 AND lease_epoch = ?3
+           AND state IN ('running', 'cancelling')",
+    )
+    .bind(&lease.run_id)
+    .bind(&lease.lease_owner)
+    .bind(to_db_integer(lease.lease_epoch))
+    .bind(run_outcome_label(outcome))
+    .bind(now.to_rfc3339())
+    .bind(error_kind)
+    .bind(error)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("finalize task board automation run: {error}")))?
+    .rows_affected();
+    ensure_single_run_changed(changed, &lease.run_id)
+}
+
+fn run_lease(
+    request: &TaskBoardRunAcquireRequest,
+    control: &TaskBoardAutomationControlRecord,
+    lease_epoch: u64,
+) -> TaskBoardAutomationRunLease {
+    TaskBoardAutomationRunLease {
+        run_id: request.run_id.clone(),
+        trigger: request.trigger,
+        lease_owner: request.lease_owner.clone(),
+        lease_epoch,
+        stop_generation: control.stop_generation,
+        started_at: request.now.to_rfc3339(),
+    }
+}
+
+fn run_fence(
+    lease: &TaskBoardAutomationRunLease,
+    control: &TaskBoardAutomationControlRecord,
+    state: &str,
+) -> TaskBoardAutomationRunFence {
+    if state == "cancelling"
+        || control.stop_generation != lease.stop_generation
+        || !admission_is_open(lease.trigger, control)
+    {
+        TaskBoardAutomationRunFence::Draining
+    } else {
+        TaskBoardAutomationRunFence::Active
+    }
+}
+
+fn final_outcome(
+    lease: &TaskBoardAutomationRunLease,
+    control: &TaskBoardAutomationControlRecord,
+    state: &str,
+    requested: TaskBoardAutomationRunOutcome,
+) -> TaskBoardAutomationRunOutcome {
+    if state == "cancelling" || control.stop_generation != lease.stop_generation {
+        TaskBoardAutomationRunOutcome::Cancelled
+    } else {
+        requested
+    }
+}
+
+fn trigger_is_enabled(
+    trigger: TaskBoardAutomationRunTrigger,
+    control: &TaskBoardAutomationControlRecord,
+) -> bool {
+    match trigger {
+        TaskBoardAutomationRunTrigger::Manual => {
+            control.admission_state != TaskBoardAutomationAdmissionState::Draining
+        }
+        TaskBoardAutomationRunTrigger::Recovery
+        | TaskBoardAutomationRunTrigger::Scheduled
+        | TaskBoardAutomationRunTrigger::Event => {
+            control.desired_mode == TaskBoardAutomationDesiredMode::Continuous
+                && control.admission_state == TaskBoardAutomationAdmissionState::Accepting
+        }
+    }
+}
+
+fn admission_is_open(
+    trigger: TaskBoardAutomationRunTrigger,
+    control: &TaskBoardAutomationControlRecord,
+) -> bool {
+    trigger == TaskBoardAutomationRunTrigger::Manual
+        || control.admission_state == TaskBoardAutomationAdmissionState::Accepting
+}
+
+pub(super) const fn run_trigger_label(trigger: TaskBoardAutomationRunTrigger) -> &'static str {
+    match trigger {
+        TaskBoardAutomationRunTrigger::Scheduled => "scheduled",
+        TaskBoardAutomationRunTrigger::Event => "event",
+        TaskBoardAutomationRunTrigger::Manual => "manual",
+        TaskBoardAutomationRunTrigger::Recovery => "recovery",
+    }
+}
+
+pub(super) const fn run_outcome_label(outcome: TaskBoardAutomationRunOutcome) -> &'static str {
+    match outcome {
+        TaskBoardAutomationRunOutcome::Completed => "completed",
+        TaskBoardAutomationRunOutcome::Noop => "noop",
+        TaskBoardAutomationRunOutcome::Partial => "partial",
+        TaskBoardAutomationRunOutcome::Failed => "failed",
+        TaskBoardAutomationRunOutcome::Cancelled => "cancelled",
+    }
+}
+
+fn ensure_single_run_changed(changed: u64, run_id: &str) -> Result<(), CliError> {
+    if changed == 1 {
+        Ok(())
+    } else {
+        Err(lost_lease(run_id))
+    }
+}
+
+fn to_db_integer(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+fn expired_lease(run_id: &str) -> CliError {
+    db_error(format!(
+        "task board automation run '{run_id}' lease expired"
+    ))
+}
+
+fn lost_lease(run_id: &str) -> CliError {
+    db_error(format!(
+        "task board automation run '{run_id}' lost its coordinator lease"
+    ))
+}

--- a/src/daemon/db/task_board/scheduler/runs_tests.rs
+++ b/src/daemon/db/task_board/scheduler/runs_tests.rs
@@ -1,0 +1,368 @@
+use std::sync::Arc;
+
+use chrono::Duration;
+use sqlx::query_as;
+use tokio::sync::Barrier;
+
+use super::test_support::{
+    acquire_request, automation_audit_count, database, fail_automation_audit_inserts, instant,
+};
+use super::{TaskBoardAutomationRunAdmission, TaskBoardAutomationRunFence};
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::{
+    TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode,
+    TaskBoardAutomationRunOutcome, TaskBoardAutomationRunTrigger,
+};
+
+#[tokio::test]
+async fn run_lease_serializes_manual_and_scheduled_triggers() {
+    let db = database().await;
+    let now = instant("2026-07-15T08:00:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    let manual = acquire(
+        &db,
+        "run-manual",
+        TaskBoardAutomationRunTrigger::Manual,
+        now,
+    )
+    .await;
+
+    let scheduled = db
+        .try_acquire_task_board_automation_run(&acquire_request(
+            "run-scheduled",
+            TaskBoardAutomationRunTrigger::Scheduled,
+            now,
+        ))
+        .await
+        .expect("try scheduled run");
+    assert_eq!(
+        scheduled,
+        TaskBoardAutomationRunAdmission::Busy {
+            run_id: "run-manual".into()
+        }
+    );
+
+    db.finalize_task_board_automation_run(
+        &manual,
+        TaskBoardAutomationRunOutcome::Completed,
+        None,
+        None,
+        now + Duration::seconds(1),
+    )
+    .await
+    .expect("finalize manual run");
+    assert!(matches!(
+        db.try_acquire_task_board_automation_run(&acquire_request(
+            "run-scheduled-next",
+            TaskBoardAutomationRunTrigger::Scheduled,
+            now + Duration::seconds(2),
+        ))
+        .await
+        .expect("acquire next scheduled run"),
+        TaskBoardAutomationRunAdmission::Acquired(_)
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_triggers_admit_exactly_one_run() {
+    let db = database().await;
+    let now = instant("2026-07-15T08:30:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    let gate = Arc::new(Barrier::new(2));
+    let manual_db = db.clone();
+    let manual_gate = Arc::clone(&gate);
+    let scheduled_db = db.clone();
+    let scheduled_gate = Arc::clone(&gate);
+
+    let (manual, scheduled) = tokio::join!(
+        async move {
+            manual_gate.wait().await;
+            manual_db
+                .try_acquire_task_board_automation_run(&acquire_request(
+                    "run-concurrent-manual",
+                    TaskBoardAutomationRunTrigger::Manual,
+                    now,
+                ))
+                .await
+        },
+        async move {
+            scheduled_gate.wait().await;
+            scheduled_db
+                .try_acquire_task_board_automation_run(&acquire_request(
+                    "run-concurrent-scheduled",
+                    TaskBoardAutomationRunTrigger::Scheduled,
+                    now,
+                ))
+                .await
+        }
+    );
+    let outcomes = [
+        manual.expect("manual admission"),
+        scheduled.expect("scheduled admission"),
+    ];
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, TaskBoardAutomationRunAdmission::Acquired(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, TaskBoardAutomationRunAdmission::Busy { .. }))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn stop_generation_fences_active_run_and_survives_restart() {
+    let db = database().await;
+    let now = instant("2026-07-15T09:00:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    let lease = acquire(
+        &db,
+        "run-fenced",
+        TaskBoardAutomationRunTrigger::Scheduled,
+        now,
+    )
+    .await;
+
+    let stopped = db
+        .stop_task_board_automation(now + Duration::seconds(1))
+        .await
+        .expect("stop automation");
+    assert_eq!(stopped.desired_mode, TaskBoardAutomationDesiredMode::Off);
+    assert_eq!(
+        stopped.admission_state,
+        TaskBoardAutomationAdmissionState::Draining
+    );
+    assert_eq!(stopped.stop_generation, 1);
+    assert_eq!(
+        db.heartbeat_task_board_automation_run(&lease, now + Duration::seconds(2))
+            .await
+            .expect("heartbeat fenced run"),
+        TaskBoardAutomationRunFence::Draining
+    );
+    assert_eq!(
+        db.finalize_task_board_automation_run(
+            &lease,
+            TaskBoardAutomationRunOutcome::Completed,
+            None,
+            None,
+            now + Duration::seconds(3),
+        )
+        .await
+        .expect("finalize fenced run"),
+        TaskBoardAutomationRunOutcome::Cancelled
+    );
+    assert_eq!(
+        db.try_acquire_task_board_automation_run(&acquire_request(
+            "run-during-drain",
+            TaskBoardAutomationRunTrigger::Manual,
+            now + Duration::seconds(4),
+        ))
+        .await
+        .expect("reject run during drain"),
+        TaskBoardAutomationRunAdmission::Disabled
+    );
+
+    let reopened = AsyncDaemonDb::connect(db.storage_path())
+        .await
+        .expect("reopen database");
+    assert_eq!(
+        reopened
+            .task_board_automation_control()
+            .await
+            .expect("load persisted control")
+            .stop_generation,
+        1
+    );
+}
+
+#[tokio::test]
+async fn expired_run_is_failed_before_recovery_acquires_new_epoch() {
+    let db = database().await;
+    let now = instant("2026-07-15T10:00:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    let first = acquire(
+        &db,
+        "run-expired",
+        TaskBoardAutomationRunTrigger::Manual,
+        now,
+    )
+    .await;
+    let recovered = acquire(
+        &db,
+        "run-recovery",
+        TaskBoardAutomationRunTrigger::Recovery,
+        now + Duration::seconds(31),
+    )
+    .await;
+    assert!(recovered.lease_epoch > first.lease_epoch);
+    let row = query_as::<_, (String, String, String)>(
+        "SELECT state, outcome, error_kind FROM task_board_orchestrator_runs WHERE run_id = ?1",
+    )
+    .bind(&first.run_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load expired run");
+    assert_eq!(
+        row,
+        ("terminal".into(), "failed".into(), "lease_expired".into())
+    );
+}
+
+#[tokio::test]
+async fn stale_run_expiry_publishes_revision_when_replacement_is_disabled() {
+    let db = database().await;
+    let now = instant("2026-07-15T10:30:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    acquire(
+        &db,
+        "run-stale-disabled",
+        TaskBoardAutomationRunTrigger::Scheduled,
+        now,
+    )
+    .await;
+    db.stop_task_board_automation(now + Duration::seconds(1))
+        .await
+        .expect("stop automation");
+    let revision_before_expiry = db
+        .task_board_revision()
+        .await
+        .expect("revision before expiry");
+
+    assert_eq!(
+        db.try_acquire_task_board_automation_run(&acquire_request(
+            "run-disabled-replacement",
+            TaskBoardAutomationRunTrigger::Scheduled,
+            now + Duration::seconds(31),
+        ))
+        .await
+        .expect("attempt disabled replacement"),
+        TaskBoardAutomationRunAdmission::Disabled
+    );
+    assert!(
+        db.task_board_revision()
+            .await
+            .expect("revision after expiry")
+            > revision_before_expiry
+    );
+}
+
+#[tokio::test]
+async fn run_acquire_rolls_back_when_audit_insert_fails() {
+    let db = database().await;
+    let now = instant("2026-07-15T11:00:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    let revision = db.task_board_revision().await.expect("initial revision");
+    fail_automation_audit_inserts(&db).await;
+
+    let error = db
+        .try_acquire_task_board_automation_run(&acquire_request(
+            "run-audit-acquire-failure",
+            TaskBoardAutomationRunTrigger::Manual,
+            now,
+        ))
+        .await
+        .expect_err("audit failure must reject acquisition");
+
+    assert!(
+        error
+            .to_string()
+            .contains("simulated automation audit failure")
+    );
+    assert_eq!(run_count(&db, "run-audit-acquire-failure").await, 0);
+    assert_eq!(
+        automation_audit_count(&db, "run-audit-acquire-failure").await,
+        0
+    );
+    assert_eq!(
+        db.task_board_revision()
+            .await
+            .expect("revision after failed acquisition"),
+        revision
+    );
+}
+
+#[tokio::test]
+async fn run_finalize_rolls_back_when_audit_insert_fails() {
+    let db = database().await;
+    let now = instant("2026-07-15T11:30:00Z");
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    let lease = acquire(
+        &db,
+        "run-audit-finalize-failure",
+        TaskBoardAutomationRunTrigger::Manual,
+        now,
+    )
+    .await;
+    fail_automation_audit_inserts(&db).await;
+
+    let error = db
+        .finalize_task_board_automation_run(
+            &lease,
+            TaskBoardAutomationRunOutcome::Completed,
+            None,
+            None,
+            now + Duration::seconds(1),
+        )
+        .await
+        .expect_err("audit failure must roll back finalization");
+
+    assert!(
+        error
+            .to_string()
+            .contains("simulated automation audit failure")
+    );
+    let row = query_as::<_, (String, Option<String>, i64)>(
+        "SELECT state, outcome, revision FROM task_board_orchestrator_runs WHERE run_id = ?1",
+    )
+    .bind(&lease.run_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load run after failed finalization");
+    assert_eq!(row, ("running".into(), None, 1));
+    assert_eq!(automation_audit_count(&db, &lease.run_id).await, 1);
+}
+
+async fn acquire(
+    db: &AsyncDaemonDb,
+    run_id: &str,
+    trigger: TaskBoardAutomationRunTrigger,
+    now: chrono::DateTime<chrono::Utc>,
+) -> super::TaskBoardAutomationRunLease {
+    let admission = db
+        .try_acquire_task_board_automation_run(&acquire_request(run_id, trigger, now))
+        .await
+        .expect("acquire automation run");
+    let TaskBoardAutomationRunAdmission::Acquired(lease) = admission else {
+        panic!("automation run should acquire");
+    };
+    lease
+}
+
+async fn run_count(db: &AsyncDaemonDb, run_id: &str) -> i64 {
+    query_as::<_, (i64,)>("SELECT COUNT(*) FROM task_board_orchestrator_runs WHERE run_id = ?1")
+        .bind(run_id)
+        .fetch_one(db.pool())
+        .await
+        .expect("count automation runs")
+        .0
+}

--- a/src/daemon/db/task_board/scheduler/stages.rs
+++ b/src/daemon/db/task_board/scheduler/stages.rs
@@ -1,0 +1,218 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{query, query_as};
+
+use super::super::ORCHESTRATOR_CHANGE_SCOPE;
+use super::super::items::bump_change_in_tx;
+use super::audit::{broadcast_automation_audits, insert_automation_audit, parse_scope};
+use super::runs::TaskBoardAutomationRunLease;
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct TaskBoardAutomationRunStage {
+    pub(crate) sequence: u64,
+    pub(crate) stage: String,
+    pub(crate) state: String,
+    pub(crate) recorded_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) payload: Option<serde_json::Value>,
+}
+
+#[derive(Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredStageSummary {
+    #[serde(default)]
+    stages: Vec<TaskBoardAutomationRunStage>,
+}
+
+impl AsyncDaemonDb {
+    pub(crate) async fn upsert_task_board_automation_run_stage(
+        &self,
+        lease: &TaskBoardAutomationRunLease,
+        stage: &TaskBoardAutomationRunStage,
+        now: DateTime<Utc>,
+    ) -> Result<u64, CliError> {
+        let run_id = &lease.run_id;
+        validate_stage(stage, run_id)?;
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation run stage upsert")
+            .await?;
+        let (stored, scope_json, revision) = query_as::<_, (String, String, i64)>(
+            "SELECT stage_summary_json, scope_json, revision
+             FROM task_board_orchestrator_runs
+             WHERE run_id = ?1 AND lease_owner = ?2 AND lease_epoch = ?3
+               AND state IN ('running', 'cancelling') AND lease_expires_at > ?4",
+        )
+        .bind(run_id)
+        .bind(&lease.lease_owner)
+        .bind(i64::try_from(lease.lease_epoch).unwrap_or(i64::MAX))
+        .bind(now.to_rfc3339())
+        .fetch_optional(transaction.as_mut())
+        .await
+        .map_err(|error| {
+            db_error(format!(
+                "load task board automation run stage summary '{run_id}': {error}"
+            ))
+        })?
+        .ok_or_else(|| {
+            db_error(format!(
+                "task board automation run '{run_id}' lost its stage-write lease"
+            ))
+        })?;
+        let stored = updated_stage_summary(&stored, stage, run_id)?;
+        let next_revision = revision.checked_add(1).ok_or_else(|| {
+            db_error(format!(
+                "task board automation run '{run_id}' revision overflow"
+            ))
+        })?;
+        update_stage_summary(
+            &mut transaction,
+            lease,
+            &stored,
+            revision,
+            next_revision,
+            now,
+        )
+        .await?;
+        bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        let scope = parse_scope(&scope_json, run_id)?;
+        let event = insert_automation_audit(
+            &mut transaction,
+            &format!("task_board.automation.stage.{}", stage.state),
+            run_id,
+            &scope,
+            &stage.recorded_at,
+            serde_json::to_value(stage).map_err(|error| {
+                db_error(format!(
+                    "serialize task board automation run stage '{run_id}': {error}"
+                ))
+            })?,
+        )
+        .await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board automation run stage update '{run_id}': {error}"
+            ))
+        })?;
+        broadcast_automation_audits(std::slice::from_ref(&event));
+        u64::try_from(next_revision).map_err(|error| {
+            db_error(format!(
+                "parse task board automation run revision '{run_id}': {error}"
+            ))
+        })
+    }
+}
+
+async fn update_stage_summary(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    lease: &TaskBoardAutomationRunLease,
+    stored: &str,
+    revision: i64,
+    next_revision: i64,
+    now: DateTime<Utc>,
+) -> Result<(), CliError> {
+    let run_id = &lease.run_id;
+    let changed = query(
+        "UPDATE task_board_orchestrator_runs
+         SET stage_summary_json = ?2, revision = ?3
+         WHERE run_id = ?1 AND revision = ?4
+           AND lease_owner = ?5 AND lease_epoch = ?6
+           AND state IN ('running', 'cancelling') AND lease_expires_at > ?7",
+    )
+    .bind(run_id)
+    .bind(stored)
+    .bind(next_revision)
+    .bind(revision)
+    .bind(&lease.lease_owner)
+    .bind(i64::try_from(lease.lease_epoch).unwrap_or(i64::MAX))
+    .bind(now.to_rfc3339())
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| {
+        db_error(format!(
+            "update task board automation run stages '{run_id}': {error}"
+        ))
+    })?
+    .rows_affected();
+    if changed == 1 {
+        Ok(())
+    } else {
+        Err(db_error(format!(
+            "task board automation run '{run_id}' revision changed during stage update"
+        )))
+    }
+}
+
+fn updated_stage_summary(
+    stored: &str,
+    stage: &TaskBoardAutomationRunStage,
+    run_id: &str,
+) -> Result<String, CliError> {
+    let mut stages = decode_stages(stored, run_id)?;
+    upsert_stage(&mut stages, stage);
+    canonicalize_stages(&mut stages, run_id)?;
+    serde_json::to_string(&StoredStageSummary { stages }).map_err(|error| {
+        db_error(format!(
+            "serialize task board automation run stages '{run_id}': {error}"
+        ))
+    })
+}
+
+fn decode_stages(value: &str, run_id: &str) -> Result<Vec<TaskBoardAutomationRunStage>, CliError> {
+    let mut summary = serde_json::from_str::<StoredStageSummary>(value).map_err(|error| {
+        db_error(format!(
+            "parse task board automation run stages '{run_id}': {error}"
+        ))
+    })?;
+    canonicalize_stages(&mut summary.stages, run_id)?;
+    Ok(summary.stages)
+}
+
+fn upsert_stage(
+    stages: &mut Vec<TaskBoardAutomationRunStage>,
+    stage: &TaskBoardAutomationRunStage,
+) {
+    if let Some(existing) = stages
+        .iter_mut()
+        .find(|existing| existing.sequence == stage.sequence)
+    {
+        existing.clone_from(stage);
+    } else {
+        stages.push(stage.clone());
+    }
+}
+
+fn canonicalize_stages(
+    stages: &mut [TaskBoardAutomationRunStage],
+    run_id: &str,
+) -> Result<(), CliError> {
+    for stage in &*stages {
+        validate_stage(stage, run_id)?;
+    }
+    stages.sort_by_key(|stage| stage.sequence);
+    if stages
+        .windows(2)
+        .any(|pair| pair[0].sequence == pair[1].sequence)
+    {
+        return Err(db_error(format!(
+            "task board automation run '{run_id}' has duplicate stage sequence"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_stage(stage: &TaskBoardAutomationRunStage, run_id: &str) -> Result<(), CliError> {
+    if stage.stage.trim().is_empty() || stage.state.trim().is_empty() {
+        return Err(db_error(format!(
+            "task board automation run '{run_id}' has an empty stage or state"
+        )));
+    }
+    DateTime::parse_from_rfc3339(&stage.recorded_at).map_err(|error| {
+        db_error(format!(
+            "parse task board automation run stage timestamp '{run_id}': {error}"
+        ))
+    })?;
+    Ok(())
+}

--- a/src/daemon/db/task_board/scheduler/stages_tests.rs
+++ b/src/daemon/db/task_board/scheduler/stages_tests.rs
@@ -1,0 +1,266 @@
+use std::sync::Arc;
+
+use serde::Deserialize;
+use sqlx::{query, query_as};
+use tokio::sync::Barrier;
+
+use super::test_support::{
+    acquire_request, automation_audit_count, database, fail_automation_audit_inserts, instant,
+};
+use crate::daemon::db::{
+    TaskBoardAutomationRunAdmission, TaskBoardAutomationRunLease, TaskBoardAutomationRunStage,
+};
+use crate::task_board::{TaskBoardAutomationRunOutcome, TaskBoardAutomationRunTrigger};
+
+#[derive(Deserialize)]
+struct StoredStageSummary {
+    #[serde(default)]
+    stages: Vec<TaskBoardAutomationRunStage>,
+}
+
+#[tokio::test]
+async fn concurrent_stage_upserts_are_canonical_and_revisioned() {
+    let db = database().await;
+    let lease = acquire_run(&db, "run-stages", instant("2026-07-15T12:00:00Z")).await;
+    let gate = Arc::new(Barrier::new(2));
+    let first_db = db.clone();
+    let first_gate = Arc::clone(&gate);
+    let first_lease = lease.clone();
+    let second_db = db.clone();
+    let second_gate = Arc::clone(&gate);
+    let second_lease = lease.clone();
+
+    let (first, second) = tokio::join!(
+        async move {
+            first_gate.wait().await;
+            first_db
+                .upsert_task_board_automation_run_stage(
+                    &first_lease,
+                    &stage(2, "evaluate", "completed"),
+                    instant("2026-07-15T12:00:00Z"),
+                )
+                .await
+        },
+        async move {
+            second_gate.wait().await;
+            second_db
+                .upsert_task_board_automation_run_stage(
+                    &second_lease,
+                    &stage(1, "synchronize", "completed"),
+                    instant("2026-07-15T12:00:00Z"),
+                )
+                .await
+        }
+    );
+    first.expect("upsert first stage");
+    second.expect("upsert second stage");
+
+    let (stages, revision) = load_stages(&db, "run-stages").await;
+    assert_eq!(stage_sequences(&stages), [1, 2]);
+    assert_eq!(revision, 3);
+
+    let mut replacement = stage(1, "synchronize", "failed");
+    replacement.summary = Some("replaced".into());
+    assert_eq!(
+        db.upsert_task_board_automation_run_stage(
+            &lease,
+            &replacement,
+            instant("2026-07-15T12:00:00Z"),
+        )
+        .await
+        .expect("replace stage"),
+        4
+    );
+    let (stages, revision) = load_stages(&db, "run-stages").await;
+    assert_eq!(stage_sequences(&stages), [1, 2]);
+    assert_eq!(stages[0].state, "failed");
+    assert_eq!(stages[0].summary.as_deref(), Some("replaced"));
+    assert_eq!(revision, 4);
+}
+
+#[tokio::test]
+async fn malformed_persisted_stage_summary_fails_closed() {
+    let db = database().await;
+    let lease = acquire_run(&db, "run-malformed", instant("2026-07-15T13:00:00Z")).await;
+    query(
+        "UPDATE task_board_orchestrator_runs SET stage_summary_json = '{\"stages\":42}'
+         WHERE run_id = 'run-malformed'",
+    )
+    .execute(db.pool())
+    .await
+    .expect("seed malformed stages");
+
+    let error = db
+        .upsert_task_board_automation_run_stage(
+            &lease,
+            &stage(1, "synchronize", "completed"),
+            instant("2026-07-15T13:00:00Z"),
+        )
+        .await
+        .expect_err("reject malformed stage summary");
+    assert!(
+        error
+            .to_string()
+            .contains("parse task board automation run stages")
+    );
+    let revision = query_as::<_, (i64,)>(
+        "SELECT revision FROM task_board_orchestrator_runs WHERE run_id = 'run-malformed'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("load unchanged revision")
+    .0;
+    assert_eq!(revision, 1);
+}
+
+#[tokio::test]
+async fn invalid_stage_input_is_rejected_before_storage() {
+    let db = database().await;
+    let lease = acquire_run(&db, "run-invalid", instant("2026-07-15T14:00:00Z")).await;
+
+    let mut invalid = stage(1, "", "running");
+    assert!(
+        db.upsert_task_board_automation_run_stage(
+            &lease,
+            &invalid,
+            instant("2026-07-15T14:00:00Z"),
+        )
+        .await
+        .is_err()
+    );
+    invalid.stage = "synchronize".into();
+    invalid.recorded_at = "not-an-instant".into();
+    assert!(
+        db.upsert_task_board_automation_run_stage(
+            &lease,
+            &invalid,
+            instant("2026-07-15T14:00:00Z"),
+        )
+        .await
+        .is_err()
+    );
+
+    let (stages, revision) = load_stages(&db, "run-invalid").await;
+    assert!(stages.is_empty());
+    assert_eq!(revision, 1);
+}
+
+#[tokio::test]
+async fn terminal_run_rejects_stage_writes_from_its_old_lease() {
+    let db = database().await;
+    let now = instant("2026-07-15T15:00:00Z");
+    let lease = acquire_run(&db, "run-terminal-stage", now).await;
+    db.finalize_task_board_automation_run(
+        &lease,
+        TaskBoardAutomationRunOutcome::Completed,
+        None,
+        None,
+        now,
+    )
+    .await
+    .expect("finalize run");
+
+    let error = db
+        .upsert_task_board_automation_run_stage(&lease, &stage(1, "synchronize", "completed"), now)
+        .await
+        .expect_err("terminal run must reject stage write");
+    assert!(error.to_string().contains("lost its stage-write lease"));
+    let (stages, revision) = load_stages(&db, "run-terminal-stage").await;
+    assert!(stages.is_empty());
+    assert_eq!(revision, 2);
+}
+
+#[tokio::test]
+async fn expired_run_rejects_stage_writes_before_recovery() {
+    let db = database().await;
+    let now = instant("2026-07-15T15:30:00Z");
+    let lease = acquire_run(&db, "run-expired-stage", now).await;
+
+    let error = db
+        .upsert_task_board_automation_run_stage(
+            &lease,
+            &stage(1, "synchronize", "completed"),
+            now + chrono::Duration::seconds(31),
+        )
+        .await
+        .expect_err("expired run must reject stage write");
+
+    assert!(error.to_string().contains("lost its stage-write lease"));
+    let (stages, revision) = load_stages(&db, "run-expired-stage").await;
+    assert!(stages.is_empty());
+    assert_eq!(revision, 1);
+    assert_eq!(automation_audit_count(&db, &lease.run_id).await, 1);
+}
+
+#[tokio::test]
+async fn stage_write_rolls_back_when_audit_insert_fails() {
+    let db = database().await;
+    let now = instant("2026-07-15T16:00:00Z");
+    let lease = acquire_run(&db, "run-stage-audit-failure", now).await;
+    fail_automation_audit_inserts(&db).await;
+
+    let error = db
+        .upsert_task_board_automation_run_stage(&lease, &stage(1, "synchronize", "completed"), now)
+        .await
+        .expect_err("audit failure must roll back stage write");
+
+    assert!(
+        error
+            .to_string()
+            .contains("simulated automation audit failure")
+    );
+    let (stages, revision) = load_stages(&db, &lease.run_id).await;
+    assert!(stages.is_empty());
+    assert_eq!(revision, 1);
+    assert_eq!(automation_audit_count(&db, &lease.run_id).await, 1);
+}
+
+fn stage(sequence: u64, name: &str, state: &str) -> TaskBoardAutomationRunStage {
+    TaskBoardAutomationRunStage {
+        sequence,
+        stage: name.into(),
+        state: state.into(),
+        recorded_at: "2026-07-15T12:00:00Z".into(),
+        summary: None,
+        payload: None,
+    }
+}
+
+async fn load_stages(
+    db: &crate::daemon::db::AsyncDaemonDb,
+    run_id: &str,
+) -> (Vec<TaskBoardAutomationRunStage>, i64) {
+    let (stored, revision) = query_as::<_, (String, i64)>(
+        "SELECT stage_summary_json, revision FROM task_board_orchestrator_runs WHERE run_id = ?1",
+    )
+    .bind(run_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load stage summary");
+    let summary =
+        serde_json::from_str::<StoredStageSummary>(&stored).expect("decode stage summary");
+    (summary.stages, revision)
+}
+
+fn stage_sequences(stages: &[TaskBoardAutomationRunStage]) -> Vec<u64> {
+    stages.iter().map(|stage| stage.sequence).collect()
+}
+
+async fn acquire_run(
+    db: &crate::daemon::db::AsyncDaemonDb,
+    run_id: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> TaskBoardAutomationRunLease {
+    match db
+        .try_acquire_task_board_automation_run(&acquire_request(
+            run_id,
+            TaskBoardAutomationRunTrigger::Manual,
+            now,
+        ))
+        .await
+        .expect("acquire run")
+    {
+        TaskBoardAutomationRunAdmission::Acquired(lease) => lease,
+        admission => panic!("expected acquired run, got {admission:?}"),
+    }
+}

--- a/src/daemon/db/task_board/scheduler/test_support.rs
+++ b/src/daemon/db/task_board/scheduler/test_support.rs
@@ -1,0 +1,83 @@
+use chrono::{DateTime, Utc};
+use sqlx::{query, query_scalar};
+
+use super::TaskBoardRunAcquireRequest;
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::{TaskBoardAutomationRunTrigger, TaskBoardAutomationScope};
+
+pub(super) fn instant(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .expect("valid test instant")
+        .with_timezone(&Utc)
+}
+
+pub(super) async fn database() -> AsyncDaemonDb {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.keep().join("harness.db");
+    AsyncDaemonDb::connect(&path).await.expect("open database")
+}
+
+pub(super) async fn fail_automation_audit_inserts(db: &AsyncDaemonDb) {
+    query(
+        "CREATE TRIGGER fail_automation_audit
+         BEFORE INSERT ON audit_events
+         BEGIN SELECT RAISE(FAIL, 'simulated automation audit failure'); END",
+    )
+    .execute(db.pool())
+    .await
+    .expect("install automation audit failure trigger");
+}
+
+pub(super) async fn automation_audit_count(db: &AsyncDaemonDb, run_id: &str) -> i64 {
+    query_scalar::<_, i64>("SELECT COUNT(*) FROM audit_events WHERE correlation_id = ?1")
+        .bind(run_id)
+        .fetch_one(db.pool())
+        .await
+        .expect("count automation audit events")
+}
+
+pub(super) fn acquire_request(
+    run_id: &str,
+    trigger: TaskBoardAutomationRunTrigger,
+    now: DateTime<Utc>,
+) -> TaskBoardRunAcquireRequest {
+    TaskBoardRunAcquireRequest {
+        run_id: run_id.to_string(),
+        trigger,
+        actor: Some("scheduler-test".into()),
+        dry_run: false,
+        scope: TaskBoardAutomationScope::default(),
+        lease_owner: format!("owner-{run_id}"),
+        now,
+    }
+}
+
+pub(super) async fn seed_run(
+    db: &AsyncDaemonDb,
+    run_id: &str,
+    state: &str,
+    outcome: Option<&str>,
+    completed_at: Option<DateTime<Utc>>,
+) {
+    let completed_at = completed_at.map(|value| value.to_rfc3339());
+    let observed_at = completed_at
+        .clone()
+        .unwrap_or_else(|| "2026-07-15T00:00:00+00:00".into());
+    query(
+        "INSERT INTO task_board_orchestrator_runs (
+            run_id, trigger, actor, dry_run, scope_json, state, outcome, lease_owner,
+            lease_epoch, lease_expires_at, stop_generation, started_at, heartbeat_at,
+            completed_at
+         ) VALUES (?1, 'manual', 'scheduler-test', 0, '{}', ?2, ?3, ?4, 1,
+                   '2026-07-16T00:00:00+00:00', 0, ?5, ?5, ?6)",
+    )
+    .bind(run_id)
+    .bind(state)
+    .bind(outcome)
+    .bind(format!("owner-{run_id}"))
+    .bind(observed_at)
+    .bind(completed_at)
+    .execute(db.pool())
+    .await
+    .expect("seed automation run");
+}

--- a/src/daemon/http/task_board_orchestrator_handlers.rs
+++ b/src/daemon/http/task_board_orchestrator_handlers.rs
@@ -144,7 +144,10 @@ async fn post_task_board_orchestrator_run_once(
         Ok(parts) => parts,
         Err(response) => return *response,
     };
-    let result = super::task_board_orchestrator_run_once::run(&state, &request).await;
+    let result = Box::pin(super::task_board_orchestrator_run_once::run(
+        &state, &request,
+    ))
+    .await;
     timed_json(
         "POST",
         http_paths::TASK_BOARD_ORCHESTRATOR_RUN_ONCE,

--- a/src/daemon/http/task_board_orchestrator_run_once.rs
+++ b/src/daemon/http/task_board_orchestrator_run_once.rs
@@ -9,5 +9,9 @@ pub(super) async fn run(
     state: &DaemonHttpState,
     request: &TaskBoardOrchestratorRunOnceRequest,
 ) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
-    super::task_board_route_executor::run_once(state, request.clone()).await
+    Box::pin(super::task_board_route_executor::run_once(
+        state,
+        request.clone(),
+    ))
+    .await
 }

--- a/src/daemon/http/task_board_route_executor.rs
+++ b/src/daemon/http/task_board_route_executor.rs
@@ -15,12 +15,15 @@ use crate::daemon::task_board_managed_agents::{
     rendered_worker_prompt, start_worker_for_applied_task,
 };
 use crate::errors::{CliError, CliErrorKind};
+use crate::feature_flags::task_board_automation_v2_enabled_from_env;
 use crate::task_board::{
     DispatchAppliedTask, DispatchExecutionSummary, DispatchFailure, DispatchFailureKind,
+    TaskBoardAutomationRunTrigger,
 };
 
 use super::{DaemonHttpState, require_async_db};
 
+mod automation_run;
 mod item_ops;
 mod orchestrator_ops;
 mod policy_ops;
@@ -115,7 +118,26 @@ pub(crate) async fn run_once(
     state: &DaemonHttpState,
     request: TaskBoardOrchestratorRunOnceRequest,
 ) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
+    Box::pin(run_once_with_trigger(
+        state,
+        request,
+        TaskBoardAutomationRunTrigger::Manual,
+    ))
+    .await
+}
+
+pub(crate) async fn run_once_with_trigger(
+    state: &DaemonHttpState,
+    request: TaskBoardOrchestratorRunOnceRequest,
+    trigger: TaskBoardAutomationRunTrigger,
+) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
     let async_db = require_async_db(state, "task board orchestrator run once")?;
+    if task_board_automation_v2_enabled_from_env() {
+        return Box::pin(automation_run::run_once_durable(
+            state, async_db, request, trigger,
+        ))
+        .await;
+    }
     let result = service::run_task_board_orchestrator_once_db(async_db, &request).await;
     handle_run_once_result(state, result, async_db).await
 }

--- a/src/daemon/http/task_board_route_executor/automation_run.rs
+++ b/src/daemon/http/task_board_route_executor/automation_run.rs
@@ -1,0 +1,253 @@
+use crate::daemon::db::AsyncDaemonDb;
+use crate::daemon::protocol::{
+    TaskBoardOrchestratorRunOnceRequest, TaskBoardOrchestratorRunOnceResponse,
+};
+use crate::daemon::service;
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::{
+    TaskBoardAutomationRunOutcome, TaskBoardAutomationRunTrigger, TaskBoardAutomationScope,
+    TaskBoardOrchestratorSettings, TaskBoardStatus,
+};
+
+use super::super::DaemonHttpState;
+use super::handle_run_once_result;
+
+pub(super) async fn run_once_durable(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    request: TaskBoardOrchestratorRunOnceRequest,
+    trigger: TaskBoardAutomationRunTrigger,
+) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
+    let settings = db.task_board_orchestrator_settings().await?;
+    let dry_run = request.dry_run.unwrap_or(settings.dry_run_default);
+    let scope = durable_scope(&request, &settings);
+    let start = service::TaskBoardAutomationRunSession::acquire(
+        db,
+        trigger,
+        request.actor.clone(),
+        dry_run,
+        scope,
+    )
+    .await?;
+    let session = admitted_session(start)?;
+    let result = execute_durable_run(state, db, &request, &session).await;
+    finish_durable_run(db, session, result).await
+}
+
+fn admitted_session(
+    start: service::TaskBoardAutomationRunStart,
+) -> Result<service::TaskBoardAutomationRunSession, CliError> {
+    match start {
+        service::TaskBoardAutomationRunStart::Acquired(session) => Ok(*session),
+        service::TaskBoardAutomationRunStart::Busy { run_id } => {
+            Err(CliErrorKind::session_agent_conflict(format!(
+                "task-board automation run '{run_id}' is already active"
+            ))
+            .into())
+        }
+        service::TaskBoardAutomationRunStart::Disabled => {
+            Err(CliErrorKind::session_agent_conflict("task-board automation is stopping").into())
+        }
+    }
+}
+
+async fn execute_durable_run(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    request: &TaskBoardOrchestratorRunOnceRequest,
+    session: &service::TaskBoardAutomationRunSession,
+) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
+    let result =
+        service::run_task_board_orchestrator_once_with_session_db(db, request, session).await;
+    let status = result?;
+    session.begin_stage(6, "worker_start", None, None).await?;
+    let status = handle_run_once_result(state, Ok(status), db).await;
+    match status {
+        Ok(status) => {
+            session
+                .complete_stage(6, "worker_start", None, None)
+                .await?;
+            Ok(status)
+        }
+        Err(error) => {
+            session.fail_stage(6, "worker_start", &error).await?;
+            Err(error)
+        }
+    }
+}
+
+async fn finish_durable_run(
+    db: &AsyncDaemonDb,
+    session: service::TaskBoardAutomationRunSession,
+    result: Result<TaskBoardOrchestratorRunOnceResponse, CliError>,
+) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
+    match result {
+        Ok(status) => {
+            let outcome = durable_run_outcome(&status, session.had_sync_failures());
+            let actual_outcome = session.finalize(outcome, None).await?;
+            ensure_not_cancelled(actual_outcome)?;
+            service::task_board_orchestrator_status_db(db).await
+        }
+        Err(error) => {
+            let actual_outcome = session
+                .finalize(TaskBoardAutomationRunOutcome::Failed, Some(&error))
+                .await?;
+            ensure_not_cancelled(actual_outcome)?;
+            Err(error)
+        }
+    }
+}
+
+fn durable_run_outcome(
+    status: &TaskBoardOrchestratorRunOnceResponse,
+    had_sync_failures: bool,
+) -> TaskBoardAutomationRunOutcome {
+    let has_failures = had_sync_failures
+        || status.last_run.as_ref().is_some_and(|run| {
+            run.dispatch
+                .as_ref()
+                .is_some_and(|dispatch| !dispatch.failures.is_empty())
+                || run.evaluation.as_ref().is_some_and(|evaluation| {
+                    evaluation.failed > 0 || !evaluation.signal_failures.is_empty()
+                })
+        });
+    completed_run_outcome(has_failures, status.last_run_applied_count())
+}
+
+fn durable_scope(
+    request: &TaskBoardOrchestratorRunOnceRequest,
+    settings: &TaskBoardOrchestratorSettings,
+) -> TaskBoardAutomationScope {
+    let status = request.item_id.is_none().then(|| {
+        request
+            .status
+            .or(settings.dispatch_status_filter)
+            .map(TaskBoardStatus::canonical_persisted_status)
+    });
+    TaskBoardAutomationScope {
+        item_id: request.item_id.clone(),
+        status: status.flatten(),
+        ..TaskBoardAutomationScope::default()
+    }
+}
+
+fn ensure_not_cancelled(outcome: TaskBoardAutomationRunOutcome) -> Result<(), CliError> {
+    if outcome == TaskBoardAutomationRunOutcome::Cancelled {
+        return Err(
+            CliErrorKind::session_agent_conflict("task-board automation is stopping").into(),
+        );
+    }
+    Ok(())
+}
+
+const fn completed_run_outcome(
+    has_failures: bool,
+    applied_count: usize,
+) -> TaskBoardAutomationRunOutcome {
+    if has_failures {
+        return TaskBoardAutomationRunOutcome::Partial;
+    }
+    if applied_count == 0 {
+        return TaskBoardAutomationRunOutcome::Noop;
+    }
+    TaskBoardAutomationRunOutcome::Completed
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::query_scalar;
+
+    use super::*;
+    use crate::task_board::TaskBoardAutomationDesiredMode;
+
+    #[test]
+    fn completed_run_outcome_distinguishes_changes_failures_and_noop() {
+        assert_eq!(
+            completed_run_outcome(false, 0),
+            TaskBoardAutomationRunOutcome::Noop
+        );
+        assert_eq!(
+            completed_run_outcome(false, 1),
+            TaskBoardAutomationRunOutcome::Completed
+        );
+        assert_eq!(
+            completed_run_outcome(true, 0),
+            TaskBoardAutomationRunOutcome::Partial
+        );
+    }
+
+    #[test]
+    fn durable_scope_ignores_status_for_an_explicit_item() {
+        let scope = durable_scope(
+            &TaskBoardOrchestratorRunOnceRequest {
+                item_id: Some("task-neutral".into()),
+                status: Some(TaskBoardStatus::New),
+                ..TaskBoardOrchestratorRunOnceRequest::default()
+            },
+            &TaskBoardOrchestratorSettings::default(),
+        );
+
+        assert_eq!(scope.item_id.as_deref(), Some("task-neutral"));
+        assert_eq!(scope.status, None);
+    }
+
+    #[test]
+    fn durable_scope_canonicalizes_the_status_filter() {
+        let scope = durable_scope(
+            &TaskBoardOrchestratorRunOnceRequest {
+                status: Some(TaskBoardStatus::New),
+                ..TaskBoardOrchestratorRunOnceRequest::default()
+            },
+            &TaskBoardOrchestratorSettings::default(),
+        );
+
+        assert_eq!(scope.status, Some(TaskBoardStatus::Todo));
+    }
+
+    #[tokio::test]
+    async fn stop_winning_the_finalization_race_surfaces_cancellation() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+        db.start_task_board_automation(
+            TaskBoardAutomationDesiredMode::Continuous,
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("start automation");
+        let start = service::TaskBoardAutomationRunSession::acquire(
+            &db,
+            TaskBoardAutomationRunTrigger::Manual,
+            Some("operator".into()),
+            false,
+            TaskBoardAutomationScope::default(),
+        )
+        .await
+        .expect("acquire session");
+        let service::TaskBoardAutomationRunStart::Acquired(session) = start else {
+            panic!("manual run should be acquired");
+        };
+        let run_id = session.run_id().to_owned();
+        let status = service::task_board_orchestrator_status_db(&db)
+            .await
+            .expect("load status");
+        db.stop_task_board_automation(chrono::Utc::now())
+            .await
+            .expect("stop automation");
+
+        let error = finish_durable_run(&db, *session, Ok(status))
+            .await
+            .expect_err("cancelled finalization must not report success");
+
+        assert_eq!(error.code(), "KSRCLI092");
+        let outcome = query_scalar::<_, String>(
+            "SELECT outcome FROM task_board_orchestrator_runs WHERE run_id = ?1",
+        )
+        .bind(run_id)
+        .fetch_one(db.pool())
+        .await
+        .expect("load durable outcome");
+        assert_eq!(outcome, "cancelled");
+    }
+}

--- a/src/daemon/http/tests/task_board_route_parity.rs
+++ b/src/daemon/http/tests/task_board_route_parity.rs
@@ -6,6 +6,9 @@ use crate::daemon::protocol::{http_paths, ws_methods};
 use crate::task_board::policy_graph::PolicyCanvasWorkspace;
 
 use super::task_board_route_parity_support::*;
+use super::task_board_support::{
+    assert_task_board_capabilities_match, without_durable_task_board_automation,
+};
 
 #[test]
 fn task_board_http_and_ws_workflow_routes_match() {
@@ -161,7 +164,9 @@ fn task_board_http_and_ws_orchestrator_routes_match() {
     let sandbox = tempdir().expect("tempdir");
     harness_testkit::with_isolated_harness_env(sandbox.path(), || {
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
-        runtime.block_on(run_task_board_orchestrator_parity());
+        without_durable_task_board_automation(|| {
+            runtime.block_on(run_task_board_orchestrator_parity());
+        });
     });
 }
 
@@ -170,24 +175,7 @@ async fn run_task_board_orchestrator_parity() {
     let (base_url, server) = serve_http(state.clone()).await;
     let client = reqwest::Client::new();
 
-    let capabilities = get_json(&client, &base_url, http_paths::TASK_BOARD_CAPABILITIES).await;
-    assert_eq!(capabilities["storage"], "database");
-    assert!(capabilities["revision"].as_i64().is_some());
-    assert!(
-        capabilities["instance_id"]
-            .as_str()
-            .is_some_and(|value| value.starts_with("task-board-"))
-    );
-    assert_eq!(
-        capabilities,
-        ws_result(
-            &base_url,
-            "req-task-board-capabilities",
-            ws_methods::TASK_BOARD_CAPABILITIES,
-            json!({}),
-        )
-        .await
-    );
+    assert_task_board_capabilities_match(&client, &base_url).await;
 
     let http_status = get_json(
         &client,
@@ -213,6 +201,7 @@ async fn run_task_board_orchestrator_parity() {
     )
     .await;
     assert_run_once_routes_match(&client, &base_url, &state).await;
+    assert_no_durable_runs(&state).await;
     assert_settings_routes_match(&client, &base_url).await;
     assert_runtime_config_routes_match(&client, &base_url).await;
     assert_http_ws_put_match(

--- a/src/daemon/http/tests/task_board_route_parity_support.rs
+++ b/src/daemon/http/tests/task_board_route_parity_support.rs
@@ -182,6 +182,14 @@ pub(super) async fn assert_run_once_routes_match(
     assert_run_once_parity(http, ws);
 }
 
+pub(super) async fn assert_no_durable_runs(state: &crate::daemon::http::DaemonHttpState) {
+    let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM task_board_orchestrator_runs")
+        .fetch_one(state.async_db.get().expect("test async db").pool())
+        .await
+        .expect("count durable runs");
+    assert_eq!(count, 0, "flag-off routes must stay on legacy state");
+}
+
 fn assert_run_once_parity(http: Value, ws: Value) {
     assert_eq!(http["dry_run"], ws["dry_run"]);
     assert_eq!(http["sync"]["operations"], ws["sync"]["operations"]);

--- a/src/daemon/http/tests/task_board_support.rs
+++ b/src/daemon/http/tests/task_board_support.rs
@@ -5,8 +5,36 @@ use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
+use crate::daemon::protocol::{http_paths, ws_methods};
 use crate::task_board::planning::{approve_plan, submit_plan};
 use crate::task_board::{AgentMode, TaskBoardItem, TaskBoardStatus};
+
+pub(super) fn without_durable_task_board_automation<R>(body: impl FnOnce() -> R) -> R {
+    temp_env::with_var(
+        crate::feature_flags::TASK_BOARD_AUTOMATION_V2_ENV,
+        None::<&str>,
+        body,
+    )
+}
+
+pub(super) async fn assert_task_board_capabilities_match(client: &reqwest::Client, base_url: &str) {
+    let capabilities = get_json(client, base_url, http_paths::TASK_BOARD_CAPABILITIES).await;
+    assert_eq!(capabilities["storage"], "database");
+    assert!(capabilities["revision"].as_i64().is_some());
+    assert!(
+        capabilities["instance_id"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("task-board-"))
+    );
+    let websocket = super::task_board_route_parity_support::ws_result(
+        base_url,
+        "req-task-board-capabilities",
+        ws_methods::TASK_BOARD_CAPABILITIES,
+        json!({}),
+    )
+    .await;
+    assert_eq!(capabilities, websocket);
+}
 
 pub(super) async fn dispatch_http_item(
     client: &reqwest::Client,
@@ -17,7 +45,7 @@ pub(super) async fn dispatch_http_item(
     post_json(
         client,
         base_url,
-        crate::daemon::protocol::http_paths::TASK_BOARD_DISPATCH,
+        http_paths::TASK_BOARD_DISPATCH,
         json!({
             "id": item_id,
             "status": "todo",

--- a/src/daemon/service/mod.rs
+++ b/src/daemon/service/mod.rs
@@ -256,6 +256,7 @@ mod signals_timeout;
 mod status;
 mod sync_support;
 mod task_board;
+mod task_board_automation_runtime;
 mod task_board_completion;
 mod task_board_db;
 mod task_board_evaluation;
@@ -264,7 +265,9 @@ mod task_board_github;
 mod task_board_host;
 #[cfg(test)]
 mod task_board_orchestrator;
+mod task_board_orchestrator_control;
 mod task_board_orchestrator_db;
+mod task_board_orchestrator_run_lease;
 mod task_board_orchestrator_settings;
 mod task_board_orchestrator_step_mode;
 mod task_board_runtime;
@@ -364,6 +367,9 @@ pub(crate) use task_board::{
     simulate_policy_pipeline, update_policy_scenario,
 };
 pub(crate) use task_board::{dispatch_task_board_async, pick_task_board_dispatch_async};
+pub(crate) use task_board_automation_runtime::{
+    TaskBoardAutomationRunSession, TaskBoardAutomationRunStart,
+};
 pub(crate) use task_board_db::{
     approve_task_board_plan_db, audit_task_board_db, begin_task_board_planning_db,
     create_task_board_item_db, delete_task_board_item_db, get_task_board_item_db,
@@ -385,11 +391,15 @@ pub use task_board_orchestrator::{
     task_board_orchestrator_settings, task_board_orchestrator_status,
     update_task_board_orchestrator_settings,
 };
-pub(crate) use task_board_orchestrator_db::{
-    run_task_board_orchestrator_once_db, start_task_board_orchestrator_db,
-    stop_task_board_orchestrator_db, task_board_orchestrator_settings_db,
-    task_board_orchestrator_status_db, update_task_board_orchestrator_settings_db,
+pub(crate) use task_board_orchestrator_control::{
+    start_task_board_orchestrator_db, stop_task_board_orchestrator_db,
+    task_board_orchestrator_settings_db, task_board_orchestrator_status_db,
+    update_task_board_orchestrator_settings_db,
 };
+pub(crate) use task_board_orchestrator_db::{
+    run_task_board_orchestrator_once_db, run_task_board_orchestrator_once_with_session_db,
+};
+pub(crate) use task_board_orchestrator_run_lease::TaskBoardOrchestratorRunGuard;
 pub(crate) use task_board_runtime::{
     acknowledge_task_board_git_runtime_secret_handoff,
     prepare_task_board_git_runtime_secret_handoff, sync_task_board_git_runtime_key_material,

--- a/src/daemon/service/serve/task_board_orchestrator_loop.rs
+++ b/src/daemon/service/serve/task_board_orchestrator_loop.rs
@@ -9,9 +9,14 @@ use tokio::time::{MissedTickBehavior, interval};
 use crate::daemon::db::AsyncDaemonDb;
 use crate::daemon::http::{DaemonHttpState, task_board_route_executor};
 use crate::errors::CliError;
+use crate::feature_flags::task_board_automation_v2_enabled_from_env;
 #[cfg(test)]
 use crate::task_board::TaskBoardOrchestratorState;
-use crate::task_board::{TaskBoardOrchestratorRunOnceRequest, TaskBoardOrchestratorStatus};
+use crate::task_board::{
+    TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode,
+    TaskBoardAutomationRunTrigger, TaskBoardOrchestratorRunOnceRequest,
+    TaskBoardOrchestratorSettings, TaskBoardOrchestratorStatus,
+};
 
 struct AutonomousOrchestratorIntent {
     enabled: bool,
@@ -39,12 +44,19 @@ async fn run_task_board_orchestrator_loop(
     tick_interval: Duration,
     mut shutdown_rx: tokio_watch::Receiver<bool>,
 ) {
+    let durable_enabled = task_board_automation_v2_enabled_from_env();
+    if durable_enabled && let Err(error) = initialize_durable_automation(db.as_ref()).await {
+        tracing::error!(%error, "task-board automation startup initialization failed");
+        return;
+    }
     let mut ticker = interval(tick_interval.max(Duration::from_secs(1)));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
     loop {
         tokio::select! {
             () = wait_for_shutdown(&mut shutdown_rx) => break,
-            _ = ticker.tick() => run_logged_tick(&state, db.as_ref()).await,
+            _ = ticker.tick() => Box::pin(
+                run_logged_tick(&state, db.as_ref(), durable_enabled)
+            ).await,
         }
     }
 }
@@ -60,24 +72,87 @@ async fn wait_for_shutdown(shutdown_rx: &mut tokio_watch::Receiver<bool>) {
     }
 }
 
-async fn run_logged_tick(state: &DaemonHttpState, db: &AsyncDaemonDb) {
+async fn run_logged_tick(state: &DaemonHttpState, db: &AsyncDaemonDb, durable_enabled: bool) {
     let request = TaskBoardOrchestratorRunOnceRequest::default();
-    let result = drive_task_board_orchestrator_once(
-        || orchestrator_state(db),
-        || task_board_route_executor::run_once(state, request),
-    )
+    let result = Box::pin(drive_task_board_orchestrator_once(
+        || automation_tick_state(db, durable_enabled),
+        || {
+            task_board_route_executor::run_once_with_trigger(
+                state,
+                request,
+                TaskBoardAutomationRunTrigger::Scheduled,
+            )
+        },
+    ))
     .await;
     log_tick_result(result);
 }
 
-async fn orchestrator_state(db: &AsyncDaemonDb) -> Result<AutonomousOrchestratorIntent, CliError> {
+async fn automation_tick_state(
+    db: &AsyncDaemonDb,
+    durable_enabled: bool,
+) -> Result<AutonomousOrchestratorIntent, CliError> {
+    if durable_enabled {
+        maintain_durable_automation(db, chrono::Utc::now()).await?;
+    }
+    orchestrator_state(db, durable_enabled).await
+}
+
+async fn maintain_durable_automation(
+    db: &AsyncDaemonDb,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), CliError> {
+    db.recover_stale_task_board_automation_runs(now).await?;
+    db.finish_task_board_automation_drain_if_idle(now).await?;
+    Ok(())
+}
+
+async fn orchestrator_state(
+    db: &AsyncDaemonDb,
+    durable_enabled: bool,
+) -> Result<AutonomousOrchestratorIntent, CliError> {
     let state = db.task_board_orchestrator_state().await?;
     let settings = db.task_board_orchestrator_settings().await?;
+    if durable_enabled {
+        let control = db.task_board_automation_control().await?;
+        return Ok(AutonomousOrchestratorIntent {
+            enabled: control.desired_mode != TaskBoardAutomationDesiredMode::Off,
+            running: control.admission_state == TaskBoardAutomationAdmissionState::Accepting,
+            step_mode: control.desired_mode == TaskBoardAutomationDesiredMode::Step,
+        });
+    }
     Ok(AutonomousOrchestratorIntent {
         enabled: state.enabled,
         running: state.running,
         step_mode: settings.step_mode,
     })
+}
+
+async fn initialize_durable_automation(db: &AsyncDaemonDb) -> Result<(), CliError> {
+    let state = db.task_board_orchestrator_state().await?;
+    let settings = db.task_board_orchestrator_settings().await?;
+    let now = chrono::Utc::now();
+    db.initialize_task_board_automation_control_from_legacy_intent(
+        desired_mode_for_legacy_intent(&state, &settings),
+        now,
+    )
+    .await?;
+    maintain_durable_automation(db, now).await?;
+    Ok(())
+}
+
+const fn desired_mode_for_legacy_intent(
+    state: &crate::task_board::TaskBoardOrchestratorState,
+    settings: &TaskBoardOrchestratorSettings,
+) -> TaskBoardAutomationDesiredMode {
+    if !state.enabled || !state.running {
+        return TaskBoardAutomationDesiredMode::Off;
+    }
+    if settings.step_mode {
+        TaskBoardAutomationDesiredMode::Step
+    } else {
+        TaskBoardAutomationDesiredMode::Continuous
+    }
 }
 
 #[expect(
@@ -112,9 +187,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use chrono::Duration as ChronoDuration;
+    use sqlx::{query, query_as};
     use tempfile::tempdir;
 
     use super::*;
+    use crate::daemon::db::{TaskBoardAutomationRunAdmission, TaskBoardRunAcquireRequest};
+    use crate::task_board::TaskBoardAutomationScope;
     use crate::task_board::{TaskBoardOrchestrator, TaskBoardOrchestratorStatus};
 
     #[tokio::test]
@@ -169,12 +248,161 @@ mod tests {
                 .await
                 .expect("save database state");
 
-            let loaded = orchestrator_state(&db).await.expect("load database state");
+            let loaded = orchestrator_state(&db, false)
+                .await
+                .expect("load database state");
 
             assert!(!loaded.enabled);
             assert!(!loaded.running);
         })
         .await;
+    }
+
+    #[test]
+    fn running_legacy_step_intent_maps_to_step_control() {
+        let state = TaskBoardOrchestratorState {
+            enabled: true,
+            running: true,
+            ..TaskBoardOrchestratorState::default()
+        };
+        let settings = TaskBoardOrchestratorSettings {
+            step_mode: true,
+            ..TaskBoardOrchestratorSettings::default()
+        };
+
+        assert_eq!(
+            desired_mode_for_legacy_intent(&state, &settings),
+            TaskBoardAutomationDesiredMode::Step
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_bridges_running_legacy_intent_once() {
+        let temp = tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+        db.replace_task_board_orchestrator_state(&state(true, true))
+            .await
+            .expect("save running legacy intent");
+
+        initialize_durable_automation(&db)
+            .await
+            .expect("initialize automation");
+
+        let control = db
+            .task_board_automation_control()
+            .await
+            .expect("load durable control");
+        assert_eq!(
+            control.desired_mode,
+            TaskBoardAutomationDesiredMode::Continuous
+        );
+        assert_eq!(
+            control.admission_state,
+            TaskBoardAutomationAdmissionState::Accepting
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_preserves_an_explicit_durable_stop() {
+        let temp = tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+        db.replace_task_board_orchestrator_state(&state(true, true))
+            .await
+            .expect("save running legacy intent");
+        db.start_task_board_automation(
+            TaskBoardAutomationDesiredMode::Continuous,
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("start durable automation");
+        db.stop_task_board_automation(chrono::Utc::now())
+            .await
+            .expect("stop durable automation");
+        db.finish_task_board_automation_drain_if_idle(chrono::Utc::now())
+            .await
+            .expect("finish durable stop");
+
+        initialize_durable_automation(&db)
+            .await
+            .expect("reinitialize automation");
+
+        let control = db
+            .task_board_automation_control()
+            .await
+            .expect("load stopped control");
+        assert_eq!(control.desired_mode, TaskBoardAutomationDesiredMode::Off);
+        assert_eq!(
+            control.admission_state,
+            TaskBoardAutomationAdmissionState::Stopped
+        );
+    }
+
+    #[tokio::test]
+    async fn durable_tick_recovers_a_dropped_stopping_run_and_finishes_drain() {
+        let temp = tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+        let started_at = chrono::Utc::now();
+        db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, started_at)
+            .await
+            .expect("start automation");
+        let admission = db
+            .try_acquire_task_board_automation_run(&TaskBoardRunAcquireRequest {
+                run_id: "run-dropped-stop".into(),
+                trigger: TaskBoardAutomationRunTrigger::Scheduled,
+                actor: Some("scheduler-test".into()),
+                dry_run: false,
+                scope: TaskBoardAutomationScope::default(),
+                lease_owner: "scheduler-test-owner".into(),
+                now: started_at,
+            })
+            .await
+            .expect("acquire durable run");
+        assert!(matches!(
+            admission,
+            TaskBoardAutomationRunAdmission::Acquired(_)
+        ));
+        db.stop_task_board_automation(started_at + ChronoDuration::seconds(1))
+            .await
+            .expect("stop automation");
+        let expired_at = started_at - ChronoDuration::seconds(1);
+        query(
+            "UPDATE task_board_orchestrator_runs
+             SET lease_expires_at = ?2 WHERE run_id = ?1",
+        )
+        .bind("run-dropped-stop")
+        .bind(expired_at.to_rfc3339())
+        .execute(db.pool())
+        .await
+        .expect("expire dropped run");
+
+        let state = automation_tick_state(&db, true)
+            .await
+            .expect("maintain durable tick");
+
+        assert!(!state.enabled);
+        assert!(!state.running);
+        let run = query_as::<_, (String, String)>(
+            "SELECT state, outcome FROM task_board_orchestrator_runs WHERE run_id = ?1",
+        )
+        .bind("run-dropped-stop")
+        .fetch_one(db.pool())
+        .await
+        .expect("load recovered run");
+        assert_eq!(run, ("terminal".into(), "cancelled".into()));
+        let control = db
+            .task_board_automation_control()
+            .await
+            .expect("load stopped control");
+        assert_eq!(
+            control.admission_state,
+            TaskBoardAutomationAdmissionState::Stopped
+        );
     }
 
     fn state(enabled: bool, running: bool) -> TaskBoardOrchestratorState {

--- a/src/daemon/service/task_board_automation_runtime.rs
+++ b/src/daemon/service/task_board_automation_runtime.rs
@@ -1,0 +1,237 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::daemon::db::{
+    AsyncDaemonDb, TaskBoardAutomationRunAdmission, TaskBoardAutomationRunStage,
+    TaskBoardRunAcquireRequest,
+};
+use crate::errors::CliError;
+use crate::task_board::{
+    TaskBoardAutomationRunOutcome, TaskBoardAutomationRunTrigger, TaskBoardAutomationScope,
+};
+
+use super::TaskBoardOrchestratorRunGuard;
+use super::task_board_db::TaskBoardSyncRunContext;
+
+pub(crate) enum TaskBoardAutomationRunStart {
+    Acquired(Box<TaskBoardAutomationRunSession>),
+    Busy { run_id: String },
+    Disabled,
+}
+
+pub(crate) struct TaskBoardAutomationRunSession {
+    db: AsyncDaemonDb,
+    guard: Option<TaskBoardOrchestratorRunGuard>,
+    run_id: String,
+    sync_failed_scopes: Arc<AtomicBool>,
+}
+
+impl TaskBoardAutomationRunSession {
+    pub(crate) async fn acquire(
+        db: &AsyncDaemonDb,
+        trigger: TaskBoardAutomationRunTrigger,
+        actor: Option<String>,
+        dry_run: bool,
+        scope: TaskBoardAutomationScope,
+    ) -> Result<TaskBoardAutomationRunStart, CliError> {
+        let token = Uuid::new_v4().simple().to_string();
+        let run_id = format!("task-board-automation-{token}");
+        let admission = db
+            .try_acquire_task_board_automation_run(&TaskBoardRunAcquireRequest {
+                run_id: run_id.clone(),
+                trigger,
+                actor,
+                dry_run,
+                scope,
+                lease_owner: format!("task-board-coordinator-{token}"),
+                now: chrono::Utc::now(),
+            })
+            .await?;
+        let lease = match admission {
+            TaskBoardAutomationRunAdmission::Acquired(lease) => lease,
+            TaskBoardAutomationRunAdmission::Busy { run_id } => {
+                return Ok(TaskBoardAutomationRunStart::Busy { run_id });
+            }
+            TaskBoardAutomationRunAdmission::Disabled => {
+                return Ok(TaskBoardAutomationRunStart::Disabled);
+            }
+        };
+        let session = Self {
+            db: db.clone(),
+            guard: Some(TaskBoardOrchestratorRunGuard::start(db, lease)),
+            run_id,
+            sync_failed_scopes: Arc::new(AtomicBool::new(false)),
+        };
+        Ok(TaskBoardAutomationRunStart::Acquired(Box::new(session)))
+    }
+
+    pub(crate) fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    pub(crate) fn sync_context(&self) -> TaskBoardSyncRunContext {
+        TaskBoardSyncRunContext::orchestrator(
+            Some(self.run_id.clone()),
+            Some(self.guard().coordinator_fence()),
+            Some(Arc::clone(&self.sync_failed_scopes)),
+        )
+    }
+
+    pub(crate) fn had_sync_failures(&self) -> bool {
+        self.sync_failed_scopes.load(Ordering::SeqCst)
+    }
+
+    pub(crate) async fn begin_stage(
+        &self,
+        sequence: u64,
+        stage: &str,
+        summary: Option<String>,
+        payload: Option<Value>,
+    ) -> Result<(), CliError> {
+        self.guard().ensure_active().await?;
+        self.record_stage(sequence, stage, "running", summary, payload)
+            .await
+    }
+
+    pub(crate) async fn complete_stage(
+        &self,
+        sequence: u64,
+        stage: &str,
+        summary: Option<String>,
+        payload: Option<Value>,
+    ) -> Result<(), CliError> {
+        self.record_stage(sequence, stage, "completed", summary, payload)
+            .await
+    }
+
+    pub(crate) async fn fail_stage(
+        &self,
+        sequence: u64,
+        stage: &str,
+        error: &CliError,
+    ) -> Result<(), CliError> {
+        self.record_stage(
+            sequence,
+            stage,
+            "failed",
+            Some(error.to_string()),
+            Some(json!({ "error_kind": error.code() })),
+        )
+        .await
+    }
+
+    pub(crate) async fn finalize(
+        mut self,
+        outcome: TaskBoardAutomationRunOutcome,
+        error: Option<&CliError>,
+    ) -> Result<TaskBoardAutomationRunOutcome, CliError> {
+        let guard = self
+            .guard
+            .take()
+            .expect("run guard is present until finalize");
+        guard.finalize(outcome, error).await
+    }
+
+    async fn record_stage(
+        &self,
+        sequence: u64,
+        stage: &str,
+        stage_state: &str,
+        summary: Option<String>,
+        payload: Option<Value>,
+    ) -> Result<(), CliError> {
+        let now = chrono::Utc::now();
+        let record = TaskBoardAutomationRunStage {
+            sequence,
+            stage: stage.to_owned(),
+            state: stage_state.to_owned(),
+            recorded_at: now.to_rfc3339(),
+            summary,
+            payload,
+        };
+        self.db
+            .upsert_task_board_automation_run_stage(self.guard().lease(), &record, now)
+            .await
+            .map(|_| ())
+    }
+
+    fn guard(&self) -> &TaskBoardOrchestratorRunGuard {
+        self.guard
+            .as_ref()
+            .expect("run guard is present until finalize")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::query_scalar;
+
+    use super::*;
+    use crate::task_board::TaskBoardAutomationDesiredMode;
+
+    async fn database() -> AsyncDaemonDb {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.keep().join("harness.db");
+        AsyncDaemonDb::connect(&path).await.expect("open database")
+    }
+
+    #[tokio::test]
+    async fn session_persists_fenced_stages_and_correlated_audit_events() {
+        let db = database().await;
+        db.start_task_board_automation(
+            TaskBoardAutomationDesiredMode::Continuous,
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("start automation");
+        let start = TaskBoardAutomationRunSession::acquire(
+            &db,
+            TaskBoardAutomationRunTrigger::Manual,
+            Some("operator".into()),
+            false,
+            TaskBoardAutomationScope {
+                item_id: Some("item-neutral".into()),
+                ..TaskBoardAutomationScope::default()
+            },
+        )
+        .await
+        .expect("acquire run");
+        let TaskBoardAutomationRunStart::Acquired(session) = start else {
+            panic!("manual run should be admitted");
+        };
+        let session = *session;
+        let run_id = session.run_id().to_owned();
+
+        session
+            .begin_stage(1, "prepare", None, None)
+            .await
+            .expect("begin stage");
+        session
+            .complete_stage(1, "prepare", Some("ready".into()), None)
+            .await
+            .expect("complete stage");
+        session
+            .finalize(TaskBoardAutomationRunOutcome::Completed, None)
+            .await
+            .expect("finalize run");
+
+        let state = query_scalar::<_, String>(
+            "SELECT state FROM task_board_orchestrator_runs WHERE run_id = ?1",
+        )
+        .bind(&run_id)
+        .fetch_one(db.pool())
+        .await
+        .expect("load run state");
+        assert_eq!(state, "terminal");
+        let audit_count =
+            query_scalar::<_, i64>("SELECT COUNT(*) FROM audit_events WHERE correlation_id = ?1")
+                .bind(&run_id)
+                .fetch_one(db.pool())
+                .await
+                .expect("count correlated audits");
+        assert_eq!(audit_count, 4);
+    }
+}

--- a/src/daemon/service/task_board_db.rs
+++ b/src/daemon/service/task_board_db.rs
@@ -24,12 +24,18 @@ use crate::workspace::utc_now;
 
 use super::task_board::load_live_spawn_grants;
 
+pub(crate) use crate::task_board::external::{
+    TaskBoardSyncCoordinatorFence, TaskBoardSyncCoordinatorFenceDecision,
+};
+
 #[cfg(test)]
 mod external_ref_tests;
+mod provider_sync_context_store;
 mod provider_sync_execution;
 mod provider_sync_store;
 mod reviews_sync;
 mod sync_audit;
+mod sync_run_context;
 
 pub(crate) use reviews_sync::reconcile_shared_review_items_db;
 use reviews_sync::shared_review_request_clients;
@@ -38,6 +44,7 @@ pub(crate) use sync_audit::{
     ReviewsProjectionAuditSummary, record_reviews_projection_result,
     record_targeted_reviews_projection_result,
 };
+pub(crate) use sync_run_context::TaskBoardSyncRunContext;
 
 pub(crate) async fn create_task_board_item_db(
     db: &AsyncDaemonDb,
@@ -222,34 +229,46 @@ pub(crate) async fn sync_task_board_db(
     db: &AsyncDaemonDb,
     request: &TaskBoardSyncRequest,
 ) -> Result<TaskBoardSyncResponse, CliError> {
-    sync_task_board_db_with_trigger(
-        db,
-        request,
-        sync_audit::TaskBoardSyncAuditTrigger::Requested,
-    )
-    .await
+    sync_task_board_db_with_context(db, request, &TaskBoardSyncRunContext::requested()).await
 }
 
 pub(crate) async fn sync_task_board_for_orchestrator_db(
     db: &AsyncDaemonDb,
     request: &TaskBoardSyncRequest,
 ) -> Result<TaskBoardSyncResponse, CliError> {
-    sync_task_board_db_with_trigger(
+    sync_task_board_for_orchestrator_with_context_db(
         db,
         request,
-        sync_audit::TaskBoardSyncAuditTrigger::Orchestrator,
+        &TaskBoardSyncRunContext::orchestrator(None, None, None),
     )
     .await
 }
 
-async fn sync_task_board_db_with_trigger(
+pub(crate) async fn sync_task_board_for_orchestrator_with_context_db(
     db: &AsyncDaemonDb,
     request: &TaskBoardSyncRequest,
-    trigger: sync_audit::TaskBoardSyncAuditTrigger,
+    context: &TaskBoardSyncRunContext,
+) -> Result<TaskBoardSyncResponse, CliError> {
+    sync_task_board_db_with_context(db, request, context).await
+}
+
+async fn sync_task_board_db_with_context(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardSyncRequest,
+    context: &TaskBoardSyncRunContext,
 ) -> Result<TaskBoardSyncResponse, CliError> {
     let mut metrics = SyncExecutionMetrics::default();
-    let result = provider_sync_execution::execute(db, request, &mut metrics).await;
-    let audit = sync_audit::record_request_result(db, request, trigger, &result, &metrics).await;
+    let result = provider_sync_execution::execute(db, request, context, &mut metrics).await;
+    context.observe_sync_metrics(&metrics);
+    let audit = sync_audit::record_request_result_with_correlation(
+        db,
+        request,
+        context.trigger(),
+        context.correlation_id(),
+        &result,
+        &metrics,
+    )
+    .await;
     combine_sync_and_audit_results(result, audit)
 }
 

--- a/src/daemon/service/task_board_db/provider_sync_context_store.rs
+++ b/src/daemon/service/task_board_db/provider_sync_context_store.rs
@@ -1,0 +1,282 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::errors::CliError;
+use crate::task_board::external::{
+    ExternalCreateOutcome, ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision,
+    ExternalProviderScopeState, TaskBoardSyncCoordinatorFence,
+    TaskBoardSyncCoordinatorFenceDecision, TaskBoardSyncItemSnapshot,
+};
+use crate::task_board::store::TaskBoardItemPatch;
+use crate::task_board::{
+    ExternalProvider, ExternalRef, ExternalSyncField, TaskBoardExternalCreateBegin,
+    TaskBoardExternalCreateFinalizeResult, TaskBoardExternalCreateIntent,
+    TaskBoardExternalCreateStore, TaskBoardItem, TaskBoardStatus, TaskBoardSyncConflict,
+    TaskBoardSyncStore,
+};
+
+pub(super) struct ProviderSyncRunStore<'a> {
+    db: &'a AsyncDaemonDb,
+    coordinator_fence: Option<Arc<dyn TaskBoardSyncCoordinatorFence>>,
+    coordinator_cancelled: AtomicBool,
+}
+
+impl<'a> ProviderSyncRunStore<'a> {
+    pub(super) fn new(
+        db: &'a AsyncDaemonDb,
+        coordinator_fence: Option<Arc<dyn TaskBoardSyncCoordinatorFence>>,
+    ) -> Self {
+        Self {
+            db,
+            coordinator_fence,
+            coordinator_cancelled: AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait]
+impl TaskBoardExternalCreateStore for ProviderSyncRunStore<'_> {
+    async fn begin_external_create_intent(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        scope_id: &str,
+        provider_target: &str,
+    ) -> Result<TaskBoardExternalCreateBegin, CliError> {
+        <AsyncDaemonDb as TaskBoardExternalCreateStore>::begin_external_create_intent(
+            self.db,
+            item_id,
+            provider,
+            scope_id,
+            provider_target,
+        )
+        .await
+    }
+
+    async fn record_external_create_outcome(
+        &self,
+        intent: &TaskBoardExternalCreateIntent,
+        outcome: &ExternalCreateOutcome,
+        provider_baseline: &ExternalRef,
+    ) -> Result<TaskBoardExternalCreateIntent, CliError> {
+        <AsyncDaemonDb as TaskBoardExternalCreateStore>::record_external_create_outcome(
+            self.db,
+            intent,
+            outcome,
+            provider_baseline,
+        )
+        .await
+    }
+
+    async fn finalize_external_create_intent(
+        &self,
+        intent: &TaskBoardExternalCreateIntent,
+    ) -> Result<TaskBoardExternalCreateFinalizeResult, CliError> {
+        <AsyncDaemonDb as TaskBoardExternalCreateStore>::finalize_external_create_intent(
+            self.db, intent,
+        )
+        .await
+    }
+
+    async fn list_created_external_create_intents(
+        &self,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        <AsyncDaemonDb as TaskBoardExternalCreateStore>::list_created_external_create_intents(
+            self.db,
+        )
+        .await
+    }
+
+    async fn list_in_flight_external_create_intents(
+        &self,
+        provider: ExternalProvider,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        <AsyncDaemonDb as TaskBoardExternalCreateStore>::list_in_flight_external_create_intents(
+            self.db, provider,
+        )
+        .await
+    }
+
+    async fn external_create_intent_by_create_key(
+        &self,
+        provider: ExternalProvider,
+        create_key: &str,
+    ) -> Result<Option<TaskBoardExternalCreateIntent>, CliError> {
+        <AsyncDaemonDb as TaskBoardExternalCreateStore>::external_create_intent_by_create_key(
+            self.db, provider, create_key,
+        )
+        .await
+    }
+
+    async fn list_pending_external_create_follow_ups(
+        &self,
+        provider: Option<ExternalProvider>,
+    ) -> Result<Vec<TaskBoardExternalCreateIntent>, CliError> {
+        <AsyncDaemonDb as TaskBoardExternalCreateStore>::list_pending_external_create_follow_ups(
+            self.db, provider,
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl TaskBoardSyncStore for ProviderSyncRunStore<'_> {
+    async fn list_items(
+        &self,
+        status: Option<TaskBoardStatus>,
+    ) -> Result<Vec<TaskBoardItem>, CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::list_items(self.db, status).await
+    }
+
+    async fn list_items_including_deleted(&self) -> Result<Vec<TaskBoardItem>, CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::list_items_including_deleted(self.db).await
+    }
+
+    async fn create_item(&self, item: TaskBoardItem) -> Result<TaskBoardItem, CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::create_item(self.db, item).await
+    }
+
+    async fn update_item(
+        &self,
+        expected_item: &TaskBoardItem,
+        patch: TaskBoardItemPatch,
+    ) -> Result<TaskBoardItem, CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::update_item(self.db, expected_item, patch).await
+    }
+
+    async fn item_snapshot(&self, item_id: &str) -> Result<TaskBoardSyncItemSnapshot, CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::item_snapshot(self.db, item_id).await
+    }
+
+    async fn provider_scope_state(
+        &self,
+        provider: ExternalProvider,
+        scope_id: &str,
+    ) -> Result<ExternalProviderScopeState, CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::provider_scope_state(self.db, provider, scope_id)
+            .await
+    }
+
+    async fn begin_provider_scope_attempt(
+        &self,
+        provider: ExternalProvider,
+        scope_id: &str,
+        now: &str,
+    ) -> Result<ExternalProviderScopeAttemptDecision, CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::begin_provider_scope_attempt(
+            self.db, provider, scope_id, now,
+        )
+        .await
+    }
+
+    async fn renew_provider_scope_attempt(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        now: &str,
+    ) -> Result<(), CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::renew_provider_scope_attempt(self.db, attempt, now)
+            .await
+    }
+
+    async fn check_coordinator_fence(
+        &self,
+    ) -> Result<TaskBoardSyncCoordinatorFenceDecision, CliError> {
+        let Some(fence) = &self.coordinator_fence else {
+            return Ok(TaskBoardSyncCoordinatorFenceDecision::Current);
+        };
+        let decision = fence.check().await?;
+        if matches!(
+            &decision,
+            TaskBoardSyncCoordinatorFenceDecision::Cancelled(_)
+        ) {
+            self.coordinator_cancelled.store(true, Ordering::SeqCst);
+        }
+        Ok(decision)
+    }
+
+    fn coordinator_cancelled(&self) -> bool {
+        self.coordinator_cancelled.load(Ordering::SeqCst)
+    }
+
+    async fn release_provider_scope_attempt(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        released_at: &str,
+    ) -> Result<(), CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::release_provider_scope_attempt(
+            self.db,
+            attempt,
+            released_at,
+        )
+        .await
+    }
+
+    async fn complete_provider_scope_success(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        base_revision: Option<&str>,
+        completed_at: &str,
+    ) -> Result<(), CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::complete_provider_scope_success(
+            self.db,
+            attempt,
+            base_revision,
+            completed_at,
+        )
+        .await
+    }
+
+    async fn complete_provider_scope_failure(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        completed_at: &str,
+    ) -> Result<ExternalProviderScopeState, CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::complete_provider_scope_failure(
+            self.db,
+            attempt,
+            completed_at,
+        )
+        .await
+    }
+
+    async fn replace_open_sync_conflicts(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        external_ref: &str,
+        item_revision: i64,
+        conflicts: &[TaskBoardSyncConflict],
+    ) -> Result<(), CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::replace_open_sync_conflicts(
+            self.db,
+            item_id,
+            provider,
+            external_ref,
+            item_revision,
+            conflicts,
+        )
+        .await
+    }
+
+    async fn supersede_open_sync_conflicts(
+        &self,
+        item_id: &str,
+        provider: ExternalProvider,
+        external_ref: &str,
+        item_revision: i64,
+        resolved_fields: &[ExternalSyncField],
+    ) -> Result<(), CliError> {
+        <AsyncDaemonDb as TaskBoardSyncStore>::supersede_open_sync_conflicts(
+            self.db,
+            item_id,
+            provider,
+            external_ref,
+            item_revision,
+            resolved_fields,
+        )
+        .await
+    }
+}

--- a/src/daemon/service/task_board_db/provider_sync_execution.rs
+++ b/src/daemon/service/task_board_db/provider_sync_execution.rs
@@ -9,11 +9,14 @@ use crate::task_board::external::{
 };
 use crate::task_board::{ExternalSyncClient, configured_sync_clients_without_review_requests};
 
+use super::TaskBoardSyncRunContext;
+use super::provider_sync_context_store::ProviderSyncRunStore;
 use super::sync_audit::SyncExecutionMetrics;
 
 pub(super) async fn execute(
     db: &AsyncDaemonDb,
     request: &TaskBoardSyncRequest,
+    context: &TaskBoardSyncRunContext,
     metrics: &mut SyncExecutionMetrics,
 ) -> Result<TaskBoardSyncResponse, CliError> {
     let options = super::super::task_board::sync_options(request);
@@ -84,7 +87,9 @@ pub(super) async fn execute(
     if !has_recovery {
         super::super::task_board::ensure_sync_request_can_run(request, &config, &clients)?;
     }
-    let mut batch = sync_external_tasks_scoped_with_recovery(db, options, &clients, plan).await?;
+    let run_store = ProviderSyncRunStore::new(db, context.coordinator_fence());
+    let mut batch =
+        sync_external_tasks_scoped_with_recovery(&run_store, options, &clients, plan).await?;
     if !options.dry_run
         && let Err(error) = super::sync_audit::record_external_create_follow_ups(
             db,
@@ -142,9 +147,14 @@ mod tests {
         let (_dir, db, request) = config_failure_fixture().await;
         let mut metrics = SyncExecutionMetrics::default();
 
-        execute(&db, &request, &mut metrics)
-            .await
-            .expect_err("configuration load must fail");
+        execute(
+            &db,
+            &request,
+            &TaskBoardSyncRunContext::requested(),
+            &mut metrics,
+        )
+        .await
+        .expect_err("configuration load must fail");
 
         assert_eq!(metrics.operations().len(), 1);
         assert!(metrics.operations()[0].applied);
@@ -174,9 +184,14 @@ mod tests {
         assert_eq!(payload["applied_operation_count"].as_u64(), Some(0));
 
         let mut second_metrics = SyncExecutionMetrics::default();
-        execute(&db, &request, &mut second_metrics)
-            .await
-            .expect_err("configuration remains invalid");
+        execute(
+            &db,
+            &request,
+            &TaskBoardSyncRunContext::requested(),
+            &mut second_metrics,
+        )
+        .await
+        .expect_err("configuration remains invalid");
 
         assert!(second_metrics.operations().is_empty());
         assert_eq!(follow_up_events(&db).await.len(), 1);
@@ -197,16 +212,26 @@ mod tests {
             .expect("finalize before simulated crash");
         let mut first_metrics = SyncExecutionMetrics::default();
 
-        execute(&db, &request, &mut first_metrics)
-            .await
-            .expect_err("configuration remains invalid");
+        execute(
+            &db,
+            &request,
+            &TaskBoardSyncRunContext::requested(),
+            &mut first_metrics,
+        )
+        .await
+        .expect_err("configuration remains invalid");
 
         assert!(first_metrics.operations().is_empty());
         assert_eq!(follow_up_events(&db).await.len(), 1);
         let mut second_metrics = SyncExecutionMetrics::default();
-        execute(&db, &request, &mut second_metrics)
-            .await
-            .expect_err("configuration remains invalid");
+        execute(
+            &db,
+            &request,
+            &TaskBoardSyncRunContext::requested(),
+            &mut second_metrics,
+        )
+        .await
+        .expect_err("configuration remains invalid");
         assert!(second_metrics.operations().is_empty());
         assert_eq!(follow_up_events(&db).await.len(), 1);
     }
@@ -227,9 +252,14 @@ mod tests {
         request.dry_run = true;
         let mut metrics = SyncExecutionMetrics::default();
 
-        let error = execute(&db, &request, &mut metrics)
-            .await
-            .expect_err("pending follow-up must block preview");
+        let error = execute(
+            &db,
+            &request,
+            &TaskBoardSyncRunContext::requested(),
+            &mut metrics,
+        )
+        .await
+        .expect_err("pending follow-up must block preview");
 
         assert!(error.message().contains("blocks dry-run"));
         assert!(metrics.operations().is_empty());

--- a/src/daemon/service/task_board_db/provider_sync_store.rs
+++ b/src/daemon/service/task_board_db/provider_sync_store.rs
@@ -151,6 +151,15 @@ impl TaskBoardSyncStore for AsyncDaemonDb {
             .await
     }
 
+    async fn release_provider_scope_attempt(
+        &self,
+        attempt: &ExternalProviderScopeAttempt,
+        released_at: &str,
+    ) -> Result<(), CliError> {
+        self.release_task_board_provider_scope_attempt(attempt, released_at)
+            .await
+    }
+
     async fn complete_provider_scope_success(
         &self,
         attempt: &ExternalProviderScopeAttempt,

--- a/src/daemon/service/task_board_db/sync_audit.rs
+++ b/src/daemon/service/task_board_db/sync_audit.rs
@@ -106,10 +106,10 @@ pub(super) async fn record_request_result_with_correlation(
 ) -> Result<(), CliError> {
     let _audit_lane = acquire_audit_lane(db, trigger).await;
     let observation = AuditObservation::for_request(result.as_ref().err(), metrics);
-    let pending = correlation_id.map_or_else(
-        || plan_audit(db, trigger, observation),
-        |_| Some(PendingAudit::untracked()),
-    );
+    let force_correlated_evidence =
+        correlation_id.is_some() && correlated_audit_is_required(result, metrics);
+    let pending = plan_audit(db, trigger, observation)
+        .or_else(|| force_correlated_evidence.then(PendingAudit::untracked));
     let Some(pending) = pending else {
         return Ok(());
     };
@@ -123,6 +123,13 @@ pub(super) async fn record_request_result_with_correlation(
     persist_sync_audit_result(db, trigger, correlation_id, payload, classification, result).await?;
     pending.commit();
     Ok(())
+}
+
+fn correlated_audit_is_required(
+    result: &Result<TaskBoardSyncResponse, CliError>,
+    metrics: &SyncExecutionMetrics,
+) -> bool {
+    result.is_err() || metrics.has_applied_change() || metrics.failed_scope_count() > 0
 }
 
 pub(crate) async fn record_reviews_projection_result(

--- a/src/daemon/service/task_board_db/sync_audit.rs
+++ b/src/daemon/service/task_board_db/sync_audit.rs
@@ -85,6 +85,7 @@ impl TaskBoardSyncAuditTrigger {
     }
 }
 
+#[cfg(test)]
 pub(super) async fn record_request_result(
     db: &AsyncDaemonDb,
     request: &TaskBoardSyncRequest,
@@ -92,9 +93,24 @@ pub(super) async fn record_request_result(
     result: &Result<TaskBoardSyncResponse, CliError>,
     metrics: &SyncExecutionMetrics,
 ) -> Result<(), CliError> {
+    record_request_result_with_correlation(db, request, trigger, None, result, metrics).await
+}
+
+pub(super) async fn record_request_result_with_correlation(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardSyncRequest,
+    trigger: TaskBoardSyncAuditTrigger,
+    correlation_id: Option<&str>,
+    result: &Result<TaskBoardSyncResponse, CliError>,
+    metrics: &SyncExecutionMetrics,
+) -> Result<(), CliError> {
     let _audit_lane = acquire_audit_lane(db, trigger).await;
     let observation = AuditObservation::for_request(result.as_ref().err(), metrics);
-    let Some(pending) = plan_audit(db, trigger, observation) else {
+    let pending = correlation_id.map_or_else(
+        || plan_audit(db, trigger, observation),
+        |_| Some(PendingAudit::untracked()),
+    );
+    let Some(pending) = pending else {
         return Ok(());
     };
     let mut payload = request_payload(request, trigger);
@@ -104,7 +120,7 @@ pub(super) async fn record_request_result(
         add_summary_counts(&mut payload, summary.total, &summary.operations);
     }
     let classification = SyncAuditClassification::for_request(result, metrics);
-    persist_sync_audit_result(db, trigger, payload, classification, result).await?;
+    persist_sync_audit_result(db, trigger, correlation_id, payload, classification, result).await?;
     pending.commit();
     Ok(())
 }
@@ -172,7 +188,7 @@ async fn persist_reviews_audit(
 ) {
     let classification = SyncAuditClassification::for_result(result);
     if let Err(error) =
-        persist_sync_audit_result(db, trigger, payload, classification, result).await
+        persist_sync_audit_result(db, trigger, None, payload, classification, result).await
     {
         log_reviews_audit_failure(trigger, &error);
         return;
@@ -229,3 +245,7 @@ mod tests;
 #[cfg(test)]
 #[path = "sync_audit_acceptance_tests.rs"]
 mod acceptance_tests;
+
+#[cfg(test)]
+#[path = "sync_audit_correlation_tests.rs"]
+mod correlation_tests;

--- a/src/daemon/service/task_board_db/sync_audit_correlation_tests.rs
+++ b/src/daemon/service/task_board_db/sync_audit_correlation_tests.rs
@@ -1,0 +1,88 @@
+use tempfile::tempdir;
+
+use super::*;
+use crate::daemon::protocol::{
+    HarnessMonitorAuditEvent, HarnessMonitorAuditEventsRequest, TaskBoardSyncRequest,
+};
+use crate::errors::CliErrorKind;
+use crate::task_board::external::{ExternalSyncBatch, ExternalSyncScopeOutcome};
+use crate::task_board::{ExternalProvider, TaskBoardSyncSummary};
+
+#[tokio::test]
+async fn each_orchestrator_run_keeps_its_correlated_sync_evidence() {
+    let (_dir, db) = open_db().await;
+    let request = TaskBoardSyncRequest::default();
+    let provider_error = CliErrorKind::workflow_io("provider unavailable").into();
+    let batch = ExternalSyncBatch {
+        operations: Vec::new(),
+        external_create_follow_ups: Vec::new(),
+        scope_outcomes: vec![ExternalSyncScopeOutcome::failed(
+            ExternalProvider::Todoist,
+            "scope-a".into(),
+            &provider_error,
+        )],
+        first_provider_failure: Some(provider_error),
+        terminal_error: None,
+    };
+    let mut metrics = SyncExecutionMetrics::default();
+    metrics.capture(&batch);
+    let result = batch
+        .into_completed()
+        .map(|completed| sync_summary(completed.operations));
+
+    record_request_result_with_correlation(
+        &db,
+        &request,
+        TaskBoardSyncAuditTrigger::Orchestrator,
+        Some("run-a"),
+        &result,
+        &metrics,
+    )
+    .await
+    .expect("record initial correlated failure");
+    record_request_result_with_correlation(
+        &db,
+        &request,
+        TaskBoardSyncAuditTrigger::Orchestrator,
+        Some("run-b"),
+        &result,
+        &metrics,
+    )
+    .await
+    .expect("record repeated failure for the next run");
+
+    let events = sync_events(&db).await;
+    assert_eq!(events.len(), 2);
+    let mut correlations = events
+        .iter()
+        .filter_map(|event| event.correlation_id.as_deref())
+        .collect::<Vec<_>>();
+    correlations.sort_unstable();
+    assert_eq!(correlations, ["run-a", "run-b"]);
+}
+
+async fn open_db() -> (tempfile::TempDir, AsyncDaemonDb) {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("open async database");
+    (dir, db)
+}
+
+async fn sync_events(db: &AsyncDaemonDb) -> Vec<HarnessMonitorAuditEvent> {
+    db.load_audit_events(&HarnessMonitorAuditEventsRequest {
+        action_keys: vec!["task_board.sync".into()],
+        ..HarnessMonitorAuditEventsRequest::default()
+    })
+    .await
+    .expect("load sync audit events")
+    .events
+}
+
+fn sync_summary(operations: Vec<crate::task_board::ExternalSyncOperation>) -> TaskBoardSyncSummary {
+    TaskBoardSyncSummary {
+        total: 0,
+        providers: Vec::new(),
+        operations,
+    }
+}

--- a/src/daemon/service/task_board_db/sync_audit_correlation_tests.rs
+++ b/src/daemon/service/task_board_db/sync_audit_correlation_tests.rs
@@ -61,6 +61,99 @@ async fn each_orchestrator_run_keeps_its_correlated_sync_evidence() {
     assert_eq!(correlations, ["run-a", "run-b"]);
 }
 
+#[tokio::test]
+async fn correlated_stable_noop_uses_background_audit_planning() {
+    let (_dir, db) = open_db().await;
+    let request = TaskBoardSyncRequest::default();
+    let metrics = SyncExecutionMetrics::default();
+    let result = Ok(sync_summary(Vec::new()));
+
+    for correlation_id in ["run-noop-a", "run-noop-b"] {
+        record_request_result_with_correlation(
+            &db,
+            &request,
+            TaskBoardSyncAuditTrigger::Orchestrator,
+            Some(correlation_id),
+            &result,
+            &metrics,
+        )
+        .await
+        .expect("plan correlated no-op audit");
+    }
+
+    assert!(sync_events(&db).await.is_empty());
+}
+
+#[tokio::test]
+async fn correlated_failure_seeds_scope_recovery_tracking() {
+    let (_dir, db) = open_db().await;
+    let request = TaskBoardSyncRequest::default();
+    let provider_error = CliErrorKind::workflow_io("provider unavailable").into();
+    let failed_batch = ExternalSyncBatch {
+        operations: Vec::new(),
+        external_create_follow_ups: Vec::new(),
+        scope_outcomes: vec![ExternalSyncScopeOutcome::failed(
+            ExternalProvider::Todoist,
+            "scope-a".into(),
+            &provider_error,
+        )],
+        first_provider_failure: Some(provider_error),
+        terminal_error: None,
+    };
+    let mut failed_metrics = SyncExecutionMetrics::default();
+    failed_metrics.capture(&failed_batch);
+    let failed_result = failed_batch
+        .into_completed()
+        .map(|completed| sync_summary(completed.operations));
+    record_request_result_with_correlation(
+        &db,
+        &request,
+        TaskBoardSyncAuditTrigger::Orchestrator,
+        Some("run-failed"),
+        &failed_result,
+        &failed_metrics,
+    )
+    .await
+    .expect("record correlated failure");
+
+    let recovered_batch = ExternalSyncBatch {
+        operations: Vec::new(),
+        external_create_follow_ups: Vec::new(),
+        scope_outcomes: vec![ExternalSyncScopeOutcome::success(
+            ExternalProvider::Todoist,
+            "scope-a".into(),
+        )],
+        first_provider_failure: None,
+        terminal_error: None,
+    };
+    let mut recovered_metrics = SyncExecutionMetrics::default();
+    recovered_metrics.capture(&recovered_batch);
+    let recovered_result = Ok(sync_summary(recovered_batch.operations));
+    record_request_result_with_correlation(
+        &db,
+        &request,
+        TaskBoardSyncAuditTrigger::Orchestrator,
+        Some("run-recovered"),
+        &recovered_result,
+        &recovered_metrics,
+    )
+    .await
+    .expect("record correlated recovery");
+
+    let events = sync_events(&db).await;
+    assert_eq!(events.len(), 2);
+    let recovered = events
+        .iter()
+        .find(|event| event.correlation_id.as_deref() == Some("run-recovered"))
+        .expect("correlated recovery event");
+    let payload = recovered.payload_json.as_ref().expect("recovery payload");
+    assert_eq!(payload["recovered"].as_bool(), Some(true));
+    assert_eq!(
+        payload["recovery"]["scopes"][0]["scope_id"].as_str(),
+        Some("scope-a")
+    );
+}
+
 async fn open_db() -> (tempfile::TempDir, AsyncDaemonDb) {
     let dir = tempdir().expect("tempdir");
     let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))

--- a/src/daemon/service/task_board_db/sync_audit_metrics.rs
+++ b/src/daemon/service/task_board_db/sync_audit_metrics.rs
@@ -100,7 +100,7 @@ impl SyncExecutionMetrics {
         self.operations.iter().any(|operation| operation.applied)
     }
 
-    pub(super) const fn failed_scope_count(&self) -> usize {
+    pub(in crate::daemon::service::task_board_db) const fn failed_scope_count(&self) -> usize {
         self.failed_scope_count
     }
 

--- a/src/daemon/service/task_board_db/sync_audit_persistence.rs
+++ b/src/daemon/service/task_board_db/sync_audit_persistence.rs
@@ -72,11 +72,18 @@ impl SyncAuditClassification {
 pub(super) async fn persist_sync_audit_result<T>(
     db: &AsyncDaemonDb,
     trigger: TaskBoardSyncAuditTrigger,
+    correlation_id: Option<&str>,
     payload_json: Value,
     classification: SyncAuditClassification,
     result: &Result<T, CliError>,
 ) -> Result<(), CliError> {
-    let event = sync_audit_event(trigger, payload_json, classification, result);
+    let event = sync_audit_event(
+        trigger,
+        correlation_id,
+        payload_json,
+        classification,
+        result,
+    );
     db.upsert_audit_event(&event).await?;
     broadcast_audit_event(&event);
     Ok(())
@@ -97,6 +104,7 @@ pub(in crate::daemon::service::task_board_db) async fn record_external_create_fo
 
 fn sync_audit_event<T>(
     trigger: TaskBoardSyncAuditTrigger,
+    correlation_id: Option<&str>,
     payload_json: Value,
     classification: SyncAuditClassification,
     result: &Result<T, CliError>,
@@ -118,7 +126,7 @@ fn sync_audit_event<T>(
         summary: presentation.summary,
         subject: None,
         actor: Some(trigger.actor().to_owned()),
-        correlation_id: None,
+        correlation_id: correlation_id.map(str::to_owned),
         action_key: Some("task_board.sync".to_owned()),
         payload_json: Some(payload_json),
         legacy_message: None,

--- a/src/daemon/service/task_board_db/sync_run_context.rs
+++ b/src/daemon/service/task_board_db/sync_run_context.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::task_board::external::TaskBoardSyncCoordinatorFence;
+
+use super::sync_audit::{SyncExecutionMetrics, TaskBoardSyncAuditTrigger};
+
+#[derive(Clone)]
+pub(crate) struct TaskBoardSyncRunContext {
+    trigger: TaskBoardSyncAuditTrigger,
+    correlation_id: Option<String>,
+    coordinator_fence: Option<Arc<dyn TaskBoardSyncCoordinatorFence>>,
+    sync_failed_scopes: Option<Arc<AtomicBool>>,
+}
+
+impl TaskBoardSyncRunContext {
+    pub(crate) fn requested() -> Self {
+        Self {
+            trigger: TaskBoardSyncAuditTrigger::Requested,
+            correlation_id: None,
+            coordinator_fence: None,
+            sync_failed_scopes: None,
+        }
+    }
+
+    pub(crate) fn orchestrator(
+        run_id: Option<String>,
+        coordinator_fence: Option<Arc<dyn TaskBoardSyncCoordinatorFence>>,
+        sync_failed_scopes: Option<Arc<AtomicBool>>,
+    ) -> Self {
+        Self {
+            trigger: TaskBoardSyncAuditTrigger::Orchestrator,
+            correlation_id: run_id,
+            coordinator_fence,
+            sync_failed_scopes,
+        }
+    }
+
+    pub(super) const fn trigger(&self) -> TaskBoardSyncAuditTrigger {
+        self.trigger
+    }
+
+    pub(super) fn correlation_id(&self) -> Option<&str> {
+        self.correlation_id.as_deref()
+    }
+
+    pub(super) fn coordinator_fence(&self) -> Option<Arc<dyn TaskBoardSyncCoordinatorFence>> {
+        self.coordinator_fence.clone()
+    }
+
+    pub(super) fn observe_sync_metrics(&self, metrics: &SyncExecutionMetrics) {
+        if metrics.failed_scope_count() > 0
+            && let Some(signal) = &self.sync_failed_scopes
+        {
+            signal.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::errors::CliErrorKind;
+    use crate::task_board::ExternalProvider;
+    use crate::task_board::external::{ExternalSyncBatch, ExternalSyncScopeOutcome};
+
+    use super::*;
+
+    #[test]
+    fn failed_provider_scope_sets_the_shared_run_signal() {
+        let signal = Arc::new(AtomicBool::new(false));
+        let context = TaskBoardSyncRunContext::orchestrator(None, None, Some(Arc::clone(&signal)));
+        let error = CliErrorKind::workflow_io("provider unavailable").into();
+        let batch = ExternalSyncBatch {
+            operations: Vec::new(),
+            external_create_follow_ups: Vec::new(),
+            scope_outcomes: vec![ExternalSyncScopeOutcome::failed(
+                ExternalProvider::Todoist,
+                "scope-neutral".into(),
+                &error,
+            )],
+            first_provider_failure: Some(error),
+            terminal_error: None,
+        };
+        let mut metrics = SyncExecutionMetrics::default();
+        metrics.capture(&batch);
+
+        context.observe_sync_metrics(&metrics);
+
+        assert!(signal.load(Ordering::SeqCst));
+    }
+}

--- a/src/daemon/service/task_board_orchestrator_control.rs
+++ b/src/daemon/service/task_board_orchestrator_control.rs
@@ -152,7 +152,7 @@ async fn status_from_state(
         let control = db.task_board_automation_control().await?;
         (
             control.desired_mode != TaskBoardAutomationDesiredMode::Off,
-            control.admission_state != TaskBoardAutomationAdmissionState::Stopped,
+            control.admission_state == TaskBoardAutomationAdmissionState::Accepting,
         )
     } else {
         (state.enabled, state.running)
@@ -185,6 +185,8 @@ mod tests {
     use sqlx::query_scalar;
 
     use super::*;
+    use crate::daemon::db::{TaskBoardAutomationRunAdmission, TaskBoardRunAcquireRequest};
+    use crate::task_board::{TaskBoardAutomationRunTrigger, TaskBoardAutomationScope};
 
     #[test]
     fn step_mode_selects_step_admission() {
@@ -250,5 +252,49 @@ mod tests {
             control.admission_state,
             TaskBoardAutomationAdmissionState::Stopped
         );
+    }
+
+    #[tokio::test]
+    async fn durable_status_is_not_running_while_control_is_draining() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+        let now = Utc::now();
+        db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+            .await
+            .expect("start automation");
+        let admission = db
+            .try_acquire_task_board_automation_run(&TaskBoardRunAcquireRequest {
+                run_id: "run-status-draining".into(),
+                trigger: TaskBoardAutomationRunTrigger::Scheduled,
+                actor: Some("scheduler-test".into()),
+                dry_run: false,
+                scope: TaskBoardAutomationScope::default(),
+                lease_owner: "scheduler-test-owner".into(),
+                now,
+            })
+            .await
+            .expect("acquire active run");
+        assert!(matches!(
+            admission,
+            TaskBoardAutomationRunAdmission::Acquired(_)
+        ));
+        db.stop_task_board_automation(Utc::now())
+            .await
+            .expect("start draining");
+
+        let status = status_from_state(
+            &db,
+            db.task_board_orchestrator_state()
+                .await
+                .expect("load orchestrator state"),
+            true,
+        )
+        .await
+        .expect("load durable status");
+
+        assert!(!status.enabled);
+        assert!(!status.running);
     }
 }

--- a/src/daemon/service/task_board_orchestrator_control.rs
+++ b/src/daemon/service/task_board_orchestrator_control.rs
@@ -1,0 +1,254 @@
+use chrono::Utc;
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::daemon::protocol::{
+    TaskBoardOrchestratorSettingsResponse, TaskBoardOrchestratorSettingsUpdateRequest,
+    TaskBoardOrchestratorStatusResponse,
+};
+use crate::errors::CliError;
+use crate::feature_flags::task_board_automation_v2_enabled_from_env;
+use crate::task_board::{
+    TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode,
+    TaskBoardOrchestratorSettings, TaskBoardOrchestratorState, TaskBoardWorkflowExecutionCount,
+    TaskBoardWorkflowStatus,
+};
+
+use super::task_board_db::task_board_host_local_db;
+use super::task_board_orchestrator_settings::{
+    apply_settings_update, normalize_github_inbox, normalize_todoist_inbox,
+};
+
+pub(crate) async fn task_board_orchestrator_status_db(
+    db: &AsyncDaemonDb,
+) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
+    let state = db.task_board_orchestrator_state().await?;
+    status_from_state(db, state, task_board_automation_v2_enabled_from_env()).await
+}
+
+pub(crate) async fn start_task_board_orchestrator_db(
+    db: &AsyncDaemonDb,
+) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
+    start_task_board_orchestrator_with_durable(db, task_board_automation_v2_enabled_from_env())
+        .await
+}
+
+async fn start_task_board_orchestrator_with_durable(
+    db: &AsyncDaemonDb,
+    durable_enabled: bool,
+) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
+    if durable_enabled {
+        let settings = db.task_board_orchestrator_settings().await?;
+        db.start_task_board_automation(desired_mode_for_settings(&settings), Utc::now())
+            .await?;
+    }
+    set_running_intent(db, true, true, durable_enabled).await
+}
+
+pub(crate) async fn stop_task_board_orchestrator_db(
+    db: &AsyncDaemonDb,
+) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
+    stop_task_board_orchestrator_with_durable(db, task_board_automation_v2_enabled_from_env()).await
+}
+
+async fn stop_task_board_orchestrator_with_durable(
+    db: &AsyncDaemonDb,
+    durable_enabled: bool,
+) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
+    if durable_enabled {
+        let now = Utc::now();
+        db.stop_task_board_automation(now).await?;
+        db.finish_task_board_automation_drain_if_idle(now).await?;
+    }
+    set_running_intent(db, false, false, durable_enabled).await
+}
+
+pub(crate) async fn task_board_orchestrator_settings_db(
+    db: &AsyncDaemonDb,
+) -> Result<TaskBoardOrchestratorSettingsResponse, CliError> {
+    db.task_board_orchestrator_settings().await
+}
+
+pub(crate) async fn update_task_board_orchestrator_settings_db(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardOrchestratorSettingsUpdateRequest,
+) -> Result<TaskBoardOrchestratorSettingsResponse, CliError> {
+    let mut settings = db.task_board_orchestrator_settings().await?;
+    apply_settings_update(&mut settings, request);
+    settings.github_inbox = normalize_github_inbox(&settings.github_inbox)?;
+    settings.todoist_inbox = normalize_todoist_inbox(&settings.todoist_inbox);
+    db.replace_task_board_orchestrator_settings(&settings)
+        .await?;
+    update_running_automation_mode(db, &settings, task_board_automation_v2_enabled_from_env())
+        .await?;
+    Ok(settings)
+}
+
+async fn update_running_automation_mode(
+    db: &AsyncDaemonDb,
+    settings: &TaskBoardOrchestratorSettings,
+    durable_enabled: bool,
+) -> Result<(), CliError> {
+    if !durable_enabled {
+        return Ok(());
+    }
+    let control = db.task_board_automation_control().await?;
+    if control.desired_mode != TaskBoardAutomationDesiredMode::Off
+        && control.admission_state == TaskBoardAutomationAdmissionState::Accepting
+    {
+        db.start_task_board_automation(desired_mode_for_settings(settings), Utc::now())
+            .await?;
+    }
+    Ok(())
+}
+
+const fn desired_mode_for_settings(
+    settings: &TaskBoardOrchestratorSettings,
+) -> TaskBoardAutomationDesiredMode {
+    if settings.step_mode {
+        TaskBoardAutomationDesiredMode::Step
+    } else {
+        TaskBoardAutomationDesiredMode::Continuous
+    }
+}
+
+async fn set_running_intent(
+    db: &AsyncDaemonDb,
+    enabled: bool,
+    running: bool,
+    durable_enabled: bool,
+) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
+    let mut state = db.task_board_orchestrator_state().await?;
+    state.enabled = enabled;
+    state.running = running;
+    db.replace_task_board_orchestrator_state(&state).await?;
+    status_from_state(db, state, durable_enabled).await
+}
+
+async fn status_from_state(
+    db: &AsyncDaemonDb,
+    state: TaskBoardOrchestratorState,
+    durable_enabled: bool,
+) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
+    let settings = db.task_board_orchestrator_settings().await?;
+    let held_dispatches = db.held_task_board_dispatch_summary().await?;
+    let machine = task_board_host_local_db(db).await.ok();
+    let items = db.list_task_board_items(None).await?;
+    let items = items.iter().filter(|item| {
+        machine
+            .as_ref()
+            .is_none_or(|machine| machine.accepts_any(&item.target_project_types))
+    });
+    let workflow_execution_counts = workflow_statuses()
+        .into_iter()
+        .filter_map(|status| {
+            let count = items
+                .clone()
+                .filter(|item| item.workflow.status == status)
+                .count();
+            (count > 0).then_some(TaskBoardWorkflowExecutionCount { status, count })
+        })
+        .collect();
+    let (enabled, running) = if durable_enabled {
+        let control = db.task_board_automation_control().await?;
+        (
+            control.desired_mode != TaskBoardAutomationDesiredMode::Off,
+            control.admission_state != TaskBoardAutomationAdmissionState::Stopped,
+        )
+    } else {
+        (state.enabled, state.running)
+    };
+    Ok(TaskBoardOrchestratorStatusResponse {
+        enabled,
+        running,
+        step_mode: settings.step_mode,
+        held_dispatches,
+        current_tick: state.current_tick,
+        last_run: state.last_run,
+        workflow_execution_counts,
+        settings,
+    })
+}
+
+const fn workflow_statuses() -> [TaskBoardWorkflowStatus; 6] {
+    [
+        TaskBoardWorkflowStatus::Idle,
+        TaskBoardWorkflowStatus::Running,
+        TaskBoardWorkflowStatus::Paused,
+        TaskBoardWorkflowStatus::Completed,
+        TaskBoardWorkflowStatus::Failed,
+        TaskBoardWorkflowStatus::Cancelled,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::query_scalar;
+
+    use super::*;
+
+    #[test]
+    fn step_mode_selects_step_admission() {
+        assert_eq!(
+            desired_mode_for_settings(&TaskBoardOrchestratorSettings {
+                step_mode: true,
+                ..TaskBoardOrchestratorSettings::default()
+            }),
+            TaskBoardAutomationDesiredMode::Step
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_control_does_not_initialize_durable_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+
+        let status = start_task_board_orchestrator_with_durable(&db, false)
+            .await
+            .expect("start legacy orchestrator");
+
+        assert!(status.enabled);
+        assert!(status.running);
+        let stopped = stop_task_board_orchestrator_with_durable(&db, false)
+            .await
+            .expect("stop legacy orchestrator");
+        assert!(!stopped.enabled);
+        assert!(!stopped.running);
+        update_running_automation_mode(&db, &TaskBoardOrchestratorSettings::default(), false)
+            .await
+            .expect("update legacy settings");
+        let durable_rows =
+            query_scalar::<_, i64>("SELECT COUNT(*) FROM task_board_orchestrator_control")
+                .fetch_one(db.pool())
+                .await
+                .expect("count durable control rows");
+        assert_eq!(durable_rows, 0);
+    }
+
+    #[tokio::test]
+    async fn durable_stop_finishes_immediately_when_no_run_is_active() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+        start_task_board_orchestrator_with_durable(&db, true)
+            .await
+            .expect("start durable orchestrator");
+
+        let status = stop_task_board_orchestrator_with_durable(&db, true)
+            .await
+            .expect("stop durable orchestrator");
+
+        assert!(!status.enabled);
+        assert!(!status.running);
+        let control = db
+            .task_board_automation_control()
+            .await
+            .expect("load durable control");
+        assert_eq!(
+            control.admission_state,
+            TaskBoardAutomationAdmissionState::Stopped
+        );
+    }
+}

--- a/src/daemon/service/task_board_orchestrator_db.rs
+++ b/src/daemon/service/task_board_orchestrator_db.rs
@@ -5,9 +5,7 @@ use uuid::Uuid;
 use crate::daemon::db::AsyncDaemonDb;
 use crate::daemon::protocol::{
     TaskBoardEvaluateRequest, TaskBoardOrchestratorRunOnceRequest,
-    TaskBoardOrchestratorRunOnceResponse, TaskBoardOrchestratorSettingsResponse,
-    TaskBoardOrchestratorSettingsUpdateRequest, TaskBoardOrchestratorStatusResponse,
-    TaskBoardSyncRequest,
+    TaskBoardOrchestratorRunOnceResponse, TaskBoardSyncRequest,
 };
 use crate::errors::CliError;
 use crate::task_board::github::GitHubAutomation;
@@ -16,70 +14,55 @@ use crate::task_board::{
     DispatchExecutionSummary, ExternalProvider, ExternalSyncConflictPolicy, ExternalSyncDirection,
     SpawnGateSwitches, TaskBoardAuditSummary, TaskBoardEvaluationSummary, TaskBoardItem,
     TaskBoardOrchestratorDispatchInput, TaskBoardOrchestratorRunStatus,
-    TaskBoardOrchestratorRunSummary, TaskBoardOrchestratorSettings, TaskBoardOrchestratorState,
-    TaskBoardOrchestratorTickInfo, TaskBoardOrchestratorTickPhase, TaskBoardStatus,
-    TaskBoardWorkflowExecutionCount, TaskBoardWorkflowStatus, build_audit_summary_with_policy,
+    TaskBoardOrchestratorRunSummary, TaskBoardOrchestratorSettings, TaskBoardOrchestratorTickInfo,
+    TaskBoardOrchestratorTickPhase, TaskBoardStatus, build_audit_summary_with_policy,
     build_sync_summary,
 };
 use crate::workspace::utc_now;
 
+use super::TaskBoardAutomationRunSession;
 use super::task_board::{dispatch_task_board_async, load_live_spawn_grants};
 use super::task_board_db::{
-    active_external_sync_config_db, sync_task_board_for_orchestrator_db, task_board_host_local_db,
+    active_external_sync_config_db, sync_task_board_for_orchestrator_db,
+    sync_task_board_for_orchestrator_with_context_db, task_board_host_local_db,
 };
 use super::task_board_evaluation::evaluate_task_board_async;
 use super::task_board_github::run_task_board_github_automation_async;
-use super::task_board_orchestrator_settings::{
-    apply_settings_update, normalize_github_inbox, normalize_todoist_inbox,
-};
+use super::task_board_orchestrator_control::task_board_orchestrator_status_db;
 use super::task_board_orchestrator_step_mode::scoped_dispatch_request;
-
-pub(crate) async fn task_board_orchestrator_status_db(
-    db: &AsyncDaemonDb,
-) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
-    let state = db.task_board_orchestrator_state().await?;
-    status_from_state(db, state).await
-}
-
-pub(crate) async fn start_task_board_orchestrator_db(
-    db: &AsyncDaemonDb,
-) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
-    set_running_intent(db, true, true).await
-}
-
-pub(crate) async fn stop_task_board_orchestrator_db(
-    db: &AsyncDaemonDb,
-) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
-    set_running_intent(db, false, false).await
-}
-
-pub(crate) async fn task_board_orchestrator_settings_db(
-    db: &AsyncDaemonDb,
-) -> Result<TaskBoardOrchestratorSettingsResponse, CliError> {
-    db.task_board_orchestrator_settings().await
-}
-
-pub(crate) async fn update_task_board_orchestrator_settings_db(
-    db: &AsyncDaemonDb,
-    request: &TaskBoardOrchestratorSettingsUpdateRequest,
-) -> Result<TaskBoardOrchestratorSettingsResponse, CliError> {
-    let mut settings = db.task_board_orchestrator_settings().await?;
-    apply_settings_update(&mut settings, request);
-    settings.github_inbox = normalize_github_inbox(&settings.github_inbox)?;
-    settings.todoist_inbox = normalize_todoist_inbox(&settings.todoist_inbox);
-    db.replace_task_board_orchestrator_settings(&settings)
-        .await?;
-    Ok(settings)
-}
 
 pub(crate) async fn run_task_board_orchestrator_once_db(
     db: &AsyncDaemonDb,
     request: &TaskBoardOrchestratorRunOnceRequest,
 ) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
+    run_task_board_orchestrator_once_inner(db, request, None).await
+}
+
+pub(crate) async fn run_task_board_orchestrator_once_with_session_db(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardOrchestratorRunOnceRequest,
+    session: &TaskBoardAutomationRunSession,
+) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
+    run_task_board_orchestrator_once_inner(db, request, Some(session)).await
+}
+
+async fn run_task_board_orchestrator_once_inner(
+    db: &AsyncDaemonDb,
+    request: &TaskBoardOrchestratorRunOnceRequest,
+    session: Option<&TaskBoardAutomationRunSession>,
+) -> Result<TaskBoardOrchestratorRunOnceResponse, CliError> {
     let settings = db.task_board_orchestrator_settings().await?;
-    let mut prepared = prepare_run(db, request, &settings).await?;
+    begin_stage(session, 1, "prepare").await?;
+    let prepared = prepare_run(
+        db,
+        request,
+        &settings,
+        session.map(TaskBoardAutomationRunSession::run_id),
+    )
+    .await;
+    let mut prepared = finish_stage(session, 1, "prepare", prepared).await?;
     let mut progress = (None, None);
-    match execute_run(db, &settings, &mut prepared, &mut progress).await {
+    match execute_run(db, &settings, &mut prepared, &mut progress, session).await {
         Ok((dispatch, evaluation)) => complete_run(db, prepared, dispatch, evaluation).await,
         Err(error) => {
             record_failed_run(db, &prepared, progress, &error).await?;
@@ -92,9 +75,13 @@ async fn prepare_run(
     db: &AsyncDaemonDb,
     request: &TaskBoardOrchestratorRunOnceRequest,
     settings: &TaskBoardOrchestratorSettings,
+    durable_run_id: Option<&str>,
 ) -> Result<TaskBoardOrchestratorPreparedRun, CliError> {
     let input = dispatch_input(request, settings);
-    let run_id = format!("task-board-run-{}", Uuid::new_v4().simple());
+    let run_id = durable_run_id.map_or_else(
+        || format!("task-board-run-{}", Uuid::new_v4().simple()),
+        ToOwned::to_owned,
+    );
     let started_at = utc_now();
     record_tick(
         db,
@@ -123,44 +110,119 @@ async fn execute_run(
         Option<DispatchExecutionSummary>,
         Option<TaskBoardEvaluationSummary>,
     ),
+    session: Option<&TaskBoardAutomationRunSession>,
 ) -> Result<(DispatchExecutionSummary, TaskBoardEvaluationSummary), CliError> {
-    sync_github_tasks(db, settings, prepared).await?;
-    let request = scoped_dispatch_request(db, settings, &prepared.input).await?;
-    let dispatch = match request.as_ref() {
-        Some(request) => dispatch_task_board_async(request, db).await?,
-        None => DispatchExecutionSummary::dry_run(Vec::new()),
-    };
+    begin_stage(session, 2, "provider_sync").await?;
+    let sync = sync_github_tasks(db, settings, prepared, session).await;
+    finish_stage(session, 2, "provider_sync", sync).await?;
+
+    begin_stage(session, 3, "dispatch").await?;
+    let dispatch = async {
+        let request = scoped_dispatch_request(db, settings, &prepared.input).await?;
+        let dispatch = match request.as_ref() {
+            Some(request) => dispatch_task_board_async(request, db).await?,
+            None => DispatchExecutionSummary::dry_run(Vec::new()),
+        };
+        Ok((request, dispatch))
+    }
+    .await;
+    let (request, dispatch) = finish_stage(session, 3, "dispatch", dispatch).await?;
     progress.0 = Some(dispatch.clone());
-    record_tick(
-        db,
-        &prepared.run_id,
-        &prepared.started_at,
-        prepared.input.dry_run,
-        TaskBoardOrchestratorTickPhase::Evaluation,
-    )
-    .await?;
-    let evaluation = evaluate_task_board_async(
-        &TaskBoardEvaluateRequest {
-            item_id: request
-                .as_ref()
-                .and_then(|request| request.item_id.clone())
-                .or_else(|| prepared.input.item_id.clone()),
-            status: None,
-            dry_run: prepared.input.dry_run,
-        },
-        db,
-    )
-    .await?;
+
+    begin_stage(session, 4, "evaluation").await?;
+    let evaluation = async {
+        record_tick(
+            db,
+            &prepared.run_id,
+            &prepared.started_at,
+            prepared.input.dry_run,
+            TaskBoardOrchestratorTickPhase::Evaluation,
+        )
+        .await?;
+        evaluate_task_board_async(
+            &TaskBoardEvaluateRequest {
+                item_id: request
+                    .as_ref()
+                    .and_then(|request| request.item_id.clone())
+                    .or_else(|| prepared.input.item_id.clone()),
+                status: None,
+                dry_run: prepared.input.dry_run,
+            },
+            db,
+        )
+        .await
+    }
+    .await;
+    let evaluation = finish_stage(session, 4, "evaluation", evaluation).await?;
     progress.1 = Some(evaluation.clone());
-    let items = items_for_input(db, &prepared.input).await?;
-    run_task_board_github_automation_async(settings, &prepared.input, &items, db).await?;
+
+    begin_stage(session, 5, "publish").await?;
+    let publish = async {
+        let items = items_for_input(db, &prepared.input).await?;
+        run_task_board_github_automation_async(settings, &prepared.input, &items, db).await
+    }
+    .await;
+    finish_stage(session, 5, "publish", publish).await?;
     Ok((dispatch, evaluation))
+}
+
+async fn finish_stage<T>(
+    session: Option<&TaskBoardAutomationRunSession>,
+    sequence: u64,
+    stage: &str,
+    result: Result<T, CliError>,
+) -> Result<T, CliError> {
+    match result {
+        Ok(value) => {
+            complete_stage(session, sequence, stage).await?;
+            Ok(value)
+        }
+        Err(error) => {
+            fail_stage(session, sequence, stage, &error).await?;
+            Err(error)
+        }
+    }
+}
+
+async fn begin_stage(
+    session: Option<&TaskBoardAutomationRunSession>,
+    sequence: u64,
+    stage: &str,
+) -> Result<(), CliError> {
+    if let Some(session) = session {
+        session.begin_stage(sequence, stage, None, None).await?;
+    }
+    Ok(())
+}
+
+async fn complete_stage(
+    session: Option<&TaskBoardAutomationRunSession>,
+    sequence: u64,
+    stage: &str,
+) -> Result<(), CliError> {
+    if let Some(session) = session {
+        session.complete_stage(sequence, stage, None, None).await?;
+    }
+    Ok(())
+}
+
+async fn fail_stage(
+    session: Option<&TaskBoardAutomationRunSession>,
+    sequence: u64,
+    stage: &str,
+    error: &CliError,
+) -> Result<(), CliError> {
+    if let Some(session) = session {
+        session.fail_stage(sequence, stage, error).await?;
+    }
+    Ok(())
 }
 
 async fn sync_github_tasks(
     db: &AsyncDaemonDb,
     settings: &TaskBoardOrchestratorSettings,
     prepared: &mut TaskBoardOrchestratorPreparedRun,
+    session: Option<&TaskBoardAutomationRunSession>,
 ) -> Result<(), CliError> {
     if prepared.input.item_id.is_some()
         || prepared
@@ -181,17 +243,19 @@ async fn sync_github_tasks(
     {
         return Ok(());
     }
-    prepared.sync = sync_task_board_for_orchestrator_db(
-        db,
-        &TaskBoardSyncRequest {
-            status: prepared.input.status,
-            provider: Some(ExternalProvider::GitHub),
-            direction: ExternalSyncDirection::Pull,
-            conflict_policy: ExternalSyncConflictPolicy::Report,
-            dry_run: prepared.input.dry_run,
-        },
-    )
-    .await?;
+    let request = TaskBoardSyncRequest {
+        status: prepared.input.status,
+        provider: Some(ExternalProvider::GitHub),
+        direction: ExternalSyncDirection::Pull,
+        conflict_policy: ExternalSyncConflictPolicy::Report,
+        dry_run: prepared.input.dry_run,
+    };
+    prepared.sync = if let Some(session) = session {
+        let context = session.sync_context();
+        sync_task_board_for_orchestrator_with_context_db(db, &request, &context).await?
+    } else {
+        sync_task_board_for_orchestrator_db(db, &request).await?
+    };
     prepared.audit = audit_summary(db, &items_for_input(db, &prepared.input).await?).await?;
     Ok(())
 }
@@ -382,62 +446,4 @@ async fn save_run_summary(
     state.last_run = Some(summary);
     db.replace_task_board_orchestrator_state(&state).await?;
     Ok(())
-}
-
-async fn set_running_intent(
-    db: &AsyncDaemonDb,
-    enabled: bool,
-    running: bool,
-) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
-    let mut state = db.task_board_orchestrator_state().await?;
-    state.enabled = enabled;
-    state.running = running;
-    db.replace_task_board_orchestrator_state(&state).await?;
-    status_from_state(db, state).await
-}
-
-async fn status_from_state(
-    db: &AsyncDaemonDb,
-    state: TaskBoardOrchestratorState,
-) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
-    let settings = db.task_board_orchestrator_settings().await?;
-    let held_dispatches = db.held_task_board_dispatch_summary().await?;
-    let machine = task_board_host_local_db(db).await.ok();
-    let items = db.list_task_board_items(None).await?;
-    let items = items.iter().filter(|item| {
-        machine
-            .as_ref()
-            .is_none_or(|machine| machine.accepts_any(&item.target_project_types))
-    });
-    let workflow_execution_counts = workflow_statuses()
-        .into_iter()
-        .filter_map(|status| {
-            let count = items
-                .clone()
-                .filter(|item| item.workflow.status == status)
-                .count();
-            (count > 0).then_some(TaskBoardWorkflowExecutionCount { status, count })
-        })
-        .collect();
-    Ok(TaskBoardOrchestratorStatusResponse {
-        enabled: state.enabled,
-        running: state.running,
-        step_mode: settings.step_mode,
-        held_dispatches,
-        current_tick: state.current_tick,
-        last_run: state.last_run,
-        workflow_execution_counts,
-        settings,
-    })
-}
-
-const fn workflow_statuses() -> [TaskBoardWorkflowStatus; 6] {
-    [
-        TaskBoardWorkflowStatus::Idle,
-        TaskBoardWorkflowStatus::Running,
-        TaskBoardWorkflowStatus::Paused,
-        TaskBoardWorkflowStatus::Completed,
-        TaskBoardWorkflowStatus::Failed,
-        TaskBoardWorkflowStatus::Cancelled,
-    ]
 }

--- a/src/daemon/service/task_board_orchestrator_run_lease.rs
+++ b/src/daemon/service/task_board_orchestrator_run_lease.rs
@@ -1,0 +1,323 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio::time::{MissedTickBehavior, interval};
+
+use crate::daemon::db::{AsyncDaemonDb, TaskBoardAutomationRunFence, TaskBoardAutomationRunLease};
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::TaskBoardAutomationRunOutcome;
+
+use super::task_board_db::{TaskBoardSyncCoordinatorFence, TaskBoardSyncCoordinatorFenceDecision};
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LeaseHealth {
+    Active,
+    Draining,
+    Failed(String),
+}
+
+pub(crate) struct TaskBoardOrchestratorRunGuard {
+    db: AsyncDaemonDb,
+    lease: TaskBoardAutomationRunLease,
+    shutdown_tx: watch::Sender<bool>,
+    health_rx: watch::Receiver<LeaseHealth>,
+    heartbeat: Option<JoinHandle<()>>,
+}
+
+impl TaskBoardOrchestratorRunGuard {
+    pub(crate) fn start(db: &AsyncDaemonDb, lease: TaskBoardAutomationRunLease) -> Self {
+        Self::start_with_heartbeat_interval(db, lease, HEARTBEAT_INTERVAL)
+    }
+
+    fn start_with_heartbeat_interval(
+        db: &AsyncDaemonDb,
+        lease: TaskBoardAutomationRunLease,
+        heartbeat_interval: Duration,
+    ) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (health_tx, health_rx) = watch::channel(LeaseHealth::Active);
+        let heartbeat = tokio::spawn(run_heartbeat(
+            db.clone(),
+            lease.clone(),
+            shutdown_rx,
+            health_tx,
+            heartbeat_interval,
+        ));
+        Self {
+            db: db.clone(),
+            lease,
+            shutdown_tx,
+            health_rx,
+            heartbeat: Some(heartbeat),
+        }
+    }
+
+    pub(crate) async fn ensure_active(&self) -> Result<(), CliError> {
+        match self.check_coordinator_fence().await? {
+            TaskBoardSyncCoordinatorFenceDecision::Current => Ok(()),
+            TaskBoardSyncCoordinatorFenceDecision::Cancelled(error) => Err(error),
+        }
+    }
+
+    pub(crate) fn coordinator_fence(&self) -> Arc<dyn TaskBoardSyncCoordinatorFence> {
+        Arc::new(TaskBoardRunFenceAdapter {
+            db: self.db.clone(),
+            lease: self.lease.clone(),
+            health_rx: self.health_rx.clone(),
+        })
+    }
+
+    pub(crate) const fn lease(&self) -> &TaskBoardAutomationRunLease {
+        &self.lease
+    }
+
+    pub(crate) async fn finalize(
+        mut self,
+        outcome: TaskBoardAutomationRunOutcome,
+        error: Option<&CliError>,
+    ) -> Result<TaskBoardAutomationRunOutcome, CliError> {
+        let heartbeat_result = self.stop_heartbeat().await;
+        let error_kind = error.map(CliError::code);
+        let error_message = error.map(ToString::to_string);
+        let actual_outcome = self
+            .db
+            .finalize_task_board_automation_run(
+                &self.lease,
+                outcome,
+                error_kind,
+                error_message.as_deref(),
+                Utc::now(),
+            )
+            .await?;
+        self.db
+            .finish_task_board_automation_drain_if_idle(Utc::now())
+            .await?;
+        heartbeat_result?;
+        Ok(actual_outcome)
+    }
+
+    async fn check_coordinator_fence(
+        &self,
+    ) -> Result<TaskBoardSyncCoordinatorFenceDecision, CliError> {
+        check_fence(&self.db, &self.lease, &self.health_rx).await
+    }
+
+    async fn stop_heartbeat(&mut self) -> Result<(), CliError> {
+        let _ = self.shutdown_tx.send_replace(true);
+        let Some(heartbeat) = self.heartbeat.take() else {
+            return Ok(());
+        };
+        heartbeat.await.map_err(|error| {
+            CliError::from(CliErrorKind::workflow_io(format!(
+                "task-board automation heartbeat task failed: {error}"
+            )))
+        })
+    }
+}
+
+impl Drop for TaskBoardOrchestratorRunGuard {
+    fn drop(&mut self) {
+        if let Some(heartbeat) = self.heartbeat.take() {
+            heartbeat.abort();
+        }
+    }
+}
+
+struct TaskBoardRunFenceAdapter {
+    db: AsyncDaemonDb,
+    lease: TaskBoardAutomationRunLease,
+    health_rx: watch::Receiver<LeaseHealth>,
+}
+
+#[async_trait]
+impl TaskBoardSyncCoordinatorFence for TaskBoardRunFenceAdapter {
+    async fn check(&self) -> Result<TaskBoardSyncCoordinatorFenceDecision, CliError> {
+        check_fence(&self.db, &self.lease, &self.health_rx).await
+    }
+}
+
+async fn check_fence(
+    db: &AsyncDaemonDb,
+    lease: &TaskBoardAutomationRunLease,
+    health_rx: &watch::Receiver<LeaseHealth>,
+) -> Result<TaskBoardSyncCoordinatorFenceDecision, CliError> {
+    if let LeaseHealth::Failed(error) = health_rx.borrow().clone() {
+        return Err(heartbeat_error(&error));
+    }
+    match db
+        .heartbeat_task_board_automation_run(lease, Utc::now())
+        .await?
+    {
+        TaskBoardAutomationRunFence::Active => Ok(TaskBoardSyncCoordinatorFenceDecision::Current),
+        TaskBoardAutomationRunFence::Draining => Ok(
+            TaskBoardSyncCoordinatorFenceDecision::Cancelled(stopping_error()),
+        ),
+    }
+}
+
+async fn run_heartbeat(
+    db: AsyncDaemonDb,
+    lease: TaskBoardAutomationRunLease,
+    mut shutdown_rx: watch::Receiver<bool>,
+    health_tx: watch::Sender<LeaseHealth>,
+    heartbeat_interval: Duration,
+) {
+    let mut ticker = interval(heartbeat_interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            result = shutdown_rx.changed() => {
+                if result.is_err() || *shutdown_rx.borrow() {
+                    break;
+                }
+            }
+            _ = ticker.tick() => {
+                match db.heartbeat_task_board_automation_run(&lease, Utc::now()).await {
+                    Ok(TaskBoardAutomationRunFence::Active) => {}
+                    Ok(TaskBoardAutomationRunFence::Draining) => {
+                        let _ = health_tx.send_replace(LeaseHealth::Draining);
+                    }
+                    Err(error) => {
+                        let _ = health_tx.send_replace(LeaseHealth::Failed(error.to_string()));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn stopping_error() -> CliError {
+    CliErrorKind::session_agent_conflict("task-board automation is stopping").into()
+}
+
+fn heartbeat_error(error: &str) -> CliError {
+    CliErrorKind::workflow_io(format!(
+        "task-board automation lease heartbeat failed: {error}"
+    ))
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Duration as ChronoDuration};
+    use sqlx::{query, query_as};
+
+    use super::*;
+    use crate::daemon::db::{TaskBoardAutomationRunAdmission, TaskBoardRunAcquireRequest};
+    use crate::task_board::{
+        TaskBoardAutomationDesiredMode, TaskBoardAutomationRunTrigger, TaskBoardAutomationScope,
+    };
+
+    async fn database() -> AsyncDaemonDb {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.keep().join("harness.db");
+        AsyncDaemonDb::connect(&path).await.expect("open database")
+    }
+
+    async fn wait_for_lease_renewal(db: &AsyncDaemonDb, shortened_expiry: DateTime<Utc>) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let row = query_as::<_, (String,)>(
+                    "SELECT lease_expires_at
+                     FROM task_board_orchestrator_runs WHERE run_id = ?1",
+                )
+                .bind("run-long-drain")
+                .fetch_one(db.pool())
+                .await
+                .expect("load lease expiry");
+                let expiry = DateTime::parse_from_rfc3339(&row.0)
+                    .expect("valid lease expiry")
+                    .with_timezone(&Utc);
+                if expiry > shortened_expiry {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("draining heartbeat should renew shortened lease");
+    }
+
+    #[tokio::test]
+    async fn draining_guard_renews_lease_until_finalization() {
+        let db = database().await;
+        let now = Utc::now();
+        db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+            .await
+            .expect("start automation");
+        let admission = db
+            .try_acquire_task_board_automation_run(&TaskBoardRunAcquireRequest {
+                run_id: "run-long-drain".into(),
+                trigger: TaskBoardAutomationRunTrigger::Scheduled,
+                actor: Some("scheduler-test".into()),
+                dry_run: false,
+                scope: TaskBoardAutomationScope::default(),
+                lease_owner: "scheduler-test-owner".into(),
+                now,
+            })
+            .await
+            .expect("acquire run");
+        let TaskBoardAutomationRunAdmission::Acquired(lease) = admission else {
+            panic!("scheduled run should acquire lease");
+        };
+        let guard = TaskBoardOrchestratorRunGuard::start_with_heartbeat_interval(
+            &db,
+            lease,
+            Duration::from_millis(10),
+        );
+
+        db.stop_task_board_automation(Utc::now())
+            .await
+            .expect("stop automation");
+        assert!(matches!(
+            guard
+                .coordinator_fence()
+                .check()
+                .await
+                .expect("check provider fence"),
+            TaskBoardSyncCoordinatorFenceDecision::Cancelled(_)
+        ));
+        guard
+            .ensure_active()
+            .await
+            .expect_err("draining run must reject a new phase");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(*guard.health_rx.borrow(), LeaseHealth::Draining);
+
+        let shortened_expiry = Utc::now() + ChronoDuration::seconds(2);
+        query(
+            "UPDATE task_board_orchestrator_runs
+             SET lease_expires_at = ?2 WHERE run_id = ?1",
+        )
+        .bind("run-long-drain")
+        .bind(shortened_expiry.to_rfc3339())
+        .execute(db.pool())
+        .await
+        .expect("shorten lease for accelerated regression");
+        wait_for_lease_renewal(&db, shortened_expiry).await;
+
+        assert_eq!(
+            guard
+                .finalize(TaskBoardAutomationRunOutcome::Completed, None)
+                .await
+                .expect("finalize long drain"),
+            TaskBoardAutomationRunOutcome::Cancelled
+        );
+        let row = query_as::<_, (String, String)>(
+            "SELECT state, outcome FROM task_board_orchestrator_runs WHERE run_id = ?1",
+        )
+        .bind("run-long-drain")
+        .fetch_one(db.pool())
+        .await
+        .expect("load finalized run");
+        assert_eq!(row, ("terminal".into(), "cancelled".into()));
+    }
+}

--- a/src/daemon/websocket/dispatch/routing.rs
+++ b/src/daemon/websocket/dispatch/routing.rs
@@ -48,10 +48,7 @@ pub(super) async fn dispatch_known_method(
     if let Some(response) = dispatch_reviews_method(request, state).await {
         return Some(response);
     }
-    if request.method.starts_with("task_board.")
-        && let Some(response) =
-            Box::pin(dispatch_task_board_method(request, state, connection)).await
-    {
+    if let Some(response) = dispatch_task_board_method(request, state, connection).await {
         return Some(response);
     }
     if let Some(response) = dispatch_core_method(request, state, connection).await {

--- a/src/daemon/websocket/dispatch/routing.rs
+++ b/src/daemon/websocket/dispatch/routing.rs
@@ -48,7 +48,10 @@ pub(super) async fn dispatch_known_method(
     if let Some(response) = dispatch_reviews_method(request, state).await {
         return Some(response);
     }
-    if let Some(response) = Box::pin(dispatch_task_board_method(request, state, connection)).await {
+    if request.method.starts_with("task_board.")
+        && let Some(response) =
+            Box::pin(dispatch_task_board_method(request, state, connection)).await
+    {
         return Some(response);
     }
     if let Some(response) = dispatch_core_method(request, state, connection).await {

--- a/src/daemon/websocket/dispatch/routing.rs
+++ b/src/daemon/websocket/dispatch/routing.rs
@@ -48,7 +48,7 @@ pub(super) async fn dispatch_known_method(
     if let Some(response) = dispatch_reviews_method(request, state).await {
         return Some(response);
     }
-    if let Some(response) = dispatch_task_board_method(request, state, connection).await {
+    if let Some(response) = Box::pin(dispatch_task_board_method(request, state, connection)).await {
         return Some(response);
     }
     if let Some(response) = dispatch_core_method(request, state, connection).await {

--- a/src/daemon/websocket/task_board.rs
+++ b/src/daemon/websocket/task_board.rs
@@ -32,6 +32,9 @@ pub(crate) async fn dispatch_task_board_method(
     state: &DaemonHttpState,
     connection: &Arc<Mutex<ConnectionState>>,
 ) -> Option<WsResponse> {
+    if let Some(response) = orchestrator::dispatch_method(request, state).await {
+        return Some(response);
+    }
     match request.method.as_str() {
         ws_methods::TASK_BOARD_CREATE => Some(dispatch_task_board_create(request, state).await),
         ws_methods::TASK_BOARD_CAPABILITIES => {
@@ -78,41 +81,6 @@ pub(crate) async fn dispatch_task_board_method(
         ws_methods::TASK_BOARD_HOST_SET_PROJECT_TYPES => {
             Some(dispatch_task_board_host_set_project_types(request, state).await)
         }
-        ws_methods::TASK_BOARD_ORCHESTRATOR_STATUS => {
-            Some(orchestrator::dispatch_task_board_orchestrator_status(request, state).await)
-        }
-        ws_methods::TASK_BOARD_ORCHESTRATOR_START => {
-            Some(orchestrator::dispatch_task_board_orchestrator_start(request, state).await)
-        }
-        ws_methods::TASK_BOARD_ORCHESTRATOR_STOP => {
-            Some(orchestrator::dispatch_task_board_orchestrator_stop(request, state).await)
-        }
-        ws_methods::TASK_BOARD_ORCHESTRATOR_RUN_ONCE => {
-            Some(orchestrator::dispatch_task_board_orchestrator_run_once(request, state).await)
-        }
-        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_GET => {
-            Some(orchestrator::dispatch_task_board_orchestrator_settings_get(request, state).await)
-        }
-        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE => Some(
-            orchestrator::dispatch_task_board_orchestrator_settings_update(request, state).await,
-        ),
-        ws_methods::TASK_BOARD_ORCHESTRATOR_RUNTIME_CONFIG_GET => Some(
-            orchestrator::dispatch_task_board_orchestrator_runtime_config_get(request, state).await,
-        ),
-        ws_methods::TASK_BOARD_ORCHESTRATOR_RUNTIME_CONFIG_UPDATE => Some(
-            orchestrator::dispatch_task_board_orchestrator_runtime_config_update(request, state)
-                .await,
-        ),
-        ws_methods::TASK_BOARD_ORCHESTRATOR_GITHUB_TOKENS_SYNC => Some(
-            orchestrator::dispatch_task_board_orchestrator_github_tokens_sync(request, state).await,
-        ),
-        ws_methods::TASK_BOARD_ORCHESTRATOR_TODOIST_TOKEN_SYNC => Some(
-            orchestrator::dispatch_task_board_orchestrator_todoist_token_sync(request, state).await,
-        ),
-        ws_methods::TASK_BOARD_ORCHESTRATOR_OPENROUTER_TOKEN_SYNC => Some(
-            orchestrator::dispatch_task_board_orchestrator_openrouter_token_sync(request, state)
-                .await,
-        ),
         ws_methods::TASK_BOARD_GIT_IDENTITY_DEFAULTS => {
             Some(dispatch_task_board_git_identity_defaults(request).await)
         }

--- a/src/daemon/websocket/task_board/orchestrator.rs
+++ b/src/daemon/websocket/task_board/orchestrator.rs
@@ -3,11 +3,53 @@ use crate::daemon::protocol::{
     TaskBoardGitHubTokensSyncRequest, TaskBoardGitRuntimeConfig,
     TaskBoardOpenRouterTokenSyncRequest, TaskBoardOrchestratorRunOnceRequest,
     TaskBoardOrchestratorSettingsUpdateRequest, TaskBoardTodoistTokenSyncRequest, WsRequest,
-    WsResponse,
+    WsResponse, ws_methods,
 };
 
 use super::super::mutations::dispatch_query_result;
 use super::{invalid_params, parse_control_plane_params, parse_params};
+
+pub(super) async fn dispatch_method(
+    request: &WsRequest,
+    state: &DaemonHttpState,
+) -> Option<WsResponse> {
+    match request.method.as_str() {
+        ws_methods::TASK_BOARD_ORCHESTRATOR_STATUS => {
+            Some(dispatch_task_board_orchestrator_status(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_START => {
+            Some(dispatch_task_board_orchestrator_start(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_STOP => {
+            Some(dispatch_task_board_orchestrator_stop(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_RUN_ONCE => {
+            Some(Box::pin(dispatch_task_board_orchestrator_run_once(request, state)).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_GET => {
+            Some(dispatch_task_board_orchestrator_settings_get(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE => {
+            Some(dispatch_task_board_orchestrator_settings_update(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_RUNTIME_CONFIG_GET => {
+            Some(dispatch_task_board_orchestrator_runtime_config_get(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_RUNTIME_CONFIG_UPDATE => {
+            Some(dispatch_task_board_orchestrator_runtime_config_update(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_GITHUB_TOKENS_SYNC => {
+            Some(dispatch_task_board_orchestrator_github_tokens_sync(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_TODOIST_TOKEN_SYNC => {
+            Some(dispatch_task_board_orchestrator_todoist_token_sync(request, state).await)
+        }
+        ws_methods::TASK_BOARD_ORCHESTRATOR_OPENROUTER_TOKEN_SYNC => {
+            Some(dispatch_task_board_orchestrator_openrouter_token_sync(request, state).await)
+        }
+        _ => None,
+    }
+}
 
 pub(super) async fn dispatch_task_board_orchestrator_status(
     request: &WsRequest,
@@ -61,7 +103,7 @@ pub(super) async fn dispatch_task_board_orchestrator_run_once(
     else {
         return invalid_params(request);
     };
-    let result = task_board_route_executor::run_once(state, body).await;
+    let result = Box::pin(task_board_route_executor::run_once(state, body)).await;
     super::record_task_board_audit_result(
         state,
         "task_board.orchestrator_run_once",

--- a/src/daemon/websocket/task_board/orchestrator.rs
+++ b/src/daemon/websocket/task_board/orchestrator.rs
@@ -1,3 +1,6 @@
+use std::future::Future;
+use std::pin::Pin;
+
 use crate::daemon::http::{DaemonHttpState, task_board_route_executor};
 use crate::daemon::protocol::{
     TaskBoardGitHubTokensSyncRequest, TaskBoardGitRuntimeConfig,
@@ -24,7 +27,9 @@ pub(super) async fn dispatch_method(
             Some(dispatch_task_board_orchestrator_stop(request, state).await)
         }
         ws_methods::TASK_BOARD_ORCHESTRATOR_RUN_ONCE => {
-            Some(Box::pin(dispatch_task_board_orchestrator_run_once(request, state)).await)
+            let future: Pin<Box<dyn Future<Output = WsResponse> + Send + '_>> =
+                Box::pin(dispatch_task_board_orchestrator_run_once(request, state));
+            Some(future.await)
         }
         ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_GET => {
             Some(dispatch_task_board_orchestrator_settings_get(request, state).await)

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -12,6 +12,8 @@
 //! - `HARNESS_FEATURE_REVIEWS_BACKGROUND_AUTO=1` enables background Reviews
 //!   policy runs. It is off by default because it can approve or merge GitHub
 //!   pull requests without a same-moment user confirmation.
+//! - `HARNESS_FEATURE_TASK_BOARD_AUTOMATION_V2=1` enables the durable Task Board
+//!   automation engine while it completes staged rollout validation.
 //! - `harness-daemon serve --disable-acp` / `--enable-acp` applies the same
 //!   gate as a process-scoped override without mutating the caller shell env.
 //!
@@ -36,6 +38,8 @@ pub const SUITE_HOOKS_ENV: &str = "HARNESS_FEATURE_SUITE_HOOKS";
 pub const ACP_ENV: &str = "HARNESS_FEATURE_ACP";
 /// Env var that enables background Reviews policy runs.
 pub const REVIEWS_BACKGROUND_AUTO_ENV: &str = "HARNESS_FEATURE_REVIEWS_BACKGROUND_AUTO";
+/// Env var that enables the durable Task Board automation engine.
+pub const TASK_BOARD_AUTOMATION_V2_ENV: &str = "HARNESS_FEATURE_TASK_BOARD_AUTOMATION_V2";
 
 static ACP_RUNTIME_OVERRIDE: Mutex<Option<bool>> = Mutex::new(None);
 
@@ -52,6 +56,12 @@ pub fn acp_enabled_from_env() -> bool {
 #[must_use]
 pub fn reviews_background_auto_enabled_from_env() -> bool {
     env_truthy(REVIEWS_BACKGROUND_AUTO_ENV)
+}
+
+/// Whether the durable Task Board automation engine may admit work.
+#[must_use]
+pub fn task_board_automation_v2_enabled_from_env() -> bool {
+    env_truthy(TASK_BOARD_AUTOMATION_V2_ENV)
 }
 
 /// Apply a process-scoped ACP enablement override for the lifetime of the guard.
@@ -151,6 +161,7 @@ mod tests {
                 (SUITE_HOOKS_ENV, None::<&str>),
                 (ACP_ENV, None::<&str>),
                 (REVIEWS_BACKGROUND_AUTO_ENV, None::<&str>),
+                (TASK_BOARD_AUTOMATION_V2_ENV, None::<&str>),
             ],
             body,
         )
@@ -163,6 +174,7 @@ mod tests {
             assert!(!flags.suite_hooks);
             assert!(acp_enabled_from_env());
             assert!(!reviews_background_auto_enabled_from_env());
+            assert!(!task_board_automation_v2_enabled_from_env());
         });
     }
 
@@ -228,6 +240,16 @@ mod tests {
         });
         temp_env::with_var(REVIEWS_BACKGROUND_AUTO_ENV, Some("false"), || {
             assert!(!reviews_background_auto_enabled_from_env());
+        });
+    }
+
+    #[test]
+    fn task_board_automation_v2_flag_uses_same_truthy_env_convention() {
+        temp_env::with_var(TASK_BOARD_AUTOMATION_V2_ENV, Some("1"), || {
+            assert!(task_board_automation_v2_enabled_from_env());
+        });
+        temp_env::with_var(TASK_BOARD_AUTOMATION_V2_ENV, Some("false"), || {
+            assert!(!task_board_automation_v2_enabled_from_env());
         });
     }
 

--- a/src/task_board/external.rs
+++ b/src/task_board/external.rs
@@ -43,7 +43,8 @@ pub use sync::{
     configured_sync_clients,
 };
 pub(crate) use sync::{
-    TaskBoardExternalCreateStore, TaskBoardSyncItemSnapshot, TaskBoardSyncStore,
+    TaskBoardExternalCreateStore, TaskBoardSyncCoordinatorFence,
+    TaskBoardSyncCoordinatorFenceDecision, TaskBoardSyncItemSnapshot, TaskBoardSyncStore,
     assign_external_create_recovery, blocked_external_create_follow_ups,
     blocked_external_create_recovery, configured_sync_clients_without_review_requests,
     load_external_create_recovery_work, prepare_external_create_recovery, sync_external_tasks,

--- a/src/task_board/external/sync.rs
+++ b/src/task_board/external/sync.rs
@@ -50,7 +50,8 @@ use reconcile::reconcile_existing_item;
 use scope::SyncClientError;
 use stale_reviews::reconcile_stale_github_review_requests;
 pub(crate) use store::{
-    TaskBoardExternalCreateStore, TaskBoardSyncItemSnapshot, TaskBoardSyncStore,
+    TaskBoardExternalCreateStore, TaskBoardSyncCoordinatorFence,
+    TaskBoardSyncCoordinatorFenceDecision, TaskBoardSyncItemSnapshot, TaskBoardSyncStore,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]

--- a/src/task_board/external/sync/batch.rs
+++ b/src/task_board/external/sync/batch.rs
@@ -282,6 +282,10 @@ async fn record_terminal_local_failure(
     error: CliError,
     batch: &mut BatchAccumulator,
 ) {
+    if board.coordinator_cancelled() {
+        record_coordinator_cancellation(board, attempt, provider, scope_id, error, batch).await;
+        return;
+    }
     let terminal_error = if let Some(attempt) = attempt {
         match board
             .complete_provider_scope_failure(attempt, &utc_now())
@@ -289,6 +293,33 @@ async fn record_terminal_local_failure(
         {
             Ok(_) => error,
             Err(finalization_error) => combined_local_failure(error, &finalization_error),
+        }
+    } else {
+        error
+    };
+    batch.scope_outcomes.push(ExternalSyncScopeOutcome::failed(
+        provider,
+        scope_id,
+        &terminal_error,
+    ));
+    batch.terminal_error = Some(terminal_error);
+}
+
+async fn record_coordinator_cancellation(
+    board: &dyn TaskBoardSyncStore,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+    provider: ExternalProvider,
+    scope_id: String,
+    error: CliError,
+    batch: &mut BatchAccumulator,
+) {
+    let terminal_error = if let Some(attempt) = attempt {
+        match board
+            .release_provider_scope_attempt(attempt, &utc_now())
+            .await
+        {
+            Ok(()) => error,
+            Err(release_error) => combined_neutral_release_failure(error, &release_error),
         }
     } else {
         error
@@ -311,6 +342,21 @@ fn combined_local_failure(local_error: CliError, finalization_error: &CliError) 
         None => finalization_details,
     };
     local_error.with_details(details)
+}
+
+fn combined_neutral_release_failure(
+    cancellation_error: CliError,
+    release_error: &CliError,
+) -> CliError {
+    let release_details = format!(
+        "neutral provider scope release also failed with {}",
+        error_with_details(release_error)
+    );
+    let details = match cancellation_error.details() {
+        Some(details) => format!("{details}; {release_details}"),
+        None => release_details,
+    };
+    cancellation_error.with_details(details)
 }
 
 fn error_with_details(error: &CliError) -> String {

--- a/src/task_board/external/sync/create_recovery.rs
+++ b/src/task_board/external/sync/create_recovery.rs
@@ -13,6 +13,7 @@ use super::TaskBoardSyncStore;
 
 mod execute;
 mod lease;
+mod provider_call;
 pub(super) use execute::{
     create_item_durably, recover_scope_intents, suppress_known_create_markers,
 };

--- a/src/task_board/external/sync/create_recovery/execute.rs
+++ b/src/task_board/external/sync/create_recovery/execute.rs
@@ -1,7 +1,7 @@
 use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::external::{
-    ExternalCreateLease, ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalCreateRequest,
-    ExternalProviderScopeAttempt, ExternalProviderScopeIdentity, ExternalSyncClient,
+    ExternalCreateRecoveryClient, ExternalCreateRequest, ExternalProviderScopeAttempt,
+    ExternalProviderScopeIdentity, ExternalSyncClient,
 };
 use crate::task_board::{
     ExternalCreateOutcome, ExternalProvider, ExternalSyncAction, ExternalSyncOperation,
@@ -14,6 +14,7 @@ use super::super::lookup::{OperationDraft, operation};
 use super::super::merge::sync_state_from_task;
 use super::super::{SyncClientError, TaskBoardSyncStore};
 use super::lease::ScopeCreateLease;
+use super::provider_call::{create_started, recover_existing};
 use super::reload_intent;
 
 pub(crate) struct DurableCreateResult {
@@ -44,7 +45,7 @@ async fn recover_scope_intent(
     operations: &mut Vec<ExternalSyncOperation>,
     follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
 ) -> Result<(), SyncClientError> {
-    lease.renew().await.map_err(SyncClientError::Local)?;
+    lease.renew_scope().await.map_err(SyncClientError::Local)?;
     let current = reload_intent(board, listed)
         .await
         .map_err(SyncClientError::Local)?;
@@ -234,69 +235,6 @@ async fn attached_marker_is_linked(
         }))
 }
 
-async fn create_started(
-    board: &dyn TaskBoardSyncStore,
-    capability: &dyn ExternalCreateRecoveryClient,
-    lease: &ScopeCreateLease<'_>,
-    intent: &TaskBoardExternalCreateIntent,
-    operations: &mut Vec<ExternalSyncOperation>,
-    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
-) -> Result<Option<TaskBoardItem>, SyncClientError> {
-    lease.renew().await.map_err(SyncClientError::Local)?;
-    let current = reload_intent(board, intent)
-        .await
-        .map_err(SyncClientError::Local)?;
-    if !matches!(current.state, TaskBoardExternalCreateIntentState::InFlight) {
-        return finish_reloaded_intent(board, &current, operations, follow_ups)
-            .await
-            .map_err(SyncClientError::Local);
-    }
-    lease.begin_provider_call();
-    let task = capability
-        .create_started(&request_from_intent(&current), lease)
-        .await
-        .map_err(|error| lease.classify_provider_call(error).into_sync_client_error())?;
-    persist_exact_task(board, &current, task, operations, follow_ups)
-        .await
-        .map_err(SyncClientError::Local)
-}
-
-async fn recover_existing(
-    board: &dyn TaskBoardSyncStore,
-    capability: &dyn ExternalCreateRecoveryClient,
-    lease: &ScopeCreateLease<'_>,
-    intent: &TaskBoardExternalCreateIntent,
-    operations: &mut Vec<ExternalSyncOperation>,
-    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
-) -> Result<Option<TaskBoardItem>, SyncClientError> {
-    lease.renew().await.map_err(SyncClientError::Local)?;
-    let current = reload_intent(board, intent)
-        .await
-        .map_err(SyncClientError::Local)?;
-    if !matches!(current.state, TaskBoardExternalCreateIntentState::InFlight) {
-        return finish_reloaded_intent(board, &current, operations, follow_ups)
-            .await
-            .map_err(SyncClientError::Local);
-    }
-    lease.begin_provider_call();
-    let probe = capability
-        .recover_existing(&request_from_intent(&current), lease)
-        .await
-        .map_err(|error| lease.classify_provider_call(error).into_sync_client_error())?;
-    let ExternalCreateProbe::Found(task) = probe else {
-        return Err(SyncClientError::Provider(
-            CliErrorKind::workflow_io(format!(
-                "provider create recovery found no task for '{}'",
-                current.item_id
-            ))
-            .into(),
-        ));
-    };
-    persist_exact_task(board, &current, task, operations, follow_ups)
-        .await
-        .map_err(SyncClientError::Local)
-}
-
 async fn recover_remote_intent(
     board: &dyn TaskBoardSyncStore,
     client: &dyn ExternalSyncClient,
@@ -311,7 +249,7 @@ async fn recover_remote_intent(
         .map(|_| ())
 }
 
-async fn finish_reloaded_intent(
+pub(super) async fn finish_reloaded_intent(
     board: &dyn TaskBoardSyncStore,
     intent: &TaskBoardExternalCreateIntent,
     operations: &mut Vec<ExternalSyncOperation>,
@@ -332,7 +270,7 @@ async fn finish_reloaded_intent(
     }
 }
 
-async fn persist_exact_task(
+pub(super) async fn persist_exact_task(
     board: &dyn TaskBoardSyncStore,
     intent: &TaskBoardExternalCreateIntent,
     task: ExternalTask,
@@ -439,7 +377,7 @@ fn create_operation(intent: &TaskBoardExternalCreateIntent) -> ExternalSyncOpera
     })
 }
 
-fn request_from_intent(intent: &TaskBoardExternalCreateIntent) -> ExternalCreateRequest {
+pub(super) fn request_from_intent(intent: &TaskBoardExternalCreateIntent) -> ExternalCreateRequest {
     ExternalCreateRequest::new(
         &intent.item_id,
         &intent.create_key,

--- a/src/task_board/external/sync/create_recovery/lease.rs
+++ b/src/task_board/external/sync/create_recovery/lease.rs
@@ -3,9 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use async_trait::async_trait;
 
 use crate::errors::CliError;
-use crate::task_board::external::{
-    ExternalCreateLease, ExternalProviderScopeAttempt, TaskBoardSyncCoordinatorFenceDecision,
-};
+use crate::task_board::external::{ExternalCreateLease, ExternalProviderScopeAttempt};
 use crate::workspace::utc_now;
 
 use super::super::{SyncClientError, TaskBoardSyncStore};
@@ -52,11 +50,7 @@ impl<'a> ScopeCreateLease<'a> {
     }
 
     pub(super) async fn renew_before_provider_call(&self) -> Result<(), CliError> {
-        self.renew_scope().await?;
-        match self.board.check_coordinator_fence().await? {
-            TaskBoardSyncCoordinatorFenceDecision::Current => Ok(()),
-            TaskBoardSyncCoordinatorFenceDecision::Cancelled(error) => Err(error),
-        }
+        super::super::scope::renew_before_provider_call(self.board, Some(self.attempt)).await
     }
 }
 

--- a/src/task_board/external/sync/create_recovery/lease.rs
+++ b/src/task_board/external/sync/create_recovery/lease.rs
@@ -3,7 +3,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use async_trait::async_trait;
 
 use crate::errors::CliError;
-use crate::task_board::external::{ExternalCreateLease, ExternalProviderScopeAttempt};
+use crate::task_board::external::{
+    ExternalCreateLease, ExternalProviderScopeAttempt, TaskBoardSyncCoordinatorFenceDecision,
+};
 use crate::workspace::utc_now;
 
 use super::super::{SyncClientError, TaskBoardSyncStore};
@@ -42,6 +44,20 @@ impl<'a> ScopeCreateLease<'a> {
             RecoveryCallError::Provider(error)
         }
     }
+
+    pub(super) async fn renew_scope(&self) -> Result<(), CliError> {
+        self.board
+            .renew_provider_scope_attempt(self.attempt, &utc_now())
+            .await
+    }
+
+    pub(super) async fn renew_before_provider_call(&self) -> Result<(), CliError> {
+        self.renew_scope().await?;
+        match self.board.check_coordinator_fence().await? {
+            TaskBoardSyncCoordinatorFenceDecision::Current => Ok(()),
+            TaskBoardSyncCoordinatorFenceDecision::Cancelled(error) => Err(error),
+        }
+    }
 }
 
 impl RecoveryCallError {
@@ -56,10 +72,7 @@ impl RecoveryCallError {
 #[async_trait]
 impl ExternalCreateLease for ScopeCreateLease<'_> {
     async fn renew(&self) -> Result<(), CliError> {
-        let result = self
-            .board
-            .renew_provider_scope_attempt(self.attempt, &utc_now())
-            .await;
+        let result = self.renew_before_provider_call().await;
         if result.is_err() {
             self.local_failure.store(true, Ordering::SeqCst);
         }

--- a/src/task_board/external/sync/create_recovery/provider_call.rs
+++ b/src/task_board/external/sync/create_recovery/provider_call.rs
@@ -1,0 +1,88 @@
+use crate::errors::CliErrorKind;
+use crate::task_board::external::{
+    ExternalCreateProbe, ExternalCreateRecoveryClient, ExternalSyncOperation,
+};
+use crate::task_board::{
+    TaskBoardExternalCreateIntent, TaskBoardExternalCreateIntentState, TaskBoardItem,
+};
+
+use super::super::{SyncClientError, TaskBoardSyncStore};
+use super::execute::{finish_reloaded_intent, persist_exact_task, request_from_intent};
+use super::lease::ScopeCreateLease;
+use super::reload_intent;
+
+pub(super) async fn create_started(
+    board: &dyn TaskBoardSyncStore,
+    capability: &dyn ExternalCreateRecoveryClient,
+    lease: &ScopeCreateLease<'_>,
+    intent: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<Option<TaskBoardItem>, SyncClientError> {
+    let current = reload_current_intent(board, lease, intent).await?;
+    if !matches!(current.state, TaskBoardExternalCreateIntentState::InFlight) {
+        return finish_reloaded_intent(board, &current, operations, follow_ups)
+            .await
+            .map_err(SyncClientError::Local);
+    }
+    lease
+        .renew_before_provider_call()
+        .await
+        .map_err(SyncClientError::Local)?;
+    lease.begin_provider_call();
+    let task = capability
+        .create_started(&request_from_intent(&current), lease)
+        .await
+        .map_err(|error| lease.classify_provider_call(error).into_sync_client_error())?;
+    persist_exact_task(board, &current, task, operations, follow_ups)
+        .await
+        .map_err(SyncClientError::Local)
+}
+
+pub(super) async fn recover_existing(
+    board: &dyn TaskBoardSyncStore,
+    capability: &dyn ExternalCreateRecoveryClient,
+    lease: &ScopeCreateLease<'_>,
+    intent: &TaskBoardExternalCreateIntent,
+    operations: &mut Vec<ExternalSyncOperation>,
+    follow_ups: &mut Vec<TaskBoardExternalCreateIntent>,
+) -> Result<Option<TaskBoardItem>, SyncClientError> {
+    let current = reload_current_intent(board, lease, intent).await?;
+    if !matches!(current.state, TaskBoardExternalCreateIntentState::InFlight) {
+        return finish_reloaded_intent(board, &current, operations, follow_ups)
+            .await
+            .map_err(SyncClientError::Local);
+    }
+    lease
+        .renew_before_provider_call()
+        .await
+        .map_err(SyncClientError::Local)?;
+    lease.begin_provider_call();
+    let probe = capability
+        .recover_existing(&request_from_intent(&current), lease)
+        .await
+        .map_err(|error| lease.classify_provider_call(error).into_sync_client_error())?;
+    let ExternalCreateProbe::Found(task) = probe else {
+        return Err(SyncClientError::Provider(
+            CliErrorKind::workflow_io(format!(
+                "provider create recovery found no task for '{}'",
+                current.item_id
+            ))
+            .into(),
+        ));
+    };
+    persist_exact_task(board, &current, task, operations, follow_ups)
+        .await
+        .map_err(SyncClientError::Local)
+}
+
+async fn reload_current_intent(
+    board: &dyn TaskBoardSyncStore,
+    lease: &ScopeCreateLease<'_>,
+    intent: &TaskBoardExternalCreateIntent,
+) -> Result<TaskBoardExternalCreateIntent, SyncClientError> {
+    lease.renew_scope().await.map_err(SyncClientError::Local)?;
+    reload_intent(board, intent)
+        .await
+        .map_err(SyncClientError::Local)
+}

--- a/src/task_board/external/sync/lease_tests.rs
+++ b/src/task_board/external/sync/lease_tests.rs
@@ -12,6 +12,7 @@ use crate::task_board::{
 };
 
 mod client;
+mod coordinator;
 mod marker;
 mod support;
 use client::DurableCreateClient;

--- a/src/task_board/external/sync/lease_tests.rs
+++ b/src/task_board/external/sync/lease_tests.rs
@@ -86,6 +86,39 @@ async fn capability_lease_io_failure_remains_a_terminal_local_error() {
 }
 
 #[tokio::test]
+async fn coordinator_cancellation_releases_scope_without_failure_backoff() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut item = unlinked_item("task-coordinator-cancel");
+    item.project_id = Some("provider-project".into());
+    let store = DurableCreateStore::coordinator_cancelled(item);
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(DurableCreateClient::new(
+        ExternalProvider::Todoist,
+        "provider-project",
+        Arc::clone(&calls),
+    ))];
+
+    let batch =
+        sync_external_tasks_scoped(&store, push_options(ExternalProvider::Todoist), &clients)
+            .await
+            .expect("coordinator cancellation retains scope evidence");
+
+    assert!(batch.terminal_error.is_some());
+    assert!(batch.first_provider_failure.is_none());
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(store.failure_completions.load(Ordering::SeqCst), 0);
+    assert_eq!(store.neutral_releases.load(Ordering::SeqCst), 1);
+    assert_eq!(store.coordinator_checks.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *store.fence_order.lock().expect("fence order"),
+        vec!["provider", "provider", "coordinator"]
+    );
+    assert!(matches!(
+        store.intent().state,
+        TaskBoardExternalCreateIntentState::InFlight
+    ));
+}
+
+#[tokio::test]
 async fn create_then_close_uses_the_finalized_current_item_status() {
     let calls = Arc::new(AtomicUsize::new(0));
     let mut item = unlinked_item("task-finalized-done");

--- a/src/task_board/external/sync/lease_tests/coordinator.rs
+++ b/src/task_board/external/sync/lease_tests/coordinator.rs
@@ -1,0 +1,181 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+
+use super::support::DurableCreateStore;
+use super::*;
+use crate::task_board::ExternalProviderCapabilities;
+
+#[derive(Default)]
+struct ProviderCalls {
+    pulls: AtomicUsize,
+    updates: AtomicUsize,
+    deletes: AtomicUsize,
+}
+
+struct FenceClient {
+    calls: Arc<ProviderCalls>,
+}
+
+#[async_trait]
+impl ExternalSyncClient for FenceClient {
+    fn provider(&self) -> ExternalProvider {
+        ExternalProvider::Todoist
+    }
+
+    fn scope_id(&self) -> String {
+        "provider-project".into()
+    }
+
+    fn scope_for_item(&self, _item: &TaskBoardItem) -> String {
+        self.scope_id()
+    }
+
+    fn capabilities(&self) -> ExternalProviderCapabilities {
+        ExternalProviderCapabilities::with_update_fields(vec![ExternalSyncField::Title])
+    }
+
+    fn allows_delete(&self) -> bool {
+        true
+    }
+
+    async fn pull_tasks(&self) -> Result<Vec<ExternalTask>, CliError> {
+        self.calls.pulls.fetch_add(1, Ordering::SeqCst);
+        Ok(Vec::new())
+    }
+
+    async fn push_task(&self, _item: &TaskBoardItem) -> Result<ExternalTaskRef, CliError> {
+        unreachable!("linked-item fence tests do not create provider tasks")
+    }
+
+    async fn update_task(
+        &self,
+        _item: &TaskBoardItem,
+        reference: &ExternalTaskRef,
+        _update: ExternalTaskUpdate,
+    ) -> Result<ExternalUpdateOutcome, CliError> {
+        self.calls.updates.fetch_add(1, Ordering::SeqCst);
+        Ok(ExternalUpdateOutcome::Applied {
+            reference: reference.clone(),
+            provider_revision: Some("provider-revision-2".into()),
+        })
+    }
+
+    async fn delete_task(
+        &self,
+        _item: &TaskBoardItem,
+        _reference: &ExternalTaskRef,
+    ) -> Result<(), CliError> {
+        self.calls.deletes.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn coordinator_cancellation_stops_pull_before_provider_call() {
+    let (store, calls, batch) = cancelled_sync(
+        unlinked_item("task-pull-fence"),
+        pull_options(ExternalProvider::Todoist),
+    )
+    .await;
+
+    assert_cancelled_scope(&store, &batch, 1);
+    assert_eq!(calls.pulls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn coordinator_cancellation_stops_linked_update_before_provider_call() {
+    let (store, calls, batch) = cancelled_sync(
+        linked_item("task-update-fence", false),
+        push_options(ExternalProvider::Todoist),
+    )
+    .await;
+
+    assert_cancelled_scope(&store, &batch, 1);
+    assert_eq!(calls.updates.load(Ordering::SeqCst), 0);
+    assert_eq!(calls.deletes.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn coordinator_cancellation_stops_delete_before_provider_call() {
+    let (store, calls, batch) = cancelled_sync(
+        linked_item("task-delete-fence", true),
+        push_options(ExternalProvider::Todoist),
+    )
+    .await;
+
+    assert_cancelled_scope(&store, &batch, 1);
+    assert_eq!(calls.deletes.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn dry_run_pull_checks_coordinator_without_provider_attempt() {
+    let mut options = pull_options(ExternalProvider::Todoist);
+    options.dry_run = true;
+    let (store, calls, batch) = cancelled_sync(unlinked_item("task-dry-run-fence"), options).await;
+
+    assert_cancelled_scope(&store, &batch, 0);
+    assert_eq!(calls.pulls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        *store.fence_order.lock().expect("fence order"),
+        vec!["coordinator"]
+    );
+}
+
+async fn cancelled_sync(
+    item: TaskBoardItem,
+    options: ExternalSyncOptions,
+) -> (
+    DurableCreateStore,
+    Arc<ProviderCalls>,
+    crate::task_board::external::ExternalSyncBatch,
+) {
+    let store = DurableCreateStore::coordinator_cancelled(item);
+    let calls = Arc::new(ProviderCalls::default());
+    let clients: Vec<Box<dyn ExternalSyncClient>> = vec![Box::new(FenceClient {
+        calls: Arc::clone(&calls),
+    })];
+    let batch = sync_external_tasks_scoped(&store, options, &clients)
+        .await
+        .expect("coordinator cancellation retains scope evidence");
+    (store, calls, batch)
+}
+
+fn assert_cancelled_scope(
+    store: &DurableCreateStore,
+    batch: &crate::task_board::external::ExternalSyncBatch,
+    expected_releases: usize,
+) {
+    assert!(batch.terminal_error.is_some());
+    assert!(batch.first_provider_failure.is_none());
+    assert_eq!(store.failure_completions.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        store.neutral_releases.load(Ordering::SeqCst),
+        expected_releases
+    );
+    assert_eq!(store.coordinator_checks.load(Ordering::SeqCst), 1);
+}
+
+fn linked_item(id: &str, deleted: bool) -> TaskBoardItem {
+    let mut item = TaskBoardItem::new(
+        id.into(),
+        "Current title".into(),
+        String::new(),
+        "2026-07-16T10:00:00Z".into(),
+    );
+    item.project_id = Some("provider-project".into());
+    item.deleted_at = deleted.then(|| "2026-07-16T12:00:00Z".into());
+    let reference = ExternalTaskRef::new(ExternalProvider::Todoist, "remote-task");
+    let mut core_reference = reference.into_core_ref();
+    core_reference.sync_state = Some(ExternalRefSyncState {
+        title: Some("Previous title".into()),
+        body: Some(String::new()),
+        status: Some(TaskBoardStatus::Backlog),
+        project_id: Some("provider-project".into()),
+        updated_at: Some("provider-revision-1".into()),
+        synced_at: Some("2026-07-16T10:00:00Z".into()),
+    });
+    item.external_refs.push(core_reference);
+    item
+}

--- a/src/task_board/external/sync/lease_tests/support.rs
+++ b/src/task_board/external/sync/lease_tests/support.rs
@@ -1,12 +1,13 @@
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 
 use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::external::{
     ExternalProviderScopeAttempt, ExternalProviderScopeAttemptDecision, ExternalProviderScopeState,
-    TaskBoardExternalCreateStore, TaskBoardSyncItemSnapshot, TaskBoardSyncStore,
+    TaskBoardExternalCreateStore, TaskBoardSyncCoordinatorFenceDecision, TaskBoardSyncItemSnapshot,
+    TaskBoardSyncStore,
 };
 use crate::task_board::store::{TaskBoardItemPatch, apply_patch};
 use crate::task_board::{
@@ -25,8 +26,12 @@ pub(super) struct DurableCreateStore {
     finalize_error: Option<&'static str>,
     completion_error: Option<&'static str>,
     conflict_error: Option<&'static str>,
+    coordinator_cancel_error: Option<&'static str>,
     status_on_finalize: Option<TaskBoardStatus>,
+    coordinator_cancelled: AtomicBool,
     pub(super) failure_completions: AtomicUsize,
+    pub(super) neutral_releases: AtomicUsize,
+    pub(super) coordinator_checks: AtomicUsize,
     pub(super) record_calls: AtomicUsize,
     pub(super) finalize_calls: AtomicUsize,
     pub(super) supersede_calls: AtomicUsize,
@@ -35,6 +40,7 @@ pub(super) struct DurableCreateStore {
     renew_calls: AtomicUsize,
     pub(super) resolved_fields: Mutex<Vec<ExternalSyncField>>,
     pub(super) success_base_revision: Mutex<Option<Option<String>>>,
+    pub(super) fence_order: Mutex<Vec<&'static str>>,
 }
 
 impl DurableCreateStore {
@@ -79,6 +85,12 @@ impl DurableCreateStore {
         Self::new(item, None, Some("local CAS failed"), None, None, None)
     }
 
+    pub(super) fn coordinator_cancelled(item: TaskBoardItem) -> Self {
+        let mut store = Self::new(item, None, None, None, None, None);
+        store.coordinator_cancel_error = Some("coordinator run was cancelled");
+        store
+    }
+
     pub(super) fn new(
         item: TaskBoardItem,
         renew_error: Option<(&'static str, bool, usize)>,
@@ -94,8 +106,12 @@ impl DurableCreateStore {
             finalize_error,
             completion_error,
             conflict_error,
+            coordinator_cancel_error: None,
             status_on_finalize,
+            coordinator_cancelled: AtomicBool::new(false),
             failure_completions: AtomicUsize::new(0),
+            neutral_releases: AtomicUsize::new(0),
+            coordinator_checks: AtomicUsize::new(0),
             record_calls: AtomicUsize::new(0),
             finalize_calls: AtomicUsize::new(0),
             supersede_calls: AtomicUsize::new(0),
@@ -104,6 +120,7 @@ impl DurableCreateStore {
             renew_calls: AtomicUsize::new(0),
             resolved_fields: Mutex::new(Vec::new()),
             success_base_revision: Mutex::new(None),
+            fence_order: Mutex::new(Vec::new()),
         }
     }
 
@@ -383,6 +400,10 @@ impl TaskBoardSyncStore for DurableCreateStore {
         _attempt: &ExternalProviderScopeAttempt,
         _now: &str,
     ) -> Result<(), CliError> {
+        self.fence_order
+            .lock()
+            .expect("fence order")
+            .push("provider");
         let call = self.renew_calls.fetch_add(1, Ordering::SeqCst);
         match self.renew_error {
             Some((message, true, fail_at)) if call == fail_at => {
@@ -393,6 +414,38 @@ impl TaskBoardSyncStore for DurableCreateStore {
             }
             Some(_) | None => Ok(()),
         }
+    }
+
+    async fn check_coordinator_fence(
+        &self,
+    ) -> Result<TaskBoardSyncCoordinatorFenceDecision, CliError> {
+        self.coordinator_checks.fetch_add(1, Ordering::SeqCst);
+        self.fence_order
+            .lock()
+            .expect("fence order")
+            .push("coordinator");
+        self.coordinator_cancel_error.map_or_else(
+            || Ok(TaskBoardSyncCoordinatorFenceDecision::Current),
+            |message| {
+                self.coordinator_cancelled.store(true, Ordering::SeqCst);
+                Ok(TaskBoardSyncCoordinatorFenceDecision::Cancelled(
+                    CliErrorKind::concurrent_modification(message).into(),
+                ))
+            },
+        )
+    }
+
+    fn coordinator_cancelled(&self) -> bool {
+        self.coordinator_cancelled.load(Ordering::SeqCst)
+    }
+
+    async fn release_provider_scope_attempt(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _released_at: &str,
+    ) -> Result<(), CliError> {
+        self.neutral_releases.fetch_add(1, Ordering::SeqCst);
+        Ok(())
     }
 
     async fn complete_provider_scope_success(

--- a/src/task_board/external/sync/scope.rs
+++ b/src/task_board/external/sync/scope.rs
@@ -1,5 +1,7 @@
 use crate::errors::CliError;
-use crate::task_board::external::ExternalProviderScopeAttempt;
+use crate::task_board::external::{
+    ExternalProviderScopeAttempt, TaskBoardSyncCoordinatorFenceDecision,
+};
 use crate::workspace::utc_now;
 
 use super::TaskBoardSyncStore;
@@ -13,11 +15,22 @@ pub(super) async fn renew_scope_attempt(
     board: &dyn TaskBoardSyncStore,
     attempt: Option<&ExternalProviderScopeAttempt>,
 ) -> Result<(), SyncClientError> {
+    renew_before_provider_call(board, attempt)
+        .await
+        .map_err(SyncClientError::Local)
+}
+
+pub(super) async fn renew_before_provider_call(
+    board: &dyn TaskBoardSyncStore,
+    attempt: Option<&ExternalProviderScopeAttempt>,
+) -> Result<(), CliError> {
     if let Some(attempt) = attempt {
         board
             .renew_provider_scope_attempt(attempt, &utc_now())
-            .await
-            .map_err(SyncClientError::Local)?;
+            .await?;
     }
-    Ok(())
+    match board.check_coordinator_fence().await? {
+        TaskBoardSyncCoordinatorFenceDecision::Current => Ok(()),
+        TaskBoardSyncCoordinatorFenceDecision::Cancelled(error) => Err(error),
+    }
 }

--- a/src/task_board/external/sync/store.rs
+++ b/src/task_board/external/sync/store.rs
@@ -27,6 +27,16 @@ impl TaskBoardSyncItemSnapshot {
     }
 }
 
+pub(crate) enum TaskBoardSyncCoordinatorFenceDecision {
+    Current,
+    Cancelled(CliError),
+}
+
+#[async_trait]
+pub(crate) trait TaskBoardSyncCoordinatorFence: Send + Sync {
+    async fn check(&self) -> Result<TaskBoardSyncCoordinatorFenceDecision, CliError>;
+}
+
 #[async_trait]
 pub(crate) trait TaskBoardExternalCreateStore: Send + Sync {
     async fn begin_external_create_intent(
@@ -118,6 +128,24 @@ pub(crate) trait TaskBoardSyncStore: TaskBoardExternalCreateStore {
         attempt: &ExternalProviderScopeAttempt,
         now: &str,
     ) -> Result<(), CliError>;
+
+    async fn check_coordinator_fence(
+        &self,
+    ) -> Result<TaskBoardSyncCoordinatorFenceDecision, CliError> {
+        Ok(TaskBoardSyncCoordinatorFenceDecision::Current)
+    }
+
+    fn coordinator_cancelled(&self) -> bool {
+        false
+    }
+
+    async fn release_provider_scope_attempt(
+        &self,
+        _attempt: &ExternalProviderScopeAttempt,
+        _released_at: &str,
+    ) -> Result<(), CliError> {
+        Err(CliErrorKind::workflow_io("neutral provider-scope release is unavailable").into())
+    }
 
     async fn complete_provider_scope_success(
         &self,

--- a/src/task_board/orchestrator/tests.rs
+++ b/src/task_board/orchestrator/tests.rs
@@ -3,8 +3,9 @@ use tempfile::tempdir;
 
 use super::*;
 use crate::task_board::{
-    DispatchAppliedTask, TaskBoardEvaluationRecord, TaskBoardEvaluationSummary, TaskBoardItem,
-    TaskBoardStatus, TaskBoardWorkflowStatus, build_dispatch_plan,
+    DispatchAppliedTask, ExternalProvider, ExternalSyncAction, ExternalSyncOperation,
+    TaskBoardEvaluationRecord, TaskBoardEvaluationSummary, TaskBoardItem, TaskBoardStatus,
+    TaskBoardWorkflowStatus, build_dispatch_plan,
 };
 
 #[test]
@@ -190,6 +191,32 @@ fn complete_run_records_evaluation_and_trace_ids() {
         last_run.policy_trace_ids,
         vec!["trace-eval-a".to_string(), "trace-eval-b".to_string()]
     );
+    assert_eq!(status.last_run_applied_count(), 1);
+}
+
+#[test]
+fn applied_count_includes_provider_mutations() {
+    let temp = tempdir().expect("tempdir");
+    let orchestrator = TaskBoardOrchestrator::new(temp.path().join("board"));
+    let mut prepared = orchestrator
+        .prepare_run(&TaskBoardOrchestratorRunOnceRequest::default())
+        .expect("prepare run");
+    prepared.sync.operations.push(ExternalSyncOperation {
+        provider: ExternalProvider::GitHub,
+        action: ExternalSyncAction::Pull,
+        board_item_id: Some("task-neutral".into()),
+        external_id: Some("item-17".into()),
+        url: None,
+        dry_run: false,
+        applied: true,
+        changed_fields: Vec::new(),
+        unsupported_fields: Vec::new(),
+    });
+
+    let status = orchestrator
+        .complete_run(prepared, DispatchExecutionSummary::dry_run(Vec::new()))
+        .expect("complete run");
+
     assert_eq!(status.last_run_applied_count(), 1);
 }
 

--- a/src/task_board/orchestrator/types.rs
+++ b/src/task_board/orchestrator/types.rs
@@ -295,6 +295,12 @@ impl TaskBoardOrchestratorStatus {
     #[must_use]
     pub fn last_run_applied_count(&self) -> usize {
         self.last_run.as_ref().map_or(0, |run| {
+            let synced = run
+                .sync
+                .operations
+                .iter()
+                .filter(|operation| operation.applied)
+                .count();
             let dispatched = run
                 .dispatch
                 .as_ref()
@@ -303,7 +309,7 @@ impl TaskBoardOrchestratorStatus {
                 .evaluation
                 .as_ref()
                 .map_or(0, |evaluation| evaluation.updated);
-            dispatched + evaluated
+            synced + dispatched + evaluated
         })
     }
 }

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-testkit"
-version = "48.1.1"
+version = "48.2.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false


### PR DESCRIPTION
## Motivation
Task Board automation currently relies on transient coordinator state, so daemon restarts, overlapping ticks, and stop requests can leave execution and audit state inconsistent. A durable, opt-in run envelope is needed before the remaining scheduler surfaces can be exposed safely.

## Implementation
- Add default-off durable automation control, run leases, stage state, stale recovery, and one-time legacy intent migration.
- Fence provider synchronization and create recovery with the active coordinator lease, including neutral cancellation and correlated sync audit evidence.
- Persist run and stage audit events atomically with scheduler transitions and classify completed, partial, no-op, failed, and cancelled outcomes consistently.
- Preserve legacy HTTP, WebSocket, and scheduled behavior when the feature flag is disabled.
- Bump the release set to 48.2.0 and validate focused scheduler, synchronization, route-parity, and repository quality gates.