### PR TITLE
test(task-board): align review projection fixtures

### DIFF
--- a/src/daemon/service/reviews_tests/projection.rs
+++ b/src/daemon/service/reviews_tests/projection.rs
@@ -208,7 +208,8 @@ async fn cached_reviews_query_creates_only_matching_task_board_reviews_idempoten
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].title, "Review acme/api#17");
     assert_eq!(items[0].status, TaskBoardStatus::Backlog);
-    assert_eq!(items[0].project_id.as_deref(), Some("acme/api"));
+    assert!(items[0].project_id.is_none());
+    assert_eq!(items[0].execution_repository.as_deref(), Some("acme/api"));
     assert_eq!(
         items[0].external_refs[0].external_id, "acme/api#17",
         "repeated projection must reuse the deterministic imported item"

--- a/src/daemon/service/reviews_tests/projection/eligibility.rs
+++ b/src/daemon/service/reviews_tests/projection/eligibility.rs
@@ -92,7 +92,12 @@ fn cache_requested_review(
 fn status_for_repository(items: &[TaskBoardItem], repository: &str) -> TaskBoardStatus {
     items
         .iter()
-        .find(|item| item.project_id.as_deref() == Some(repository))
+        .find(|item| {
+            item.execution_repository
+                .as_deref()
+                .or(item.project_id.as_deref())
+                == Some(repository)
+        })
         .unwrap_or_else(|| panic!("missing task for {repository}"))
         .status
 }

--- a/tests/integration/architecture/docs_and_policy/version_sync/fixtures.rs
+++ b/tests/integration/architecture/docs_and_policy/version_sync/fixtures.rs
@@ -223,6 +223,8 @@ pub(super) fn setup_version_script_fixture_with_pbxproj(
         "crates/harness-hook/Cargo.toml",
         "crates/harness-mcp/Cargo.toml",
         "crates/harness-protocol/Cargo.toml",
+        "crates/harness-systemd/Cargo.toml",
+        "crates/harness-systemd-protocol/Cargo.toml",
         "crates/harness-telemetry/Cargo.toml",
         "testkit/Cargo.toml",
         "src/observe/output.rs",


### PR DESCRIPTION
## Motivation
Recent identity and package-split changes left focused review projection and version-sync fixtures behind the current contracts. The stale fixtures fail independently and obscure unrelated validation.

## Implementation
- Assert projected review tasks store repository ownership in execution_repository while leaving project_id unset.
- Preserve legacy eligibility lookups by falling back to project_id only when execution_repository is absent.
- Include standalone service manifests required by the version synchronization fixture.
- Validate the three exact regressions, formatting, source-size limits, and whitespace.