### PR TITLE
feat(task-board): drive automation from durable wakes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "aff"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "harness-bridge"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "harness-command"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "tempfile",
  "uzers",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "harness-daemon"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "harness-daemon-client"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "fs2",
  "reqwest",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "harness-hook"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "harness-mcp"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "clap",
  "serde",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "harness-systemd"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "harness-systemd-protocol"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "nix 0.31.3",
  "temp-env",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "harness-telemetry"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "harness-testkit"
-version = "48.3.0"
+version = "48.4.0"
 dependencies = [
  "temp-env",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 
 [package]
 name = "harness"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 autoexamples = false
@@ -38,11 +38,11 @@ include = [
 ]
 
 [dependencies]
-harness-command = { path = "crates/harness-command", version = "48.3.0" }
-harness-mcp = { path = "crates/harness-mcp", version = "48.3.0", optional = true }
-harness-protocol = { path = "crates/harness-protocol", version = "48.3.0" }
-harness-systemd-protocol = { path = "crates/harness-systemd-protocol", version = "48.3.0", optional = true }
-harness-telemetry = { path = "crates/harness-telemetry", version = "48.3.0" }
+harness-command = { path = "crates/harness-command", version = "48.4.0" }
+harness-mcp = { path = "crates/harness-mcp", version = "48.4.0", optional = true }
+harness-protocol = { path = "crates/harness-protocol", version = "48.4.0" }
+harness-systemd-protocol = { path = "crates/harness-systemd-protocol", version = "48.4.0", optional = true }
+harness-telemetry = { path = "crates/harness-telemetry", version = "48.4.0" }
 arc-swap = "1.9.1"
 bollard = "0.21.0"
 bytes = "1.10.1"

--- a/aff/Cargo.toml
+++ b/aff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aff"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 

--- a/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
+++ b/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>48.3.0</string>
+	<string>48.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>48.3.0</string>
+	<string>48.4.0</string>
 	<key>LSBackgroundOnly</key>
 	<true/>
 </dict>

--- a/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
+++ b/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
@@ -32,7 +32,7 @@ public enum BuildSettings {
         "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS": .string(
             compilationCacheDiagnosticRemarksSetting
         ),
-        "CURRENT_PROJECT_VERSION": "48.3.0", // VERSION_MARKER_CURRENT
+        "CURRENT_PROJECT_VERSION": "48.4.0", // VERSION_MARKER_CURRENT
         "DEVELOPMENT_TEAM": "Q498EB36N4",
         "DEAD_CODE_STRIPPING": "YES",
         "ENABLE_HARDENED_RUNTIME": "YES",
@@ -61,7 +61,7 @@ public enum BuildSettings {
         "HARNESS_MONITOR_BUILD_GIT_COMMIT": "local-dev",
         "HARNESS_MONITOR_BUILD_GIT_DIRTY": "false",
         "HARNESS_MONITOR_BUILD_WORKSPACE_FINGERPRINT": "local-dev",
-        "MARKETING_VERSION": "48.3.0" // VERSION_MARKER_MARKETING
+        "MARKETING_VERSION": "48.4.0" // VERSION_MARKER_MARKETING
     ]
 
     public static let previewOverrides: SettingsDictionary = [

--- a/crates/harness-bridge/Cargo.toml
+++ b/crates/harness-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-bridge"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -21,9 +21,9 @@ clap = { version = "4.6.0", features = ["derive", "env"] }
 crossterm = "0.29.0"
 fs2 = "0.4.3"
 fs-err = "3.3.0"
-harness-hook = { path = "../harness-hook", version = "48.3.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.3.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.3.0" }
+harness-hook = { path = "../harness-hook", version = "48.4.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.4.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.4.0" }
 hex = "0.4.3"
 nix = { version = "0.31", features = ["signal"] }
 notify = "8.2.0"

--- a/crates/harness-command/Cargo.toml
+++ b/crates/harness-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-command"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 

--- a/crates/harness-daemon-client/Cargo.toml
+++ b/crates/harness-daemon-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-daemon-client"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-daemon/Cargo.toml
+++ b/crates/harness-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-daemon"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -28,11 +28,11 @@ fs-err = "3.3.0"
 futures-util = "0.3.31"
 gix = { version = "0.83.0", features = ["status", "worktree-mutation", "index", "blocking-http-transport-reqwest-rust-tls"] }
 gray_matter = { version = "0.3.2", default-features = false, features = ["yaml"] }
-harness-command = { path = "../harness-command", version = "48.3.0" }
-harness-hook = { path = "../harness-hook", version = "48.3.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.3.0" }
-harness-systemd-protocol = { path = "../harness-systemd-protocol", version = "48.3.0", optional = true }
-harness-telemetry = { path = "../harness-telemetry", version = "48.3.0" }
+harness-command = { path = "../harness-command", version = "48.4.0" }
+harness-hook = { path = "../harness-hook", version = "48.4.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.4.0" }
+harness-systemd-protocol = { path = "../harness-systemd-protocol", version = "48.4.0", optional = true }
+harness-telemetry = { path = "../harness-telemetry", version = "48.4.0" }
 hex = "0.4.3"
 hickory-resolver = "0.26.1"
 hmac = "0.13.0"

--- a/crates/harness-hook/Cargo.toml
+++ b/crates/harness-hook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-hook"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -14,9 +14,9 @@ test = false
 
 [dependencies]
 clap = { version = "4.6.0", features = ["derive", "env"] }
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.3.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.3.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.3.0" }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.4.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.4.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.4.0" }
 chrono = { version = "0.4.44", features = ["serde"] }
 fs-err = "3.3.0"
 fs2 = "0.4.3"

--- a/crates/harness-mcp/Cargo.toml
+++ b/crates/harness-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-mcp"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -13,9 +13,9 @@ async-trait = "0.1.83"
 base64 = "0.22.1"
 clap = { version = "4.6.0", features = ["derive", "env"] }
 futures-util = "0.3.31"
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.3.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.3.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.3.0" }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.4.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.4.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.4.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
@@ -26,7 +26,7 @@ uuid = { version = "1.18.1", features = ["v4"] }
 
 [dev-dependencies]
 axum = { version = "0.8.7", features = ["ws"] }
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.3.0", features = ["test-support"] }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.4.0", features = ["test-support"] }
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tempfile = "3.27.0"
 

--- a/crates/harness-protocol/Cargo.toml
+++ b/crates/harness-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-protocol"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-systemd-protocol/Cargo.toml
+++ b/crates/harness-systemd-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-systemd-protocol"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-systemd/Cargo.toml
+++ b/crates/harness-systemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-systemd"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 build = "build.rs"
@@ -14,7 +14,7 @@ chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive"] }
 fs-err = "3.3.0"
 fs2 = "0.4.3"
-harness-command = { path = "../harness-command", version = "48.3.0" }
+harness-command = { path = "../harness-command", version = "48.4.0" }
 hex = "0.4.3"
 libc = "0.2"
 nix = { version = "0.31", features = ["fs", "signal", "user"] }

--- a/crates/harness-telemetry/Cargo.toml
+++ b/crates/harness-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-telemetry"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -68,6 +68,7 @@ mod schema;
 mod schema_migrations;
 mod schema_repairs;
 mod schema_repairs_external_creates;
+mod schema_repairs_wake_events;
 mod schema_sql;
 mod schema_v10;
 mod schema_v11;

--- a/src/daemon/db/schema_repairs.rs
+++ b/src/daemon/db/schema_repairs.rs
@@ -114,6 +114,7 @@ pub(super) fn current_schema_shape_needs_repair(
         }
     }
     super::schema_repairs_external_creates::require_table_shape(conn)?;
+    super::schema_repairs_wake_events::require_table_shape(conn)?;
     if !table_sql_contains(conn, "task_board_dispatch_intents", "'held'")? {
         return Ok(true);
     }
@@ -133,6 +134,9 @@ pub(super) fn current_schema_shape_needs_repair(
         }
     }
     if super::schema_repairs_external_creates::indexes_need_repair(conn)? {
+        return Ok(true);
+    }
+    if super::schema_repairs_wake_events::indexes_need_repair(conn)? {
         return Ok(true);
     }
     Ok(false)
@@ -169,6 +173,7 @@ pub(super) fn repair_current_schema_shape(db: &DaemonDb) -> Result<(), CliError>
     super::schema_v37::run(&db.conn)?;
     super::schema_v38::run(&db.conn)?;
     super::schema_repairs_external_creates::require_complete_shape(&db.conn)?;
+    super::schema_repairs_wake_events::require_complete_shape(&db.conn)?;
     db.conn
         .execute(
             "UPDATE schema_meta SET value = ?1 WHERE key = 'version'",

--- a/src/daemon/db/schema_repairs_wake_events.rs
+++ b/src/daemon/db/schema_repairs_wake_events.rs
@@ -1,0 +1,83 @@
+use super::{CliError, Connection, db_error};
+
+const TABLE_NAME: &str = "task_board_orchestrator_wake_events";
+const INDEX_NAME: &str = "task_board_orchestrator_wake_events_pending";
+const EXPECTED_TABLE_SQL: &str = "
+CREATE TABLE task_board_orchestrator_wake_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    cause TEXT NOT NULL,
+    entity_id TEXT,
+    entity_revision INTEGER,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    processed_at TEXT
+)";
+const EXPECTED_INDEX_SQL: &str = "
+CREATE INDEX task_board_orchestrator_wake_events_pending
+    ON task_board_orchestrator_wake_events(processed_at, sequence)";
+
+pub(super) fn require_table_shape(conn: &Connection) -> Result<(), CliError> {
+    require_object_shape(conn, "table", TABLE_NAME, EXPECTED_TABLE_SQL).map_err(|_| {
+        db_error(
+            "incompatible task_board_orchestrator_wake_events schema; refusing destructive repair",
+        )
+    })
+}
+
+pub(super) fn indexes_need_repair(conn: &Connection) -> Result<bool, CliError> {
+    if !object_exists(conn, "index", INDEX_NAME)? {
+        return Ok(true);
+    }
+    require_object_shape(conn, "index", INDEX_NAME, EXPECTED_INDEX_SQL).map_err(|_| {
+        db_error(
+            "incompatible task_board_orchestrator_wake_events_pending index; refusing destructive repair",
+        )
+    })?;
+    Ok(false)
+}
+
+pub(super) fn require_complete_shape(conn: &Connection) -> Result<(), CliError> {
+    require_table_shape(conn)?;
+    if indexes_need_repair(conn)? {
+        return Err(db_error(
+            "task-board wake-event repair left required indexes missing",
+        ));
+    }
+    Ok(())
+}
+
+fn require_object_shape(
+    conn: &Connection,
+    object_type: &str,
+    name: &str,
+    expected_sql: &str,
+) -> Result<(), CliError> {
+    let stored_sql = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = ?1 AND name = ?2",
+            [object_type, name],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|error| db_error(format!("read {name} definition: {error}")))?;
+    if normalize_sql(&stored_sql) == normalize_sql(expected_sql) {
+        return Ok(());
+    }
+    Err(db_error(format!("unexpected {name} definition")))
+}
+
+fn object_exists(conn: &Connection, object_type: &str, name: &str) -> Result<bool, CliError> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = ?1 AND name = ?2",
+        [object_type, name],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|count| count > 0)
+    .map_err(|error| db_error(format!("check {name} existence: {error}")))
+}
+
+fn normalize_sql(sql: &str) -> String {
+    sql.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}

--- a/src/daemon/db/task_board/aggregates.rs
+++ b/src/daemon/db/task_board/aggregates.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 
 use serde::de::DeserializeOwned;
 
-use sqlx::{query, query_as};
+use sqlx::{Sqlite, Transaction, query, query_as};
 
 use super::mapper::{machine_from_row, parse_json, to_json};
 use super::rows::MachineRow;
@@ -144,20 +144,7 @@ impl AsyncDaemonDb {
         let mut transaction = self
             .begin_immediate_transaction("task board orchestrator settings")
             .await?;
-        query(
-            "INSERT INTO task_board_orchestrator_settings (
-            singleton, settings_json, revision, updated_at
-        ) VALUES (1, ?1, 1, ?2)
-        ON CONFLICT(singleton) DO UPDATE SET settings_json = excluded.settings_json,
-            revision = task_board_orchestrator_settings.revision + 1,
-            updated_at = excluded.updated_at",
-        )
-        .bind(to_json(settings, "task board orchestrator settings")?)
-        .bind(utc_now())
-        .execute(transaction.as_mut())
-        .await
-        .map_err(|error| db_error(format!("save orchestrator settings: {error}")))?;
-        let revision = bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        let revision = replace_orchestrator_settings_in_tx(&mut transaction, settings).await?;
         transaction
             .commit()
             .await
@@ -248,6 +235,26 @@ impl AsyncDaemonDb {
             .map_err(|error| db_error(format!("commit task board runtime config: {error}")))?;
         Ok(revision)
     }
+}
+
+pub(super) async fn replace_orchestrator_settings_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    settings: &TaskBoardOrchestratorSettings,
+) -> Result<i64, CliError> {
+    query(
+        "INSERT INTO task_board_orchestrator_settings (
+            singleton, settings_json, revision, updated_at
+         ) VALUES (1, ?1, 1, ?2)
+         ON CONFLICT(singleton) DO UPDATE SET settings_json = excluded.settings_json,
+             revision = task_board_orchestrator_settings.revision + 1,
+             updated_at = excluded.updated_at",
+    )
+    .bind(to_json(settings, "task board orchestrator settings")?)
+    .bind(utc_now())
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("save orchestrator settings: {error}")))?;
+    bump_change_in_tx(transaction, ORCHESTRATOR_CHANGE_SCOPE).await
 }
 
 pub(super) async fn upsert_machine_in_tx(

--- a/src/daemon/db/task_board/scheduler.rs
+++ b/src/daemon/db/task_board/scheduler.rs
@@ -8,6 +8,7 @@ mod recovery;
 mod runs;
 mod stages;
 mod status;
+mod wake;
 
 #[cfg(test)]
 mod control_tests;
@@ -27,6 +28,8 @@ mod status_atomicity_tests;
 mod status_tests;
 #[cfg(test)]
 mod test_support;
+#[cfg(test)]
+mod wake_tests;
 
 pub(crate) use crate::task_board::TaskBoardAutomationRunStage;
 pub(crate) use control::TaskBoardAutomationControlRecord;

--- a/src/daemon/db/task_board/scheduler/control.rs
+++ b/src/daemon/db/task_board/scheduler/control.rs
@@ -4,7 +4,11 @@ use sqlx::{Sqlite, Transaction, query, query_as};
 use super::super::ORCHESTRATOR_CHANGE_SCOPE;
 use super::super::items::bump_change_in_tx;
 use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
-use crate::task_board::{TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode};
+use crate::task_board::{
+    TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode,
+    TaskBoardAutomationWakeEntityKind, TaskBoardAutomationWakePayload,
+    TaskBoardAutomationWakeRequest, TaskBoardOrchestratorSettings,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TaskBoardAutomationControlRecord {
@@ -87,6 +91,26 @@ impl AsyncDaemonDb {
         desired_mode: TaskBoardAutomationDesiredMode,
         now: DateTime<Utc>,
     ) -> Result<TaskBoardAutomationControlRecord, CliError> {
+        self.start_task_board_automation_inner(desired_mode, None, now)
+            .await
+    }
+
+    pub(crate) async fn start_task_board_automation_with_wake(
+        &self,
+        desired_mode: TaskBoardAutomationDesiredMode,
+        wake: &TaskBoardAutomationWakeRequest,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationControlRecord, CliError> {
+        self.start_task_board_automation_inner(desired_mode, Some(wake), now)
+            .await
+    }
+
+    async fn start_task_board_automation_inner(
+        &self,
+        desired_mode: TaskBoardAutomationDesiredMode,
+        wake: Option<&TaskBoardAutomationWakeRequest>,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationControlRecord, CliError> {
         let mut transaction = self
             .begin_immediate_transaction("task board automation start")
             .await?;
@@ -102,12 +126,76 @@ impl AsyncDaemonDb {
         .await
         .map_err(|error| db_error(format!("start task board automation: {error}")))?;
         bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        if let Some(wake) = wake {
+            super::wake::enqueue_in_tx(&mut transaction, wake, now).await?;
+        }
         let control = load_control_in_tx(&mut transaction).await?;
         transaction
             .commit()
             .await
             .map_err(|error| db_error(format!("commit task board automation start: {error}")))?;
         Ok(control)
+    }
+
+    pub(crate) async fn replace_task_board_orchestrator_settings_for_automation(
+        &self,
+        settings: &TaskBoardOrchestratorSettings,
+        desired_mode: TaskBoardAutomationDesiredMode,
+        now: DateTime<Utc>,
+    ) -> Result<i64, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation settings update")
+            .await?;
+        let revision = super::super::aggregates::replace_orchestrator_settings_in_tx(
+            &mut transaction,
+            settings,
+        )
+        .await?;
+        let changed = query(
+            "UPDATE task_board_orchestrator_control
+             SET desired_mode = ?1, admission_state = 'accepting', updated_at = ?2
+             WHERE singleton = 1 AND desired_mode != 'off'
+               AND admission_state = 'accepting'",
+        )
+        .bind(desired_mode_label(desired_mode))
+        .bind(now.to_rfc3339())
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("update task board automation settings: {error}")))?
+        .rows_affected();
+        if changed > 1 {
+            return Err(db_error(
+                "task board automation settings updated multiple control rows",
+            ));
+        }
+        if changed == 1 {
+            bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+            if desired_mode == TaskBoardAutomationDesiredMode::Continuous {
+                let revision = u64::try_from(revision).map_err(|error| {
+                    db_error(format!(
+                        "convert task board settings change revision: {error}"
+                    ))
+                })?;
+                super::wake::enqueue_in_tx(
+                    &mut transaction,
+                    &TaskBoardAutomationWakeRequest {
+                        entity_id: Some("automation-settings".into()),
+                        entity_revision: Some(revision),
+                        payload: TaskBoardAutomationWakePayload::ledger_changed(
+                            TaskBoardAutomationWakeEntityKind::Settings,
+                        ),
+                    },
+                    now,
+                )
+                .await?;
+            }
+        }
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board automation settings update: {error}"
+            ))
+        })?;
+        Ok(revision)
     }
 
     pub(crate) async fn stop_task_board_automation(

--- a/src/daemon/db/task_board/scheduler/control_tests.rs
+++ b/src/daemon/db/task_board/scheduler/control_tests.rs
@@ -1,7 +1,12 @@
 use chrono::Duration;
+use sqlx::{query, query_scalar};
 
 use super::test_support::{database, instant};
-use crate::task_board::{TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode};
+use crate::task_board::{
+    TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode,
+    TaskBoardAutomationWakeEntityKind, TaskBoardAutomationWakePayload,
+    TaskBoardAutomationWakeRequest, TaskBoardOrchestratorSettings,
+};
 
 #[tokio::test]
 async fn control_defaults_without_persisted_intent() {
@@ -96,5 +101,78 @@ async fn idle_drain_transitions_to_stopped_once() {
             .await
             .expect("revision after repeated completion"),
         revision_after
+    );
+}
+
+#[tokio::test]
+async fn start_and_control_wake_roll_back_together() {
+    let db = database().await;
+    query("DROP TABLE task_board_orchestrator_wake_events")
+        .execute(db.pool())
+        .await
+        .expect("drop wake table");
+
+    db.start_task_board_automation_with_wake(
+        TaskBoardAutomationDesiredMode::Continuous,
+        &TaskBoardAutomationWakeRequest {
+            entity_id: Some("automation-control".into()),
+            entity_revision: None,
+            payload: TaskBoardAutomationWakePayload::ledger_changed(
+                TaskBoardAutomationWakeEntityKind::Control,
+            ),
+        },
+        instant("2026-07-15T08:00:00Z"),
+    )
+    .await
+    .expect_err("missing wake table must fail start");
+
+    let control_rows =
+        query_scalar::<_, i64>("SELECT COUNT(*) FROM task_board_orchestrator_control")
+            .fetch_one(db.pool())
+            .await
+            .expect("count control rows");
+    assert_eq!(control_rows, 0);
+}
+
+#[tokio::test]
+async fn settings_control_and_wake_roll_back_together() {
+    let db = database().await;
+    let baseline = TaskBoardOrchestratorSettings::default();
+    db.replace_task_board_orchestrator_settings(&baseline)
+        .await
+        .expect("save baseline settings");
+    let now = instant("2026-07-15T08:30:00Z");
+    let control = db
+        .start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    query("DROP TABLE task_board_orchestrator_wake_events")
+        .execute(db.pool())
+        .await
+        .expect("drop wake table");
+    let updated = TaskBoardOrchestratorSettings {
+        dry_run_default: !baseline.dry_run_default,
+        ..baseline.clone()
+    };
+
+    db.replace_task_board_orchestrator_settings_for_automation(
+        &updated,
+        TaskBoardAutomationDesiredMode::Continuous,
+        now + Duration::seconds(1),
+    )
+    .await
+    .expect_err("missing wake table must fail settings update");
+
+    assert_eq!(
+        db.task_board_orchestrator_settings()
+            .await
+            .expect("reload settings"),
+        baseline
+    );
+    assert_eq!(
+        db.task_board_automation_control()
+            .await
+            .expect("reload control"),
+        control
     );
 }

--- a/src/daemon/db/task_board/scheduler/status.rs
+++ b/src/daemon/db/task_board/scheduler/status.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Duration, Utc};
 use sqlx::{Sqlite, SqliteConnection, Transaction, query_as};
 
+mod wake;
+
 use super::super::ORCHESTRATOR_CHANGE_SCOPE;
 use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
 use crate::task_board::{
@@ -23,13 +25,7 @@ struct SnapshotLedger {
     runs: Vec<TaskBoardAutomationRunInfo>,
     provider_backoff: Option<ProviderBackoff>,
     open_conflict: bool,
-}
-
-struct SnapshotActivity {
-    revision: u64,
-    runs: Vec<TaskBoardAutomationRunInfo>,
-    provider_backoff: Option<ProviderBackoff>,
-    open_conflict: bool,
+    wake: wake::WakeObservation,
 }
 
 #[derive(sqlx::FromRow)]
@@ -117,27 +113,16 @@ async fn load_snapshot_ledger(
 ) -> Result<SnapshotLedger, CliError> {
     let (settings_revision, offline_after) = load_settings(connection).await?;
     let control = load_control(connection).await?;
-    let activity = load_snapshot_activity(connection).await?;
     Ok(SnapshotLedger {
-        revision: activity.revision,
+        revision: load_revision(connection).await?,
         settings_revision,
         policy_revision,
         offline_after,
         control,
-        runs: activity.runs,
-        provider_backoff: activity.provider_backoff,
-        open_conflict: activity.open_conflict,
-    })
-}
-
-async fn load_snapshot_activity(
-    connection: &mut SqliteConnection,
-) -> Result<SnapshotActivity, CliError> {
-    Ok(SnapshotActivity {
-        revision: load_revision(connection).await?,
         runs: super::history::load_snapshot_run_infos(connection).await?,
         provider_backoff: load_provider_backoff(connection).await?,
         open_conflict: load_open_conflict(connection).await?,
+        wake: wake::load(connection).await?,
     })
 }
 
@@ -325,13 +310,15 @@ fn build_snapshot(
         observed_at: observed_at.to_rfc3339(),
         heartbeat_at: facts.heartbeat_at.value,
         heartbeat_age_seconds: Some(u64::try_from(heartbeat_age.num_seconds()).unwrap_or(u64::MAX)),
-        next_run_at: ledger
-            .provider_backoff
-            .as_ref()
-            .map(|backoff| backoff.earliest.value.clone()),
+        next_run_at: ledger.wake.next_run_at(
+            ledger
+                .provider_backoff
+                .as_ref()
+                .map(|backoff| &backoff.earliest),
+        ),
         next_retry_at: None,
         last_success_at: facts.last_success.map(|value| value.value),
-        last_reconciliation_at: None,
+        last_reconciliation_at: ledger.wake.last_reconciliation_at(),
         settings_revision: ledger.settings_revision,
         policy_revision: ledger.policy_revision,
         queue: TaskBoardAutomationQueueSummary::default(),
@@ -351,6 +338,7 @@ struct RunFacts {
 fn run_facts(ledger: &SnapshotLedger) -> Result<RunFacts, CliError> {
     let mut active = Vec::new();
     let mut heartbeat_at = ledger.control.updated_at.clone();
+    ledger.wake.promote_heartbeat(&mut heartbeat_at);
     let mut last_success = None::<StoredInstant>;
     let mut latest_terminal = None::<(StoredInstant, String, TaskBoardAutomationRunOutcome)>;
     for run in &ledger.runs {
@@ -445,6 +433,9 @@ fn derive_effective_state(
                 "provider_backoff",
             );
         }
+        return (TaskBoardAutomationEffectiveState::Scheduled, None);
+    }
+    if ledger.wake.is_pending() {
         return (TaskBoardAutomationEffectiveState::Scheduled, None);
     }
     (TaskBoardAutomationEffectiveState::Idle, None)

--- a/src/daemon/db/task_board/scheduler/status/wake.rs
+++ b/src/daemon/db/task_board/scheduler/status/wake.rs
@@ -1,0 +1,94 @@
+use sqlx::{SqliteConnection, query_as};
+
+use super::{StoredInstant, keep_latest, stored_instant};
+use crate::daemon::db::{CliError, db_error};
+use crate::task_board::TASK_BOARD_AUTOMATION_WAKE_BATCH_LIMIT;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug)]
+pub(super) struct WakeObservation {
+    next_pending: Option<StoredInstant>,
+    last_processed: Option<StoredInstant>,
+}
+
+impl WakeObservation {
+    pub(super) fn promote_heartbeat(&self, heartbeat: &mut StoredInstant) {
+        if let Some(processed) = self.last_processed.as_ref() {
+            keep_latest(heartbeat, processed.clone());
+        }
+    }
+
+    pub(super) fn next_run_at(&self, other: Option<&StoredInstant>) -> Option<String> {
+        match (self.next_pending.as_ref(), other) {
+            (Some(wake), Some(other)) if other.instant < wake.instant => Some(other.value.clone()),
+            (Some(wake), _) => Some(wake.value.clone()),
+            (None, Some(other)) => Some(other.value.clone()),
+            (None, None) => None,
+        }
+    }
+
+    pub(super) fn last_reconciliation_at(&self) -> Option<String> {
+        self.last_processed
+            .as_ref()
+            .map(|processed| processed.value.clone())
+    }
+
+    pub(super) const fn is_pending(&self) -> bool {
+        self.next_pending.is_some()
+    }
+}
+
+pub(super) async fn load(connection: &mut SqliteConnection) -> Result<WakeObservation, CliError> {
+    let pending = query_as::<_, super::super::wake::TaskBoardAutomationWakeRow>(
+        "SELECT sequence, cause, entity_id, entity_revision, payload_json, created_at,
+                processed_at
+         FROM task_board_orchestrator_wake_events
+         WHERE processed_at IS NULL ORDER BY sequence LIMIT ?1",
+    )
+    .bind(i64::from(TASK_BOARD_AUTOMATION_WAKE_BATCH_LIMIT))
+    .fetch_all(&mut *connection)
+    .await
+    .map_err(|error| db_error(format!("load task board snapshot pending wakes: {error}")))?;
+    let processed = query_as::<_, super::super::wake::TaskBoardAutomationWakeRow>(
+        "SELECT sequence, cause, entity_id, entity_revision, payload_json, created_at,
+                processed_at
+         FROM task_board_orchestrator_wake_events
+         WHERE processed_at IS NOT NULL
+         ORDER BY sequence DESC LIMIT 1",
+    )
+    .fetch_optional(&mut *connection)
+    .await
+    .map_err(|error| db_error(format!("load last task board snapshot wake: {error}")))?;
+    Ok(WakeObservation {
+        next_pending: first_pending(pending)?,
+        last_processed: processed.map(decode_processed).transpose()?,
+    })
+}
+
+fn first_pending(
+    rows: Vec<super::super::wake::TaskBoardAutomationWakeRow>,
+) -> Result<Option<StoredInstant>, CliError> {
+    let mut first = None::<StoredInstant>;
+    for row in rows {
+        let observation = super::super::wake::decode_task_board_automation_wake_row(row)?;
+        if first.is_none() {
+            first = Some(stored_instant(
+                observation.event.created_at,
+                "automation snapshot wake created timestamp",
+            )?);
+        }
+    }
+    Ok(first)
+}
+
+fn decode_processed(
+    row: super::super::wake::TaskBoardAutomationWakeRow,
+) -> Result<StoredInstant, CliError> {
+    let observation = super::super::wake::decode_task_board_automation_wake_row(row)?;
+    let processed_at = observation
+        .processed_at
+        .ok_or_else(|| db_error("task board snapshot processed wake has no timestamp"))?;
+    stored_instant(processed_at, "automation snapshot wake processed timestamp")
+}

--- a/src/daemon/db/task_board/scheduler/status/wake/tests.rs
+++ b/src/daemon/db/task_board/scheduler/status/wake/tests.rs
@@ -1,0 +1,136 @@
+use chrono::{DateTime, Duration, Utc};
+use sqlx::{query, query_as};
+
+use super::super::super::test_support::database;
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::{
+    TaskBoardAutomationEffectiveState, TaskBoardAutomationWakeEntityKind,
+    TaskBoardAutomationWakePayload, TaskBoardAutomationWakeRecoveryReason,
+    TaskBoardAutomationWakeRequest,
+};
+
+#[tokio::test]
+async fn wake_projection_uses_sequence_order_and_is_read_only() {
+    let db = database().await;
+    let now = Utc::now();
+    seed_control(&db, now - Duration::minutes(5)).await;
+    let first_processed = enqueue_recovery(&db, now - Duration::minutes(3)).await;
+    db.acknowledge_task_board_automation_wake_events(
+        &[first_processed.sequence],
+        now - Duration::minutes(1),
+    )
+    .await
+    .expect("acknowledge first wake");
+    let latest_processed = enqueue_recovery(&db, now - Duration::seconds(50)).await;
+    let latest_processed_at = now - Duration::minutes(2);
+    db.acknowledge_task_board_automation_wake_events(
+        &[latest_processed.sequence],
+        latest_processed_at,
+    )
+    .await
+    .expect("acknowledge latest sequence after clock rollback");
+    let first_pending_at = now - Duration::seconds(30);
+    enqueue_recovery(&db, first_pending_at).await;
+    db.enqueue_task_board_automation_wake_event(&item_wake(), now - Duration::minutes(4))
+        .await
+        .expect("enqueue later sequence after clock rollback");
+    let before = fingerprint(&db).await;
+
+    let current = db
+        .task_board_automation_snapshot()
+        .await
+        .expect("build wake snapshot");
+    assert_eq!(
+        current.effective_state,
+        TaskBoardAutomationEffectiveState::Scheduled
+    );
+    assert_eq!(
+        current.next_run_at.as_deref(),
+        Some(timestamp(first_pending_at).as_str())
+    );
+    assert_eq!(
+        current.last_reconciliation_at.as_deref(),
+        Some(timestamp(latest_processed_at).as_str())
+    );
+    assert_eq!(current.heartbeat_at, timestamp(latest_processed_at));
+    assert!(matches!(current.heartbeat_age_seconds, Some(119..=125)));
+    assert_eq!(fingerprint(&db).await, before);
+}
+
+#[tokio::test]
+async fn snapshot_fails_closed_for_a_malformed_wake() {
+    let db = database().await;
+    let now = Utc::now();
+    seed_control(&db, now).await;
+    let wake = enqueue_recovery(&db, now).await;
+    query(
+        "UPDATE task_board_orchestrator_wake_events
+         SET payload_json = '{\"schema_version\":1,\"unexpected\":true}'
+         WHERE sequence = ?1",
+    )
+    .bind(i64::try_from(wake.sequence).expect("stored wake sequence"))
+    .execute(db.pool())
+    .await
+    .expect("corrupt wake payload");
+
+    let error = db
+        .task_board_automation_snapshot()
+        .await
+        .expect_err("malformed wake must fail snapshot decoding");
+    assert!(error.to_string().contains("wake payload"));
+}
+
+async fn seed_control(db: &AsyncDaemonDb, updated_at: DateTime<Utc>) {
+    query(
+        "INSERT INTO task_board_orchestrator_control (
+            singleton, desired_mode, admission_state, stop_generation, updated_at
+         ) VALUES (1, 'step', 'accepting', 0, ?1)",
+    )
+    .bind(timestamp(updated_at))
+    .execute(db.pool())
+    .await
+    .expect("seed control");
+}
+
+async fn enqueue_recovery(
+    db: &AsyncDaemonDb,
+    created_at: DateTime<Utc>,
+) -> crate::task_board::TaskBoardAutomationWakeEvent {
+    db.enqueue_task_board_automation_wake_event(&recovery_wake(), created_at)
+        .await
+        .expect("enqueue recovery wake")
+}
+
+const fn recovery_wake() -> TaskBoardAutomationWakeRequest {
+    TaskBoardAutomationWakeRequest {
+        entity_id: None,
+        entity_revision: None,
+        payload: TaskBoardAutomationWakePayload::recovery(
+            TaskBoardAutomationWakeRecoveryReason::Startup,
+        ),
+    }
+}
+
+fn item_wake() -> TaskBoardAutomationWakeRequest {
+    TaskBoardAutomationWakeRequest {
+        entity_id: Some("item-sequence".into()),
+        entity_revision: Some(1),
+        payload: TaskBoardAutomationWakePayload::ledger_changed(
+            TaskBoardAutomationWakeEntityKind::Item,
+        ),
+    }
+}
+
+async fn fingerprint(db: &AsyncDaemonDb) -> (i64, i64, Option<String>) {
+    query_as(
+        "SELECT COUNT(*), COUNT(processed_at), MAX(processed_at)
+         FROM task_board_orchestrator_wake_events",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("load wake fingerprint")
+}
+
+fn timestamp(value: DateTime<Utc>) -> String {
+    value.to_rfc3339()
+}

--- a/src/daemon/db/task_board/scheduler/status_atomicity_tests.rs
+++ b/src/daemon/db/task_board/scheduler/status_atomicity_tests.rs
@@ -7,6 +7,10 @@ use super::status::{
 use super::test_support::{database, instant};
 use crate::daemon::db::AsyncDaemonDb;
 use crate::task_board::policy_graph::{PolicyCanvasWorkspace, PolicyGraphMode};
+use crate::task_board::{
+    TaskBoardAutomationEffectiveState, TaskBoardAutomationWakePayload,
+    TaskBoardAutomationWakeRecoveryReason, TaskBoardAutomationWakeRequest,
+};
 
 #[tokio::test]
 async fn lean_policy_revision_matches_active_live_policy_semantics() {
@@ -128,6 +132,50 @@ async fn snapshot_ledger_read_succeeds_on_a_query_only_connection() {
         .expect("disable query-only mode");
 }
 
+#[tokio::test]
+async fn wake_acknowledgement_uses_the_pinned_read_snapshot() {
+    let db = ready_database().await;
+    let created_at = Utc::now();
+    let wake = db
+        .enqueue_task_board_automation_wake_event(&recovery_wake(), created_at)
+        .await
+        .expect("enqueue wake before snapshot");
+    let mut transaction = db.pool().begin().await.expect("begin deferred read");
+    let (policy_revision, observed_at) = begin_snapshot_observation(transaction.as_mut())
+        .await
+        .expect("pin snapshot observation");
+    let processed_at = wait_until_after(observed_at).await;
+    db.acknowledge_task_board_automation_wake_events(&[wake.sequence], processed_at)
+        .await
+        .expect("acknowledge wake after observation");
+
+    let pinned = snapshot_after_observation(&mut transaction, policy_revision, observed_at)
+        .await
+        .expect("build pinned wake snapshot");
+    assert_eq!(
+        pinned.effective_state,
+        TaskBoardAutomationEffectiveState::Scheduled
+    );
+    assert_eq!(
+        pinned.next_run_at.as_deref(),
+        Some(wake.created_at.as_str())
+    );
+    assert_eq!(pinned.last_reconciliation_at, None);
+    transaction.commit().await.expect("commit read transaction");
+
+    let current = snapshot(&db).await;
+    assert_eq!(
+        current.effective_state,
+        TaskBoardAutomationEffectiveState::Idle
+    );
+    assert_eq!(current.next_run_at, None);
+    assert_eq!(
+        current.last_reconciliation_at.as_deref(),
+        Some(timestamp(processed_at).as_str())
+    );
+    assert_eq!(current.heartbeat_at, timestamp(processed_at));
+}
+
 async fn ready_database() -> AsyncDaemonDb {
     let db = database().await;
     let settings =
@@ -185,6 +233,16 @@ async fn snapshot(db: &AsyncDaemonDb) -> crate::task_board::TaskBoardAutomationS
 
 fn timestamp(value: DateTime<Utc>) -> String {
     value.to_rfc3339()
+}
+
+fn recovery_wake() -> TaskBoardAutomationWakeRequest {
+    TaskBoardAutomationWakeRequest {
+        entity_id: None,
+        entity_revision: None,
+        payload: TaskBoardAutomationWakePayload::recovery(
+            TaskBoardAutomationWakeRecoveryReason::Startup,
+        ),
+    }
 }
 
 async fn wait_until_after(instant: DateTime<Utc>) -> DateTime<Utc> {

--- a/src/daemon/db/task_board/scheduler/wake.rs
+++ b/src/daemon/db/task_board/scheduler/wake.rs
@@ -1,0 +1,426 @@
+use std::collections::BTreeSet;
+
+use chrono::{DateTime, Utc};
+use sqlx::{QueryBuilder, Sqlite, query, query_as};
+
+use super::super::ORCHESTRATOR_CHANGE_SCOPE;
+use super::super::items::bump_change_in_tx;
+use super::super::mapper::{parse_json, to_json};
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error};
+use crate::task_board::{
+    TASK_BOARD_AUTOMATION_WAKE_BATCH_LIMIT, TASK_BOARD_AUTOMATION_WAKE_PAYLOAD_SCHEMA_VERSION,
+    TaskBoardAutomationLedgerChangedWakeV1, TaskBoardAutomationRecoveryWakeV1,
+    TaskBoardAutomationWakeCause, TaskBoardAutomationWakeEvent, TaskBoardAutomationWakePayload,
+    TaskBoardAutomationWakeRequest,
+};
+
+const PROCESSED_WAKE_RETENTION_LIMIT: i64 = 500;
+
+#[derive(sqlx::FromRow)]
+pub(super) struct TaskBoardAutomationWakeRow {
+    pub(super) sequence: i64,
+    pub(super) cause: String,
+    pub(super) entity_id: Option<String>,
+    pub(super) entity_revision: Option<i64>,
+    pub(super) payload_json: String,
+    pub(super) created_at: String,
+    pub(super) processed_at: Option<String>,
+}
+
+pub(super) struct TaskBoardAutomationWakeObservation {
+    pub(super) event: TaskBoardAutomationWakeEvent,
+    pub(super) processed_at: Option<String>,
+}
+
+#[derive(sqlx::FromRow)]
+struct WakeAcknowledgementRow {
+    sequence: i64,
+    processed_at: Option<String>,
+}
+
+impl AsyncDaemonDb {
+    pub(crate) async fn enqueue_task_board_automation_wake_event(
+        &self,
+        request: &TaskBoardAutomationWakeRequest,
+        now: DateTime<Utc>,
+    ) -> Result<TaskBoardAutomationWakeEvent, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation wake enqueue")
+            .await?;
+        let event = enqueue_in_tx(&mut transaction, request, now).await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board automation wake enqueue: {error}"
+            ))
+        })?;
+        Ok(event)
+    }
+
+    pub(crate) async fn pending_task_board_automation_wake_events(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<TaskBoardAutomationWakeEvent>, CliError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let rows = query_as::<_, TaskBoardAutomationWakeRow>(
+            "SELECT sequence, cause, entity_id, entity_revision, payload_json, created_at,
+                    processed_at
+             FROM task_board_orchestrator_wake_events
+             WHERE processed_at IS NULL ORDER BY sequence
+             LIMIT ?1",
+        )
+        .bind(i64::from(limit.min(TASK_BOARD_AUTOMATION_WAKE_BATCH_LIMIT)))
+        .fetch_all(self.pool())
+        .await
+        .map_err(|error| db_error(format!("load pending task board wake events: {error}")))?;
+        rows.into_iter()
+            .map(decode_task_board_automation_wake_row)
+            .map(|observation| observation.map(|observation| observation.event))
+            .collect()
+    }
+
+    pub(crate) async fn acknowledge_task_board_automation_wake_events(
+        &self,
+        sequences: &[u64],
+        processed_at: DateTime<Utc>,
+    ) -> Result<u64, CliError> {
+        let sequences = normalize_sequences(sequences)?;
+        if sequences.is_empty() {
+            return Ok(0);
+        }
+        let mut transaction = self
+            .begin_immediate_transaction("task board automation wake acknowledgement")
+            .await?;
+        let rows = load_acknowledgement_rows(&mut transaction, &sequences).await?;
+        validate_acknowledgement_rows(&sequences, &rows)?;
+        let pending = rows
+            .into_iter()
+            .filter(|row| row.processed_at.is_none())
+            .map(|row| row.sequence)
+            .collect::<Vec<_>>();
+        let changed = acknowledge_pending_rows(&mut transaction, &pending, processed_at).await?;
+        if changed > 0 {
+            prune_processed_rows(&mut transaction).await?;
+            bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+        }
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board automation wake acknowledgement: {error}"
+            ))
+        })?;
+        Ok(changed)
+    }
+}
+
+pub(super) async fn enqueue_in_tx(
+    transaction: &mut sqlx::Transaction<'_, Sqlite>,
+    request: &TaskBoardAutomationWakeRequest,
+    now: DateTime<Utc>,
+) -> Result<TaskBoardAutomationWakeEvent, CliError> {
+    validate_wake(
+        request.entity_id.as_deref(),
+        request.entity_revision,
+        &request.payload,
+    )?;
+    let cause = cause_label(request.payload.cause());
+    let entity_revision = request
+        .entity_revision
+        .map(|revision| stored_integer(revision, "wake entity revision"))
+        .transpose()?;
+    let payload_json = encode_payload(&request.payload)?;
+    if let Some(row) = load_duplicate(
+        transaction,
+        cause,
+        request.entity_id.as_deref(),
+        entity_revision,
+        &payload_json,
+    )
+    .await?
+    {
+        return decode_task_board_automation_wake_row(row).map(|value| value.event);
+    }
+    let created_at = now.to_rfc3339();
+    let inserted = query(
+        "INSERT INTO task_board_orchestrator_wake_events (
+            cause, entity_id, entity_revision, payload_json, created_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5)",
+    )
+    .bind(cause)
+    .bind(request.entity_id.as_deref())
+    .bind(entity_revision)
+    .bind(&payload_json)
+    .bind(&created_at)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("enqueue task board automation wake event: {error}")))?;
+    let sequence = event_sequence(inserted.last_insert_rowid())?;
+    bump_change_in_tx(transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+    Ok(TaskBoardAutomationWakeEvent {
+        sequence,
+        entity_id: request.entity_id.clone(),
+        entity_revision: request.entity_revision,
+        payload: request.payload.clone(),
+        created_at,
+    })
+}
+
+async fn load_duplicate(
+    transaction: &mut sqlx::Transaction<'_, Sqlite>,
+    cause: &str,
+    entity_id: Option<&str>,
+    entity_revision: Option<i64>,
+    payload_json: &str,
+) -> Result<Option<TaskBoardAutomationWakeRow>, CliError> {
+    query_as::<_, TaskBoardAutomationWakeRow>(
+        "SELECT sequence, cause, entity_id, entity_revision, payload_json, created_at,
+                processed_at
+         FROM task_board_orchestrator_wake_events
+         WHERE processed_at IS NULL AND cause = ?1 AND entity_id IS ?2
+           AND entity_revision IS ?3 AND payload_json = ?4
+         ORDER BY sequence LIMIT 1",
+    )
+    .bind(cause)
+    .bind(entity_id)
+    .bind(entity_revision)
+    .bind(payload_json)
+    .fetch_optional(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load duplicate task board wake event: {error}")))
+}
+
+async fn load_acknowledgement_rows(
+    transaction: &mut sqlx::Transaction<'_, Sqlite>,
+    sequences: &[i64],
+) -> Result<Vec<WakeAcknowledgementRow>, CliError> {
+    let mut builder = QueryBuilder::<Sqlite>::new(
+        "SELECT sequence, processed_at FROM task_board_orchestrator_wake_events WHERE sequence IN (",
+    );
+    push_sequence_set(&mut builder, sequences);
+    builder.push(") ORDER BY sequence");
+    builder
+        .build_query_as::<WakeAcknowledgementRow>()
+        .fetch_all(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load task board wake acknowledgements: {error}")))
+}
+
+fn validate_acknowledgement_rows(
+    requested: &[i64],
+    rows: &[WakeAcknowledgementRow],
+) -> Result<(), CliError> {
+    let stored = rows.iter().map(|row| row.sequence).collect::<Vec<_>>();
+    if stored != requested {
+        return Err(db_error(
+            "task board wake acknowledgement contains an unknown sequence",
+        ));
+    }
+    for row in rows {
+        if let Some(processed_at) = row.processed_at.as_deref() {
+            parse_timestamp(processed_at, "task board wake processed timestamp")?;
+        }
+    }
+    Ok(())
+}
+
+async fn acknowledge_pending_rows(
+    transaction: &mut sqlx::Transaction<'_, Sqlite>,
+    sequences: &[i64],
+    processed_at: DateTime<Utc>,
+) -> Result<u64, CliError> {
+    if sequences.is_empty() {
+        return Ok(0);
+    }
+    let mut builder = QueryBuilder::<Sqlite>::new(
+        "UPDATE task_board_orchestrator_wake_events SET processed_at = ",
+    );
+    builder.push_bind(processed_at.to_rfc3339());
+    builder.push(" WHERE processed_at IS NULL AND sequence IN (");
+    push_sequence_set(&mut builder, sequences);
+    builder.push(")");
+    let changed = builder
+        .build()
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("acknowledge task board wake events: {error}")))?
+        .rows_affected();
+    let expected = u64::try_from(sequences.len())
+        .map_err(|error| db_error(format!("count task board wake acknowledgements: {error}")))?;
+    if changed != expected {
+        return Err(db_error(
+            "task board wake acknowledgement changed an unexpected sequence set",
+        ));
+    }
+    Ok(changed)
+}
+
+async fn prune_processed_rows(
+    transaction: &mut sqlx::Transaction<'_, Sqlite>,
+) -> Result<(), CliError> {
+    query(
+        "DELETE FROM task_board_orchestrator_wake_events
+         WHERE processed_at IS NOT NULL
+           AND sequence NOT IN (
+               SELECT sequence FROM task_board_orchestrator_wake_events
+               WHERE processed_at IS NOT NULL
+               ORDER BY sequence DESC LIMIT ?1
+           )",
+    )
+    .bind(PROCESSED_WAKE_RETENTION_LIMIT)
+    .execute(transaction.as_mut())
+    .await
+    .map(|_| ())
+    .map_err(|error| db_error(format!("prune processed task board wake events: {error}")))
+}
+
+fn push_sequence_set(builder: &mut QueryBuilder<Sqlite>, sequences: &[i64]) {
+    let mut separated = builder.separated(", ");
+    for sequence in sequences {
+        separated.push_bind(*sequence);
+    }
+}
+
+fn normalize_sequences(sequences: &[u64]) -> Result<Vec<i64>, CliError> {
+    let unique = sequences.iter().copied().collect::<BTreeSet<_>>();
+    if unique.len() > usize::try_from(TASK_BOARD_AUTOMATION_WAKE_BATCH_LIMIT).unwrap_or(usize::MAX)
+    {
+        return Err(db_error("too many task board wake acknowledgements"));
+    }
+    unique
+        .into_iter()
+        .map(|sequence| stored_integer(sequence, "wake sequence"))
+        .collect()
+}
+
+pub(super) fn decode_task_board_automation_wake_row(
+    row: TaskBoardAutomationWakeRow,
+) -> Result<TaskBoardAutomationWakeObservation, CliError> {
+    let sequence = event_sequence(row.sequence)?;
+    let entity_revision = row
+        .entity_revision
+        .map(|revision| event_revision(revision, sequence))
+        .transpose()?;
+    let payload = decode_payload(&row.cause, &row.payload_json, sequence)?;
+    parse_timestamp(&row.created_at, "task board wake created timestamp")?;
+    if let Some(processed_at) = row.processed_at.as_deref() {
+        parse_timestamp(processed_at, "task board wake processed timestamp")?;
+    }
+    validate_wake(row.entity_id.as_deref(), entity_revision, &payload)?;
+    Ok(TaskBoardAutomationWakeObservation {
+        event: TaskBoardAutomationWakeEvent {
+            sequence,
+            entity_id: row.entity_id,
+            entity_revision,
+            payload,
+            created_at: row.created_at,
+        },
+        processed_at: row.processed_at,
+    })
+}
+
+fn validate_wake(
+    entity_id: Option<&str>,
+    entity_revision: Option<u64>,
+    payload: &TaskBoardAutomationWakePayload,
+) -> Result<(), CliError> {
+    if entity_id.is_some_and(|value| value.trim().is_empty()) {
+        return Err(db_error("task board wake event has an empty entity id"));
+    }
+    if entity_revision.is_some() && entity_id.is_none() {
+        return Err(db_error(
+            "task board wake event revision requires an entity id",
+        ));
+    }
+    match payload {
+        TaskBoardAutomationWakePayload::LedgerChanged(value) => {
+            validate_schema(value.schema_version)?;
+            if entity_id.is_none() {
+                return Err(db_error("task board ledger wake requires an entity id"));
+            }
+        }
+        TaskBoardAutomationWakePayload::Recovery(value) => validate_schema(value.schema_version)?,
+    }
+    Ok(())
+}
+
+fn validate_schema(schema_version: u32) -> Result<(), CliError> {
+    if schema_version != TASK_BOARD_AUTOMATION_WAKE_PAYLOAD_SCHEMA_VERSION {
+        return Err(db_error(format!(
+            "unsupported task board wake payload schema v{schema_version}"
+        )));
+    }
+    Ok(())
+}
+
+fn encode_payload(payload: &TaskBoardAutomationWakePayload) -> Result<String, CliError> {
+    match payload {
+        TaskBoardAutomationWakePayload::LedgerChanged(value) => {
+            to_json(value, "task board ledger wake payload")
+        }
+        TaskBoardAutomationWakePayload::Recovery(value) => {
+            to_json(value, "task board recovery wake payload")
+        }
+    }
+}
+
+fn decode_payload(
+    cause: &str,
+    value: &str,
+    sequence: u64,
+) -> Result<TaskBoardAutomationWakePayload, CliError> {
+    let context = format!("task board wake payload {sequence}");
+    match parse_cause(cause)? {
+        TaskBoardAutomationWakeCause::LedgerChanged => {
+            parse_json::<TaskBoardAutomationLedgerChangedWakeV1>(value, &context)
+                .map(TaskBoardAutomationWakePayload::LedgerChanged)
+        }
+        TaskBoardAutomationWakeCause::Recovery => {
+            parse_json::<TaskBoardAutomationRecoveryWakeV1>(value, &context)
+                .map(TaskBoardAutomationWakePayload::Recovery)
+        }
+    }
+}
+
+const fn cause_label(cause: TaskBoardAutomationWakeCause) -> &'static str {
+    match cause {
+        TaskBoardAutomationWakeCause::LedgerChanged => "ledger_changed",
+        TaskBoardAutomationWakeCause::Recovery => "recovery",
+    }
+}
+
+fn parse_cause(value: &str) -> Result<TaskBoardAutomationWakeCause, CliError> {
+    match value {
+        "ledger_changed" => Ok(TaskBoardAutomationWakeCause::LedgerChanged),
+        "recovery" => Ok(TaskBoardAutomationWakeCause::Recovery),
+        value => Err(db_error(format!(
+            "invalid task board automation wake cause '{value}'"
+        ))),
+    }
+}
+
+fn parse_timestamp(value: &str, context: &str) -> Result<(), CliError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|_| ())
+        .map_err(|error| db_error(format!("parse {context}: {error}")))
+}
+
+fn stored_integer(value: u64, context: &str) -> Result<i64, CliError> {
+    i64::try_from(value).map_err(|error| db_error(format!("convert task board {context}: {error}")))
+}
+
+fn event_sequence(value: i64) -> Result<u64, CliError> {
+    let sequence = u64::try_from(value)
+        .map_err(|error| db_error(format!("parse task board wake sequence: {error}")))?;
+    if sequence == 0 {
+        return Err(db_error("task board wake sequence must be positive"));
+    }
+    Ok(sequence)
+}
+
+fn event_revision(value: i64, sequence: u64) -> Result<u64, CliError> {
+    u64::try_from(value).map_err(|error| {
+        db_error(format!(
+            "parse task board wake entity revision {sequence}: {error}"
+        ))
+    })
+}

--- a/src/daemon/db/task_board/scheduler/wake_tests.rs
+++ b/src/daemon/db/task_board/scheduler/wake_tests.rs
@@ -1,0 +1,324 @@
+use std::sync::Arc;
+
+use sqlx::{query, query_scalar};
+use tokio::sync::Barrier;
+
+use super::test_support::{database, instant};
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::{
+    TaskBoardAutomationWakeEntityKind, TaskBoardAutomationWakePayload,
+    TaskBoardAutomationWakeRecoveryReason, TaskBoardAutomationWakeRequest,
+};
+
+#[tokio::test]
+async fn pending_wake_batch_is_bounded_and_stable_by_sequence() {
+    let db = database().await;
+    query(
+        "WITH RECURSIVE values_to_insert(value) AS (
+             SELECT 1 UNION ALL SELECT value + 1 FROM values_to_insert WHERE value < 501
+         )
+         INSERT INTO task_board_orchestrator_wake_events (
+             cause, payload_json, created_at
+         )
+         SELECT 'recovery', '{\"schema_version\":1,\"reason\":\"startup\"}',
+                '2026-07-15T10:00:00+00:00'
+         FROM values_to_insert",
+    )
+    .execute(db.pool())
+    .await
+    .expect("seed pending wake events");
+
+    let first = db
+        .pending_task_board_automation_wake_events(u32::MAX)
+        .await
+        .expect("load first pending batch");
+    let second = db
+        .pending_task_board_automation_wake_events(u32::MAX)
+        .await
+        .expect("load second pending batch");
+
+    assert_eq!(first.len(), 500);
+    assert_eq!(first.first().map(|event| event.sequence), Some(1));
+    assert_eq!(first.last().map(|event| event.sequence), Some(500));
+    assert_eq!(first, second);
+    assert!(
+        db.pending_task_board_automation_wake_events(0)
+            .await
+            .expect("load empty pending batch")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn identical_pending_wake_is_deduplicated_without_revision_churn() {
+    let db = database().await;
+    let request = item_wake("item-neutral", 7);
+    let version_before = orchestrator_version(&db).await;
+    let barrier = Arc::new(Barrier::new(2));
+
+    let (first, second) = tokio::join!(
+        enqueue_after_barrier(db.clone(), request.clone(), Arc::clone(&barrier)),
+        enqueue_after_barrier(db.clone(), request.clone(), Arc::clone(&barrier)),
+    );
+    let first = first.expect("enqueue first wake");
+    let second = second.expect("enqueue duplicate wake");
+
+    assert_eq!(first, second);
+    assert_eq!(orchestrator_version(&db).await, version_before + 1);
+    assert_eq!(pending_sequences(&db).await, vec![first.sequence]);
+}
+
+#[tokio::test]
+async fn sequence_order_survives_a_backward_wall_clock_adjustment() {
+    let db = database().await;
+    let first = db
+        .enqueue_task_board_automation_wake_event(
+            &item_wake("item-first", 1),
+            instant("2026-07-15T11:00:00Z"),
+        )
+        .await
+        .expect("enqueue first wake");
+    let second = db
+        .enqueue_task_board_automation_wake_event(
+            &item_wake("item-second", 1),
+            instant("2026-07-15T10:59:59Z"),
+        )
+        .await
+        .expect("enqueue wake after clock adjustment");
+
+    assert_eq!((first.sequence, second.sequence), (1, 2));
+    assert_eq!(pending_sequences(&db).await, vec![1, 2]);
+}
+
+#[tokio::test]
+async fn wake_acknowledgement_is_exact_atomic_and_idempotent() {
+    let db = database().await;
+    let first = enqueue_item(&db, "item-first", 1).await;
+    let second = enqueue_item(&db, "item-second", 2).await;
+    let third = enqueue_item(&db, "item-third", 3).await;
+    let version_before = orchestrator_version(&db).await;
+
+    assert_eq!(
+        db.acknowledge_task_board_automation_wake_events(
+            &[third, first, first],
+            instant("2026-07-15T12:03:00Z"),
+        )
+        .await
+        .expect("acknowledge exact wake set"),
+        2
+    );
+    assert_eq!(pending_sequences(&db).await, vec![second]);
+    let version_after = orchestrator_version(&db).await;
+    assert_eq!(version_after, version_before + 1);
+
+    assert_eq!(
+        db.acknowledge_task_board_automation_wake_events(
+            &[first, third],
+            instant("2026-07-15T12:04:00Z"),
+        )
+        .await
+        .expect("repeat wake acknowledgement"),
+        0
+    );
+    assert_eq!(orchestrator_version(&db).await, version_after);
+    assert!(
+        db.acknowledge_task_board_automation_wake_events(
+            &[second, 999_999],
+            instant("2026-07-15T12:05:00Z"),
+        )
+        .await
+        .is_err()
+    );
+    assert_eq!(pending_sequences(&db).await, vec![second]);
+}
+
+#[tokio::test]
+async fn acknowledgement_prunes_old_processed_wakes_to_the_retention_bound() {
+    let db = database().await;
+    seed_wakes(&db, 502).await;
+    let first = (1..=500).collect::<Vec<_>>();
+    db.acknowledge_task_board_automation_wake_events(&first, instant("2026-07-15T12:10:00Z"))
+        .await
+        .expect("acknowledge first batch");
+    db.acknowledge_task_board_automation_wake_events(&[501, 502], instant("2026-07-15T12:11:00Z"))
+        .await
+        .expect("acknowledge final batch");
+
+    let retained = query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM task_board_orchestrator_wake_events
+         WHERE processed_at IS NOT NULL",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("count retained wakes");
+    let oldest = query_scalar::<_, i64>(
+        "SELECT MIN(sequence) FROM task_board_orchestrator_wake_events
+         WHERE processed_at IS NOT NULL",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("load oldest retained wake");
+    assert_eq!((retained, oldest), (500, 3));
+}
+
+#[tokio::test]
+async fn malformed_persisted_wake_data_fails_closed() {
+    let db = database().await;
+    let sequence = enqueue_item(&db, "item-strict", 1).await;
+
+    set_wake_column(&db, sequence, "cause", "invalid_cause").await;
+    assert_pending_fails(&db).await;
+    set_wake_column(&db, sequence, "cause", "ledger_changed").await;
+    set_wake_column(
+        &db,
+        sequence,
+        "payload_json",
+        r#"{"schema_version":1,"entity_kind":"item","unexpected":true}"#,
+    )
+    .await;
+    assert_pending_fails(&db).await;
+    set_wake_column(
+        &db,
+        sequence,
+        "payload_json",
+        r#"{"schema_version":2,"entity_kind":"item"}"#,
+    )
+    .await;
+    assert_pending_fails(&db).await;
+    set_wake_column(
+        &db,
+        sequence,
+        "payload_json",
+        r#"{"schema_version":1,"entity_kind":"item"}"#,
+    )
+    .await;
+    set_wake_column(&db, sequence, "created_at", "invalid-timestamp").await;
+    assert_pending_fails(&db).await;
+}
+
+#[tokio::test]
+async fn unacknowledged_wake_survives_database_reopen() {
+    let db = database().await;
+    let path = db.storage_path().to_path_buf();
+    let event = db
+        .enqueue_task_board_automation_wake_event(&recovery_wake(), instant("2026-07-15T14:00:00Z"))
+        .await
+        .expect("enqueue durable wake");
+    drop(db);
+
+    let reopened = AsyncDaemonDb::connect(&path)
+        .await
+        .expect("reopen wake database");
+    assert_eq!(
+        reopened
+            .pending_task_board_automation_wake_events(10)
+            .await
+            .expect("load wake after reopen"),
+        vec![event]
+    );
+}
+
+async fn enqueue_after_barrier(
+    db: AsyncDaemonDb,
+    request: TaskBoardAutomationWakeRequest,
+    barrier: Arc<Barrier>,
+) -> Result<crate::task_board::TaskBoardAutomationWakeEvent, crate::errors::CliError> {
+    barrier.wait().await;
+    db.enqueue_task_board_automation_wake_event(&request, instant("2026-07-15T11:00:00Z"))
+        .await
+}
+
+fn item_wake(entity_id: &str, revision: u64) -> TaskBoardAutomationWakeRequest {
+    TaskBoardAutomationWakeRequest {
+        entity_id: Some(entity_id.into()),
+        entity_revision: Some(revision),
+        payload: TaskBoardAutomationWakePayload::ledger_changed(
+            TaskBoardAutomationWakeEntityKind::Item,
+        ),
+    }
+}
+
+fn recovery_wake() -> TaskBoardAutomationWakeRequest {
+    TaskBoardAutomationWakeRequest {
+        entity_id: None,
+        entity_revision: None,
+        payload: TaskBoardAutomationWakePayload::recovery(
+            TaskBoardAutomationWakeRecoveryReason::Startup,
+        ),
+    }
+}
+
+async fn enqueue_item(db: &AsyncDaemonDb, entity_id: &str, revision: u64) -> u64 {
+    db.enqueue_task_board_automation_wake_event(
+        &item_wake(entity_id, revision),
+        instant("2026-07-15T12:00:00Z"),
+    )
+    .await
+    .expect("enqueue item wake")
+    .sequence
+}
+
+async fn seed_wakes(db: &AsyncDaemonDb, count: i64) {
+    query(
+        "WITH RECURSIVE values_to_insert(value) AS (
+             SELECT 1 UNION ALL SELECT value + 1 FROM values_to_insert WHERE value < ?1
+         )
+         INSERT INTO task_board_orchestrator_wake_events (
+             cause, entity_id, entity_revision, payload_json, created_at
+         )
+         SELECT 'ledger_changed', 'item-' || value, value,
+                '{\"schema_version\":1,\"entity_kind\":\"item\"}',
+                '2026-07-15T12:00:00+00:00'
+         FROM values_to_insert",
+    )
+    .bind(count)
+    .execute(db.pool())
+    .await
+    .expect("seed wake rows");
+}
+
+async fn pending_sequences(db: &AsyncDaemonDb) -> Vec<u64> {
+    db.pending_task_board_automation_wake_events(500)
+        .await
+        .expect("load pending wake sequences")
+        .into_iter()
+        .map(|event| event.sequence)
+        .collect()
+}
+
+async fn orchestrator_version(db: &AsyncDaemonDb) -> i64 {
+    query_scalar::<_, i64>(
+        "SELECT COALESCE((SELECT version FROM change_tracking WHERE scope = ?1), 0)",
+    )
+    .bind(super::super::ORCHESTRATOR_CHANGE_SCOPE)
+    .fetch_one(db.pool())
+    .await
+    .expect("load orchestrator change version")
+}
+
+async fn set_wake_column(db: &AsyncDaemonDb, sequence: u64, column: &str, value: &str) {
+    let sql = match column {
+        "cause" => "UPDATE task_board_orchestrator_wake_events SET cause = ?2 WHERE sequence = ?1",
+        "payload_json" => {
+            "UPDATE task_board_orchestrator_wake_events SET payload_json = ?2 WHERE sequence = ?1"
+        }
+        "created_at" => {
+            "UPDATE task_board_orchestrator_wake_events SET created_at = ?2 WHERE sequence = ?1"
+        }
+        _ => panic!("unsupported wake fixture column"),
+    };
+    query(sql)
+        .bind(i64::try_from(sequence).expect("stored sequence"))
+        .bind(value)
+        .execute(db.pool())
+        .await
+        .expect("update wake fixture");
+}
+
+async fn assert_pending_fails(db: &AsyncDaemonDb) {
+    assert!(
+        db.pending_task_board_automation_wake_events(10)
+            .await
+            .is_err()
+    );
+}

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -32,6 +32,7 @@ mod schema;
 mod schema_backfill;
 mod schema_migrations;
 mod schema_shape_repairs;
+mod schema_shape_repairs_wake_events;
 mod signals;
 mod sync;
 mod sync_change_tracking;

--- a/src/daemon/db/tests/schema_shape_repairs_wake_events.rs
+++ b/src/daemon/db/tests/schema_shape_repairs_wake_events.rs
@@ -1,0 +1,170 @@
+use tempfile::tempdir;
+
+use super::*;
+
+const WAKE_TABLE_SQL: &str = "
+CREATE TABLE task_board_orchestrator_wake_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    cause TEXT NOT NULL,
+    entity_id TEXT,
+    entity_revision INTEGER,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    processed_at TEXT
+)";
+
+#[tokio::test]
+async fn async_connect_repairs_missing_wake_event_table_and_index() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute("DROP TABLE task_board_orchestrator_wake_events", [])
+        .expect("drop wake-event table");
+    drop(sync_db);
+
+    let async_db = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect("repair wake-event table");
+    let objects: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE (type = 'table' AND name = 'task_board_orchestrator_wake_events')
+            OR (type = 'index' AND name = 'task_board_orchestrator_wake_events_pending')",
+    )
+    .fetch_one(async_db.pool())
+    .await
+    .expect("inspect repaired wake-event objects");
+
+    assert_eq!(objects, 2);
+}
+
+#[tokio::test]
+async fn async_connect_repairs_missing_wake_event_pending_index() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute("DROP INDEX task_board_orchestrator_wake_events_pending", [])
+        .expect("drop wake-event pending index");
+    drop(sync_db);
+
+    let async_db = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect("repair wake-event pending index");
+    let columns: Vec<String> = sqlx::query_scalar(
+        "SELECT name FROM pragma_index_xinfo('task_board_orchestrator_wake_events_pending')
+         WHERE key = 1 ORDER BY seqno",
+    )
+    .fetch_all(async_db.pool())
+    .await
+    .expect("inspect repaired wake-event pending index");
+
+    assert_eq!(columns, ["processed_at", "sequence"]);
+}
+
+#[tokio::test]
+async fn async_connect_refuses_incompatible_wake_event_table_shapes() {
+    for (case, sql) in [
+        (
+            "missing autoincrement",
+            WAKE_TABLE_SQL.replace(" PRIMARY KEY AUTOINCREMENT", " PRIMARY KEY"),
+        ),
+        (
+            "wrong cause type",
+            WAKE_TABLE_SQL.replace("cause TEXT NOT NULL", "cause BLOB NOT NULL"),
+        ),
+        (
+            "wrong payload default",
+            WAKE_TABLE_SQL.replace("DEFAULT '{}'", "DEFAULT '[]'"),
+        ),
+        (
+            "extra column",
+            WAKE_TABLE_SQL.replace(
+                "processed_at TEXT",
+                "processed_at TEXT, sentinel TEXT NOT NULL DEFAULT 'preserve-me'",
+            ),
+        ),
+    ] {
+        assert_wake_table_shape_rejected(case, &sql).await;
+    }
+}
+
+#[tokio::test]
+async fn async_connect_refuses_malformed_wake_event_pending_index() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute_batch(
+            "DROP INDEX task_board_orchestrator_wake_events_pending;
+             CREATE UNIQUE INDEX task_board_orchestrator_wake_events_pending
+             ON task_board_orchestrator_wake_events(sequence, processed_at)
+             WHERE processed_at IS NULL;",
+        )
+        .expect("replace wake-event pending index");
+    drop(sync_db);
+
+    let error = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect_err("malformed wake-event index must fail closed");
+
+    assert!(error.to_string().contains("wake_events_pending"));
+    let conn = Connection::open(&db_path).expect("reopen incompatible database");
+    let definition: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'index' AND name = 'task_board_orchestrator_wake_events_pending'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("inspect preserved wake-event index");
+    assert!(definition.contains("CREATE UNIQUE INDEX"));
+    assert!(definition.contains("sequence, processed_at"));
+}
+
+async fn assert_wake_table_shape_rejected(case: &str, table_sql: &str) {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute_batch("DROP TABLE task_board_orchestrator_wake_events")
+        .expect("drop canonical wake-event table");
+    sync_db
+        .connection()
+        .execute_batch(table_sql)
+        .unwrap_or_else(|error| panic!("create {case} fixture: {error}"));
+    sync_db
+        .connection()
+        .execute(
+            "INSERT INTO task_board_orchestrator_wake_events (
+                 cause, payload_json, created_at
+             ) VALUES ('ledger_changed', '{\"sentinel\":true}', '2026-07-17T12:00:00Z')",
+            [],
+        )
+        .unwrap_or_else(|error| panic!("seed {case} fixture: {error}"));
+    drop(sync_db);
+
+    let error = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect_err("incompatible wake-event table must fail closed");
+    assert!(
+        error
+            .to_string()
+            .contains("incompatible task_board_orchestrator_wake_events schema"),
+        "case {case}: {error}"
+    );
+
+    let conn = Connection::open(&db_path).expect("reopen incompatible database");
+    let payload: String = conn
+        .query_row(
+            "SELECT payload_json FROM task_board_orchestrator_wake_events WHERE sequence = 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read preserved wake-event sentinel");
+    assert_eq!(payload, "{\"sentinel\":true}");
+}

--- a/src/daemon/service/serve/mod.rs
+++ b/src/daemon/service/serve/mod.rs
@@ -12,6 +12,7 @@ mod open_db;
 mod policy_bootstrap;
 mod remote;
 mod shutdown_signals;
+mod task_board_automation_loop;
 mod task_board_dispatch_loop;
 mod task_board_migration;
 mod task_board_orchestrator_loop;

--- a/src/daemon/service/serve/task_board_automation_loop.rs
+++ b/src/daemon/service/serve/task_board_automation_loop.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
+use sha2::{Digest, Sha256};
 use tokio::sync::watch as tokio_watch;
 use tokio::task::JoinHandle;
 use tokio::time::{MissedTickBehavior, interval};
@@ -58,7 +59,9 @@ async fn run_task_board_automation_loop(
             () = wait_for_shutdown(&mut shutdown_rx) => break,
             _ = ticker.tick() => {
                 if let Err(error) = run_loop_tick(&state, db.as_ref(), &mut loop_state).await {
-                    loop_state.record_failure(db.as_ref()).await;
+                    loop_state
+                        .record_failure(db.as_ref(), &state.daemon_epoch)
+                        .await;
                     tracing::warn!(%error, "task-board automation coordinator tick failed");
                 }
             }
@@ -88,14 +91,14 @@ impl AutomationLoopState {
             .is_some_and(|deadline| Instant::now() < deadline)
     }
 
-    async fn record_failure(&mut self, db: &AsyncDaemonDb) {
+    async fn record_failure(&mut self, db: &AsyncDaemonDb, stable_key: &str) {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
         let retry = db.task_board_orchestrator_settings().await.map_or_else(
             |_| TaskBoardAutomationRetrySettings::default(),
             |value| value.retry,
         );
         self.retry_not_before =
-            Some(Instant::now() + retry_delay(&retry, self.consecutive_failures));
+            Some(Instant::now() + retry_delay(&retry, stable_key, self.consecutive_failures));
     }
 
     fn record_success(&mut self) {
@@ -105,15 +108,16 @@ impl AutomationLoopState {
     }
 }
 
-fn retry_delay(retry: &TaskBoardAutomationRetrySettings, failures: u32) -> Duration {
+fn retry_delay(
+    retry: &TaskBoardAutomationRetrySettings,
+    stable_key: &str,
+    failures: u32,
+) -> Duration {
     let cap = retry
         .max_delay_seconds
         .clamp(1, MAX_COORDINATOR_BACKOFF_SECONDS);
     let mut seconds = retry.base_delay_seconds.max(1).min(cap);
     let multiplier = u64::from(retry.multiplier.max(1));
-    if multiplier == 1 {
-        return Duration::from_secs(seconds);
-    }
     let steps = failures
         .saturating_sub(1)
         .min(retry.max_attempts.saturating_sub(1));
@@ -123,7 +127,32 @@ fn retry_delay(retry: &TaskBoardAutomationRetrySettings, failures: u32) -> Durat
         }
         seconds = seconds.saturating_mul(multiplier).min(cap);
     }
-    Duration::from_secs(seconds)
+    Duration::from_secs(
+        deterministic_jitter(
+            seconds,
+            stable_key,
+            failures,
+            retry.deterministic_jitter_percent,
+        )
+        .min(cap),
+    )
+}
+
+fn deterministic_jitter(base: u64, stable_key: &str, attempt: u32, percent: u8) -> u64 {
+    let percent = u64::from(percent.min(100));
+    if percent == 0 {
+        return base;
+    }
+    let digest = Sha256::digest(format!("{stable_key}:{attempt}").as_bytes());
+    let sample = u64::from_be_bytes(
+        digest[..8]
+            .try_into()
+            .expect("sha256 prefix is eight bytes"),
+    );
+    let offset =
+        i128::from(sample % (percent.saturating_mul(2).saturating_add(1))) - i128::from(percent);
+    let scaled = i128::from(base).saturating_mul(100_i128.saturating_add(offset)) / 100;
+    u64::try_from(scaled.max(1)).unwrap_or(u64::MAX)
 }
 
 async fn initialize_automation(db: &AsyncDaemonDb) -> Result<i64, CliError> {

--- a/src/daemon/service/serve/task_board_automation_loop.rs
+++ b/src/daemon/service/serve/task_board_automation_loop.rs
@@ -1,0 +1,364 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use tokio::sync::watch as tokio_watch;
+use tokio::task::JoinHandle;
+use tokio::time::{MissedTickBehavior, interval};
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::daemon::http::{DaemonHttpState, task_board_route_executor};
+use crate::daemon::protocol::TaskBoardOrchestratorRunOnceRequest;
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::{
+    TASK_BOARD_AUTOMATION_WAKE_BATCH_LIMIT, TaskBoardAutomationAdmissionState,
+    TaskBoardAutomationDesiredMode, TaskBoardAutomationRetrySettings,
+    TaskBoardAutomationRunTrigger, TaskBoardAutomationWakeCause, TaskBoardAutomationWakeEntityKind,
+    TaskBoardAutomationWakeEvent, TaskBoardAutomationWakePayload,
+    TaskBoardAutomationWakeRecoveryReason, TaskBoardAutomationWakeRequest,
+    TaskBoardOrchestratorSettings, TaskBoardOrchestratorState,
+};
+
+const MINIMUM_TICK_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_COORDINATOR_BACKOFF_SECONDS: u64 = 3_600;
+
+pub(super) fn spawn_task_board_automation_loop(
+    state: DaemonHttpState,
+    db: Arc<AsyncDaemonDb>,
+    tick_interval: Duration,
+    shutdown_rx: tokio_watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    tokio::spawn(run_task_board_automation_loop(
+        state,
+        db,
+        tick_interval,
+        shutdown_rx,
+    ))
+}
+
+async fn run_task_board_automation_loop(
+    state: DaemonHttpState,
+    db: Arc<AsyncDaemonDb>,
+    tick_interval: Duration,
+    mut shutdown_rx: tokio_watch::Receiver<bool>,
+) {
+    let change_sequence = match initialize_automation(db.as_ref()).await {
+        Ok(sequence) => sequence,
+        Err(error) => {
+            tracing::error!(%error, "task-board automation startup recovery failed");
+            return;
+        }
+    };
+    let mut loop_state = AutomationLoopState::new(change_sequence);
+    let mut ticker = interval(tick_interval.max(MINIMUM_TICK_INTERVAL));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            () = wait_for_shutdown(&mut shutdown_rx) => break,
+            _ = ticker.tick() => {
+                if let Err(error) = run_loop_tick(&state, db.as_ref(), &mut loop_state).await {
+                    loop_state.record_failure(db.as_ref()).await;
+                    tracing::warn!(%error, "task-board automation coordinator tick failed");
+                }
+            }
+        }
+    }
+}
+
+struct AutomationLoopState {
+    change_sequence: i64,
+    last_reconciliation: Instant,
+    retry_not_before: Option<Instant>,
+    consecutive_failures: u32,
+}
+
+impl AutomationLoopState {
+    fn new(change_sequence: i64) -> Self {
+        Self {
+            change_sequence,
+            last_reconciliation: Instant::now(),
+            retry_not_before: None,
+            consecutive_failures: 0,
+        }
+    }
+
+    fn is_backing_off(&self) -> bool {
+        self.retry_not_before
+            .is_some_and(|deadline| Instant::now() < deadline)
+    }
+
+    async fn record_failure(&mut self, db: &AsyncDaemonDb) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        let retry = db.task_board_orchestrator_settings().await.map_or_else(
+            |_| TaskBoardAutomationRetrySettings::default(),
+            |value| value.retry,
+        );
+        self.retry_not_before =
+            Some(Instant::now() + retry_delay(&retry, self.consecutive_failures));
+    }
+
+    fn record_success(&mut self) {
+        self.retry_not_before = None;
+        self.consecutive_failures = 0;
+        self.last_reconciliation = Instant::now();
+    }
+}
+
+fn retry_delay(retry: &TaskBoardAutomationRetrySettings, failures: u32) -> Duration {
+    let cap = retry
+        .max_delay_seconds
+        .clamp(1, MAX_COORDINATOR_BACKOFF_SECONDS);
+    let mut seconds = retry.base_delay_seconds.max(1).min(cap);
+    let multiplier = u64::from(retry.multiplier.max(1));
+    if multiplier == 1 {
+        return Duration::from_secs(seconds);
+    }
+    let steps = failures
+        .saturating_sub(1)
+        .min(retry.max_attempts.saturating_sub(1));
+    for _ in 0..steps {
+        if seconds >= cap {
+            break;
+        }
+        seconds = seconds.saturating_mul(multiplier).min(cap);
+    }
+    Duration::from_secs(seconds)
+}
+
+async fn initialize_automation(db: &AsyncDaemonDb) -> Result<i64, CliError> {
+    let now = Utc::now();
+    initialize_control_from_legacy_intent(db, now).await?;
+    let expired = maintain_automation_state(db, now).await?;
+    if automatic_runs_enabled(db).await? {
+        let reason = if expired > 0 {
+            TaskBoardAutomationWakeRecoveryReason::LeaseExpired
+        } else {
+            TaskBoardAutomationWakeRecoveryReason::Startup
+        };
+        db.enqueue_task_board_automation_wake_event(
+            &TaskBoardAutomationWakeRequest {
+                entity_id: None,
+                entity_revision: None,
+                payload: TaskBoardAutomationWakePayload::recovery(reason),
+            },
+            now,
+        )
+        .await?;
+    }
+    db.current_change_sequence().await
+}
+
+async fn maintain_automation_state(
+    db: &AsyncDaemonDb,
+    now: chrono::DateTime<Utc>,
+) -> Result<u64, CliError> {
+    db.finish_task_board_automation_drain_if_idle(now).await?;
+    let expired = db.recover_stale_task_board_automation_runs(now).await?;
+    db.finish_task_board_automation_drain_if_idle(now).await?;
+    Ok(expired)
+}
+
+async fn initialize_control_from_legacy_intent(
+    db: &AsyncDaemonDb,
+    now: chrono::DateTime<Utc>,
+) -> Result<(), CliError> {
+    let state = db.task_board_orchestrator_state().await?;
+    let settings = db.task_board_orchestrator_settings().await?;
+    db.initialize_task_board_automation_control_from_legacy_intent(
+        desired_mode_for_legacy_intent(&state, &settings),
+        now,
+    )
+    .await?;
+    Ok(())
+}
+
+const fn desired_mode_for_legacy_intent(
+    state: &TaskBoardOrchestratorState,
+    settings: &TaskBoardOrchestratorSettings,
+) -> TaskBoardAutomationDesiredMode {
+    if !state.enabled || !state.running {
+        return TaskBoardAutomationDesiredMode::Off;
+    }
+    if settings.step_mode {
+        TaskBoardAutomationDesiredMode::Step
+    } else {
+        TaskBoardAutomationDesiredMode::Continuous
+    }
+}
+
+async fn run_loop_tick(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    loop_state: &mut AutomationLoopState,
+) -> Result<(), CliError> {
+    maintain_automation_tick(db).await?;
+    if !capture_automatic_change_wakes(db, &mut loop_state.change_sequence).await?
+        || loop_state.is_backing_off()
+    {
+        return Ok(());
+    }
+    if !automatic_runs_enabled(db).await? {
+        return Ok(());
+    }
+    let wakes = db
+        .pending_task_board_automation_wake_events(TASK_BOARD_AUTOMATION_WAKE_BATCH_LIMIT)
+        .await?;
+    if !wakes.is_empty() {
+        process_wake_batch(db, &wakes, |trigger| async move {
+            task_board_route_executor::run_once_with_trigger(
+                state,
+                TaskBoardOrchestratorRunOnceRequest::default(),
+                trigger,
+            )
+            .await
+            .map(|_| ())
+        })
+        .await?;
+        loop_state.record_success();
+        return Ok(());
+    }
+    run_interval_fallback(state, db, loop_state).await
+}
+
+async fn maintain_automation_tick(db: &AsyncDaemonDb) -> Result<(), CliError> {
+    let now = Utc::now();
+    let expired = maintain_automation_state(db, now).await?;
+    if expired > 0 && automatic_runs_enabled(db).await? {
+        db.enqueue_task_board_automation_wake_event(
+            &TaskBoardAutomationWakeRequest {
+                entity_id: None,
+                entity_revision: None,
+                payload: TaskBoardAutomationWakePayload::recovery(
+                    TaskBoardAutomationWakeRecoveryReason::LeaseExpired,
+                ),
+            },
+            now,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn run_interval_fallback(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    loop_state: &mut AutomationLoopState,
+) -> Result<(), CliError> {
+    let settings = db.task_board_orchestrator_settings().await?;
+    let reconcile_after =
+        Duration::from_secs(settings.scheduling.reconcile_interval_seconds.max(1));
+    if loop_state.last_reconciliation.elapsed() < reconcile_after {
+        return Ok(());
+    }
+    task_board_route_executor::run_once_with_trigger(
+        state,
+        TaskBoardOrchestratorRunOnceRequest::default(),
+        TaskBoardAutomationRunTrigger::Scheduled,
+    )
+    .await?;
+    loop_state.record_success();
+    Ok(())
+}
+
+async fn capture_automatic_change_wakes(
+    db: &AsyncDaemonDb,
+    change_sequence: &mut i64,
+) -> Result<bool, CliError> {
+    if !automatic_runs_enabled(db).await? {
+        *change_sequence = db.current_change_sequence().await?;
+        return Ok(false);
+    }
+    enqueue_change_wakes(db, change_sequence).await?;
+    Ok(true)
+}
+
+async fn enqueue_change_wakes(
+    db: &AsyncDaemonDb,
+    change_sequence: &mut i64,
+) -> Result<(), CliError> {
+    for (scope, sequence) in db.load_change_tracking_since(*change_sequence).await? {
+        if let Some(entity_kind) = wake_entity_kind(&scope) {
+            let revision = u64::try_from(sequence).map_err(|error| {
+                CliErrorKind::workflow_io(format!(
+                    "task-board change sequence is out of range: {error}"
+                ))
+            })?;
+            db.enqueue_task_board_automation_wake_event(
+                &TaskBoardAutomationWakeRequest {
+                    entity_id: Some(scope),
+                    entity_revision: Some(revision),
+                    payload: TaskBoardAutomationWakePayload::ledger_changed(entity_kind),
+                },
+                Utc::now(),
+            )
+            .await?;
+        }
+        *change_sequence = (*change_sequence).max(sequence);
+    }
+    Ok(())
+}
+
+fn wake_entity_kind(scope: &str) -> Option<TaskBoardAutomationWakeEntityKind> {
+    match scope {
+        "task_board:items" => Some(TaskBoardAutomationWakeEntityKind::Item),
+        "task_board:runtime_config" => Some(TaskBoardAutomationWakeEntityKind::Settings),
+        "task_board:policy_pipeline" => Some(TaskBoardAutomationWakeEntityKind::Policy),
+        _ => None,
+    }
+}
+
+async fn process_wake_batch<Run, RunFuture>(
+    db: &AsyncDaemonDb,
+    wakes: &[TaskBoardAutomationWakeEvent],
+    run: Run,
+) -> Result<(), CliError>
+where
+    Run: FnOnce(TaskBoardAutomationRunTrigger) -> RunFuture,
+    RunFuture: Future<Output = Result<(), CliError>>,
+{
+    // The durable route returns `Ok` only after finalization. A partial run is
+    // terminal and acknowledged here; provider-scope backoff owns its retry.
+    run(trigger_for_wakes(wakes)).await?;
+    let sequences = wakes.iter().map(|wake| wake.sequence).collect::<Vec<_>>();
+    db.acknowledge_task_board_automation_wake_events(&sequences, Utc::now())
+        .await?;
+    Ok(())
+}
+
+async fn automatic_runs_enabled(db: &AsyncDaemonDb) -> Result<bool, CliError> {
+    let control = db.task_board_automation_control().await?;
+    Ok(
+        control.desired_mode == TaskBoardAutomationDesiredMode::Continuous
+            && control.admission_state == TaskBoardAutomationAdmissionState::Accepting,
+    )
+}
+
+fn trigger_for_wakes(wakes: &[TaskBoardAutomationWakeEvent]) -> TaskBoardAutomationRunTrigger {
+    if wakes
+        .iter()
+        .any(|wake| wake.payload.cause() == TaskBoardAutomationWakeCause::Recovery)
+    {
+        return TaskBoardAutomationRunTrigger::Recovery;
+    }
+    TaskBoardAutomationRunTrigger::Event
+}
+
+async fn wait_for_shutdown(shutdown_rx: &mut tokio_watch::Receiver<bool>) {
+    if *shutdown_rx.borrow() {
+        return;
+    }
+    while shutdown_rx.changed().await.is_ok() {
+        if *shutdown_rx.borrow() {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "task_board_automation_loop_tests.rs"]
+mod tests;
+
+#[cfg(test)]
+#[path = "task_board_automation_loop_recovery_tests.rs"]
+mod recovery_tests;

--- a/src/daemon/service/serve/task_board_automation_loop_recovery_tests.rs
+++ b/src/daemon/service/serve/task_board_automation_loop_recovery_tests.rs
@@ -1,0 +1,103 @@
+use chrono::{Duration, Utc};
+use sqlx::{query, query_as};
+
+use super::*;
+use crate::daemon::db::{TaskBoardAutomationRunAdmission, TaskBoardRunAcquireRequest};
+use crate::task_board::{
+    TaskBoardAutomationScope, TaskBoardAutomationWakeEvent, TaskBoardAutomationWakePayload,
+};
+
+async fn database() -> AsyncDaemonDb {
+    let temp = tempfile::tempdir().expect("tempdir");
+    AsyncDaemonDb::connect(&temp.keep().join("harness.db"))
+        .await
+        .expect("open database")
+}
+
+async fn acquire_run(db: &AsyncDaemonDb, run_id: &str, now: chrono::DateTime<Utc>) {
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, now)
+        .await
+        .expect("start automation");
+    let admission = db
+        .try_acquire_task_board_automation_run(&TaskBoardRunAcquireRequest {
+            run_id: run_id.into(),
+            trigger: TaskBoardAutomationRunTrigger::Scheduled,
+            actor: Some("scheduler-test".into()),
+            dry_run: false,
+            scope: TaskBoardAutomationScope::default(),
+            lease_owner: "scheduler-test-owner".into(),
+            now,
+        })
+        .await
+        .expect("acquire run");
+    assert!(matches!(
+        admission,
+        TaskBoardAutomationRunAdmission::Acquired(_)
+    ));
+}
+
+async fn expire_run(db: &AsyncDaemonDb, run_id: &str, now: chrono::DateTime<Utc>) {
+    query("UPDATE task_board_orchestrator_runs SET lease_expires_at = ?2 WHERE run_id = ?1")
+        .bind(run_id)
+        .bind((now - Duration::seconds(1)).to_rfc3339())
+        .execute(db.pool())
+        .await
+        .expect("expire run");
+}
+
+#[tokio::test]
+async fn tick_maintenance_finishes_a_dropped_stop_without_restart() {
+    let db = database().await;
+    let now = Utc::now();
+    acquire_run(&db, "run-dropped-stop", now).await;
+    db.stop_task_board_automation(now + Duration::seconds(1))
+        .await
+        .expect("stop automation");
+    expire_run(&db, "run-dropped-stop", now).await;
+
+    maintain_automation_tick(&db)
+        .await
+        .expect("maintain stopped automation");
+
+    let run = query_as::<_, (String, String)>(
+        "SELECT state, outcome FROM task_board_orchestrator_runs WHERE run_id = ?1",
+    )
+    .bind("run-dropped-stop")
+    .fetch_one(db.pool())
+    .await
+    .expect("load recovered run");
+    assert_eq!(run, ("terminal".into(), "cancelled".into()));
+    let control = db
+        .task_board_automation_control()
+        .await
+        .expect("load stopped control");
+    assert_eq!(control.desired_mode, TaskBoardAutomationDesiredMode::Off);
+    assert_eq!(
+        control.admission_state,
+        TaskBoardAutomationAdmissionState::Stopped
+    );
+}
+
+#[tokio::test]
+async fn tick_maintenance_enqueues_lease_expired_recovery() {
+    let db = database().await;
+    let now = Utc::now();
+    acquire_run(&db, "run-dropped-continuous", now).await;
+    expire_run(&db, "run-dropped-continuous", now).await;
+
+    maintain_automation_tick(&db)
+        .await
+        .expect("maintain continuous automation");
+
+    let wakes = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load recovery wake");
+    assert!(matches!(
+        wakes.as_slice(),
+        [TaskBoardAutomationWakeEvent {
+            payload: TaskBoardAutomationWakePayload::Recovery(value),
+            ..
+        }] if value.reason == TaskBoardAutomationWakeRecoveryReason::LeaseExpired
+    ));
+}

--- a/src/daemon/service/serve/task_board_automation_loop_tests.rs
+++ b/src/daemon/service/serve/task_board_automation_loop_tests.rs
@@ -96,11 +96,11 @@ fn retry_delay_is_exponential_and_bounded() {
         deterministic_jitter_percent: 0,
     };
 
-    assert_eq!(retry_delay(&retry, 1), Duration::from_secs(2));
-    assert_eq!(retry_delay(&retry, 2), Duration::from_secs(6));
-    assert_eq!(retry_delay(&retry, 3), Duration::from_secs(18));
-    assert_eq!(retry_delay(&retry, 4), Duration::from_secs(20));
-    assert_eq!(retry_delay(&retry, 10), Duration::from_secs(20));
+    assert_eq!(retry_delay(&retry, "epoch", 1), Duration::from_secs(2));
+    assert_eq!(retry_delay(&retry, "epoch", 2), Duration::from_secs(6));
+    assert_eq!(retry_delay(&retry, "epoch", 3), Duration::from_secs(18));
+    assert_eq!(retry_delay(&retry, "epoch", 4), Duration::from_secs(20));
+    assert_eq!(retry_delay(&retry, "epoch", 10), Duration::from_secs(20));
 
     let unbounded = TaskBoardAutomationRetrySettings {
         max_attempts: u32::MAX,
@@ -110,9 +110,32 @@ fn retry_delay_is_exponential_and_bounded() {
         deterministic_jitter_percent: 0,
     };
     assert_eq!(
-        retry_delay(&unbounded, u32::MAX),
+        retry_delay(&unbounded, "epoch", u32::MAX),
         Duration::from_secs(MAX_COORDINATOR_BACKOFF_SECONDS)
     );
+
+    let jittered = TaskBoardAutomationRetrySettings {
+        max_attempts: 1,
+        base_delay_seconds: 100,
+        multiplier: 1,
+        max_delay_seconds: 200,
+        deterministic_jitter_percent: 20,
+    };
+    assert_eq!(
+        retry_delay(&jittered, "epoch-a", 1),
+        Duration::from_secs(86)
+    );
+    assert_ne!(
+        retry_delay(&jittered, "epoch-a", 1),
+        retry_delay(&jittered, "epoch-b", 1)
+    );
+
+    let capped = TaskBoardAutomationRetrySettings {
+        base_delay_seconds: 200,
+        deterministic_jitter_percent: 100,
+        ..jittered
+    };
+    assert_eq!(retry_delay(&capped, "epoch-a", 1), Duration::from_secs(200));
 }
 
 #[test]

--- a/src/daemon/service/serve/task_board_automation_loop_tests.rs
+++ b/src/daemon/service/serve/task_board_automation_loop_tests.rs
@@ -1,0 +1,462 @@
+use chrono::{Duration as ChronoDuration, Utc};
+use sqlx::{query, query_as};
+
+use super::*;
+use crate::daemon::db::{TaskBoardAutomationRunAdmission, TaskBoardRunAcquireRequest};
+use crate::task_board::{
+    TaskBoardAutomationScope, TaskBoardAutomationWakePayload, TaskBoardAutomationWakeRequest,
+    TaskBoardItem,
+};
+
+async fn database() -> AsyncDaemonDb {
+    let temp = tempfile::tempdir().expect("tempdir");
+    AsyncDaemonDb::connect(&temp.keep().join("harness.db"))
+        .await
+        .expect("open database")
+}
+
+async fn start_automation(db: &AsyncDaemonDb) {
+    db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, Utc::now())
+        .await
+        .expect("start automation");
+}
+
+async fn enqueue_item_wake(
+    db: &AsyncDaemonDb,
+    entity_id: &str,
+    revision: u64,
+) -> TaskBoardAutomationWakeEvent {
+    db.enqueue_task_board_automation_wake_event(
+        &TaskBoardAutomationWakeRequest {
+            entity_id: Some(entity_id.into()),
+            entity_revision: Some(revision),
+            payload: TaskBoardAutomationWakePayload::ledger_changed(
+                TaskBoardAutomationWakeEntityKind::Item,
+            ),
+        },
+        Utc::now(),
+    )
+    .await
+    .expect("enqueue item wake")
+}
+
+#[test]
+fn only_current_coordinator_inputs_map_to_change_wakes() {
+    assert_eq!(
+        wake_entity_kind("task_board:items"),
+        Some(TaskBoardAutomationWakeEntityKind::Item)
+    );
+    assert_eq!(
+        wake_entity_kind("task_board:runtime_config"),
+        Some(TaskBoardAutomationWakeEntityKind::Settings)
+    );
+    assert_eq!(
+        wake_entity_kind("task_board:policy_pipeline"),
+        Some(TaskBoardAutomationWakeEntityKind::Policy)
+    );
+    assert_eq!(wake_entity_kind("task_board:orchestrator"), None);
+    assert_eq!(wake_entity_kind("task_board:machines"), None);
+    assert_eq!(wake_entity_kind("task_board:policy_runtime"), None);
+}
+
+#[test]
+fn recovery_wakes_take_precedence_over_ledger_wakes() {
+    let ledger = TaskBoardAutomationWakeEvent {
+        sequence: 1,
+        entity_id: Some("task_board:items".into()),
+        entity_revision: Some(1),
+        payload: TaskBoardAutomationWakePayload::ledger_changed(
+            TaskBoardAutomationWakeEntityKind::Item,
+        ),
+        created_at: "2026-07-17T10:00:00Z".into(),
+    };
+    let recovery = TaskBoardAutomationWakeEvent {
+        sequence: 2,
+        entity_id: None,
+        entity_revision: None,
+        payload: TaskBoardAutomationWakePayload::recovery(
+            TaskBoardAutomationWakeRecoveryReason::Startup,
+        ),
+        created_at: "2026-07-17T10:00:01Z".into(),
+    };
+
+    assert_eq!(
+        trigger_for_wakes(&[ledger, recovery]),
+        TaskBoardAutomationRunTrigger::Recovery
+    );
+}
+
+#[test]
+fn retry_delay_is_exponential_and_bounded() {
+    let retry = TaskBoardAutomationRetrySettings {
+        max_attempts: 4,
+        base_delay_seconds: 2,
+        multiplier: 3,
+        max_delay_seconds: 20,
+        deterministic_jitter_percent: 0,
+    };
+
+    assert_eq!(retry_delay(&retry, 1), Duration::from_secs(2));
+    assert_eq!(retry_delay(&retry, 2), Duration::from_secs(6));
+    assert_eq!(retry_delay(&retry, 3), Duration::from_secs(18));
+    assert_eq!(retry_delay(&retry, 4), Duration::from_secs(20));
+    assert_eq!(retry_delay(&retry, 10), Duration::from_secs(20));
+
+    let unbounded = TaskBoardAutomationRetrySettings {
+        max_attempts: u32::MAX,
+        base_delay_seconds: 1,
+        multiplier: 2,
+        max_delay_seconds: u64::MAX,
+        deterministic_jitter_percent: 0,
+    };
+    assert_eq!(
+        retry_delay(&unbounded, u32::MAX),
+        Duration::from_secs(MAX_COORDINATOR_BACKOFF_SECONDS)
+    );
+}
+
+#[test]
+fn retry_backoff_blocks_an_already_due_interval() {
+    let mut loop_state = AutomationLoopState::new(0);
+    loop_state.last_reconciliation = Instant::now() - Duration::from_secs(60);
+    loop_state.retry_not_before = Some(Instant::now() + Duration::from_secs(60));
+
+    assert!(loop_state.last_reconciliation.elapsed() >= Duration::from_secs(1));
+    assert!(loop_state.is_backing_off());
+}
+
+#[tokio::test]
+async fn startup_bridges_running_legacy_intent_and_enqueues_recovery() {
+    let db = database().await;
+    db.replace_task_board_orchestrator_state(&TaskBoardOrchestratorState {
+        enabled: true,
+        running: true,
+        ..TaskBoardOrchestratorState::default()
+    })
+    .await
+    .expect("save running legacy intent");
+
+    initialize_automation(&db)
+        .await
+        .expect("initialize automation");
+
+    let control = db
+        .task_board_automation_control()
+        .await
+        .expect("load control");
+    assert_eq!(
+        control.desired_mode,
+        TaskBoardAutomationDesiredMode::Continuous
+    );
+    assert_eq!(
+        control.admission_state,
+        TaskBoardAutomationAdmissionState::Accepting
+    );
+    let wakes = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load startup wakes");
+    assert_eq!(wakes.len(), 1);
+    assert_eq!(
+        wakes[0].payload.cause(),
+        TaskBoardAutomationWakeCause::Recovery
+    );
+}
+
+#[tokio::test]
+async fn startup_bridges_legacy_step_without_an_automatic_recovery_wake() {
+    let db = database().await;
+    db.replace_task_board_orchestrator_state(&TaskBoardOrchestratorState {
+        enabled: true,
+        running: true,
+        ..TaskBoardOrchestratorState::default()
+    })
+    .await
+    .expect("save running legacy intent");
+    db.replace_task_board_orchestrator_settings(&TaskBoardOrchestratorSettings {
+        step_mode: true,
+        ..TaskBoardOrchestratorSettings::default()
+    })
+    .await
+    .expect("save step settings");
+
+    initialize_automation(&db)
+        .await
+        .expect("initialize step automation");
+
+    let control = db
+        .task_board_automation_control()
+        .await
+        .expect("load step control");
+    assert_eq!(control.desired_mode, TaskBoardAutomationDesiredMode::Step);
+    assert_eq!(
+        control.admission_state,
+        TaskBoardAutomationAdmissionState::Accepting
+    );
+    assert!(
+        db.pending_task_board_automation_wake_events(10)
+            .await
+            .expect("load step wakes")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn startup_preserves_an_explicit_durable_stop() {
+    let db = database().await;
+    db.replace_task_board_orchestrator_state(&TaskBoardOrchestratorState {
+        enabled: true,
+        running: true,
+        ..TaskBoardOrchestratorState::default()
+    })
+    .await
+    .expect("save running legacy intent");
+    start_automation(&db).await;
+    db.stop_task_board_automation(Utc::now())
+        .await
+        .expect("stop automation");
+    db.finish_task_board_automation_drain_if_idle(Utc::now())
+        .await
+        .expect("finish stop");
+
+    initialize_automation(&db)
+        .await
+        .expect("reinitialize automation");
+
+    let control = db
+        .task_board_automation_control()
+        .await
+        .expect("load stopped control");
+    assert_eq!(control.desired_mode, TaskBoardAutomationDesiredMode::Off);
+    assert_eq!(
+        control.admission_state,
+        TaskBoardAutomationAdmissionState::Stopped
+    );
+    assert!(
+        db.pending_task_board_automation_wake_events(10)
+            .await
+            .expect("load stopped wakes")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn startup_recovery_marks_expired_runs_and_uses_lease_expired_wake() {
+    let db = database().await;
+    let started_at = Utc::now();
+    start_automation(&db).await;
+    let admission = db
+        .try_acquire_task_board_automation_run(&TaskBoardRunAcquireRequest {
+            run_id: "run-expired-startup".into(),
+            trigger: TaskBoardAutomationRunTrigger::Scheduled,
+            actor: Some("scheduler-test".into()),
+            dry_run: false,
+            scope: TaskBoardAutomationScope::default(),
+            lease_owner: "scheduler-test-owner".into(),
+            now: started_at,
+        })
+        .await
+        .expect("acquire run");
+    assert!(matches!(
+        admission,
+        TaskBoardAutomationRunAdmission::Acquired(_)
+    ));
+    query("UPDATE task_board_orchestrator_runs SET lease_expires_at = ?2 WHERE run_id = ?1")
+        .bind("run-expired-startup")
+        .bind((started_at - ChronoDuration::seconds(1)).to_rfc3339())
+        .execute(db.pool())
+        .await
+        .expect("expire run");
+
+    initialize_automation(&db)
+        .await
+        .expect("recover automation");
+
+    let run = query_as::<_, (String, String)>(
+        "SELECT state, outcome FROM task_board_orchestrator_runs WHERE run_id = ?1",
+    )
+    .bind("run-expired-startup")
+    .fetch_one(db.pool())
+    .await
+    .expect("load recovered run");
+    assert_eq!(run, ("terminal".into(), "failed".into()));
+    let wakes = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load recovery wake");
+    assert!(matches!(
+        wakes.as_slice(),
+        [TaskBoardAutomationWakeEvent {
+            payload: TaskBoardAutomationWakePayload::Recovery(value),
+            ..
+        }] if value.reason == TaskBoardAutomationWakeRecoveryReason::LeaseExpired
+    ));
+}
+
+#[tokio::test]
+async fn stopped_automation_advances_the_cursor_without_wake_churn() {
+    let db = database().await;
+    let mut change_sequence = db
+        .current_change_sequence()
+        .await
+        .expect("initial sequence");
+    db.create_task_board_item(TaskBoardItem::new(
+        "task-stopped-change".into(),
+        "Stopped change".into(),
+        "Body".into(),
+        "2026-07-17T10:00:00Z".into(),
+    ))
+    .await
+    .expect("create item");
+
+    assert!(
+        !capture_automatic_change_wakes(&db, &mut change_sequence)
+            .await
+            .expect("capture stopped changes")
+    );
+    assert_eq!(
+        change_sequence,
+        db.current_change_sequence()
+            .await
+            .expect("current sequence")
+    );
+    assert!(
+        db.pending_task_board_automation_wake_events(10)
+            .await
+            .expect("load stopped wakes")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn relevant_cursor_advances_only_after_durable_enqueue() {
+    let db = database().await;
+    start_automation(&db).await;
+    let mut change_sequence = db
+        .current_change_sequence()
+        .await
+        .expect("initial sequence");
+    db.create_task_board_item(TaskBoardItem::new(
+        "task-enqueue-failure".into(),
+        "Enqueue failure".into(),
+        "Body".into(),
+        "2026-07-17T10:00:00Z".into(),
+    ))
+    .await
+    .expect("create item");
+    let initial = change_sequence;
+    query("DROP TABLE task_board_orchestrator_wake_events")
+        .execute(db.pool())
+        .await
+        .expect("remove wake storage");
+
+    enqueue_change_wakes(&db, &mut change_sequence)
+        .await
+        .expect_err("enqueue must fail closed");
+
+    assert_eq!(change_sequence, initial);
+}
+
+#[tokio::test]
+async fn finalized_success_acknowledges_only_the_pre_run_batch() {
+    let db = database().await;
+    start_automation(&db).await;
+    enqueue_item_wake(&db, "task-before-run", 1).await;
+    let wakes = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load pre-run wakes");
+
+    process_wake_batch(&db, &wakes, |_| async {
+        enqueue_item_wake(&db, "task-during-run", 2).await;
+        Ok(())
+    })
+    .await
+    .expect("acknowledge finalized run");
+
+    let pending = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load remaining wakes");
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].entity_id.as_deref(), Some("task-during-run"));
+}
+
+#[tokio::test]
+async fn finalized_partial_acknowledges_the_batch_for_provider_backoff_to_own_retry() {
+    let db = database().await;
+    start_automation(&db).await;
+    enqueue_item_wake(&db, "task-partial-run", 1).await;
+    let wakes = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load partial-run wakes");
+
+    // The production route represents a finalized Partial as `Ok`; provider
+    // backoff and the interval fallback own any later reconciliation.
+    process_wake_batch(&db, &wakes, |_| async { Ok(()) })
+        .await
+        .expect("acknowledge finalized partial run");
+
+    assert!(
+        db.pending_task_board_automation_wake_events(10)
+            .await
+            .expect("load acknowledged wakes")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn busy_error_or_cancellation_keeps_the_batch_pending() {
+    let db = database().await;
+    start_automation(&db).await;
+    enqueue_item_wake(&db, "task-failed-run", 1).await;
+    let wakes = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load wakes");
+
+    process_wake_batch(&db, &wakes, |_| async {
+        Err::<(), CliError>(CliErrorKind::session_agent_conflict("run is busy").into())
+    })
+    .await
+    .expect_err("failed run must retain wakes");
+
+    assert_eq!(
+        db.pending_task_board_automation_wake_events(10)
+            .await
+            .expect("load retained wakes")
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn acknowledgement_failure_keeps_the_remaining_batch_pending() {
+    let db = database().await;
+    start_automation(&db).await;
+    let removed = enqueue_item_wake(&db, "task-removed-before-ack", 1).await;
+    enqueue_item_wake(&db, "task-still-pending", 2).await;
+    let wakes = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load wakes");
+
+    process_wake_batch(&db, &wakes, |_| async {
+        query("DELETE FROM task_board_orchestrator_wake_events WHERE sequence = ?1")
+            .bind(i64::try_from(removed.sequence).expect("stored sequence"))
+            .execute(db.pool())
+            .await
+            .expect("simulate acknowledgement race");
+        Ok(())
+    })
+    .await
+    .expect_err("incomplete acknowledgement must fail");
+
+    let pending = db
+        .pending_task_board_automation_wake_events(10)
+        .await
+        .expect("load pending batch");
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].entity_id.as_deref(), Some("task-still-pending"));
+}

--- a/src/daemon/service/serve/task_board_orchestrator_loop.rs
+++ b/src/daemon/service/serve/task_board_orchestrator_loop.rs
@@ -12,11 +12,7 @@ use crate::errors::CliError;
 use crate::feature_flags::task_board_automation_v2_enabled_from_env;
 #[cfg(test)]
 use crate::task_board::TaskBoardOrchestratorState;
-use crate::task_board::{
-    TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode,
-    TaskBoardAutomationRunTrigger, TaskBoardOrchestratorRunOnceRequest,
-    TaskBoardOrchestratorSettings, TaskBoardOrchestratorStatus,
-};
+use crate::task_board::{TaskBoardOrchestratorRunOnceRequest, TaskBoardOrchestratorStatus};
 
 struct AutonomousOrchestratorIntent {
     enabled: bool,
@@ -30,6 +26,14 @@ pub(super) fn spawn_task_board_orchestrator_loop(
     tick_interval: Duration,
     shutdown_rx: tokio_watch::Receiver<bool>,
 ) -> JoinHandle<()> {
+    if task_board_automation_v2_enabled_from_env() {
+        return super::task_board_automation_loop::spawn_task_board_automation_loop(
+            state,
+            db,
+            tick_interval,
+            shutdown_rx,
+        );
+    }
     tokio::spawn(run_task_board_orchestrator_loop(
         state,
         db,
@@ -44,19 +48,12 @@ async fn run_task_board_orchestrator_loop(
     tick_interval: Duration,
     mut shutdown_rx: tokio_watch::Receiver<bool>,
 ) {
-    let durable_enabled = task_board_automation_v2_enabled_from_env();
-    if durable_enabled && let Err(error) = initialize_durable_automation(db.as_ref()).await {
-        tracing::error!(%error, "task-board automation startup initialization failed");
-        return;
-    }
     let mut ticker = interval(tick_interval.max(Duration::from_secs(1)));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
     loop {
         tokio::select! {
             () = wait_for_shutdown(&mut shutdown_rx) => break,
-            _ = ticker.tick() => Box::pin(
-                run_logged_tick(&state, db.as_ref(), durable_enabled)
-            ).await,
+            _ = ticker.tick() => run_logged_tick(&state, db.as_ref()).await,
         }
     }
 }
@@ -72,87 +69,24 @@ async fn wait_for_shutdown(shutdown_rx: &mut tokio_watch::Receiver<bool>) {
     }
 }
 
-async fn run_logged_tick(state: &DaemonHttpState, db: &AsyncDaemonDb, durable_enabled: bool) {
+async fn run_logged_tick(state: &DaemonHttpState, db: &AsyncDaemonDb) {
     let request = TaskBoardOrchestratorRunOnceRequest::default();
-    let result = Box::pin(drive_task_board_orchestrator_once(
-        || automation_tick_state(db, durable_enabled),
-        || {
-            task_board_route_executor::run_once_with_trigger(
-                state,
-                request,
-                TaskBoardAutomationRunTrigger::Scheduled,
-            )
-        },
-    ))
+    let result = drive_task_board_orchestrator_once(
+        || orchestrator_state(db),
+        || task_board_route_executor::run_once(state, request),
+    )
     .await;
     log_tick_result(result);
 }
 
-async fn automation_tick_state(
-    db: &AsyncDaemonDb,
-    durable_enabled: bool,
-) -> Result<AutonomousOrchestratorIntent, CliError> {
-    if durable_enabled {
-        maintain_durable_automation(db, chrono::Utc::now()).await?;
-    }
-    orchestrator_state(db, durable_enabled).await
-}
-
-async fn maintain_durable_automation(
-    db: &AsyncDaemonDb,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<(), CliError> {
-    db.recover_stale_task_board_automation_runs(now).await?;
-    db.finish_task_board_automation_drain_if_idle(now).await?;
-    Ok(())
-}
-
-async fn orchestrator_state(
-    db: &AsyncDaemonDb,
-    durable_enabled: bool,
-) -> Result<AutonomousOrchestratorIntent, CliError> {
+async fn orchestrator_state(db: &AsyncDaemonDb) -> Result<AutonomousOrchestratorIntent, CliError> {
     let state = db.task_board_orchestrator_state().await?;
     let settings = db.task_board_orchestrator_settings().await?;
-    if durable_enabled {
-        let control = db.task_board_automation_control().await?;
-        return Ok(AutonomousOrchestratorIntent {
-            enabled: control.desired_mode != TaskBoardAutomationDesiredMode::Off,
-            running: control.admission_state == TaskBoardAutomationAdmissionState::Accepting,
-            step_mode: control.desired_mode == TaskBoardAutomationDesiredMode::Step,
-        });
-    }
     Ok(AutonomousOrchestratorIntent {
         enabled: state.enabled,
         running: state.running,
         step_mode: settings.step_mode,
     })
-}
-
-async fn initialize_durable_automation(db: &AsyncDaemonDb) -> Result<(), CliError> {
-    let state = db.task_board_orchestrator_state().await?;
-    let settings = db.task_board_orchestrator_settings().await?;
-    let now = chrono::Utc::now();
-    db.initialize_task_board_automation_control_from_legacy_intent(
-        desired_mode_for_legacy_intent(&state, &settings),
-        now,
-    )
-    .await?;
-    maintain_durable_automation(db, now).await?;
-    Ok(())
-}
-
-const fn desired_mode_for_legacy_intent(
-    state: &crate::task_board::TaskBoardOrchestratorState,
-    settings: &TaskBoardOrchestratorSettings,
-) -> TaskBoardAutomationDesiredMode {
-    if !state.enabled || !state.running {
-        return TaskBoardAutomationDesiredMode::Off;
-    }
-    if settings.step_mode {
-        TaskBoardAutomationDesiredMode::Step
-    } else {
-        TaskBoardAutomationDesiredMode::Continuous
-    }
 }
 
 #[expect(
@@ -187,13 +121,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use chrono::Duration as ChronoDuration;
-    use sqlx::{query, query_as};
     use tempfile::tempdir;
 
     use super::*;
-    use crate::daemon::db::{TaskBoardAutomationRunAdmission, TaskBoardRunAcquireRequest};
-    use crate::task_board::TaskBoardAutomationScope;
     use crate::task_board::{TaskBoardOrchestrator, TaskBoardOrchestratorStatus};
 
     #[tokio::test]
@@ -248,161 +178,12 @@ mod tests {
                 .await
                 .expect("save database state");
 
-            let loaded = orchestrator_state(&db, false)
-                .await
-                .expect("load database state");
+            let loaded = orchestrator_state(&db).await.expect("load database state");
 
             assert!(!loaded.enabled);
             assert!(!loaded.running);
         })
         .await;
-    }
-
-    #[test]
-    fn running_legacy_step_intent_maps_to_step_control() {
-        let state = TaskBoardOrchestratorState {
-            enabled: true,
-            running: true,
-            ..TaskBoardOrchestratorState::default()
-        };
-        let settings = TaskBoardOrchestratorSettings {
-            step_mode: true,
-            ..TaskBoardOrchestratorSettings::default()
-        };
-
-        assert_eq!(
-            desired_mode_for_legacy_intent(&state, &settings),
-            TaskBoardAutomationDesiredMode::Step
-        );
-    }
-
-    #[tokio::test]
-    async fn startup_bridges_running_legacy_intent_once() {
-        let temp = tempdir().expect("tempdir");
-        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
-            .await
-            .expect("open database");
-        db.replace_task_board_orchestrator_state(&state(true, true))
-            .await
-            .expect("save running legacy intent");
-
-        initialize_durable_automation(&db)
-            .await
-            .expect("initialize automation");
-
-        let control = db
-            .task_board_automation_control()
-            .await
-            .expect("load durable control");
-        assert_eq!(
-            control.desired_mode,
-            TaskBoardAutomationDesiredMode::Continuous
-        );
-        assert_eq!(
-            control.admission_state,
-            TaskBoardAutomationAdmissionState::Accepting
-        );
-    }
-
-    #[tokio::test]
-    async fn startup_preserves_an_explicit_durable_stop() {
-        let temp = tempdir().expect("tempdir");
-        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
-            .await
-            .expect("open database");
-        db.replace_task_board_orchestrator_state(&state(true, true))
-            .await
-            .expect("save running legacy intent");
-        db.start_task_board_automation(
-            TaskBoardAutomationDesiredMode::Continuous,
-            chrono::Utc::now(),
-        )
-        .await
-        .expect("start durable automation");
-        db.stop_task_board_automation(chrono::Utc::now())
-            .await
-            .expect("stop durable automation");
-        db.finish_task_board_automation_drain_if_idle(chrono::Utc::now())
-            .await
-            .expect("finish durable stop");
-
-        initialize_durable_automation(&db)
-            .await
-            .expect("reinitialize automation");
-
-        let control = db
-            .task_board_automation_control()
-            .await
-            .expect("load stopped control");
-        assert_eq!(control.desired_mode, TaskBoardAutomationDesiredMode::Off);
-        assert_eq!(
-            control.admission_state,
-            TaskBoardAutomationAdmissionState::Stopped
-        );
-    }
-
-    #[tokio::test]
-    async fn durable_tick_recovers_a_dropped_stopping_run_and_finishes_drain() {
-        let temp = tempdir().expect("tempdir");
-        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
-            .await
-            .expect("open database");
-        let started_at = chrono::Utc::now();
-        db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, started_at)
-            .await
-            .expect("start automation");
-        let admission = db
-            .try_acquire_task_board_automation_run(&TaskBoardRunAcquireRequest {
-                run_id: "run-dropped-stop".into(),
-                trigger: TaskBoardAutomationRunTrigger::Scheduled,
-                actor: Some("scheduler-test".into()),
-                dry_run: false,
-                scope: TaskBoardAutomationScope::default(),
-                lease_owner: "scheduler-test-owner".into(),
-                now: started_at,
-            })
-            .await
-            .expect("acquire durable run");
-        assert!(matches!(
-            admission,
-            TaskBoardAutomationRunAdmission::Acquired(_)
-        ));
-        db.stop_task_board_automation(started_at + ChronoDuration::seconds(1))
-            .await
-            .expect("stop automation");
-        let expired_at = started_at - ChronoDuration::seconds(1);
-        query(
-            "UPDATE task_board_orchestrator_runs
-             SET lease_expires_at = ?2 WHERE run_id = ?1",
-        )
-        .bind("run-dropped-stop")
-        .bind(expired_at.to_rfc3339())
-        .execute(db.pool())
-        .await
-        .expect("expire dropped run");
-
-        let state = automation_tick_state(&db, true)
-            .await
-            .expect("maintain durable tick");
-
-        assert!(!state.enabled);
-        assert!(!state.running);
-        let run = query_as::<_, (String, String)>(
-            "SELECT state, outcome FROM task_board_orchestrator_runs WHERE run_id = ?1",
-        )
-        .bind("run-dropped-stop")
-        .fetch_one(db.pool())
-        .await
-        .expect("load recovered run");
-        assert_eq!(run, ("terminal".into(), "cancelled".into()));
-        let control = db
-            .task_board_automation_control()
-            .await
-            .expect("load stopped control");
-        assert_eq!(
-            control.admission_state,
-            TaskBoardAutomationAdmissionState::Stopped
-        );
     }
 
     fn state(enabled: bool, running: bool) -> TaskBoardOrchestratorState {

--- a/src/daemon/service/task_board_orchestrator_control.rs
+++ b/src/daemon/service/task_board_orchestrator_control.rs
@@ -9,8 +9,9 @@ use crate::errors::CliError;
 use crate::feature_flags::task_board_automation_v2_enabled_from_env;
 use crate::task_board::{
     TaskBoardAutomationAdmissionState, TaskBoardAutomationDesiredMode,
-    TaskBoardOrchestratorSettings, TaskBoardOrchestratorState, TaskBoardWorkflowExecutionCount,
-    TaskBoardWorkflowStatus,
+    TaskBoardAutomationWakeEntityKind, TaskBoardAutomationWakePayload,
+    TaskBoardAutomationWakeRequest, TaskBoardOrchestratorSettings, TaskBoardOrchestratorState,
+    TaskBoardWorkflowExecutionCount, TaskBoardWorkflowStatus,
 };
 
 use super::task_board_db::task_board_host_local_db;
@@ -38,8 +39,24 @@ async fn start_task_board_orchestrator_with_durable(
 ) -> Result<TaskBoardOrchestratorStatusResponse, CliError> {
     if durable_enabled {
         let settings = db.task_board_orchestrator_settings().await?;
-        db.start_task_board_automation(desired_mode_for_settings(&settings), Utc::now())
+        let desired_mode = desired_mode_for_settings(&settings);
+        let now = Utc::now();
+        if desired_mode == TaskBoardAutomationDesiredMode::Continuous {
+            db.start_task_board_automation_with_wake(
+                desired_mode,
+                &TaskBoardAutomationWakeRequest {
+                    entity_id: Some("automation-control".into()),
+                    entity_revision: None,
+                    payload: TaskBoardAutomationWakePayload::ledger_changed(
+                        TaskBoardAutomationWakeEntityKind::Control,
+                    ),
+                },
+                now,
+            )
             .await?;
+        } else {
+            db.start_task_board_automation(desired_mode, now).await?;
+        }
     }
     set_running_intent(db, true, true, durable_enabled).await
 }
@@ -76,29 +93,29 @@ pub(crate) async fn update_task_board_orchestrator_settings_db(
     apply_settings_update(&mut settings, request);
     settings.github_inbox = normalize_github_inbox(&settings.github_inbox)?;
     settings.todoist_inbox = normalize_todoist_inbox(&settings.todoist_inbox);
-    db.replace_task_board_orchestrator_settings(&settings)
-        .await?;
-    update_running_automation_mode(db, &settings, task_board_automation_v2_enabled_from_env())
-        .await?;
+    replace_orchestrator_settings_with_durable(
+        db,
+        &settings,
+        task_board_automation_v2_enabled_from_env(),
+    )
+    .await?;
     Ok(settings)
 }
 
-async fn update_running_automation_mode(
+async fn replace_orchestrator_settings_with_durable(
     db: &AsyncDaemonDb,
     settings: &TaskBoardOrchestratorSettings,
     durable_enabled: bool,
-) -> Result<(), CliError> {
+) -> Result<i64, CliError> {
     if !durable_enabled {
-        return Ok(());
+        return db.replace_task_board_orchestrator_settings(settings).await;
     }
-    let control = db.task_board_automation_control().await?;
-    if control.desired_mode != TaskBoardAutomationDesiredMode::Off
-        && control.admission_state == TaskBoardAutomationAdmissionState::Accepting
-    {
-        db.start_task_board_automation(desired_mode_for_settings(settings), Utc::now())
-            .await?;
-    }
-    Ok(())
+    db.replace_task_board_orchestrator_settings_for_automation(
+        settings,
+        desired_mode_for_settings(settings),
+        Utc::now(),
+    )
+    .await
 }
 
 const fn desired_mode_for_settings(
@@ -224,15 +241,100 @@ mod tests {
         assert!(!stopped.enabled);
         assert!(!stopped.running);
         assert!(stopped.automation.is_none());
-        update_running_automation_mode(&db, &TaskBoardOrchestratorSettings::default(), false)
-            .await
-            .expect("update legacy settings");
+        replace_orchestrator_settings_with_durable(
+            &db,
+            &TaskBoardOrchestratorSettings::default(),
+            false,
+        )
+        .await
+        .expect("update legacy settings");
         let durable_rows =
             query_scalar::<_, i64>("SELECT COUNT(*) FROM task_board_orchestrator_control")
                 .fetch_one(db.pool())
                 .await
                 .expect("count durable control rows");
         assert_eq!(durable_rows, 0);
+    }
+
+    #[tokio::test]
+    async fn durable_continuous_start_enqueues_a_control_wake() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+
+        start_task_board_orchestrator_with_durable(&db, true)
+            .await
+            .expect("start durable orchestrator");
+
+        let wakes = db
+            .pending_task_board_automation_wake_events(10)
+            .await
+            .expect("load control wake");
+        assert_eq!(wakes.len(), 1);
+        assert_eq!(wakes[0].entity_id.as_deref(), Some("automation-control"));
+        assert!(matches!(
+            wakes[0].payload,
+            TaskBoardAutomationWakePayload::LedgerChanged(ref payload)
+                if payload.entity_kind == TaskBoardAutomationWakeEntityKind::Control
+        ));
+    }
+
+    #[tokio::test]
+    async fn durable_step_start_does_not_enqueue_an_automatic_wake() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+        db.replace_task_board_orchestrator_settings(&TaskBoardOrchestratorSettings {
+            step_mode: true,
+            ..TaskBoardOrchestratorSettings::default()
+        })
+        .await
+        .expect("save step settings");
+
+        start_task_board_orchestrator_with_durable(&db, true)
+            .await
+            .expect("start step orchestrator");
+
+        assert!(
+            db.pending_task_board_automation_wake_events(10)
+                .await
+                .expect("load step wakes")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn running_continuous_settings_update_enqueues_its_revision() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
+            .await
+            .expect("open database");
+        db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, Utc::now())
+            .await
+            .expect("start durable automation");
+
+        let revision = replace_orchestrator_settings_with_durable(
+            &db,
+            &TaskBoardOrchestratorSettings::default(),
+            true,
+        )
+        .await
+        .expect("update running settings");
+
+        let wakes = db
+            .pending_task_board_automation_wake_events(10)
+            .await
+            .expect("load settings wake");
+        assert_eq!(wakes.len(), 1);
+        assert_eq!(wakes[0].entity_id.as_deref(), Some("automation-settings"));
+        assert_eq!(wakes[0].entity_revision, u64::try_from(revision).ok());
+        assert!(matches!(
+            wakes[0].payload,
+            TaskBoardAutomationWakePayload::LedgerChanged(ref payload)
+                if payload.entity_kind == TaskBoardAutomationWakeEntityKind::Settings
+        ));
     }
 
     #[tokio::test]

--- a/src/task_board/automation.rs
+++ b/src/task_board/automation.rs
@@ -4,6 +4,7 @@ mod interfaces;
 mod remote;
 mod settings;
 mod status;
+mod wake;
 mod workflow;
 
 pub use interfaces::*;
@@ -11,3 +12,5 @@ pub use remote::*;
 pub use settings::*;
 pub use status::*;
 pub use workflow::*;
+
+pub(crate) use wake::*;

--- a/src/task_board/automation/wake.rs
+++ b/src/task_board/automation/wake.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+
+pub(crate) const TASK_BOARD_AUTOMATION_WAKE_PAYLOAD_SCHEMA_VERSION: u32 = 1;
+pub(crate) const TASK_BOARD_AUTOMATION_WAKE_BATCH_LIMIT: u32 = 500;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TaskBoardAutomationWakeCause {
+    LedgerChanged,
+    Recovery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TaskBoardAutomationWakeEntityKind {
+    Item,
+    Control,
+    Settings,
+    Policy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TaskBoardAutomationWakeRecoveryReason {
+    Startup,
+    LeaseExpired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TaskBoardAutomationLedgerChangedWakeV1 {
+    pub(crate) schema_version: u32,
+    pub(crate) entity_kind: TaskBoardAutomationWakeEntityKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TaskBoardAutomationRecoveryWakeV1 {
+    pub(crate) schema_version: u32,
+    pub(crate) reason: TaskBoardAutomationWakeRecoveryReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "cause", content = "payload", rename_all = "snake_case")]
+pub(crate) enum TaskBoardAutomationWakePayload {
+    LedgerChanged(TaskBoardAutomationLedgerChangedWakeV1),
+    Recovery(TaskBoardAutomationRecoveryWakeV1),
+}
+
+impl TaskBoardAutomationWakePayload {
+    pub(crate) const fn cause(&self) -> TaskBoardAutomationWakeCause {
+        match self {
+            Self::LedgerChanged(_) => TaskBoardAutomationWakeCause::LedgerChanged,
+            Self::Recovery(_) => TaskBoardAutomationWakeCause::Recovery,
+        }
+    }
+
+    pub(crate) const fn ledger_changed(entity_kind: TaskBoardAutomationWakeEntityKind) -> Self {
+        Self::LedgerChanged(TaskBoardAutomationLedgerChangedWakeV1 {
+            schema_version: TASK_BOARD_AUTOMATION_WAKE_PAYLOAD_SCHEMA_VERSION,
+            entity_kind,
+        })
+    }
+
+    pub(crate) const fn recovery(reason: TaskBoardAutomationWakeRecoveryReason) -> Self {
+        Self::Recovery(TaskBoardAutomationRecoveryWakeV1 {
+            schema_version: TASK_BOARD_AUTOMATION_WAKE_PAYLOAD_SCHEMA_VERSION,
+            reason,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskBoardAutomationWakeRequest {
+    pub(crate) entity_id: Option<String>,
+    pub(crate) entity_revision: Option<u64>,
+    pub(crate) payload: TaskBoardAutomationWakePayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskBoardAutomationWakeEvent {
+    pub(crate) sequence: u64,
+    pub(crate) entity_id: Option<String>,
+    pub(crate) entity_revision: Option<u64>,
+    pub(crate) payload: TaskBoardAutomationWakePayload,
+    pub(crate) created_at: String,
+}

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-testkit"
-version = "48.3.0"
+version = "48.4.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false


### PR DESCRIPTION
## Motivation
The opt-in durable automation run envelope still relied on periodic polling and could not persist or acknowledge the exact state changes that triggered coordination. That left restart recovery, retry ownership, and compact scheduling status ambiguous.

## Implementation
- Add crate-private durable wake records with strict table and index repair, deterministic deduplication and ordering, exact acknowledgement, and bounded pruning.
- Drive continuous coordination from item, settings, policy, startup, and stale-lease wakes while retaining bounded backoff, interval fallback, explicit stops, and the feature-off legacy loop.
- Make durable control and settings updates atomic with their wake enqueue, and recover stale runs plus finish drains before every scheduling gate.
- Derive compact wake scheduling facts inside the existing pinned status snapshot without widening public wake APIs.
- Synchronize version 48.4.0 and validate focused wake, schema, status, control, and loop suites plus `mise run test:unit`, `mise run harness:check`, `mise run check`, and `mise run version:check`.
