### PR TITLE
feat(task-board): enforce durable policy admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "aff"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "harness-bridge"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "harness-command"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "tempfile",
  "uzers",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "harness-daemon"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "agent-client-protocol",
  "arc-swap",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "harness-daemon-client"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "fs2",
  "reqwest",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "harness-hook"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "harness-mcp"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "harness-protocol"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "clap",
  "serde",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "harness-systemd"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "harness-systemd-protocol"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "nix 0.31.3",
  "temp-env",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "harness-telemetry"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "harness-testkit"
-version = "48.4.0"
+version = "48.5.0"
 dependencies = [
  "temp-env",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,6 +3547,7 @@ dependencies = [
  "bollard",
  "bytes",
  "chrono",
+ "chrono-tz",
  "clap",
  "compose_spec",
  "core-foundation 0.10.1",
@@ -3670,6 +3681,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "chrono-tz",
  "clap",
  "core-foundation 0.10.1",
  "crossterm",
@@ -5812,6 +5824,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7325,6 +7355,12 @@ checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 dependencies = [
  "bstr",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ sha2 = "0.11.0"
 hex = "0.4.3"
 hmac = { version = "0.13.0", optional = true }
 chrono = { version = "0.4.44", features = ["serde"] }
+chrono-tz = "0.10.4"
 tempfile = "3.27.0"
 uzers = { version = "0.12.2", default-features = false }
 shell-words = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 
 [package]
 name = "harness"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 autoexamples = false
@@ -38,11 +38,11 @@ include = [
 ]
 
 [dependencies]
-harness-command = { path = "crates/harness-command", version = "48.4.0" }
-harness-mcp = { path = "crates/harness-mcp", version = "48.4.0", optional = true }
-harness-protocol = { path = "crates/harness-protocol", version = "48.4.0" }
-harness-systemd-protocol = { path = "crates/harness-systemd-protocol", version = "48.4.0", optional = true }
-harness-telemetry = { path = "crates/harness-telemetry", version = "48.4.0" }
+harness-command = { path = "crates/harness-command", version = "48.5.0" }
+harness-mcp = { path = "crates/harness-mcp", version = "48.5.0", optional = true }
+harness-protocol = { path = "crates/harness-protocol", version = "48.5.0" }
+harness-systemd-protocol = { path = "crates/harness-systemd-protocol", version = "48.5.0", optional = true }
+harness-telemetry = { path = "crates/harness-telemetry", version = "48.5.0" }
 arc-swap = "1.9.1"
 bollard = "0.21.0"
 bytes = "1.10.1"

--- a/aff/Cargo.toml
+++ b/aff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aff"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 

--- a/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
+++ b/apps/harness-monitor/Resources/LaunchAgents/io.harnessmonitor.daemon.Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>48.4.0</string>
+	<string>48.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>48.4.0</string>
+	<string>48.5.0</string>
 	<key>LSBackgroundOnly</key>
 	<true/>
 </dict>

--- a/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/TaskBoardItemWireTypes.generated.swift
+++ b/apps/harness-monitor/Sources/HarnessMonitorKit/Models/Generated/TaskBoardItemWireTypes.generated.swift
@@ -15,6 +15,8 @@ public struct TaskBoardItemWire: Codable, Equatable, Sendable {
   public var projectId: String?
   public var targetProjectTypes: [String]
   public var agentMode: TaskBoardAgentMode
+  public var estimatedTokens: UInt64?
+  public var estimatedCostMicrousd: UInt64?
   public var externalRefs: [ExternalRefWire]
   public var importedFromProvider: ExternalRefProviderWire?
   public var planning: PlanningStateWire
@@ -26,7 +28,7 @@ public struct TaskBoardItemWire: Codable, Equatable, Sendable {
   public var updatedAt: String
   public var deletedAt: String?
 
-  public init(schemaVersion: UInt32, id: String, title: String, body: String = "", status: TaskBoardStatus = .todo, priority: TaskBoardPriority = .medium, tags: [String] = [], projectId: String? = nil, targetProjectTypes: [String] = [], agentMode: TaskBoardAgentMode = .headless, externalRefs: [ExternalRefWire] = [], importedFromProvider: ExternalRefProviderWire? = nil, planning: PlanningStateWire = PlanningStateWire(), workflow: TaskBoardWorkflowStateWire? = nil, sessionId: String? = nil, workItemId: String? = nil, usage: TaskUsageWire = TaskUsageWire(), createdAt: String, updatedAt: String, deletedAt: String? = nil) {
+  public init(schemaVersion: UInt32, id: String, title: String, body: String = "", status: TaskBoardStatus = .todo, priority: TaskBoardPriority = .medium, tags: [String] = [], projectId: String? = nil, targetProjectTypes: [String] = [], agentMode: TaskBoardAgentMode = .headless, estimatedTokens: UInt64? = nil, estimatedCostMicrousd: UInt64? = nil, externalRefs: [ExternalRefWire] = [], importedFromProvider: ExternalRefProviderWire? = nil, planning: PlanningStateWire = PlanningStateWire(), workflow: TaskBoardWorkflowStateWire? = nil, sessionId: String? = nil, workItemId: String? = nil, usage: TaskUsageWire = TaskUsageWire(), createdAt: String, updatedAt: String, deletedAt: String? = nil) {
     self.schemaVersion = schemaVersion
     self.id = id
     self.title = title
@@ -37,6 +39,8 @@ public struct TaskBoardItemWire: Codable, Equatable, Sendable {
     self.projectId = projectId
     self.targetProjectTypes = targetProjectTypes
     self.agentMode = agentMode
+    self.estimatedTokens = estimatedTokens
+    self.estimatedCostMicrousd = estimatedCostMicrousd
     self.externalRefs = externalRefs
     self.importedFromProvider = importedFromProvider
     self.planning = planning
@@ -61,6 +65,8 @@ public struct TaskBoardItemWire: Codable, Equatable, Sendable {
     projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
     targetProjectTypes = try container.decodeIfPresent([String].self, forKey: .targetProjectTypes) ?? []
     agentMode = try container.decodeIfPresent(TaskBoardAgentMode.self, forKey: .agentMode) ?? .headless
+    estimatedTokens = try container.decodeIfPresent(UInt64.self, forKey: .estimatedTokens)
+    estimatedCostMicrousd = try container.decodeIfPresent(UInt64.self, forKey: .estimatedCostMicrousd)
     externalRefs = try container.decodeIfPresent([ExternalRefWire].self, forKey: .externalRefs) ?? []
     importedFromProvider = try container.decodeIfPresent(ExternalRefProviderWire.self, forKey: .importedFromProvider)
     planning = try container.decodeIfPresent(PlanningStateWire.self, forKey: .planning) ?? PlanningStateWire()
@@ -84,6 +90,8 @@ public struct TaskBoardItemWire: Codable, Equatable, Sendable {
     case projectId = "project_id"
     case targetProjectTypes = "target_project_types"
     case agentMode = "agent_mode"
+    case estimatedTokens = "estimated_tokens"
+    case estimatedCostMicrousd = "estimated_cost_microusd"
     case externalRefs = "external_refs"
     case importedFromProvider = "imported_from_provider"
     case planning

--- a/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
+++ b/apps/harness-monitor/Tuist/ProjectDescriptionHelpers/BuildSettings.swift
@@ -32,7 +32,7 @@ public enum BuildSettings {
         "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS": .string(
             compilationCacheDiagnosticRemarksSetting
         ),
-        "CURRENT_PROJECT_VERSION": "48.4.0", // VERSION_MARKER_CURRENT
+        "CURRENT_PROJECT_VERSION": "48.5.0", // VERSION_MARKER_CURRENT
         "DEVELOPMENT_TEAM": "Q498EB36N4",
         "DEAD_CODE_STRIPPING": "YES",
         "ENABLE_HARDENED_RUNTIME": "YES",
@@ -61,7 +61,7 @@ public enum BuildSettings {
         "HARNESS_MONITOR_BUILD_GIT_COMMIT": "local-dev",
         "HARNESS_MONITOR_BUILD_GIT_DIRTY": "false",
         "HARNESS_MONITOR_BUILD_WORKSPACE_FINGERPRINT": "local-dev",
-        "MARKETING_VERSION": "48.4.0" // VERSION_MARKER_MARKETING
+        "MARKETING_VERSION": "48.5.0" // VERSION_MARKER_MARKETING
     ]
 
     public static let previewOverrides: SettingsDictionary = [

--- a/crates/harness-bridge/Cargo.toml
+++ b/crates/harness-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-bridge"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -21,9 +21,9 @@ clap = { version = "4.6.0", features = ["derive", "env"] }
 crossterm = "0.29.0"
 fs2 = "0.4.3"
 fs-err = "3.3.0"
-harness-hook = { path = "../harness-hook", version = "48.4.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.4.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.4.0" }
+harness-hook = { path = "../harness-hook", version = "48.5.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.5.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.5.0" }
 hex = "0.4.3"
 nix = { version = "0.31", features = ["signal"] }
 notify = "8.2.0"

--- a/crates/harness-command/Cargo.toml
+++ b/crates/harness-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-command"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 

--- a/crates/harness-daemon-client/Cargo.toml
+++ b/crates/harness-daemon-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-daemon-client"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-daemon/Cargo.toml
+++ b/crates/harness-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-daemon"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -29,11 +29,11 @@ fs-err = "3.3.0"
 futures-util = "0.3.31"
 gix = { version = "0.83.0", features = ["status", "worktree-mutation", "index", "blocking-http-transport-reqwest-rust-tls"] }
 gray_matter = { version = "0.3.2", default-features = false, features = ["yaml"] }
-harness-command = { path = "../harness-command", version = "48.4.0" }
-harness-hook = { path = "../harness-hook", version = "48.4.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.4.0" }
-harness-systemd-protocol = { path = "../harness-systemd-protocol", version = "48.4.0", optional = true }
-harness-telemetry = { path = "../harness-telemetry", version = "48.4.0" }
+harness-command = { path = "../harness-command", version = "48.5.0" }
+harness-hook = { path = "../harness-hook", version = "48.5.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.5.0" }
+harness-systemd-protocol = { path = "../harness-systemd-protocol", version = "48.5.0", optional = true }
+harness-telemetry = { path = "../harness-telemetry", version = "48.5.0" }
 hex = "0.4.3"
 hickory-resolver = "0.26.1"
 hmac = "0.13.0"

--- a/crates/harness-daemon/Cargo.toml
+++ b/crates/harness-daemon/Cargo.toml
@@ -21,6 +21,7 @@ axum = { version = "0.8.7", features = ["json", "ws"] }
 base64 = "0.22.1"
 bytes = "1.10.1"
 chrono = { version = "0.4.44", features = ["serde"] }
+chrono-tz = "0.10.4"
 clap = { version = "4.6.0", features = ["derive", "env"] }
 crossterm = "0.29.0"
 fs2 = "0.4.3"

--- a/crates/harness-hook/Cargo.toml
+++ b/crates/harness-hook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-hook"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -14,9 +14,9 @@ test = false
 
 [dependencies]
 clap = { version = "4.6.0", features = ["derive", "env"] }
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.4.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.4.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.4.0" }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.5.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.5.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.5.0" }
 chrono = { version = "0.4.44", features = ["serde"] }
 fs-err = "3.3.0"
 fs2 = "0.4.3"

--- a/crates/harness-mcp/Cargo.toml
+++ b/crates/harness-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-mcp"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 
@@ -13,9 +13,9 @@ async-trait = "0.1.83"
 base64 = "0.22.1"
 clap = { version = "4.6.0", features = ["derive", "env"] }
 futures-util = "0.3.31"
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.4.0" }
-harness-protocol = { path = "../harness-protocol", version = "48.4.0" }
-harness-telemetry = { path = "../harness-telemetry", version = "48.4.0" }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.5.0" }
+harness-protocol = { path = "../harness-protocol", version = "48.5.0" }
+harness-telemetry = { path = "../harness-telemetry", version = "48.5.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
@@ -26,7 +26,7 @@ uuid = { version = "1.18.1", features = ["v4"] }
 
 [dev-dependencies]
 axum = { version = "0.8.7", features = ["ws"] }
-harness-daemon-client = { path = "../harness-daemon-client", version = "48.4.0", features = ["test-support"] }
+harness-daemon-client = { path = "../harness-daemon-client", version = "48.5.0", features = ["test-support"] }
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tempfile = "3.27.0"
 

--- a/crates/harness-protocol/Cargo.toml
+++ b/crates/harness-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-protocol"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-systemd-protocol/Cargo.toml
+++ b/crates/harness-systemd-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-systemd-protocol"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/crates/harness-systemd/Cargo.toml
+++ b/crates/harness-systemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-systemd"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 build = "build.rs"
@@ -14,7 +14,7 @@ chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive"] }
 fs-err = "3.3.0"
 fs2 = "0.4.3"
-harness-command = { path = "../harness-command", version = "48.4.0" }
+harness-command = { path = "../harness-command", version = "48.5.0" }
 hex = "0.4.3"
 libc = "0.2"
 nix = { version = "0.31", features = ["fs", "signal", "user"] }

--- a/crates/harness-telemetry/Cargo.toml
+++ b/crates/harness-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-telemetry"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/examples/policy-codegen.rs
+++ b/examples/policy-codegen.rs
@@ -1948,6 +1948,7 @@ const OMITTED_WIRE_FIELDS: &[(&str, &str)] = &[
     ("TaskBoardOrchestratorSettings", "reviewers"),
     ("TaskBoardOrchestratorSettings", "repositories"),
     ("TaskBoardOrchestratorSettings", "execution_hosts"),
+    ("TaskBoardOrchestratorSettings", "admission_policy"),
     ("TaskBoardOrchestratorStatus", "automation"),
 ];
 
@@ -3832,6 +3833,38 @@ pub struct Drop { pub other: String }
             .collect();
 
         assert_eq!(properties, vec!["enabled"], "automation is deferred");
+    }
+
+    #[test]
+    fn admission_policy_is_deferred_from_monitor_settings_wire() {
+        let source = r"
+            #[derive(Serialize, Deserialize)]
+            pub struct TaskBoardOrchestratorSettings {
+                pub dry_run_default: bool,
+                pub admission_policy: TaskBoardAutomationPolicy,
+            }
+        ";
+        let symbols = build_symbol_table(&[source]);
+        let defaults = DefaultLiterals::new();
+        let file = syn::parse_file(source).expect("source parses");
+        let item = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                Item::Struct(item) if item.ident == "TaskBoardOrchestratorSettings" => {
+                    Some(item.clone())
+                }
+                _ => None,
+            })
+            .expect("TaskBoardOrchestratorSettings present");
+        let spec = build_struct(&item, &defaults, &symbols).expect("struct builds");
+        let properties: Vec<_> = spec
+            .fields
+            .iter()
+            .map(|field| field.property.as_str())
+            .collect();
+
+        assert_eq!(properties, vec!["dryRunDefault"]);
     }
 
     #[test]

--- a/src/app/cli/tests.rs
+++ b/src/app/cli/tests.rs
@@ -36,6 +36,8 @@ mod session_review;
 mod session_task;
 #[path = "tests/setup.rs"]
 mod setup;
+#[path = "tests/task_board_estimates.rs"]
+mod task_board_estimates;
 #[path = "tests/task_board_policy.rs"]
 mod task_board_policy;
 

--- a/src/app/cli/tests/task_board_estimates.rs
+++ b/src/app/cli/tests/task_board_estimates.rs
@@ -1,0 +1,76 @@
+use clap::Parser;
+
+use super::{Cli, TaskBoardCommand, task_board_command};
+
+const MAX_ESTIMATE: &str = "9223372036854775807";
+
+#[test]
+fn task_board_estimates_accept_the_persisted_integer_range() {
+    let cli = Cli::try_parse_from([
+        "harness",
+        "task-board",
+        "create",
+        "--title",
+        "Bounded task",
+        "--estimated-tokens",
+        "1",
+        "--estimated-cost-microusd",
+        MAX_ESTIMATE,
+    ])
+    .expect("parse bounded estimates");
+
+    match task_board_command(cli.command) {
+        TaskBoardCommand::Create(args) => {
+            assert_eq!(args.fields.estimated_tokens, Some(1));
+            assert_eq!(args.fields.estimated_cost_microusd, Some(i64::MAX as u64));
+        }
+        _ => panic!("expected Task Board Create"),
+    }
+}
+
+#[test]
+fn task_board_estimates_reject_values_outside_the_persisted_range() {
+    for value in ["0", "9223372036854775808", "-1", "1.5"] {
+        assert!(
+            Cli::try_parse_from([
+                "harness",
+                "task-board",
+                "create",
+                "--title",
+                "Invalid task",
+                "--estimated-tokens",
+                value,
+            ])
+            .is_err(),
+            "estimate {value} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn task_board_update_rejects_setting_and_clearing_the_same_estimate() {
+    assert!(
+        Cli::try_parse_from([
+            "harness",
+            "task-board",
+            "update",
+            "task-1",
+            "--estimated-tokens",
+            "1",
+            "--clear-estimated-tokens",
+        ])
+        .is_err()
+    );
+    assert!(
+        Cli::try_parse_from([
+            "harness",
+            "task-board",
+            "update",
+            "task-1",
+            "--estimated-cost-microusd",
+            "1",
+            "--clear-estimated-cost-microusd",
+        ])
+        .is_err()
+    );
+}

--- a/src/app/cli/tests/task_board_policy.rs
+++ b/src/app/cli/tests/task_board_policy.rs
@@ -123,6 +123,36 @@ fn parse_orchestrator_step_mode() {
 }
 
 #[test]
+fn parse_orchestrator_admission_policy() {
+    let cli = Cli::try_parse_from([
+        "harness",
+        "task-board",
+        "orchestrator",
+        "settings",
+        "--admission-policy",
+        "{}",
+        "--json",
+    ])
+    .expect("parse orchestrator admission policy");
+    match task_board_command(cli.command) {
+        TaskBoardCommand::Orchestrator {
+            command: TaskBoardOrchestratorCommand::Settings(args),
+        } => assert_eq!(args.admission_policy, Some(Default::default())),
+        _ => panic!("expected TaskBoard Orchestrator Settings"),
+    }
+
+    let invalid = Cli::try_parse_from([
+        "harness",
+        "task-board",
+        "orchestrator",
+        "settings",
+        "--admission-policy",
+        r#"{"limits":[{"kind":"concurrency","scope":{"kind":"global"},"limit":0,"reservation":1}]}"#,
+    ]);
+    assert!(invalid.is_err(), "invalid policy must fail CLI parsing");
+}
+
+#[test]
 fn parse_policy_grants() {
     let grants = Cli::try_parse_from(["harness", "task-board", "policy", "grants", "--json"])
         .expect("parse policy grants");

--- a/src/daemon/codex_controller/handle_admission_recovery.rs
+++ b/src/daemon/codex_controller/handle_admission_recovery.rs
@@ -1,0 +1,114 @@
+use crate::daemon::db::{
+    AsyncDaemonDb, TaskBoardAdmissionMissingRunRecovery, TaskBoardAdmissionWorkerRecovery,
+};
+use crate::daemon::protocol::{CodexRunSnapshot, TaskBoardEvaluateRequest};
+use crate::daemon::service as daemon_service;
+use crate::errors::{CliError, CliErrorKind};
+
+use super::handle::CodexControllerHandle;
+
+const MISSING_RUN_RECOVERY_REASON: &str = "Codex worker was missing after daemon restart";
+
+impl CodexControllerHandle {
+    pub(crate) async fn reconcile_task_board_admission_workers_after_restart(
+        &self,
+    ) -> Result<(), CliError> {
+        let db = self.state.async_db.get().cloned().ok_or_else(|| {
+            CliError::from(CliErrorKind::workflow_io(
+                "task board admission recovery requires the async daemon database".to_string(),
+            ))
+        })?;
+        for recovery in db.task_board_admission_worker_recoveries().await? {
+            if !recovery.managed_worker_id.starts_with("codex-") {
+                tracing::warn!(
+                    managed_worker_id = %recovery.managed_worker_id,
+                    "preserving committed admission for an unsupported managed worker type",
+                );
+                continue;
+            }
+            if self.state.active_runs.contains(&recovery.managed_worker_id) {
+                continue;
+            }
+            if let Some(run) = db.codex_run(&recovery.managed_worker_id).await? {
+                self.reconcile_existing_admission_run(db.as_ref(), run)
+                    .await?;
+                continue;
+            }
+            self.reconcile_missing_admission_run(db.as_ref(), &recovery)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn reconcile_existing_admission_run(
+        &self,
+        db: &AsyncDaemonDb,
+        run: CodexRunSnapshot,
+    ) -> Result<(), CliError> {
+        if !run.status.is_active() {
+            db.release_task_board_admission_for_managed_worker(&run.run_id)
+                .await?;
+        }
+        self.reconcile_run(run).map(|_| ())
+    }
+
+    async fn reconcile_missing_admission_run(
+        &self,
+        db: &AsyncDaemonDb,
+        recovery: &TaskBoardAdmissionWorkerRecovery,
+    ) -> Result<(), CliError> {
+        let Some(outcome) = db
+            .reconcile_missing_task_board_admission_worker(recovery, MISSING_RUN_RECOVERY_REASON)
+            .await?
+        else {
+            if let Some(run) = db.codex_run(&recovery.managed_worker_id).await? {
+                self.reconcile_existing_admission_run(db, run).await?;
+            }
+            return Ok(());
+        };
+        let publish_result = self.publish_missing_admission_recovery(db, &outcome).await;
+        let evaluation_result = daemon_service::evaluate_task_board_async(
+            &TaskBoardEvaluateRequest {
+                item_id: Some(outcome.item_id.clone()),
+                status: None,
+                dry_run: false,
+            },
+            db,
+        )
+        .await;
+        publish_result?;
+        evaluation_result?;
+        tracing::warn!(
+            managed_worker_id = %recovery.managed_worker_id,
+            item_id = %outcome.item_id,
+            session_id = %outcome.session_id,
+            concurrency_released = outcome.concurrency_released,
+            session_changed = outcome.session_changed,
+            "reconciled committed task board admission without a durable Codex run",
+        );
+        Ok(())
+    }
+
+    async fn publish_missing_admission_recovery(
+        &self,
+        db: &AsyncDaemonDb,
+        outcome: &TaskBoardAdmissionMissingRunRecovery,
+    ) -> Result<(), CliError> {
+        if !outcome.session_changed {
+            return Ok(());
+        }
+        let mirror_result =
+            daemon_service::sync_file_state_from_async_db(db, &outcome.session_id).await;
+        let session_change_result = db.bump_change(&outcome.session_id).await;
+        let global_change_result = db.bump_change("global").await;
+        daemon_service::broadcast_session_snapshot_async(
+            &self.state.sender,
+            &outcome.session_id,
+            Some(db),
+        )
+        .await;
+        mirror_result?;
+        session_change_result?;
+        global_change_result
+    }
+}

--- a/src/daemon/codex_controller/mod.rs
+++ b/src/daemon/codex_controller/mod.rs
@@ -4,6 +4,7 @@ mod completion_evidence;
 mod effort;
 mod events;
 mod handle;
+mod handle_admission_recovery;
 mod handle_control;
 mod handle_orchestration;
 mod handle_orchestration_lifecycle;

--- a/src/daemon/codex_controller/tests.rs
+++ b/src/daemon/codex_controller/tests.rs
@@ -10,6 +10,7 @@ use super::{
 use crate::daemon::protocol::{CodexRunMode, CodexRunRequest, CodexRunStatus};
 use crate::session::types::{AgentStatus, SessionRole};
 
+mod admission_recovery;
 mod completion_evidence;
 mod registration_recovery;
 mod request_validation;

--- a/src/daemon/codex_controller/tests/admission_recovery.rs
+++ b/src/daemon/codex_controller/tests/admission_recovery.rs
@@ -1,0 +1,341 @@
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::daemon::protocol::CodexRunStatus;
+use crate::session::storage as session_storage;
+use crate::session::types::{SessionMetrics, SessionState, TaskStatus};
+use crate::task_board::dispatch::{
+    DispatchLifecycle, DispatchLifecyclePhase, DispatchLifecycleStatus, DispatchLifecycleStep,
+};
+use crate::task_board::{
+    AgentMode, DispatchAppliedTask, TaskBoardItem, TaskBoardStatus, TaskBoardWorkflowStatus,
+};
+
+use super::super::worker::CodexRunWorker;
+use super::test_support::{
+    codex_run_snapshot, controller_with_async_session_state,
+    sample_session_state_with_open_task_and_codex_agent, with_isolated_async_harness_env,
+};
+
+const SESSION_ID: &str = "eadbcb3e-6ef7-53d2-ad56-0347cb7189fc";
+const TASK_ID: &str = "task-1";
+const ITEM_ID: &str = "board-admission-recovery";
+const WORKER_ID: &str = "codex-run-1";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rate_only_committed_worker_is_included_in_recovery_projection() {
+    with_isolated_async_harness_env(|_| async move {
+        let (_controller, db, _tempdir) =
+            controller_with_async_session_state(bound_in_progress_state()).await;
+        let (intent_id, dispatch) = seed_committed_admission(&db, &["rate"]).await;
+
+        let recoveries = db
+            .task_board_admission_worker_recoveries()
+            .await
+            .expect("load worker recovery projection");
+
+        assert_eq!(recoveries.len(), 1);
+        let recovery = &recoveries[0];
+        assert_eq!(recovery.managed_worker_id, WORKER_ID);
+        assert_eq!(recovery.intent_id, intent_id);
+        assert_eq!(recovery.item_id, ITEM_ID);
+        assert_eq!(recovery.session_id, SESSION_ID);
+        assert_eq!(recovery.task_id, TASK_ID);
+        assert_eq!(recovery.dispatch, dispatch);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_run_blocks_linked_task_and_board_without_refunding_rate_usage() {
+    with_isolated_async_harness_env(|_| async move {
+        let (controller, db, tempdir) =
+            controller_with_async_session_state(bound_in_progress_state()).await;
+        let (intent_id, _) = seed_committed_admission(&db, &["concurrency", "rate"]).await;
+        let mut events = controller.state.sender.subscribe();
+
+        controller
+            .reconcile_task_board_admission_workers_after_restart()
+            .await
+            .expect("reconcile missing durable run");
+
+        let resolved = db
+            .resolve_session(SESSION_ID)
+            .await
+            .expect("load recovered session")
+            .expect("recovered session");
+        assert_blocked_task(&resolved.state);
+        let layout =
+            session_storage::layout_from_project_dir(&tempdir.path().join("project"), SESSION_ID)
+                .expect("session layout");
+        let mirrored = session_storage::load_state(&layout)
+            .expect("load session mirror")
+            .expect("mirrored session");
+        assert_blocked_task(&mirrored);
+        let board_item = db.task_board_item(ITEM_ID).await.expect("load board item");
+        assert_eq!(board_item.status, TaskBoardStatus::Failed);
+        assert_eq!(board_item.workflow.status, TaskBoardWorkflowStatus::Failed);
+        assert_eq!(
+            board_item.workflow.current_step_id.as_deref(),
+            Some("blocked")
+        );
+        assert_eq!(
+            ledger_state(&db, &intent_id, "concurrency").await.0,
+            "released"
+        );
+        assert_eq!(
+            ledger_state(&db, &intent_id, "rate").await,
+            ("committed".into(), None)
+        );
+        let published = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let event = events.recv().await.expect("receive session recovery event");
+                if event.session_id.as_deref() == Some(SESSION_ID) {
+                    return event;
+                }
+            }
+        })
+        .await
+        .expect("session recovery broadcast");
+        assert!(
+            matches!(
+                published.event.as_str(),
+                "session_updated" | "sessions_updated_delta" | "session_extensions"
+            ),
+            "unexpected recovery event: {}",
+            published.event
+        );
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn terminal_save_releases_concurrency_before_board_reconciliation() {
+    with_isolated_async_harness_env(|_| async move {
+        let (controller, db, _tempdir) =
+            controller_with_async_session_state(bound_in_progress_state()).await;
+        let (intent_id, _) = seed_committed_admission(&db, &["concurrency", "rate"]).await;
+        let mut run = codex_run_snapshot(CodexRunStatus::Running);
+        run.task_id = Some(TASK_ID.into());
+        run.board_item_id = Some(ITEM_ID.into());
+        run.session_agent_id = Some("agent-1".into());
+        let (_control, control_rx) = mpsc::unbounded_channel();
+        let mut worker = CodexRunWorker::new(controller, run, control_rx);
+
+        worker
+            .handle_turn_completed(Some("failed"), Some("worker failed".into()))
+            .expect("persist and reconcile terminal worker");
+
+        assert_eq!(worker.snapshot.status, CodexRunStatus::Failed);
+        let resolved = db
+            .resolve_session(SESSION_ID)
+            .await
+            .expect("load reconciled session")
+            .expect("reconciled session");
+        assert_eq!(resolved.state.tasks[TASK_ID].status, TaskStatus::Blocked);
+        let board_item = db.task_board_item(ITEM_ID).await.expect("load board item");
+        assert_eq!(board_item.status, TaskBoardStatus::Failed);
+        assert_eq!(
+            ledger_state(&db, &intent_id, "concurrency").await.0,
+            "released"
+        );
+        assert_eq!(
+            ledger_state(&db, &intent_id, "rate").await,
+            ("committed".into(), None)
+        );
+    })
+    .await;
+}
+
+fn bound_in_progress_state() -> SessionState {
+    let mut state = sample_session_state_with_open_task_and_codex_agent();
+    let task = state.tasks.get_mut(TASK_ID).expect("open task");
+    task.status = TaskStatus::InProgress;
+    task.assigned_to = Some("agent-1".into());
+    task.updated_at = "2026-07-17T10:00:01Z".into();
+    state
+        .agents
+        .get_mut("agent-1")
+        .expect("Codex agent")
+        .current_task_id = Some(TASK_ID.into());
+    state.metrics = SessionMetrics::recalculate(&state);
+    state
+}
+
+fn assert_blocked_task(state: &SessionState) {
+    let task = &state.tasks[TASK_ID];
+    assert_eq!(task.status, TaskStatus::Blocked);
+    assert_eq!(
+        task.blocked_reason.as_deref(),
+        Some("Codex worker was missing after daemon restart")
+    );
+    assert!(state.agents["agent-1"].current_task_id.is_none());
+}
+
+async fn seed_committed_admission(
+    db: &AsyncDaemonDb,
+    kinds: &[&str],
+) -> (String, DispatchAppliedTask) {
+    let item = TaskBoardItem::new(
+        ITEM_ID.into(),
+        "Admission recovery".into(),
+        "Recover the missing worker".into(),
+        "2026-07-17T10:00:00Z".into(),
+    );
+    db.create_task_board_item(item)
+        .await
+        .expect("create recovery item");
+    let dispatch = db
+        .link_and_enqueue_task_board_dispatch(ITEM_ID, SESSION_ID, TASK_ID, &applied_lifecycle())
+        .await
+        .expect("link recovery dispatch");
+    let intent_id: String =
+        sqlx::query_scalar("SELECT intent_id FROM task_board_dispatch_intents WHERE item_id = ?1")
+            .bind(ITEM_ID)
+            .fetch_one(db.pool())
+            .await
+            .expect("load recovery intent");
+    db.update_task_board_item(ITEM_ID, |item| {
+        item.workflow.current_step_id = Some("worker_running".into());
+        Ok(true)
+    })
+    .await
+    .expect("mark worker running");
+    sqlx::query(
+        "UPDATE task_board_dispatch_intents
+         SET status = 'completed', updated_at = ?2, completed_at = ?2
+         WHERE intent_id = ?1",
+    )
+    .bind(&intent_id)
+    .bind("2026-07-17T10:00:02Z")
+    .execute(db.pool())
+    .await
+    .expect("complete recovery intent");
+    insert_allowed_decision(db, &intent_id).await;
+    for kind in kinds {
+        insert_committed_ledger(db, &intent_id, kind).await;
+    }
+    (intent_id, dispatch)
+}
+
+async fn insert_allowed_decision(db: &AsyncDaemonDb, intent_id: &str) {
+    let item_revision: i64 =
+        sqlx::query_scalar("SELECT revision FROM task_board_items WHERE item_id = ?1")
+            .bind(ITEM_ID)
+            .fetch_one(db.pool())
+            .await
+            .expect("load item revision");
+    let settings_revision: i64 = sqlx::query_scalar(
+        "SELECT revision FROM task_board_orchestrator_settings WHERE singleton = 1",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("load settings revision");
+    sqlx::query(
+        "INSERT INTO task_board_dispatch_admission_decisions (
+            decision_id, intent_id, generation, item_id, item_revision, settings_revision,
+            decision, policy_json, context_json, requirements_json, blockers_json,
+            launch_profile, evaluated_at, next_available_at, is_current, created_at
+         ) VALUES (
+            'decision-recovery', ?1, 1, ?2, ?3, ?4,
+            'allowed', '{}', '{}', '[]', '[]',
+            'workspace_write', ?5, NULL, 1, ?5
+         )",
+    )
+    .bind(intent_id)
+    .bind(ITEM_ID)
+    .bind(item_revision)
+    .bind(settings_revision)
+    .bind("2026-07-17T10:00:00Z")
+    .execute(db.pool())
+    .await
+    .expect("insert allowed recovery decision");
+}
+
+async fn insert_committed_ledger(db: &AsyncDaemonDb, intent_id: &str, kind: &str) {
+    let (window_start, window_end, limit) = match kind {
+        "concurrency" => (None, None, 1_i64),
+        "rate" => (
+            Some("2026-07-17T10:00:00Z"),
+            Some("2026-07-17T11:00:00Z"),
+            100_i64,
+        ),
+        other => panic!("unsupported test ledger kind {other}"),
+    };
+    sqlx::query(
+        "INSERT INTO task_board_dispatch_admission_ledger (
+            ledger_id, decision_id, decision, intent_id, generation, item_id,
+            canonical_key, kind, scope, amount, limit_value,
+            window_started_at, window_ends_at, state, managed_worker_id,
+            expires_at, reserved_at, committed_at, released_at
+         ) VALUES (
+            ?1, 'decision-recovery', 'allowed', ?2, 1, ?3,
+            ?4, ?5, 'global', 1, ?6,
+            ?7, ?8, 'committed', ?9,
+            NULL, ?10, ?11, NULL
+         )",
+    )
+    .bind(format!("ledger-{kind}"))
+    .bind(intent_id)
+    .bind(ITEM_ID)
+    .bind(format!("{kind}:global"))
+    .bind(kind)
+    .bind(limit)
+    .bind(window_start)
+    .bind(window_end)
+    .bind(WORKER_ID)
+    .bind("2026-07-17T10:00:00Z")
+    .bind("2026-07-17T10:00:01Z")
+    .execute(db.pool())
+    .await
+    .expect("insert committed recovery ledger");
+}
+
+async fn ledger_state(db: &AsyncDaemonDb, intent_id: &str, kind: &str) -> (String, Option<String>) {
+    sqlx::query_as(
+        "SELECT state, released_at FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND kind = ?2",
+    )
+    .bind(intent_id)
+    .bind(kind)
+    .fetch_one(db.pool())
+    .await
+    .expect("load recovery ledger state")
+}
+
+fn applied_lifecycle() -> DispatchLifecycle {
+    DispatchLifecycle {
+        worker: lifecycle_step(
+            DispatchLifecyclePhase::Worker,
+            DispatchLifecycleStatus::SessionTaskLinked,
+            Some(AgentMode::Headless),
+        ),
+        reviewer: lifecycle_step(
+            DispatchLifecyclePhase::Reviewer,
+            DispatchLifecycleStatus::WaitingForWorkerReview,
+            None,
+        ),
+        evaluator: lifecycle_step(
+            DispatchLifecyclePhase::Evaluator,
+            DispatchLifecycleStatus::WaitingForReviewCompletion,
+            None,
+        ),
+    }
+}
+
+fn lifecycle_step(
+    phase: DispatchLifecyclePhase,
+    status: DispatchLifecycleStatus,
+    mode: Option<AgentMode>,
+) -> DispatchLifecycleStep {
+    DispatchLifecycleStep {
+        phase,
+        status,
+        mode,
+        suggested_persona: None,
+        required_consensus: None,
+        native_signal: None,
+    }
+}

--- a/src/daemon/db/async_bootstrap.rs
+++ b/src/daemon/db/async_bootstrap.rs
@@ -135,6 +135,7 @@ const fn migration_floor_version(migration_version: i64) -> u64 {
         30 => 36,
         31 => 37,
         32 => 38,
+        33 => 39,
         _ => u64::MAX,
     }
 }

--- a/src/daemon/db/async_runtime.rs
+++ b/src/daemon/db/async_runtime.rs
@@ -100,6 +100,9 @@ impl AsyncDaemonDb {
     /// # Errors
     /// Returns [`CliError`] on SQL or serialization failures.
     pub(crate) async fn save_codex_run(&self, snapshot: &CodexRunSnapshot) -> Result<(), CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("async codex run save")
+            .await?;
         let pending_approvals_json = serde_json::to_string(&snapshot.pending_approvals)
             .map_err(|error| db_error(format!("serialize async codex approvals: {error}")))?;
         let resolved_approvals_json =
@@ -132,10 +135,20 @@ impl AsyncDaemonDb {
             .bind(&snapshot.updated_at)
             .bind(&snapshot.model)
             .bind(&snapshot.effort)
-            .execute(self.pool())
+            .execute(transaction.as_mut())
             .await
             .map_err(|error| db_error(format!("save async codex run: {error}")))?;
-        Ok(())
+        if !snapshot.status.is_active() {
+            super::task_board::release_managed_worker_admission_in_tx(
+                &mut transaction,
+                &snapshot.run_id,
+            )
+            .await?;
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit async codex run: {error}")))
     }
 
     /// Load one Codex controller run snapshot from the canonical async DB.

--- a/src/daemon/db/async_runtime.rs
+++ b/src/daemon/db/async_runtime.rs
@@ -100,9 +100,6 @@ impl AsyncDaemonDb {
     /// # Errors
     /// Returns [`CliError`] on SQL or serialization failures.
     pub(crate) async fn save_codex_run(&self, snapshot: &CodexRunSnapshot) -> Result<(), CliError> {
-        let mut transaction = self
-            .begin_immediate_transaction("async codex run save")
-            .await?;
         let pending_approvals_json = serde_json::to_string(&snapshot.pending_approvals)
             .map_err(|error| db_error(format!("serialize async codex approvals: {error}")))?;
         let resolved_approvals_json =
@@ -111,6 +108,9 @@ impl AsyncDaemonDb {
             })?;
         let events_json = serde_json::to_string(&snapshot.events)
             .map_err(|error| db_error(format!("serialize async codex events: {error}")))?;
+        let mut transaction = self
+            .begin_immediate_transaction("async codex run save")
+            .await?;
         query(UPSERT_CODEX_RUN_SQL)
             .bind(&snapshot.run_id)
             .bind(&snapshot.session_id)

--- a/src/daemon/db/async_writes.rs
+++ b/src/daemon/db/async_writes.rs
@@ -292,7 +292,7 @@ struct AsyncSessionMutationRow {
     project_id: String,
 }
 
-async fn sync_session_in_transaction(
+pub(in crate::daemon::db) async fn sync_session_in_transaction(
     transaction: &mut Transaction<'_, Sqlite>,
     project_id: &str,
     state: &SessionState,

--- a/src/daemon/db/migrations/0033_daemon_v39_task_board_policy_admission.sql
+++ b/src/daemon/db/migrations/0033_daemon_v39_task_board_policy_admission.sql
@@ -18,6 +18,20 @@ ALTER TABLE task_board_items
             )
         );
 
+ALTER TABLE task_board_dispatch_intents
+    ADD COLUMN compensation_pending INTEGER NOT NULL DEFAULT 0
+        CHECK (
+            compensation_pending IN (0, 1)
+            AND (
+                compensation_pending = 0
+                OR (
+                    status IN ('pending', 'starting')
+                    AND last_error IS NOT NULL
+                    AND length(last_error) > 0
+                )
+            )
+        );
+
 CREATE UNIQUE INDEX IF NOT EXISTS task_board_dispatch_intents_admission_identity
     ON task_board_dispatch_intents(intent_id, item_id);
 
@@ -79,7 +93,7 @@ CREATE TABLE IF NOT EXISTS task_board_dispatch_admission_decisions (
         OR (decision IN ('deferred', 'rejected') AND intent_id IS NULL)
     ),
     CHECK (
-        (decision = 'deferred' AND next_available_at IS NOT NULL)
+        decision = 'deferred'
         OR (decision != 'deferred' AND next_available_at IS NULL)
     ),
     CHECK (
@@ -91,6 +105,7 @@ CREATE TABLE IF NOT EXISTS task_board_dispatch_admission_decisions (
         )
     ),
     UNIQUE(intent_id, generation),
+    UNIQUE(item_id, generation),
     UNIQUE(decision_id, intent_id, generation, item_id, decision),
     FOREIGN KEY (intent_id, item_id)
         REFERENCES task_board_dispatch_intents(intent_id, item_id)
@@ -171,13 +186,13 @@ CREATE TABLE IF NOT EXISTS task_board_dispatch_admission_ledger (
     CHECK (
         (
             kind = 'concurrency'
-            AND amount = 1
+            AND amount > 0
             AND window_started_at IS NULL
             AND window_ends_at IS NULL
         )
         OR (
             kind = 'rate'
-            AND amount = 1
+            AND amount > 0
             AND window_started_at IS NOT NULL
             AND window_ends_at > window_started_at
         )
@@ -199,6 +214,7 @@ CREATE TABLE IF NOT EXISTS task_board_dispatch_admission_ledger (
             state = 'reserved'
             AND managed_worker_id IS NULL
             AND expires_at IS NOT NULL
+            AND expires_at > reserved_at
             AND committed_at IS NULL
             AND released_at IS NULL
         )
@@ -207,6 +223,7 @@ CREATE TABLE IF NOT EXISTS task_board_dispatch_admission_ledger (
             AND managed_worker_id IS NOT NULL
             AND expires_at IS NULL
             AND committed_at IS NOT NULL
+            AND committed_at >= reserved_at
             AND released_at IS NULL
         )
         OR (
@@ -217,11 +234,13 @@ CREATE TABLE IF NOT EXISTS task_board_dispatch_admission_ledger (
                 (
                     committed_at IS NULL
                     AND managed_worker_id IS NULL
+                    AND released_at >= reserved_at
                 )
                 OR (
                     kind = 'concurrency'
                     AND committed_at IS NOT NULL
                     AND managed_worker_id IS NOT NULL
+                    AND committed_at >= reserved_at
                     AND released_at >= committed_at
                 )
             )

--- a/src/daemon/db/migrations/0033_daemon_v39_task_board_policy_admission.sql
+++ b/src/daemon/db/migrations/0033_daemon_v39_task_board_policy_admission.sql
@@ -1,0 +1,262 @@
+ALTER TABLE task_board_items
+    ADD COLUMN estimated_tokens INTEGER
+        CHECK (
+            estimated_tokens IS NULL
+            OR (
+                typeof(estimated_tokens) = 'integer'
+                AND estimated_tokens BETWEEN 1 AND 9223372036854775807
+            )
+        );
+
+ALTER TABLE task_board_items
+    ADD COLUMN estimated_cost_microusd INTEGER
+        CHECK (
+            estimated_cost_microusd IS NULL
+            OR (
+                typeof(estimated_cost_microusd) = 'integer'
+                AND estimated_cost_microusd BETWEEN 1 AND 9223372036854775807
+            )
+        );
+
+CREATE UNIQUE INDEX IF NOT EXISTS task_board_dispatch_intents_admission_identity
+    ON task_board_dispatch_intents(intent_id, item_id);
+
+CREATE TABLE IF NOT EXISTS task_board_dispatch_admission_decisions (
+    decision_id          TEXT PRIMARY KEY CHECK (length(decision_id) > 0),
+    intent_id            TEXT,
+    generation           INTEGER NOT NULL
+                             CHECK (typeof(generation) = 'integer' AND generation > 0),
+    item_id              TEXT NOT NULL,
+    item_revision        INTEGER NOT NULL
+                             CHECK (typeof(item_revision) = 'integer' AND item_revision > 0),
+    settings_revision    INTEGER NOT NULL
+                             CHECK (typeof(settings_revision) = 'integer' AND settings_revision > 0),
+    decision             TEXT NOT NULL
+                             CHECK (decision IN ('allowed', 'deferred', 'rejected')),
+    policy_json          TEXT NOT NULL
+                             CHECK (
+                                 json_valid(policy_json)
+                                 AND json_type(policy_json) = 'object'
+                             ),
+    context_json         TEXT NOT NULL
+                             CHECK (
+                                 json_valid(context_json)
+                                 AND json_type(context_json) = 'object'
+                             ),
+    requirements_json    TEXT NOT NULL
+                             CHECK (
+                                 json_valid(requirements_json)
+                                 AND json_type(requirements_json) = 'array'
+                             ),
+    blockers_json        TEXT NOT NULL
+                             CHECK (
+                                 json_valid(blockers_json)
+                                 AND json_type(blockers_json) = 'array'
+                             ),
+    launch_profile       TEXT
+                             CHECK (
+                                 launch_profile IS NULL
+                                 OR launch_profile IN ('read_only', 'workspace_write')
+                             ),
+    evaluated_at         TEXT NOT NULL
+                             CHECK (evaluated_at GLOB '????-??-??T??:??:??Z'),
+    next_available_at    TEXT
+                             CHECK (
+                                 next_available_at IS NULL
+                                 OR next_available_at GLOB '????-??-??T??:??:??Z'
+                             ),
+    is_current           INTEGER NOT NULL DEFAULT 1
+                             CHECK (is_current IN (0, 1)),
+    superseded_at        TEXT
+                             CHECK (
+                                 superseded_at IS NULL
+                                 OR superseded_at GLOB '????-??-??T??:??:??Z'
+                             ),
+    created_at           TEXT NOT NULL
+                             CHECK (created_at GLOB '????-??-??T??:??:??Z'),
+    CHECK (
+        (decision = 'allowed' AND intent_id IS NOT NULL)
+        OR (decision IN ('deferred', 'rejected') AND intent_id IS NULL)
+    ),
+    CHECK (
+        (decision = 'deferred' AND next_available_at IS NOT NULL)
+        OR (decision != 'deferred' AND next_available_at IS NULL)
+    ),
+    CHECK (
+        (is_current = 1 AND superseded_at IS NULL)
+        OR (
+            is_current = 0
+            AND superseded_at IS NOT NULL
+            AND superseded_at >= created_at
+        )
+    ),
+    UNIQUE(intent_id, generation),
+    UNIQUE(decision_id, intent_id, generation, item_id, decision),
+    FOREIGN KEY (intent_id, item_id)
+        REFERENCES task_board_dispatch_intents(intent_id, item_id)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (item_id)
+        REFERENCES task_board_items(item_id)
+        ON DELETE RESTRICT
+) WITHOUT ROWID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS task_board_dispatch_admission_decisions_current_intent
+    ON task_board_dispatch_admission_decisions(intent_id)
+    WHERE intent_id IS NOT NULL AND is_current = 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS task_board_dispatch_admission_decisions_current_item
+    ON task_board_dispatch_admission_decisions(item_id)
+    WHERE intent_id IS NULL AND is_current = 1;
+
+CREATE INDEX IF NOT EXISTS task_board_dispatch_admission_decisions_item_history
+    ON task_board_dispatch_admission_decisions(
+        item_id, created_at DESC, generation DESC, decision_id
+    );
+
+CREATE TABLE IF NOT EXISTS task_board_dispatch_admission_ledger (
+    ledger_id            TEXT PRIMARY KEY CHECK (length(ledger_id) > 0),
+    decision_id          TEXT NOT NULL,
+    decision             TEXT NOT NULL CHECK (decision = 'allowed'),
+    intent_id            TEXT NOT NULL,
+    generation           INTEGER NOT NULL
+                             CHECK (typeof(generation) = 'integer' AND generation > 0),
+    item_id              TEXT NOT NULL,
+    canonical_key        TEXT NOT NULL CHECK (length(canonical_key) > 0),
+    kind                 TEXT NOT NULL
+                             CHECK (
+                                 kind IN (
+                                     'concurrency', 'rate', 'time_window',
+                                     'token_budget', 'monetary_budget'
+                                 )
+                             ),
+    scope                TEXT NOT NULL CHECK (length(scope) > 0),
+    amount               INTEGER NOT NULL
+                             CHECK (typeof(amount) = 'integer' AND amount >= 0),
+    limit_value          INTEGER NOT NULL
+                             CHECK (typeof(limit_value) = 'integer' AND limit_value > 0),
+    window_started_at    TEXT
+                             CHECK (
+                                 window_started_at IS NULL
+                                 OR window_started_at GLOB '????-??-??T??:??:??Z'
+                             ),
+    window_ends_at       TEXT
+                             CHECK (
+                                 window_ends_at IS NULL
+                                 OR window_ends_at GLOB '????-??-??T??:??:??Z'
+                             ),
+    state                TEXT NOT NULL
+                             CHECK (state IN ('reserved', 'committed', 'released')),
+    managed_worker_id    TEXT
+                             CHECK (
+                                 managed_worker_id IS NULL
+                                 OR length(managed_worker_id) > 0
+                             ),
+    expires_at           TEXT
+                             CHECK (
+                                 expires_at IS NULL
+                                 OR expires_at GLOB '????-??-??T??:??:??Z'
+                             ),
+    reserved_at          TEXT NOT NULL
+                             CHECK (reserved_at GLOB '????-??-??T??:??:??Z'),
+    committed_at         TEXT
+                             CHECK (
+                                 committed_at IS NULL
+                                 OR committed_at GLOB '????-??-??T??:??:??Z'
+                             ),
+    released_at          TEXT
+                             CHECK (
+                                 released_at IS NULL
+                                 OR released_at GLOB '????-??-??T??:??:??Z'
+                             ),
+    CHECK (
+        (
+            kind = 'concurrency'
+            AND amount = 1
+            AND window_started_at IS NULL
+            AND window_ends_at IS NULL
+        )
+        OR (
+            kind = 'rate'
+            AND amount = 1
+            AND window_started_at IS NOT NULL
+            AND window_ends_at > window_started_at
+        )
+        OR (
+            kind = 'time_window'
+            AND amount = 0
+            AND window_started_at IS NOT NULL
+            AND window_ends_at > window_started_at
+        )
+        OR (
+            kind IN ('token_budget', 'monetary_budget')
+            AND amount > 0
+            AND window_started_at IS NOT NULL
+            AND window_ends_at > window_started_at
+        )
+    ),
+    CHECK (
+        (
+            state = 'reserved'
+            AND managed_worker_id IS NULL
+            AND expires_at IS NOT NULL
+            AND committed_at IS NULL
+            AND released_at IS NULL
+        )
+        OR (
+            state = 'committed'
+            AND managed_worker_id IS NOT NULL
+            AND expires_at IS NULL
+            AND committed_at IS NOT NULL
+            AND released_at IS NULL
+        )
+        OR (
+            state = 'released'
+            AND expires_at IS NULL
+            AND released_at IS NOT NULL
+            AND (
+                (
+                    committed_at IS NULL
+                    AND managed_worker_id IS NULL
+                )
+                OR (
+                    kind = 'concurrency'
+                    AND committed_at IS NOT NULL
+                    AND managed_worker_id IS NOT NULL
+                    AND released_at >= committed_at
+                )
+            )
+        )
+    ),
+    UNIQUE(decision_id, canonical_key),
+    FOREIGN KEY (decision_id, intent_id, generation, item_id, decision)
+        REFERENCES task_board_dispatch_admission_decisions(
+            decision_id, intent_id, generation, item_id, decision
+        )
+        ON DELETE RESTRICT
+) WITHOUT ROWID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS task_board_dispatch_admission_ledger_current_requirement
+    ON task_board_dispatch_admission_ledger(intent_id, canonical_key)
+    WHERE state IN ('reserved', 'committed');
+
+CREATE INDEX IF NOT EXISTS task_board_dispatch_admission_ledger_usage
+    ON task_board_dispatch_admission_ledger(
+        kind, scope, window_started_at, window_ends_at, state
+    );
+
+CREATE INDEX IF NOT EXISTS task_board_dispatch_admission_ledger_intent_generation
+    ON task_board_dispatch_admission_ledger(
+        intent_id, generation, state, canonical_key
+    );
+
+INSERT INTO task_board_orchestrator_settings (
+    singleton, settings_json, revision, updated_at
+) VALUES (
+    1,
+    '{"admission_policy":{"limits":[],"windows":[]}}',
+    1,
+    strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+)
+ON CONFLICT(singleton) DO NOTHING;
+
+UPDATE schema_meta SET value = '39' WHERE key = 'version';

--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -106,9 +106,10 @@ mod task_board;
 #[allow(unused_imports)]
 pub(crate) use task_board::{
     ClaimedTaskBoardDispatch, ClaimedTaskBoardDispatchPreparation, ReservedTaskBoardDispatch,
+    TaskBoardAdmissionMissingRunRecovery, TaskBoardAdmissionWorkerRecovery,
     TaskBoardAutomationControlRecord, TaskBoardAutomationRunAdmission, TaskBoardAutomationRunFence,
-    TaskBoardAutomationRunLease, TaskBoardAutomationRunStage, TaskBoardImportMarker,
-    TaskBoardItemSnapshot, TaskBoardRunAcquireRequest,
+    TaskBoardAutomationRunLease, TaskBoardAutomationRunStage, TaskBoardDispatchClaimAction,
+    TaskBoardImportMarker, TaskBoardItemSnapshot, TaskBoardRunAcquireRequest,
 };
 mod session_data;
 mod signals;

--- a/src/daemon/db/mod.rs
+++ b/src/daemon/db/mod.rs
@@ -67,6 +67,7 @@ mod runtime;
 mod schema;
 mod schema_migrations;
 mod schema_repairs;
+mod schema_repairs_admission;
 mod schema_repairs_external_creates;
 mod schema_repairs_wake_events;
 mod schema_sql;
@@ -99,6 +100,7 @@ mod schema_v35;
 mod schema_v36;
 mod schema_v37;
 mod schema_v38;
+mod schema_v39;
 #[allow(dead_code)]
 mod task_board;
 #[allow(unused_imports)]
@@ -302,7 +304,7 @@ impl fmt::Debug for DaemonDb {
     }
 }
 
-pub(crate) const SCHEMA_VERSION: &str = "38";
+pub(crate) const SCHEMA_VERSION: &str = "39";
 
 /// Summary of what was imported from file-based storage.
 #[derive(Debug, Default)]

--- a/src/daemon/db/policy/approval_grants_tests.rs
+++ b/src/daemon/db/policy/approval_grants_tests.rs
@@ -410,6 +410,7 @@ async fn stale_consumed_grant_prevents_dispatch_preparation_completion() {
     let intent_id = match reserved {
         ReservedTaskBoardDispatch::Preparing { intent_id, .. } => intent_id,
         ReservedTaskBoardDispatch::Applied(_) => panic!("new reservation was already applied"),
+        ReservedTaskBoardDispatch::Blocked(_) => panic!("default admission blocked reservation"),
     };
     let claim = db
         .claim_task_board_dispatch_preparation(&intent_id)

--- a/src/daemon/db/schema.rs
+++ b/src/daemon/db/schema.rs
@@ -214,6 +214,9 @@ impl DaemonDb {
         if version_number <= 37 {
             self.migrate_v37_to_v38()?;
         }
+        if version_number <= 38 {
+            self.migrate_v38_to_v39()?;
+        }
         Ok(())
     }
 
@@ -357,6 +360,10 @@ impl DaemonDb {
 
     fn migrate_v37_to_v38(&self) -> Result<(), CliError> {
         super::schema_v38::run(&self.conn)
+    }
+
+    fn migrate_v38_to_v39(&self) -> Result<(), CliError> {
+        super::schema_v39::run(&self.conn)
     }
 }
 

--- a/src/daemon/db/schema_repairs.rs
+++ b/src/daemon/db/schema_repairs.rs
@@ -32,6 +32,8 @@ const CURRENT_SCHEMA_POLICY_COLUMNS: &[(&str, &str)] = &[
     ("task_board_dispatch_intents", "consumed_approval_grant_id"),
     ("task_board_items", "workflow_kind"),
     ("task_board_items", "execution_repository"),
+    ("task_board_items", "estimated_tokens"),
+    ("task_board_items", "estimated_cost_microusd"),
 ];
 
 const CURRENT_SCHEMA_CODEX_RUN_COLUMNS: &[(&str, &str)] = &[
@@ -94,6 +96,8 @@ pub(super) fn current_schema_shape_needs_repair(
         "task_board_admission_leases",
         "task_board_provider_scope_state",
         "task_board_external_create_intents",
+        "task_board_dispatch_admission_decisions",
+        "task_board_dispatch_admission_ledger",
         "task_board_sync_conflicts",
         "task_board_execution_hosts",
         "task_board_remote_assignments",
@@ -139,6 +143,9 @@ pub(super) fn current_schema_shape_needs_repair(
     if super::schema_repairs_wake_events::indexes_need_repair(conn)? {
         return Ok(true);
     }
+    if super::schema_repairs_admission::shape_needs_repair(conn)? {
+        return Ok(true);
+    }
     Ok(false)
 }
 
@@ -172,8 +179,10 @@ pub(super) fn repair_current_schema_shape(db: &DaemonDb) -> Result<(), CliError>
     super::schema_v36::run(&db.conn)?;
     super::schema_v37::run(&db.conn)?;
     super::schema_v38::run(&db.conn)?;
+    super::schema_v39::run(&db.conn)?;
     super::schema_repairs_external_creates::require_complete_shape(&db.conn)?;
     super::schema_repairs_wake_events::require_complete_shape(&db.conn)?;
+    super::schema_repairs_admission::require_complete_shape(&db.conn)?;
     db.conn
         .execute(
             "UPDATE schema_meta SET value = ?1 WHERE key = 'version'",

--- a/src/daemon/db/schema_repairs.rs
+++ b/src/daemon/db/schema_repairs.rs
@@ -30,6 +30,7 @@ const CURRENT_SCHEMA_POLICY_COLUMNS: &[(&str, &str)] = &[
     ("policy_nodes", "layout_source"),
     ("policy_decisions", "evaluated_at"),
     ("task_board_dispatch_intents", "consumed_approval_grant_id"),
+    ("task_board_dispatch_intents", "compensation_pending"),
     ("task_board_items", "workflow_kind"),
     ("task_board_items", "execution_repository"),
     ("task_board_items", "estimated_tokens"),

--- a/src/daemon/db/schema_repairs_admission.rs
+++ b/src/daemon/db/schema_repairs_admission.rs
@@ -1,0 +1,251 @@
+use rusqlite::{OptionalExtension, Transaction, TransactionBehavior};
+
+use super::{CliError, Connection, db_error};
+
+const MIGRATION_SQL: &str =
+    include_str!("migrations/0033_daemon_v39_task_board_policy_admission.sql");
+const OBJECTS_MARKER: &str =
+    "CREATE UNIQUE INDEX IF NOT EXISTS task_board_dispatch_intents_admission_identity";
+const ESTIMATED_TOKENS_DEFINITION: &str = "
+estimated_tokens INTEGER
+    CHECK (
+        estimated_tokens IS NULL
+        OR (
+            typeof(estimated_tokens) = 'integer'
+            AND estimated_tokens BETWEEN 1 AND 9223372036854775807
+        )
+    )";
+const ESTIMATED_COST_DEFINITION: &str = "
+estimated_cost_microusd INTEGER
+    CHECK (
+        estimated_cost_microusd IS NULL
+        OR (
+            typeof(estimated_cost_microusd) = 'integer'
+            AND estimated_cost_microusd BETWEEN 1 AND 9223372036854775807
+        )
+    )";
+
+struct ObjectShape {
+    object_type: &'static str,
+    create_kind: &'static str,
+    name: &'static str,
+}
+
+type StoredColumn = (String, bool, Option<String>, i64, i64);
+
+const OBJECT_SHAPES: &[ObjectShape] = &[
+    ObjectShape {
+        object_type: "index",
+        create_kind: "UNIQUE INDEX",
+        name: "task_board_dispatch_intents_admission_identity",
+    },
+    ObjectShape {
+        object_type: "table",
+        create_kind: "TABLE",
+        name: "task_board_dispatch_admission_decisions",
+    },
+    ObjectShape {
+        object_type: "index",
+        create_kind: "UNIQUE INDEX",
+        name: "task_board_dispatch_admission_decisions_current_intent",
+    },
+    ObjectShape {
+        object_type: "index",
+        create_kind: "UNIQUE INDEX",
+        name: "task_board_dispatch_admission_decisions_current_item",
+    },
+    ObjectShape {
+        object_type: "index",
+        create_kind: "INDEX",
+        name: "task_board_dispatch_admission_decisions_item_history",
+    },
+    ObjectShape {
+        object_type: "table",
+        create_kind: "TABLE",
+        name: "task_board_dispatch_admission_ledger",
+    },
+    ObjectShape {
+        object_type: "index",
+        create_kind: "UNIQUE INDEX",
+        name: "task_board_dispatch_admission_ledger_current_requirement",
+    },
+    ObjectShape {
+        object_type: "index",
+        create_kind: "INDEX",
+        name: "task_board_dispatch_admission_ledger_usage",
+    },
+    ObjectShape {
+        object_type: "index",
+        create_kind: "INDEX",
+        name: "task_board_dispatch_admission_ledger_intent_generation",
+    },
+];
+
+pub(super) fn shape_needs_repair(conn: &Connection) -> Result<bool, CliError> {
+    if item_column_needs_repair(conn, "estimated_tokens", ESTIMATED_TOKENS_DEFINITION)?
+        || item_column_needs_repair(conn, "estimated_cost_microusd", ESTIMATED_COST_DEFINITION)?
+    {
+        return Ok(true);
+    }
+    for shape in OBJECT_SHAPES {
+        let Some(actual) = object_sql(conn, shape)? else {
+            return Ok(true);
+        };
+        let expected = expected_object_sql(shape)?;
+        if normalize_sql(&actual) != expected {
+            return Err(incompatible_shape(shape.name));
+        }
+    }
+    Ok(false)
+}
+
+pub(super) fn repair_and_stamp(conn: &Connection) -> Result<(), CliError> {
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|error| db_error(format!("begin task-board admission schema repair: {error}")))?;
+    ensure_item_column(
+        &transaction,
+        "estimated_tokens",
+        ESTIMATED_TOKENS_DEFINITION,
+    )?;
+    ensure_item_column(
+        &transaction,
+        "estimated_cost_microusd",
+        ESTIMATED_COST_DEFINITION,
+    )?;
+    transaction
+        .execute_batch(migration_objects_sql()?)
+        .map_err(|error| db_error(format!("create task-board admission schema: {error}")))?;
+    require_complete_shape(&transaction)?;
+    transaction
+        .commit()
+        .map_err(|error| db_error(format!("commit task-board admission schema: {error}")))
+}
+
+pub(super) fn require_complete_shape(conn: &Connection) -> Result<(), CliError> {
+    require_item_column(conn, "estimated_tokens", ESTIMATED_TOKENS_DEFINITION)?;
+    require_item_column(conn, "estimated_cost_microusd", ESTIMATED_COST_DEFINITION)?;
+    for shape in OBJECT_SHAPES {
+        let actual = object_sql(conn, shape)?
+            .ok_or_else(|| db_error(format!("missing task-board admission {}", shape.name)))?;
+        if normalize_sql(&actual) != expected_object_sql(shape)? {
+            return Err(incompatible_shape(shape.name));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_item_column(conn: &Connection, name: &str, definition: &str) -> Result<(), CliError> {
+    if stored_item_column(conn, name)?.is_none() {
+        conn.execute_batch(&format!(
+            "ALTER TABLE task_board_items ADD COLUMN {definition};"
+        ))
+        .map_err(|error| db_error(format!("add task-board {name} column: {error}")))?;
+    }
+    require_item_column(conn, name, definition)
+}
+
+fn item_column_needs_repair(
+    conn: &Connection,
+    name: &str,
+    definition: &str,
+) -> Result<bool, CliError> {
+    if stored_item_column(conn, name)?.is_none() {
+        return Ok(true);
+    }
+    require_item_column(conn, name, definition)?;
+    Ok(false)
+}
+
+fn require_item_column(conn: &Connection, name: &str, definition: &str) -> Result<(), CliError> {
+    let Some((declared_type, not_null, default_value, primary_key, hidden)) =
+        stored_item_column(conn, name)?
+    else {
+        return Err(db_error(format!("missing task-board {name} column")));
+    };
+    let table_sql: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'table' AND name = 'task_board_items'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| db_error(format!("read task_board_items definition: {error}")))?;
+    let metadata_matches = declared_type == "INTEGER"
+        && !not_null
+        && default_value.is_none()
+        && primary_key == 0
+        && hidden == 0;
+    if metadata_matches && normalize_sql(&table_sql).contains(&normalize_sql(definition)) {
+        return Ok(());
+    }
+    Err(db_error(format!(
+        "incompatible task-board {name} column; refusing destructive repair"
+    )))
+}
+
+fn stored_item_column(conn: &Connection, name: &str) -> Result<Option<StoredColumn>, CliError> {
+    conn.query_row(
+        "SELECT type, \"notnull\", dflt_value, pk, hidden
+         FROM pragma_table_xinfo('task_board_items')
+         WHERE name = ?1",
+        [name],
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get::<_, i64>(1)? != 0,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(|error| db_error(format!("read task-board {name} column: {error}")))
+}
+
+fn object_sql(conn: &Connection, shape: &ObjectShape) -> Result<Option<String>, CliError> {
+    conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = ?1 AND name = ?2",
+        [shape.object_type, shape.name],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(|error| db_error(format!("read task-board admission {}: {error}", shape.name)))
+}
+
+fn expected_object_sql(shape: &ObjectShape) -> Result<String, CliError> {
+    let prefix = format!("CREATE {} IF NOT EXISTS {}", shape.create_kind, shape.name);
+    let tail = MIGRATION_SQL
+        .split_once(&prefix)
+        .map(|(_, tail)| tail)
+        .ok_or_else(|| db_error(format!("admission migration is missing {}", shape.name)))?;
+    let body = tail
+        .split_once(";\n\n")
+        .map_or_else(|| tail.trim_end_matches(';'), |(body, _)| body);
+    Ok(normalize_sql(&format!(
+        "CREATE {} {}{}",
+        shape.create_kind, shape.name, body
+    )))
+}
+
+fn migration_objects_sql() -> Result<&'static str, CliError> {
+    MIGRATION_SQL
+        .find(OBJECTS_MARKER)
+        .map(|offset| &MIGRATION_SQL[offset..])
+        .ok_or_else(|| db_error("admission migration has no object boundary"))
+}
+
+fn incompatible_shape(name: &str) -> CliError {
+    db_error(format!(
+        "incompatible task-board admission {name}; refusing destructive repair"
+    ))
+}
+
+fn normalize_sql(sql: &str) -> String {
+    sql.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace("IF NOT EXISTS ", "")
+        .replace("if not exists ", "")
+        .to_ascii_lowercase()
+}

--- a/src/daemon/db/schema_repairs_admission.rs
+++ b/src/daemon/db/schema_repairs_admission.rs
@@ -24,6 +24,19 @@ estimated_cost_microusd INTEGER
             AND estimated_cost_microusd BETWEEN 1 AND 9223372036854775807
         )
     )";
+const COMPENSATION_PENDING_DEFINITION: &str = "
+compensation_pending INTEGER NOT NULL DEFAULT 0
+    CHECK (
+        compensation_pending IN (0, 1)
+        AND (
+            compensation_pending = 0
+            OR (
+                status IN ('pending', 'starting')
+                AND last_error IS NOT NULL
+                AND length(last_error) > 0
+            )
+        )
+    )";
 
 struct ObjectShape {
     object_type: &'static str,
@@ -84,6 +97,11 @@ const OBJECT_SHAPES: &[ObjectShape] = &[
 pub(super) fn shape_needs_repair(conn: &Connection) -> Result<bool, CliError> {
     if item_column_needs_repair(conn, "estimated_tokens", ESTIMATED_TOKENS_DEFINITION)?
         || item_column_needs_repair(conn, "estimated_cost_microusd", ESTIMATED_COST_DEFINITION)?
+        || dispatch_column_needs_repair(
+            conn,
+            "compensation_pending",
+            COMPENSATION_PENDING_DEFINITION,
+        )?
     {
         return Ok(true);
     }
@@ -96,7 +114,7 @@ pub(super) fn shape_needs_repair(conn: &Connection) -> Result<bool, CliError> {
             return Err(incompatible_shape(shape.name));
         }
     }
-    Ok(false)
+    Ok(!settings_singleton_exists(conn)?)
 }
 
 pub(super) fn repair_and_stamp(conn: &Connection) -> Result<(), CliError> {
@@ -112,6 +130,11 @@ pub(super) fn repair_and_stamp(conn: &Connection) -> Result<(), CliError> {
         "estimated_cost_microusd",
         ESTIMATED_COST_DEFINITION,
     )?;
+    ensure_dispatch_column(
+        &transaction,
+        "compensation_pending",
+        COMPENSATION_PENDING_DEFINITION,
+    )?;
     transaction
         .execute_batch(migration_objects_sql()?)
         .map_err(|error| db_error(format!("create task-board admission schema: {error}")))?;
@@ -124,6 +147,11 @@ pub(super) fn repair_and_stamp(conn: &Connection) -> Result<(), CliError> {
 pub(super) fn require_complete_shape(conn: &Connection) -> Result<(), CliError> {
     require_item_column(conn, "estimated_tokens", ESTIMATED_TOKENS_DEFINITION)?;
     require_item_column(conn, "estimated_cost_microusd", ESTIMATED_COST_DEFINITION)?;
+    require_dispatch_column(
+        conn,
+        "compensation_pending",
+        COMPENSATION_PENDING_DEFINITION,
+    )?;
     for shape in OBJECT_SHAPES {
         let actual = object_sql(conn, shape)?
             .ok_or_else(|| db_error(format!("missing task-board admission {}", shape.name)))?;
@@ -131,17 +159,46 @@ pub(super) fn require_complete_shape(conn: &Connection) -> Result<(), CliError> 
             return Err(incompatible_shape(shape.name));
         }
     }
+    if !settings_singleton_exists(conn)? {
+        return Err(db_error(
+            "missing task-board orchestrator settings singleton",
+        ));
+    }
     Ok(())
 }
 
+fn settings_singleton_exists(conn: &Connection) -> Result<bool, CliError> {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM task_board_orchestrator_settings WHERE singleton = 1
+         )",
+        [],
+        |row| row.get(0),
+    )
+    .map_err(|error| db_error(format!("read task-board orchestrator settings: {error}")))
+}
+
 fn ensure_item_column(conn: &Connection, name: &str, definition: &str) -> Result<(), CliError> {
-    if stored_item_column(conn, name)?.is_none() {
-        conn.execute_batch(&format!(
-            "ALTER TABLE task_board_items ADD COLUMN {definition};"
-        ))
-        .map_err(|error| db_error(format!("add task-board {name} column: {error}")))?;
-    }
+    ensure_column(conn, "task_board_items", name, definition)?;
     require_item_column(conn, name, definition)
+}
+
+fn ensure_dispatch_column(conn: &Connection, name: &str, definition: &str) -> Result<(), CliError> {
+    ensure_column(conn, "task_board_dispatch_intents", name, definition)?;
+    require_dispatch_column(conn, name, definition)
+}
+
+fn ensure_column(
+    conn: &Connection,
+    table: &str,
+    name: &str,
+    definition: &str,
+) -> Result<(), CliError> {
+    if stored_column(conn, table, name)?.is_none() {
+        conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {definition};"))
+            .map_err(|error| db_error(format!("add task-board {name} column: {error}")))?;
+    }
+    Ok(())
 }
 
 fn item_column_needs_repair(
@@ -149,16 +206,28 @@ fn item_column_needs_repair(
     name: &str,
     definition: &str,
 ) -> Result<bool, CliError> {
-    if stored_item_column(conn, name)?.is_none() {
+    if stored_column(conn, "task_board_items", name)?.is_none() {
         return Ok(true);
     }
     require_item_column(conn, name, definition)?;
     Ok(false)
 }
 
+fn dispatch_column_needs_repair(
+    conn: &Connection,
+    name: &str,
+    definition: &str,
+) -> Result<bool, CliError> {
+    if stored_column(conn, "task_board_dispatch_intents", name)?.is_none() {
+        return Ok(true);
+    }
+    require_dispatch_column(conn, name, definition)?;
+    Ok(false)
+}
+
 fn require_item_column(conn: &Connection, name: &str, definition: &str) -> Result<(), CliError> {
     let Some((declared_type, not_null, default_value, primary_key, hidden)) =
-        stored_item_column(conn, name)?
+        stored_column(conn, "task_board_items", name)?
     else {
         return Err(db_error(format!("missing task-board {name} column")));
     };
@@ -183,12 +252,51 @@ fn require_item_column(conn: &Connection, name: &str, definition: &str) -> Resul
     )))
 }
 
-fn stored_item_column(conn: &Connection, name: &str) -> Result<Option<StoredColumn>, CliError> {
+fn require_dispatch_column(
+    conn: &Connection,
+    name: &str,
+    definition: &str,
+) -> Result<(), CliError> {
+    let Some((declared_type, not_null, default_value, primary_key, hidden)) =
+        stored_column(conn, "task_board_dispatch_intents", name)?
+    else {
+        return Err(db_error(format!("missing task-board {name} column")));
+    };
+    let table_sql: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'table' AND name = 'task_board_dispatch_intents'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| {
+            db_error(format!(
+                "read task_board_dispatch_intents definition: {error}"
+            ))
+        })?;
+    let metadata_matches = declared_type == "INTEGER"
+        && not_null
+        && default_value.as_deref() == Some("0")
+        && primary_key == 0
+        && hidden == 0;
+    if metadata_matches && normalize_sql(&table_sql).contains(&normalize_sql(definition)) {
+        return Ok(());
+    }
+    Err(db_error(format!(
+        "incompatible task-board {name} column; refusing destructive repair"
+    )))
+}
+
+fn stored_column(
+    conn: &Connection,
+    table: &str,
+    name: &str,
+) -> Result<Option<StoredColumn>, CliError> {
     conn.query_row(
         "SELECT type, \"notnull\", dflt_value, pk, hidden
-         FROM pragma_table_xinfo('task_board_items')
-         WHERE name = ?1",
-        [name],
+         FROM pragma_table_xinfo(?1)
+         WHERE name = ?2",
+        rusqlite::params![table, name],
         |row| {
             Ok((
                 row.get(0)?,

--- a/src/daemon/db/schema_v33.rs
+++ b/src/daemon/db/schema_v33.rs
@@ -8,8 +8,22 @@ pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
     if !table_exists(conn, "task_board_dispatch_intents")? {
         return stamp_schema_version(conn);
     }
+    if dispatch_intents_support_held(conn)? {
+        return stamp_schema_version(conn);
+    }
     conn.execute_batch(HELD_DISPATCH_DDL)
         .map_err(|error| db_error(format!("apply held dispatch schema v33: {error}")))
+}
+
+fn dispatch_intents_support_held(conn: &Connection) -> Result<bool, CliError> {
+    conn.query_row(
+        "SELECT sql FROM sqlite_master
+         WHERE type = 'table' AND name = 'task_board_dispatch_intents'",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .map(|sql| sql.contains("'held'"))
+    .map_err(|error| db_error(format!("read task-board dispatch intent schema: {error}")))
 }
 
 fn table_exists(conn: &Connection, table_name: &str) -> Result<bool, CliError> {

--- a/src/daemon/db/schema_v37.rs
+++ b/src/daemon/db/schema_v37.rs
@@ -75,12 +75,11 @@ mod tests {
              ) VALUES (
                  'legacy-item', 0, 'github', '42', '{\"status\":\"umbrella\"}'
              );
-             INSERT INTO task_board_orchestrator_settings (
-                 singleton, settings_json, revision, updated_at
-             ) VALUES (
-                 1, '{\"dispatch_status_filter\":\"umbrella\"}', 1,
-                 '2026-07-16T00:00:00Z'
-             );
+             UPDATE task_board_orchestrator_settings
+                SET settings_json = '{\"dispatch_status_filter\":\"umbrella\"}',
+                    revision = 1,
+                    updated_at = '2026-07-16T00:00:00Z'
+              WHERE singleton = 1;
              INSERT INTO task_board_orchestrator_state (
                  singleton, state_json, enabled, running, revision, updated_at
              ) VALUES (

--- a/src/daemon/db/schema_v39.rs
+++ b/src/daemon/db/schema_v39.rs
@@ -8,8 +8,13 @@ pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
 
 #[cfg(test)]
 mod tests {
+    use rusqlite::{Connection, Result as SqlResult, params};
+
     use super::run;
     use crate::daemon::db::DaemonDb;
+
+    const NOW: &str = "2026-07-17T10:00:00Z";
+    const LATER: &str = "2026-07-17T10:15:00Z";
 
     #[test]
     fn current_schema_contains_task_board_admission_storage() {
@@ -28,6 +33,20 @@ mod tests {
                 .expect("read task-board item column");
             assert_eq!(exists, 1, "missing task-board item column {column}");
         }
+        let compensation_column: (String, i64, Option<String>, i64) = db
+            .connection()
+            .query_row(
+                "SELECT type, \"notnull\", dflt_value, hidden
+                 FROM pragma_table_xinfo('task_board_dispatch_intents')
+                 WHERE name = 'compensation_pending'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("read dispatch compensation column");
+        assert_eq!(
+            compensation_column,
+            ("INTEGER".to_string(), 1, Some("0".to_string()), 0)
+        );
         for table in [
             "task_board_dispatch_admission_decisions",
             "task_board_dispatch_admission_ledger",
@@ -70,6 +89,7 @@ mod tests {
                  DROP TABLE task_board_dispatch_admission_ledger;
                  DROP TABLE task_board_dispatch_admission_decisions;
                  DROP INDEX task_board_dispatch_intents_admission_identity;
+                 ALTER TABLE task_board_dispatch_intents DROP COLUMN compensation_pending;
                  ALTER TABLE task_board_items DROP COLUMN estimated_cost_microusd;
                  UPDATE schema_meta SET value = '38' WHERE key = 'version';",
             )
@@ -90,6 +110,48 @@ mod tests {
             .expect("read preserved settings");
         assert_eq!(settings_json, r#"{"enabled":true}"#);
         assert_eq!(revision, 7);
+        let compensation_column: i64 = db
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_xinfo('task_board_dispatch_intents')
+                 WHERE name = 'compensation_pending'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read repaired compensation column");
+        assert_eq!(compensation_column, 1);
+    }
+
+    #[test]
+    fn compensation_marker_requires_a_recoverable_dispatch_and_reason() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+        seed_admission_fixture(db.connection());
+
+        let terminal_marker = db.connection().execute(
+            "UPDATE task_board_dispatch_intents
+             SET last_error = 'stop worker', compensation_pending = 1
+             WHERE intent_id = 'intent-a'",
+            [],
+        );
+        assert!(terminal_marker.is_err(), "terminal marker must fail");
+        let empty_reason = db.connection().execute(
+            "UPDATE task_board_dispatch_intents
+             SET status = 'starting', claim_token = 'claim', claimed_at = ?1,
+                 completed_at = NULL, last_error = NULL, compensation_pending = 1
+             WHERE intent_id = 'intent-a'",
+            [NOW],
+        );
+        assert!(empty_reason.is_err(), "reasonless marker must fail");
+
+        db.connection()
+            .execute(
+                "UPDATE task_board_dispatch_intents
+                 SET status = 'starting', claim_token = 'claim', claimed_at = ?1,
+                     completed_at = NULL, last_error = 'stop worker', compensation_pending = 1
+                 WHERE intent_id = 'intent-a'",
+                [NOW],
+            )
+            .expect("mark a recoverable compensation");
     }
 
     #[test]
@@ -111,5 +173,234 @@ mod tests {
                 .contains("admission task_board_dispatch_admission_ledger_current_requirement"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn admission_decision_generation_is_unique_per_item() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+        seed_admission_fixture(db.connection());
+        insert_allowed_decision(db.connection(), "decision-a", "intent-a", 1)
+            .expect("insert first decision");
+
+        let duplicate = insert_allowed_decision(db.connection(), "decision-b", "intent-b", 1);
+
+        assert!(duplicate.is_err(), "duplicate item generation must fail");
+    }
+
+    #[test]
+    fn admission_ledger_enforces_kind_amount_and_window_shape() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+        seed_admission_fixture(db.connection());
+        insert_allowed_decision(db.connection(), "decision-a", "intent-a", 1)
+            .expect("insert decision");
+
+        for (id, kind, amount, window) in [
+            ("concurrency", "concurrency", 2, None),
+            ("rate", "rate", 3, Some((NOW, LATER))),
+            ("time-window", "time_window", 0, Some((NOW, LATER))),
+            ("token", "token_budget", 4, Some((NOW, LATER))),
+            ("money", "monetary_budget", 5, Some((NOW, LATER))),
+        ] {
+            insert_ledger(
+                db.connection(),
+                id,
+                kind,
+                amount,
+                window,
+                LedgerLifecycle::Reserved { expires_at: LATER },
+            )
+            .unwrap_or_else(|error| panic!("insert valid {kind} ledger: {error}"));
+        }
+
+        for (id, kind, amount, window) in [
+            ("bad-concurrency", "concurrency", 0, None),
+            ("bad-rate", "rate", 0, Some((NOW, LATER))),
+            ("bad-window", "time_window", 1, Some((NOW, LATER))),
+            ("bad-token", "token_budget", 0, Some((NOW, LATER))),
+        ] {
+            assert!(
+                insert_ledger(
+                    db.connection(),
+                    id,
+                    kind,
+                    amount,
+                    window,
+                    LedgerLifecycle::Reserved { expires_at: LATER },
+                )
+                .is_err(),
+                "invalid {kind} ledger must fail"
+            );
+        }
+    }
+
+    #[test]
+    fn admission_ledger_timestamps_are_monotonic() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+        seed_admission_fixture(db.connection());
+        insert_allowed_decision(db.connection(), "decision-a", "intent-a", 1)
+            .expect("insert decision");
+
+        for (id, lifecycle) in [
+            (
+                "expired-before-reserved",
+                LedgerLifecycle::Reserved { expires_at: NOW },
+            ),
+            (
+                "committed-before-reserved",
+                LedgerLifecycle::Committed {
+                    committed_at: "2026-07-17T09:59:59Z",
+                },
+            ),
+            (
+                "released-before-reserved",
+                LedgerLifecycle::Released {
+                    committed_at: None,
+                    released_at: "2026-07-17T09:59:59Z",
+                },
+            ),
+            (
+                "committed-release-before-reserved",
+                LedgerLifecycle::Released {
+                    committed_at: Some("2026-07-17T09:59:58Z"),
+                    released_at: "2026-07-17T09:59:59Z",
+                },
+            ),
+        ] {
+            assert!(
+                insert_ledger(db.connection(), id, "concurrency", 1, None, lifecycle).is_err(),
+                "non-monotonic ledger {id} must fail"
+            );
+        }
+
+        insert_ledger(
+            db.connection(),
+            "valid-released",
+            "concurrency",
+            1,
+            None,
+            LedgerLifecycle::Released {
+                committed_at: Some(NOW),
+                released_at: NOW,
+            },
+        )
+        .expect("equal monotonic timestamps are valid");
+    }
+
+    #[derive(Clone, Copy)]
+    enum LedgerLifecycle<'a> {
+        Reserved {
+            expires_at: &'a str,
+        },
+        Committed {
+            committed_at: &'a str,
+        },
+        Released {
+            committed_at: Option<&'a str>,
+            released_at: &'a str,
+        },
+    }
+
+    fn seed_admission_fixture(conn: &Connection) {
+        conn.execute_batch(
+            "INSERT INTO task_board_items (
+                 item_id, schema_version, title, body, status, priority, tags_json,
+                 project_id, target_project_types_json, agent_mode, imported_from_provider,
+                 planning_json, workflow_json, session_id, work_item_id, usage_json,
+                 created_at, updated_at, deleted_at, revision, workflow_kind
+             ) VALUES (
+                 'item', 1, 'Item', '', 'todo', 'medium', '[]', NULL, '[]',
+                 'headless', NULL, '{}', '{}', NULL, NULL, '{}',
+                 '2026-07-17T10:00:00Z', '2026-07-17T10:00:00Z', NULL, 1,
+                 'default_task'
+             );
+             INSERT INTO task_board_dispatch_intents (
+                 intent_id, item_id, session_id, work_item_id, workflow_execution_id,
+                 payload_json, status, attempts, available_at, created_at, updated_at,
+                 completed_at
+             ) VALUES
+             (
+                 'intent-a', 'item', 'session-a', 'work-a', 'execution-a', '{}',
+                 'completed', 0, '2026-07-17T10:00:00Z', '2026-07-17T10:00:00Z',
+                 '2026-07-17T10:00:00Z', '2026-07-17T10:00:00Z'
+             ),
+             (
+                 'intent-b', 'item', 'session-b', 'work-b', 'execution-b', '{}',
+                 'completed', 0, '2026-07-17T10:00:00Z', '2026-07-17T10:00:00Z',
+                 '2026-07-17T10:00:00Z', '2026-07-17T10:00:00Z'
+             );",
+        )
+        .expect("seed task-board admission fixture");
+    }
+
+    fn insert_allowed_decision(
+        conn: &Connection,
+        decision_id: &str,
+        intent_id: &str,
+        generation: i64,
+    ) -> SqlResult<usize> {
+        conn.execute(
+            "INSERT INTO task_board_dispatch_admission_decisions (
+                 decision_id, intent_id, generation, item_id, item_revision,
+                 settings_revision, decision, policy_json, context_json,
+                 requirements_json, blockers_json, launch_profile, evaluated_at,
+                 next_available_at, is_current, superseded_at, created_at
+             ) VALUES (
+                 ?1, ?2, ?3, 'item', 1, 1, 'allowed', '{}', '{}', '[]', '[]',
+                 'workspace_write', ?4, NULL, 0, ?4, ?4
+             )",
+            params![decision_id, intent_id, generation, NOW],
+        )
+    }
+
+    fn insert_ledger(
+        conn: &Connection,
+        ledger_id: &str,
+        kind: &str,
+        amount: i64,
+        window: Option<(&str, &str)>,
+        lifecycle: LedgerLifecycle<'_>,
+    ) -> SqlResult<usize> {
+        let (state, worker, expires_at, committed_at, released_at) = match lifecycle {
+            LedgerLifecycle::Reserved { expires_at } => {
+                ("reserved", None, Some(expires_at), None, None)
+            }
+            LedgerLifecycle::Committed { committed_at } => {
+                ("committed", Some("worker"), None, Some(committed_at), None)
+            }
+            LedgerLifecycle::Released {
+                committed_at,
+                released_at,
+            } => (
+                "released",
+                committed_at.map(|_| "worker"),
+                None,
+                committed_at,
+                Some(released_at),
+            ),
+        };
+        conn.execute(
+            "INSERT INTO task_board_dispatch_admission_ledger (
+                 ledger_id, decision_id, decision, intent_id, generation, item_id,
+                 canonical_key, kind, scope, amount, limit_value, window_started_at,
+                 window_ends_at, state, managed_worker_id, expires_at, reserved_at,
+                 committed_at, released_at
+             ) VALUES (
+                 ?1, 'decision-a', 'allowed', 'intent-a', 1, 'item', ?1, ?2,
+                 'global', ?3, 10, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11
+             )",
+            params![
+                ledger_id,
+                kind,
+                amount,
+                window.map(|value| value.0),
+                window.map(|value| value.1),
+                state,
+                worker,
+                expires_at,
+                NOW,
+                committed_at,
+                released_at,
+            ],
+        )
     }
 }

--- a/src/daemon/db/schema_v39.rs
+++ b/src/daemon/db/schema_v39.rs
@@ -1,0 +1,115 @@
+use rusqlite::Connection;
+
+use super::CliError;
+
+pub(super) fn run(conn: &Connection) -> Result<(), CliError> {
+    super::schema_repairs_admission::repair_and_stamp(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+    use crate::daemon::db::DaemonDb;
+
+    #[test]
+    fn current_schema_contains_task_board_admission_storage() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+
+        assert_eq!(db.schema_version().expect("schema version"), "39");
+        for column in ["estimated_tokens", "estimated_cost_microusd"] {
+            let exists: i64 = db
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM pragma_table_xinfo('task_board_items')
+                     WHERE name = ?1",
+                    [column],
+                    |row| row.get(0),
+                )
+                .expect("read task-board item column");
+            assert_eq!(exists, 1, "missing task-board item column {column}");
+        }
+        for table in [
+            "task_board_dispatch_admission_decisions",
+            "task_board_dispatch_admission_ledger",
+        ] {
+            let exists: i64 = db
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master
+                     WHERE type = 'table' AND name = ?1",
+                    [table],
+                    |row| row.get(0),
+                )
+                .expect("read task-board admission table");
+            assert_eq!(exists, 1, "missing task-board admission table {table}");
+        }
+        let settings_json: String = db
+            .connection()
+            .query_row(
+                "SELECT settings_json FROM task_board_orchestrator_settings
+                 WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read seeded orchestrator settings");
+        assert_eq!(
+            settings_json,
+            r#"{"admission_policy":{"limits":[],"windows":[]}}"#
+        );
+    }
+
+    #[test]
+    fn migration_is_restart_safe_and_preserves_existing_settings() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+        db.connection()
+            .execute_batch(
+                "UPDATE task_board_orchestrator_settings
+                     SET settings_json = '{\"enabled\":true}', revision = 7,
+                         updated_at = '2026-07-17T10:00:00Z'
+                   WHERE singleton = 1;
+                 DROP TABLE task_board_dispatch_admission_ledger;
+                 DROP TABLE task_board_dispatch_admission_decisions;
+                 DROP INDEX task_board_dispatch_intents_admission_identity;
+                 ALTER TABLE task_board_items DROP COLUMN estimated_cost_microusd;
+                 UPDATE schema_meta SET value = '38' WHERE key = 'version';",
+            )
+            .expect("restore a partially migrated v38 shape");
+
+        run(db.connection()).expect("repair partial v39 migration");
+        run(db.connection()).expect("repeat v39 migration");
+
+        assert_eq!(db.schema_version().expect("schema version"), "39");
+        let (settings_json, revision): (String, i64) = db
+            .connection()
+            .query_row(
+                "SELECT settings_json, revision
+                 FROM task_board_orchestrator_settings WHERE singleton = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read preserved settings");
+        assert_eq!(settings_json, r#"{"enabled":true}"#);
+        assert_eq!(revision, 7);
+    }
+
+    #[test]
+    fn migration_refuses_weakened_admission_index() {
+        let db = DaemonDb::open_in_memory().expect("open daemon db");
+        db.connection()
+            .execute_batch(
+                "DROP INDEX task_board_dispatch_admission_ledger_current_requirement;
+                 CREATE INDEX task_board_dispatch_admission_ledger_current_requirement
+                     ON task_board_dispatch_admission_ledger(intent_id, canonical_key);",
+            )
+            .expect("weaken admission index");
+
+        let error = run(db.connection()).expect_err("weakened index must fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("admission task_board_dispatch_admission_ledger_current_requirement"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/src/daemon/db/task_board/admission.rs
+++ b/src/daemon/db/task_board/admission.rs
@@ -1,0 +1,167 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sqlx::{Sqlite, Transaction, query_as};
+
+use super::admission_reservations::admission_usage_in_tx;
+use crate::daemon::db::{CliError, db_error, utc_now};
+use crate::task_board::{
+    TaskBoardAdmissionDecision, TaskBoardAdmissionRequirement, TaskBoardAutomationPolicy,
+    TaskBoardItem, TaskBoardLaunchCapability, TaskBoardOrchestratorSettings,
+    TaskBoardPolicyCompilationContext, TaskBoardPolicyCompilationError, compile_task_board_policy,
+    evaluate_admission_requirements, launch_capability_for_agent_mode,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TaskBoardDispatchAdmissionSnapshot {
+    pub(crate) decision_id: String,
+    pub(crate) generation: i64,
+    pub(crate) item_revision: i64,
+    pub(crate) settings_revision: i64,
+    pub(crate) policy: TaskBoardAutomationPolicy,
+    pub(crate) context: TaskBoardPolicyCompilationContext,
+    pub(crate) decision: TaskBoardAdmissionDecision,
+    pub(crate) requirements: Vec<TaskBoardAdmissionRequirement>,
+    pub(crate) blockers: Value,
+    pub(crate) next_available_at: Option<String>,
+    pub(crate) launch_capability: Option<TaskBoardLaunchCapability>,
+    pub(crate) evaluated_at: String,
+}
+
+impl TaskBoardDispatchAdmissionSnapshot {
+    pub(crate) const fn is_allowed(&self) -> bool {
+        matches!(self.decision, TaskBoardAdmissionDecision::Allowed)
+    }
+
+    pub(crate) fn refusal_message(&self) -> String {
+        let disposition = match self.decision {
+            TaskBoardAdmissionDecision::Allowed => "allowed",
+            TaskBoardAdmissionDecision::Deferred => "deferred",
+            TaskBoardAdmissionDecision::Rejected => "rejected",
+        };
+        let detail = self
+            .blockers
+            .as_array()
+            .filter(|values| !values.is_empty())
+            .map_or_else(String::new, |values| {
+                format!(": {}", Value::Array(values.clone()))
+            });
+        format!("task-board dispatch admission {disposition}{detail}")
+    }
+}
+
+pub(super) async fn evaluate_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item: &TaskBoardItem,
+    item_revision: i64,
+    excluded_intent_id: Option<&str>,
+) -> Result<Option<TaskBoardDispatchAdmissionSnapshot>, CliError> {
+    let (policy, settings_revision) = load_admission_policy_in_tx(transaction).await?;
+    let evaluated_at = utc_now();
+    let context = TaskBoardPolicyCompilationContext {
+        workflow_kind: item.workflow_kind,
+        repository: item.execution_repository.clone(),
+        evaluated_at: evaluated_at.clone(),
+        estimated_tokens: item.estimated_tokens,
+        estimated_cost_microusd: item.estimated_cost_microusd,
+    };
+    let launch_capability = match launch_capability_for_agent_mode(item.agent_mode) {
+        Ok(capability) => Some(capability),
+        Err(error) => {
+            let message = error.to_string();
+            return Ok(Some(rejected_candidate(
+                policy,
+                context,
+                item_revision,
+                settings_revision,
+                evaluated_at,
+                &message,
+            )));
+        }
+    };
+    if policy.limits.is_empty() && policy.windows.is_empty() {
+        return Ok(None);
+    }
+    let compiled = match compile_task_board_policy(&policy, &context) {
+        Ok(compiled) => compiled,
+        Err(error) => {
+            let message = policy_error(&error);
+            return Ok(Some(rejected_candidate(
+                policy,
+                context,
+                item_revision,
+                settings_revision,
+                evaluated_at,
+                &message,
+            )));
+        }
+    };
+    let usage = admission_usage_in_tx(
+        transaction,
+        &compiled.requirements,
+        &compiled.evaluated_at,
+        excluded_intent_id,
+    )
+    .await?;
+    let evaluation =
+        evaluate_admission_requirements(compiled.requirements, usage, &compiled.evaluated_at)
+            .map_err(|error| db_error(format!("evaluate task board admission: {error}")))?;
+    let blockers = serde_json::to_value(&evaluation.blockers)
+        .map_err(|error| db_error(format!("serialize task board admission blockers: {error}")))?;
+    Ok(Some(TaskBoardDispatchAdmissionSnapshot {
+        decision_id: String::new(),
+        generation: 0,
+        item_revision,
+        settings_revision,
+        policy,
+        context,
+        decision: evaluation.decision,
+        requirements: evaluation.requirements,
+        blockers,
+        next_available_at: evaluation.next_available_at,
+        launch_capability,
+        evaluated_at: evaluation.evaluated_at,
+    }))
+}
+
+async fn load_admission_policy_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+) -> Result<(TaskBoardAutomationPolicy, i64), CliError> {
+    let (settings_json, revision) = query_as::<_, (String, i64)>(
+        "SELECT settings_json, revision
+         FROM task_board_orchestrator_settings WHERE singleton = 1",
+    )
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load task board admission settings: {error}")))?;
+    let settings = serde_json::from_str::<TaskBoardOrchestratorSettings>(&settings_json)
+        .map_err(|error| db_error(format!("decode task board admission settings: {error}")))?;
+    Ok((settings.admission_policy, revision))
+}
+
+fn rejected_candidate(
+    policy: TaskBoardAutomationPolicy,
+    context: TaskBoardPolicyCompilationContext,
+    item_revision: i64,
+    settings_revision: i64,
+    evaluated_at: String,
+    message: &str,
+) -> TaskBoardDispatchAdmissionSnapshot {
+    TaskBoardDispatchAdmissionSnapshot {
+        decision_id: String::new(),
+        generation: 0,
+        item_revision,
+        settings_revision,
+        policy,
+        context,
+        decision: TaskBoardAdmissionDecision::Rejected,
+        requirements: Vec::new(),
+        blockers: json!([{"kind": "policy_compilation", "message": message}]),
+        next_available_at: None,
+        launch_capability: None,
+        evaluated_at,
+    }
+}
+
+fn policy_error(error: &TaskBoardPolicyCompilationError) -> String {
+    error.to_string()
+}

--- a/src/daemon/db/task_board/admission_lifecycle.rs
+++ b/src/daemon/db/task_board/admission_lifecycle.rs
@@ -1,0 +1,491 @@
+use sqlx::{Sqlite, Transaction, query, query_as, query_scalar};
+
+mod compensation;
+mod validation;
+
+pub(super) use self::compensation::{
+    commit_compensating_dispatch_admission_in_tx, finalize_compensating_dispatch_admission_in_tx,
+};
+use self::validation::{
+    CurrentAllowedAdmission, admission_policy_is_configured_in_tx, current_allowed_admission,
+    current_settings_revision, decode_requirements, intent_item_in_tx,
+    stored_reservation_is_complete, stored_reservation_time_is_current,
+};
+use super::ITEMS_CHANGE_SCOPE;
+use super::admission::{TaskBoardDispatchAdmissionSnapshot, evaluate_dispatch_admission_in_tx};
+use super::admission_reservations::{
+    clear_current_admission_in_tx, persist_admission_snapshot_in_tx,
+};
+use super::items::bump_change_in_tx;
+use crate::daemon::db::{AsyncDaemonDb, CliError, CliErrorKind, db_error, utc_now};
+use crate::task_board::{TaskBoardItem, TaskBoardLaunchCapability, validate_launch_capability};
+
+#[derive(Debug)]
+pub(super) enum TaskBoardAdmissionCheck {
+    Unconfigured,
+    Allowed(TaskBoardLaunchCapability),
+    Blocked(Box<TaskBoardDispatchAdmissionSnapshot>),
+}
+
+impl TaskBoardAdmissionCheck {
+    pub(super) fn ensure_allowed(self) -> Result<Option<TaskBoardLaunchCapability>, CliError> {
+        match self {
+            Self::Unconfigured => Ok(None),
+            Self::Allowed(capability) => Ok(Some(capability)),
+            Self::Blocked(snapshot) => {
+                Err(CliErrorKind::invalid_transition(snapshot.refusal_message()).into())
+            }
+        }
+    }
+}
+
+pub(super) async fn revalidate_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    item: &TaskBoardItem,
+    item_revision: i64,
+) -> Result<TaskBoardAdmissionCheck, CliError> {
+    let settings_revision = current_settings_revision(transaction).await?;
+    if let Some(recorded) = current_allowed_admission(transaction, intent_id).await?
+        && recorded.item_revision == item_revision
+        && recorded.settings_revision == settings_revision
+        && stored_reservation_is_complete(transaction, intent_id, &recorded).await?
+        && stored_reservation_time_is_current(transaction, intent_id, &recorded).await?
+    {
+        renew_recorded_dispatch_admission_in_tx(transaction, intent_id, &recorded).await?;
+        return Ok(TaskBoardAdmissionCheck::Allowed(parse_launch_profile(
+            recorded.launch_profile.as_deref(),
+        )?));
+    }
+    let candidate =
+        evaluate_dispatch_admission_in_tx(transaction, item, item_revision, Some(intent_id))
+            .await?;
+    let Some(mut candidate) = candidate else {
+        clear_current_admission_in_tx(transaction, &item.id, Some(intent_id)).await?;
+        return Ok(TaskBoardAdmissionCheck::Unconfigured);
+    };
+    if candidate.is_allowed() {
+        persist_admission_snapshot_in_tx(transaction, &item.id, Some(intent_id), &mut candidate)
+            .await?;
+        let capability = candidate
+            .launch_capability
+            .ok_or_else(|| db_error("allowed task board admission has no launch capability"))?;
+        return Ok(TaskBoardAdmissionCheck::Allowed(capability));
+    }
+    clear_current_admission_in_tx(transaction, &item.id, Some(intent_id)).await?;
+    persist_admission_snapshot_in_tx(transaction, &item.id, None, &mut candidate).await?;
+    Ok(TaskBoardAdmissionCheck::Blocked(Box::new(candidate)))
+}
+
+pub(super) async fn renew_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<(), CliError> {
+    let Some(recorded) = current_allowed_admission(transaction, intent_id).await? else {
+        let active_rows = active_reserved_row_count(transaction, intent_id).await?;
+        if active_rows == 0 && !admission_policy_is_configured_in_tx(transaction).await? {
+            return Ok(());
+        }
+        return Err(db_error(format!(
+            "task board admission renewal found {active_rows} reserved ledger rows without a current allowed decision under the configured policy"
+        )));
+    };
+    ensure_recorded_reservation_is_complete(transaction, intent_id, &recorded).await?;
+    let (item, item_revision) = intent_item_in_tx(transaction, intent_id).await?;
+    revalidate_dispatch_admission_in_tx(transaction, intent_id, &item, item_revision)
+        .await?
+        .ensure_allowed()?;
+    Ok(())
+}
+
+pub(super) async fn renew_frozen_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<(), CliError> {
+    // The worker claim spans the external launch boundary. Extend only the
+    // exact generation authorized at that boundary; preparation owns revalidation.
+    let Some(recorded) = current_allowed_admission(transaction, intent_id).await? else {
+        let active_rows = active_reserved_row_count(transaction, intent_id).await?;
+        if active_rows == 0 {
+            return Ok(());
+        }
+        return Err(db_error(format!(
+            "task board frozen admission renewal found {active_rows} reserved ledger rows without a current allowed decision"
+        )));
+    };
+    restore_recorded_dispatch_admission_in_tx(transaction, intent_id, &recorded).await?;
+    renew_recorded_dispatch_admission_in_tx(transaction, intent_id, &recorded).await
+}
+
+async fn restore_recorded_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    recorded: &CurrentAllowedAdmission,
+) -> Result<(), CliError> {
+    // A durable `starting` claim can outlive the reservation horizon while its
+    // deterministic worker keeps running. Restore only that claim's exact
+    // frozen generation; current policy must not erase truthful start evidence.
+    query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'reserved',
+             expires_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '+900 seconds'),
+             released_at = NULL
+         WHERE decision_id = ?1 AND intent_id = ?2 AND generation = ?3
+           AND committed_at IS NULL AND managed_worker_id IS NULL
+           AND (
+               state = 'released'
+               OR (state = 'reserved' AND datetime(expires_at) <= datetime('now'))
+           )",
+    )
+    .bind(&recorded.decision_id)
+    .bind(intent_id)
+    .bind(recorded.generation)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("restore frozen task board admission: {error}")))?;
+    Ok(())
+}
+
+async fn renew_recorded_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    recorded: &CurrentAllowedAdmission,
+) -> Result<(), CliError> {
+    let expected_rows =
+        ensure_recorded_reservation_is_complete(transaction, intent_id, recorded).await?;
+    let changed = query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET expires_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '+900 seconds')
+         WHERE decision_id = ?1 AND intent_id = ?2 AND generation = ?3
+           AND state = 'reserved' AND datetime(expires_at) > datetime('now')",
+    )
+    .bind(&recorded.decision_id)
+    .bind(intent_id)
+    .bind(recorded.generation)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("renew task board admission reservation: {error}")))?
+    .rows_affected();
+    if usize::try_from(changed).ok() != Some(expected_rows) {
+        return Err(db_error(format!(
+            "task board admission renewal changed {changed} ledger rows, expected {expected_rows}"
+        )));
+    }
+    Ok(())
+}
+
+async fn ensure_recorded_reservation_is_complete(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    recorded: &CurrentAllowedAdmission,
+) -> Result<usize, CliError> {
+    let expected_rows = decode_requirements(&recorded.requirements_json)?.len();
+    let active_rows = active_reserved_row_count(transaction, intent_id).await?;
+    if usize::try_from(active_rows).ok() != Some(expected_rows)
+        || !stored_reservation_is_complete(transaction, intent_id, recorded).await?
+    {
+        return Err(db_error(format!(
+            "task board admission renewal found {active_rows} valid reserved ledger rows, expected {expected_rows}"
+        )));
+    }
+    Ok(expected_rows)
+}
+
+pub(super) async fn commit_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    managed_worker_id: &str,
+) -> Result<(), CliError> {
+    let recorded = current_allowed_admission(transaction, intent_id).await?;
+    if let Some(recorded) = recorded.as_ref() {
+        ensure_recorded_reservation_is_complete(transaction, intent_id, recorded).await?;
+    } else {
+        let active_rows = active_reserved_row_count(transaction, intent_id).await?;
+        if active_rows != 0 || admission_policy_is_configured_in_tx(transaction).await? {
+            return Err(db_error(format!(
+                "task board admission commit found {active_rows} reserved ledger rows without a current allowed decision under the configured policy"
+            )));
+        }
+    }
+    let expected_rows = current_allowed_admission(transaction, intent_id)
+        .await?
+        .map(|recorded| decode_requirements(&recorded.requirements_json).map(|values| values.len()))
+        .transpose()?
+        .unwrap_or(0);
+    let worker_is_terminal =
+        managed_worker_is_terminal_in_tx(transaction, managed_worker_id).await?;
+    let now = utc_now();
+    let changed = query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = CASE
+                 WHEN kind = 'concurrency' AND ?3 = 1 THEN 'released'
+                 ELSE 'committed'
+             END,
+             managed_worker_id = ?2, expires_at = NULL, committed_at = ?4,
+             released_at = CASE
+                 WHEN kind = 'concurrency' AND ?3 = 1 THEN ?4
+                 ELSE NULL
+             END
+         WHERE intent_id = ?1 AND state = 'reserved'",
+    )
+    .bind(intent_id)
+    .bind(managed_worker_id)
+    .bind(worker_is_terminal)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("commit task board admission ledger: {error}")))?
+    .rows_affected();
+    if usize::try_from(changed).ok() != Some(expected_rows) {
+        return Err(db_error(format!(
+            "task board admission commit changed {changed} ledger rows, expected {expected_rows}"
+        )));
+    }
+    Ok(())
+}
+
+async fn managed_worker_is_terminal_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    managed_worker_id: &str,
+) -> Result<bool, CliError> {
+    let status = query_scalar::<_, String>("SELECT status FROM codex_runs WHERE run_id = ?1")
+        .bind(managed_worker_id)
+        .fetch_optional(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load managed worker status: {error}")))?;
+    Ok(
+        status
+            .is_some_and(|status| matches!(status.as_str(), "completed" | "failed" | "cancelled")),
+    )
+}
+
+pub(super) async fn release_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<(), CliError> {
+    let now = utc_now();
+    query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'released', expires_at = NULL, released_at = ?2
+         WHERE intent_id = ?1 AND state = 'reserved'",
+    )
+    .bind(intent_id)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("release task board admission ledger: {error}")))?;
+    Ok(())
+}
+
+pub(super) async fn release_item_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+) -> Result<(), CliError> {
+    let now = utc_now();
+    query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'released', expires_at = NULL, released_at = ?2
+         WHERE item_id = ?1
+           AND (state = 'reserved' OR (kind = 'concurrency' AND state = 'committed'))",
+    )
+    .bind(item_id)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("release task board item admission: {error}")))?;
+    Ok(())
+}
+
+pub(super) async fn ensure_item_admission_can_terminate_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+) -> Result<(), CliError> {
+    let active = query_scalar::<_, bool>(
+        "SELECT EXISTS(
+             SELECT 1 FROM task_board_dispatch_admission_ledger
+             WHERE item_id = ?1 AND kind = 'concurrency' AND state = 'committed'
+         )",
+    )
+    .bind(item_id)
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("check active task board admission: {error}")))?;
+    if active {
+        return Err(CliErrorKind::invalid_transition(format!(
+            "task-board item '{item_id}' cannot become terminal while its managed worker is active"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+pub(in crate::daemon::db) async fn release_managed_worker_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    managed_worker_id: &str,
+) -> Result<bool, CliError> {
+    let changed = query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'released', released_at = ?2
+         WHERE managed_worker_id = ?1 AND kind = 'concurrency'
+           AND state = 'committed'",
+    )
+    .bind(managed_worker_id)
+    .bind(utc_now())
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("release managed worker admission: {error}")))?
+    .rows_affected();
+    if changed > 0 {
+        bump_change_in_tx(transaction, ITEMS_CHANGE_SCOPE).await?;
+    }
+    Ok(changed > 0)
+}
+
+impl AsyncDaemonDb {
+    pub(crate) async fn validate_task_board_dispatch_admission_start(
+        &self,
+        intent_id: &str,
+        claim_token: &str,
+        actual_capability: Option<TaskBoardLaunchCapability>,
+    ) -> Result<(), CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board admission start validation")
+            .await?;
+        let (item_id, item_revision, session_id, work_item_id, execution_id) =
+            claimed_item_identity(&mut transaction, intent_id, claim_token).await?;
+        let (item, loaded_revision) = super::items::load_item_in_tx(&mut transaction, &item_id)
+            .await?
+            .ok_or_else(|| db_error(format!("task-board item '{item_id}' not found")))?;
+        if loaded_revision != item_revision {
+            return Err(db_error(
+                "task board admission item revision changed while loading",
+            ));
+        }
+        super::dispatch_intents::ensure_dispatch_item_startable(
+            &item,
+            &session_id,
+            &work_item_id,
+            Some(&execution_id),
+        )?;
+        let admission = revalidate_dispatch_admission_in_tx(
+            &mut transaction,
+            intent_id,
+            &item,
+            loaded_revision,
+        )
+        .await?;
+        let expected = match admission {
+            TaskBoardAdmissionCheck::Blocked(snapshot) => {
+                let error = CliErrorKind::invalid_transition(snapshot.refusal_message()).into();
+                transaction.commit().await.map_err(|error| {
+                    db_error(format!(
+                        "commit blocked task board admission validation: {error}"
+                    ))
+                })?;
+                return Err(error);
+            }
+            admission => admission.ensure_allowed()?,
+        };
+        if let Some(expected) = expected {
+            let actual_capability = actual_capability.ok_or_else(|| {
+                CliError::from(CliErrorKind::invalid_transition(
+                    "task board admission requires an enforceable launch capability".to_string(),
+                ))
+            })?;
+            validate_launch_capability(item.agent_mode, actual_capability).map_err(|error| {
+                CliError::from(CliErrorKind::invalid_transition(format!(
+                    "task board launch capability refused: {error}"
+                )))
+            })?;
+            if expected != actual_capability {
+                return Err(CliErrorKind::invalid_transition(format!(
+                    "task board launch capability changed from {expected:?} to {actual_capability:?}"
+                ))
+                .into());
+            }
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit task board admission validation: {error}")))
+    }
+
+    pub(crate) async fn release_task_board_admission_for_managed_worker(
+        &self,
+        managed_worker_id: &str,
+    ) -> Result<bool, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("managed worker admission release")
+            .await?;
+        let changed =
+            release_managed_worker_admission_in_tx(&mut transaction, managed_worker_id).await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!("commit managed worker admission release: {error}"))
+        })?;
+        Ok(changed)
+    }
+}
+
+async fn active_reserved_row_count(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<i64, CliError> {
+    query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND state = 'reserved'
+           AND datetime(expires_at) > datetime('now')",
+    )
+    .bind(intent_id)
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("count task board admission reservations: {error}")))
+}
+
+async fn claimed_item_identity(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    claim_token: &str,
+) -> Result<(String, i64, String, String, String), CliError> {
+    let (item_id, session_id, work_item_id, execution_id) =
+        query_as::<_, (String, String, String, String)>(
+            "SELECT item_id, session_id, work_item_id, workflow_execution_id
+         FROM task_board_dispatch_intents
+         WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'",
+        )
+        .bind(intent_id)
+        .bind(claim_token)
+        .fetch_optional(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load claimed task board admission intent: {error}")))?
+        .ok_or_else(|| {
+            db_error(format!(
+                "task board dispatch intent '{intent_id}' is not claimed"
+            ))
+        })?;
+    let item_revision =
+        query_scalar::<_, i64>("SELECT revision FROM task_board_items WHERE item_id = ?1")
+            .bind(&item_id)
+            .fetch_one(transaction.as_mut())
+            .await
+            .map_err(|error| db_error(format!("load claimed task board item revision: {error}")))?;
+    Ok((
+        item_id,
+        item_revision,
+        session_id,
+        work_item_id,
+        execution_id,
+    ))
+}
+
+fn parse_launch_profile(value: Option<&str>) -> Result<TaskBoardLaunchCapability, CliError> {
+    match value {
+        Some("read_only") => Ok(TaskBoardLaunchCapability::ReportReadOnly),
+        Some("workspace_write") => Ok(TaskBoardLaunchCapability::WorkspaceWrite),
+        Some(other) => Err(db_error(format!(
+            "unknown task board admission launch profile '{other}'"
+        ))),
+        None => Err(db_error(
+            "allowed task board admission has no launch capability",
+        )),
+    }
+}

--- a/src/daemon/db/task_board/admission_lifecycle/compensation.rs
+++ b/src/daemon/db/task_board/admission_lifecycle/compensation.rs
@@ -1,0 +1,156 @@
+use sqlx::{Sqlite, Transaction, query, query_scalar};
+
+use super::super::{ITEMS_CHANGE_SCOPE, items::bump_change_in_tx};
+use super::validation::{CurrentAllowedAdmission, current_allowed_admission, decode_requirements};
+use crate::daemon::db::{CliError, db_error, utc_now};
+use crate::task_board::TaskBoardAdmissionRequirementKind;
+
+pub(in crate::daemon::db::task_board) async fn commit_compensating_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    managed_worker_id: &str,
+) -> Result<(), CliError> {
+    if managed_worker_id.is_empty() {
+        return Err(db_error(
+            "task board compensation managed worker id is empty",
+        ));
+    }
+    let Some(recorded) = current_allowed_admission(transaction, intent_id).await? else {
+        ensure_no_active_admission_rows(transaction, intent_id, "compensation commit").await?;
+        return Ok(());
+    };
+    let expected_rows =
+        super::ensure_recorded_reservation_is_complete(transaction, intent_id, &recorded).await?;
+    let changed = query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'committed', managed_worker_id = ?4, expires_at = NULL,
+             committed_at = ?5
+         WHERE decision_id = ?1 AND intent_id = ?2 AND generation = ?3
+           AND state = 'reserved' AND datetime(expires_at) > datetime('now')",
+    )
+    .bind(&recorded.decision_id)
+    .bind(intent_id)
+    .bind(recorded.generation)
+    .bind(managed_worker_id)
+    .bind(utc_now())
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("commit compensating task board admission: {error}")))?
+    .rows_affected();
+    ensure_row_count(changed, expected_rows, "commit changed")
+}
+
+pub(in crate::daemon::db::task_board) async fn finalize_compensating_dispatch_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    managed_worker_id: &str,
+) -> Result<(), CliError> {
+    let Some(recorded) = current_allowed_admission(transaction, intent_id).await? else {
+        ensure_no_active_admission_rows(transaction, intent_id, "compensation finalize").await?;
+        return Ok(());
+    };
+    let requirements = decode_requirements(&recorded.requirements_json)?;
+    ensure_compensating_admission_is_complete(
+        transaction,
+        intent_id,
+        managed_worker_id,
+        &recorded,
+        requirements.len(),
+    )
+    .await?;
+    let expected_concurrency = requirements
+        .iter()
+        .filter(|requirement| requirement.kind == TaskBoardAdmissionRequirementKind::Concurrency)
+        .count();
+    let changed = query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'released', released_at = ?5
+         WHERE decision_id = ?1 AND intent_id = ?2 AND generation = ?3
+           AND managed_worker_id = ?4 AND kind = 'concurrency' AND state = 'committed'",
+    )
+    .bind(&recorded.decision_id)
+    .bind(intent_id)
+    .bind(recorded.generation)
+    .bind(managed_worker_id)
+    .bind(utc_now())
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| {
+        db_error(format!(
+            "finalize compensating task board admission: {error}"
+        ))
+    })?
+    .rows_affected();
+    ensure_row_count(changed, expected_concurrency, "finalize released")?;
+    if changed > 0 {
+        bump_change_in_tx(transaction, ITEMS_CHANGE_SCOPE).await?;
+    }
+    Ok(())
+}
+
+async fn ensure_compensating_admission_is_complete(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    managed_worker_id: &str,
+    recorded: &CurrentAllowedAdmission,
+    expected_rows: usize,
+) -> Result<(), CliError> {
+    let rows = query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM task_board_dispatch_admission_ledger
+         WHERE decision_id = ?1 AND intent_id = ?2 AND generation = ?3
+           AND managed_worker_id = ?4 AND state = 'committed'",
+    )
+    .bind(&recorded.decision_id)
+    .bind(intent_id)
+    .bind(recorded.generation)
+    .bind(managed_worker_id)
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load compensating task board admission: {error}")))?;
+    let active_rows = active_admission_row_count(transaction, intent_id).await?;
+    if usize::try_from(rows).ok() != Some(expected_rows)
+        || usize::try_from(active_rows).ok() != Some(expected_rows)
+    {
+        return Err(db_error(format!(
+            "task board compensation found {rows} exact committed ledger rows and {active_rows} active rows, expected {expected_rows}"
+        )));
+    }
+    Ok(())
+}
+
+async fn ensure_no_active_admission_rows(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    operation: &str,
+) -> Result<(), CliError> {
+    let active_rows = active_admission_row_count(transaction, intent_id).await?;
+    if active_rows != 0 {
+        return Err(db_error(format!(
+            "task board admission {operation} found {active_rows} active ledger rows without a current allowed decision"
+        )));
+    }
+    Ok(())
+}
+
+async fn active_admission_row_count(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<i64, CliError> {
+    query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND state IN ('reserved', 'committed')",
+    )
+    .bind(intent_id)
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("count active task board admission rows: {error}")))
+}
+
+fn ensure_row_count(changed: u64, expected: usize, operation: &str) -> Result<(), CliError> {
+    if usize::try_from(changed).ok() != Some(expected) {
+        return Err(db_error(format!(
+            "task board compensation {operation} {changed} ledger rows, expected {expected}"
+        )));
+    }
+    Ok(())
+}

--- a/src/daemon/db/task_board/admission_lifecycle/validation.rs
+++ b/src/daemon/db/task_board/admission_lifecycle/validation.rs
@@ -1,0 +1,224 @@
+use chrono::{DateTime, Duration, Utc};
+use sqlx::{Sqlite, Transaction, query_as, query_scalar};
+
+use crate::daemon::db::{CliError, db_error, utc_now};
+use crate::task_board::{
+    TaskBoardAdmissionRequirement, TaskBoardAdmissionRequirementKind, TaskBoardItem,
+    TaskBoardOrchestratorSettings, canonical_admission_requirement_key,
+};
+
+pub(super) struct CurrentAllowedAdmission {
+    pub(super) item_revision: i64,
+    pub(super) settings_revision: i64,
+    pub(super) launch_profile: Option<String>,
+    pub(super) decision_id: String,
+    pub(super) generation: i64,
+    pub(super) requirements_json: String,
+}
+
+pub(super) async fn admission_policy_is_configured_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+) -> Result<bool, CliError> {
+    let settings_json = query_scalar::<_, String>(
+        "SELECT settings_json FROM task_board_orchestrator_settings WHERE singleton = 1",
+    )
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load task board admission settings: {error}")))?;
+    let settings = serde_json::from_str::<TaskBoardOrchestratorSettings>(&settings_json)
+        .map_err(|error| db_error(format!("decode task board admission settings: {error}")))?;
+    Ok(!settings.admission_policy.limits.is_empty()
+        || !settings.admission_policy.windows.is_empty())
+}
+
+pub(super) async fn intent_item_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<(TaskBoardItem, i64), CliError> {
+    let item_id = query_scalar::<_, String>(
+        "SELECT item_id FROM task_board_dispatch_intents WHERE intent_id = ?1",
+    )
+    .bind(intent_id)
+    .fetch_optional(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load task board admission intent item: {error}")))?
+    .ok_or_else(|| {
+        db_error(format!(
+            "task board dispatch intent '{intent_id}' not found"
+        ))
+    })?;
+    super::super::items::load_item_in_tx(transaction, &item_id)
+        .await?
+        .ok_or_else(|| db_error(format!("task-board item '{item_id}' not found")))
+}
+
+pub(super) async fn current_settings_revision(
+    transaction: &mut Transaction<'_, Sqlite>,
+) -> Result<i64, CliError> {
+    query_scalar::<_, i64>(
+        "SELECT revision FROM task_board_orchestrator_settings WHERE singleton = 1",
+    )
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| {
+        db_error(format!(
+            "load task board admission settings revision: {error}"
+        ))
+    })
+}
+
+pub(super) async fn current_allowed_admission(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+) -> Result<Option<CurrentAllowedAdmission>, CliError> {
+    query_as::<_, (i64, i64, Option<String>, String, i64, String)>(
+        "SELECT item_revision, settings_revision, launch_profile,
+                decision_id, generation, requirements_json
+         FROM task_board_dispatch_admission_decisions
+         WHERE intent_id = ?1 AND decision = 'allowed' AND is_current = 1",
+    )
+    .bind(intent_id)
+    .fetch_optional(transaction.as_mut())
+    .await
+    .map(|value| {
+        value.map(
+            |(
+                item_revision,
+                settings_revision,
+                launch_profile,
+                decision_id,
+                generation,
+                requirements_json,
+            )| CurrentAllowedAdmission {
+                item_revision,
+                settings_revision,
+                launch_profile,
+                decision_id,
+                generation,
+                requirements_json,
+            },
+        )
+    })
+    .map_err(|error| db_error(format!("load current task board admission: {error}")))
+}
+
+pub(super) async fn stored_reservation_is_complete(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    recorded: &CurrentAllowedAdmission,
+) -> Result<bool, CliError> {
+    let mut expected = decode_requirements(&recorded.requirements_json)?
+        .iter()
+        .map(canonical_admission_requirement_key)
+        .map(|key| {
+            key.map(|key| key.stable_id())
+                .map_err(|error| db_error(format!("key stored task board admission: {error}")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    expected.sort();
+    let actual = query_scalar::<_, String>(
+        "SELECT canonical_key FROM task_board_dispatch_admission_ledger
+         WHERE decision_id = ?1 AND intent_id = ?2 AND generation = ?3
+           AND state = 'reserved' AND datetime(expires_at) > datetime('now')
+         ORDER BY canonical_key",
+    )
+    .bind(&recorded.decision_id)
+    .bind(intent_id)
+    .bind(recorded.generation)
+    .fetch_all(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load stored task board admission ledger: {error}")))?;
+    Ok(actual == expected)
+}
+
+pub(super) async fn stored_reservation_time_is_current(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    recorded: &CurrentAllowedAdmission,
+) -> Result<bool, CliError> {
+    let now = parse_admission_time(&utc_now())?;
+    for requirement in decode_requirements(&recorded.requirements_json)? {
+        if requirement.kind == TaskBoardAdmissionRequirementKind::Concurrency {
+            continue;
+        }
+        let key = canonical_admission_requirement_key(&requirement)
+            .map_err(|error| db_error(format!("key stored task board admission: {error}")))?;
+        let window = query_as::<_, (Option<String>, Option<String>)>(
+            "SELECT window_started_at, window_ends_at
+             FROM task_board_dispatch_admission_ledger
+             WHERE decision_id = ?1 AND intent_id = ?2 AND generation = ?3
+               AND canonical_key = ?4 AND state = 'reserved'
+               AND datetime(expires_at) > datetime('now')",
+        )
+        .bind(&recorded.decision_id)
+        .bind(intent_id)
+        .bind(recorded.generation)
+        .bind(key.stable_id())
+        .fetch_optional(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load task board admission window: {error}")))?;
+        let Some((Some(starts_at), Some(ends_at))) = window else {
+            return Ok(false);
+        };
+        if !requirement_window_is_current(&requirement, &starts_at, &ends_at, now)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn requirement_window_is_current(
+    requirement: &TaskBoardAdmissionRequirement,
+    stored_start: &str,
+    stored_end: &str,
+    now: DateTime<Utc>,
+) -> Result<bool, CliError> {
+    let stored_start = parse_admission_time(stored_start)?;
+    let stored_end = parse_admission_time(stored_end)?;
+    let seconds = requirement
+        .window_seconds
+        .and_then(|value| i64::try_from(value).ok())
+        .ok_or_else(|| db_error("windowed task board admission has no valid duration"))?;
+    let (expected_start, expected_end) = match requirement.kind {
+        TaskBoardAdmissionRequirementKind::TimeWindow => {
+            let start = requirement
+                .available_at
+                .as_deref()
+                .ok_or_else(|| db_error("time-window task board admission has no start"))?;
+            let start = parse_admission_time(start)?;
+            let end = start
+                .checked_add_signed(Duration::seconds(seconds))
+                .ok_or_else(|| db_error("task board admission window end overflow"))?;
+            if now < start || now >= end {
+                return Ok(false);
+            }
+            (start, end)
+        }
+        TaskBoardAdmissionRequirementKind::Rate
+        | TaskBoardAdmissionRequirementKind::TokenBudget
+        | TaskBoardAdmissionRequirementKind::MonetaryBudget => {
+            let started_at = now.timestamp().div_euclid(seconds) * seconds;
+            let start = DateTime::<Utc>::from_timestamp(started_at, 0)
+                .ok_or_else(|| db_error("task board admission window start overflow"))?;
+            let end = start
+                .checked_add_signed(Duration::seconds(seconds))
+                .ok_or_else(|| db_error("task board admission window end overflow"))?;
+            (start, end)
+        }
+        TaskBoardAdmissionRequirementKind::Concurrency => return Ok(true),
+    };
+    Ok(stored_start == expected_start && stored_end == expected_end)
+}
+
+fn parse_admission_time(value: &str) -> Result<DateTime<Utc>, CliError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| db_error(format!("parse task board admission timestamp: {error}")))
+}
+
+pub(super) fn decode_requirements(
+    value: &str,
+) -> Result<Vec<TaskBoardAdmissionRequirement>, CliError> {
+    serde_json::from_str(value)
+        .map_err(|error| db_error(format!("decode stored task board admission: {error}")))
+}

--- a/src/daemon/db/task_board/admission_recovery.rs
+++ b/src/daemon/db/task_board/admission_recovery.rs
@@ -1,0 +1,289 @@
+use std::collections::BTreeMap;
+
+use sqlx::{Sqlite, Transaction, query_as, query_scalar};
+
+use super::admission_lifecycle::release_managed_worker_admission_in_tx;
+use super::dispatch_intents::decode_applied;
+use super::items::load_item_in_tx;
+use crate::daemon::db::{AsyncDaemonDb, CliError, SessionState, db_error, utc_now};
+use crate::session::service as session_service;
+use crate::session::types::{CONTROL_PLANE_ACTOR_ID, ManagedAgentRef, TaskStatus};
+use crate::task_board::{DispatchAppliedTask, TaskBoardItem, TaskBoardWorkflowStatus};
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TaskBoardAdmissionWorkerRecovery {
+    pub(crate) managed_worker_id: String,
+    pub(crate) intent_id: String,
+    pub(crate) item_id: String,
+    pub(crate) session_id: String,
+    pub(crate) task_id: String,
+    pub(crate) workflow_execution_id: String,
+    pub(crate) dispatch: DispatchAppliedTask,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskBoardAdmissionMissingRunRecovery {
+    pub(crate) item_id: String,
+    pub(crate) session_id: String,
+    pub(crate) session_changed: bool,
+    pub(crate) concurrency_released: bool,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct AdmissionRecoveryRow {
+    managed_worker_id: String,
+    intent_id: String,
+    item_id: String,
+    session_id: String,
+    work_item_id: String,
+    workflow_execution_id: String,
+    payload_json: String,
+    intent_status: String,
+}
+
+#[derive(sqlx::FromRow)]
+struct AdmissionRecoverySessionRow {
+    state_json: String,
+    project_id: String,
+}
+
+impl AsyncDaemonDb {
+    pub(crate) async fn task_board_admission_worker_recoveries(
+        &self,
+    ) -> Result<Vec<TaskBoardAdmissionWorkerRecovery>, CliError> {
+        let rows = query_as::<_, AdmissionRecoveryRow>(ADMISSION_RECOVERY_SQL)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|error| {
+                db_error(format!(
+                    "load committed task board admission workers: {error}"
+                ))
+            })?;
+        recoveries_from_rows(rows)
+    }
+
+    pub(crate) async fn reconcile_missing_task_board_admission_worker(
+        &self,
+        expected: &TaskBoardAdmissionWorkerRecovery,
+        reason: &str,
+    ) -> Result<Option<TaskBoardAdmissionMissingRunRecovery>, CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("missing task board admission worker recovery")
+            .await?;
+        let current =
+            load_worker_recovery_in_tx(&mut transaction, &expected.managed_worker_id).await?;
+        let Some(current) = current else {
+            transaction.commit().await.map_err(|error| {
+                db_error(format!(
+                    "commit absent task board admission worker recovery: {error}"
+                ))
+            })?;
+            return Ok(None);
+        };
+        if current != *expected {
+            return Err(db_error(format!(
+                "task board admission worker '{}' changed dispatch identity during recovery",
+                expected.managed_worker_id
+            )));
+        }
+        if codex_run_exists_in_tx(&mut transaction, &expected.managed_worker_id).await? {
+            transaction.commit().await.map_err(|error| {
+                db_error(format!(
+                    "commit raced task board admission worker recovery: {error}"
+                ))
+            })?;
+            return Ok(None);
+        }
+
+        let concurrency_released =
+            release_managed_worker_admission_in_tx(&mut transaction, &expected.managed_worker_id)
+                .await?;
+        let session_changed = block_linked_session_task(&mut transaction, expected, reason).await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit missing task board admission worker recovery: {error}"
+            ))
+        })?;
+        Ok(Some(TaskBoardAdmissionMissingRunRecovery {
+            item_id: expected.item_id.clone(),
+            session_id: expected.session_id.clone(),
+            session_changed,
+            concurrency_released,
+        }))
+    }
+}
+
+const ADMISSION_RECOVERY_SQL: &str =
+    "SELECT DISTINCT ledger.managed_worker_id, intent.intent_id, intent.item_id,
+        intent.session_id, intent.work_item_id, intent.workflow_execution_id,
+        intent.payload_json, intent.status AS intent_status
+     FROM task_board_dispatch_admission_ledger AS ledger
+     JOIN task_board_dispatch_intents AS intent ON intent.intent_id = ledger.intent_id
+     WHERE ledger.state = 'committed' AND ledger.managed_worker_id IS NOT NULL
+     ORDER BY ledger.managed_worker_id, intent.intent_id";
+
+const ADMISSION_RECOVERY_FOR_WORKER_SQL: &str =
+    "SELECT DISTINCT ledger.managed_worker_id, intent.intent_id, intent.item_id,
+        intent.session_id, intent.work_item_id, intent.workflow_execution_id,
+        intent.payload_json, intent.status AS intent_status
+     FROM task_board_dispatch_admission_ledger AS ledger
+     JOIN task_board_dispatch_intents AS intent ON intent.intent_id = ledger.intent_id
+     WHERE ledger.state = 'committed' AND ledger.managed_worker_id = ?1
+     ORDER BY ledger.managed_worker_id, intent.intent_id";
+
+fn recoveries_from_rows(
+    rows: Vec<AdmissionRecoveryRow>,
+) -> Result<Vec<TaskBoardAdmissionWorkerRecovery>, CliError> {
+    let mut recoveries = BTreeMap::new();
+    for row in rows {
+        let recovery = recovery_from_row(row)?;
+        if let Some(existing) = recoveries.get(&recovery.managed_worker_id) {
+            if existing != &recovery {
+                return Err(db_error(format!(
+                    "managed worker '{}' has committed admission for multiple dispatches",
+                    recovery.managed_worker_id
+                )));
+            }
+        } else {
+            recoveries.insert(recovery.managed_worker_id.clone(), recovery);
+        }
+    }
+    Ok(recoveries.into_values().collect())
+}
+
+fn recovery_from_row(
+    row: AdmissionRecoveryRow,
+) -> Result<TaskBoardAdmissionWorkerRecovery, CliError> {
+    if row.intent_status != "completed" {
+        return Err(db_error(format!(
+            "managed worker '{}' has committed admission for non-completed intent '{}'",
+            row.managed_worker_id, row.intent_id
+        )));
+    }
+    let dispatch = decode_applied(&row.payload_json)?;
+    let matches = dispatch.board_item_id == row.item_id
+        && dispatch.session_id == row.session_id
+        && dispatch.work_item_id == row.work_item_id
+        && dispatch.item.id == row.item_id
+        && dispatch.item.session_id.as_deref() == Some(row.session_id.as_str())
+        && dispatch.item.work_item_id.as_deref() == Some(row.work_item_id.as_str())
+        && dispatch.item.workflow.execution_id.as_deref()
+            == Some(row.workflow_execution_id.as_str());
+    if !matches {
+        return Err(db_error(format!(
+            "task board admission intent '{}' has inconsistent dispatch recovery identity",
+            row.intent_id
+        )));
+    }
+    Ok(TaskBoardAdmissionWorkerRecovery {
+        managed_worker_id: row.managed_worker_id,
+        intent_id: row.intent_id,
+        item_id: row.item_id,
+        session_id: row.session_id,
+        task_id: row.work_item_id,
+        workflow_execution_id: row.workflow_execution_id,
+        dispatch,
+    })
+}
+
+async fn load_worker_recovery_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    managed_worker_id: &str,
+) -> Result<Option<TaskBoardAdmissionWorkerRecovery>, CliError> {
+    let rows = query_as::<_, AdmissionRecoveryRow>(ADMISSION_RECOVERY_FOR_WORKER_SQL)
+        .bind(managed_worker_id)
+        .fetch_all(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("reload task board admission worker: {error}")))?;
+    let mut recoveries = recoveries_from_rows(rows)?;
+    match recoveries.len() {
+        0 => Ok(None),
+        1 => Ok(recoveries.pop()),
+        _ => Err(db_error(format!(
+            "managed worker '{managed_worker_id}' resolved to multiple recovery records"
+        ))),
+    }
+}
+
+async fn codex_run_exists_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    managed_worker_id: &str,
+) -> Result<bool, CliError> {
+    query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM codex_runs WHERE run_id = ?1)")
+        .bind(managed_worker_id)
+        .fetch_one(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("check durable Codex run during recovery: {error}")))
+}
+
+async fn block_linked_session_task(
+    transaction: &mut Transaction<'_, Sqlite>,
+    recovery: &TaskBoardAdmissionWorkerRecovery,
+    reason: &str,
+) -> Result<bool, CliError> {
+    let item_is_linked = load_item_in_tx(transaction, &recovery.item_id)
+        .await?
+        .is_some_and(|(item, _)| item_matches_recovery(&item, recovery));
+    if !item_is_linked {
+        return Ok(false);
+    }
+    let Some(row) = query_as::<_, AdmissionRecoverySessionRow>(
+        "SELECT state_json, project_id FROM sessions WHERE session_id = ?1",
+    )
+    .bind(&recovery.session_id)
+    .fetch_optional(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load linked recovery session: {error}")))?
+    else {
+        return Ok(false);
+    };
+    let mut state: SessionState = serde_json::from_str(&row.state_json)
+        .map_err(|error| db_error(format!("decode linked recovery session: {error}")))?;
+    if !session_task_matches_recovery(&state, recovery) {
+        return Ok(false);
+    }
+    session_service::apply_update_task_for_managed_run(
+        &mut state,
+        &recovery.task_id,
+        TaskStatus::Blocked,
+        Some(reason),
+        CONTROL_PLANE_ACTOR_ID,
+        &utc_now(),
+    )?;
+    super::super::async_writes::sync_session_in_transaction(transaction, &row.project_id, &state)
+        .await?;
+    Ok(true)
+}
+
+fn item_matches_recovery(
+    item: &TaskBoardItem,
+    recovery: &TaskBoardAdmissionWorkerRecovery,
+) -> bool {
+    !item.is_deleted()
+        && item.session_id.as_deref() == Some(recovery.session_id.as_str())
+        && item.work_item_id.as_deref() == Some(recovery.task_id.as_str())
+        && item.workflow.execution_id.as_deref() == Some(recovery.workflow_execution_id.as_str())
+        && item.workflow.status == TaskBoardWorkflowStatus::Running
+        && item.workflow.current_step_id.as_deref() == Some("worker_running")
+}
+
+fn session_task_matches_recovery(
+    state: &SessionState,
+    recovery: &TaskBoardAdmissionWorkerRecovery,
+) -> bool {
+    if !state.status.allows_managed_run_mutation() {
+        return false;
+    }
+    let Some(task) = state.tasks.get(&recovery.task_id) else {
+        return false;
+    };
+    if task.is_deleted() || task.status != TaskStatus::InProgress {
+        return false;
+    }
+    let Some(agent_id) = task.assigned_to.as_deref() else {
+        return false;
+    };
+    state.agents.get(agent_id).is_some_and(|agent| {
+        agent.matches_managed_agent(&ManagedAgentRef::codex(recovery.managed_worker_id.as_str()))
+    })
+}

--- a/src/daemon/db/task_board/admission_reservations.rs
+++ b/src/daemon/db/task_board/admission_reservations.rs
@@ -1,0 +1,332 @@
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use sqlx::{Sqlite, Transaction, query, query_scalar};
+use uuid::Uuid;
+
+use super::admission::TaskBoardDispatchAdmissionSnapshot;
+use crate::daemon::db::{CliError, db_error, utc_now};
+use crate::task_board::{
+    TaskBoardAdmissionDecision, TaskBoardAdmissionRequirement, TaskBoardAdmissionRequirementKind,
+    TaskBoardAdmissionUsage, TaskBoardLaunchCapability, canonical_admission_requirement_key,
+};
+
+const ADMISSION_RESERVATION_SECONDS: i64 = 900;
+
+pub(super) async fn admission_usage_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    requirements: &[TaskBoardAdmissionRequirement],
+    evaluated_at: &str,
+    excluded_intent_id: Option<&str>,
+) -> Result<Vec<TaskBoardAdmissionUsage>, CliError> {
+    release_expired_admission_in_tx(transaction, evaluated_at).await?;
+    let mut usage = Vec::with_capacity(requirements.len());
+    for requirement in requirements {
+        if requirement.kind == TaskBoardAdmissionRequirementKind::TimeWindow {
+            continue;
+        }
+        let key = canonical_admission_requirement_key(requirement)
+            .map_err(|error| db_error(format!("key task board admission requirement: {error}")))?;
+        let window = ledger_window(requirement, evaluated_at)?;
+        let consumed = query_scalar::<_, i64>(
+            "SELECT COALESCE(SUM(amount), 0)
+             FROM task_board_dispatch_admission_ledger
+             WHERE canonical_key = ?1 AND state IN ('reserved', 'committed')
+               AND (?2 IS NULL OR window_started_at = ?2)
+               AND (?3 IS NULL OR window_ends_at = ?3)
+               AND (?4 IS NULL OR intent_id != ?4)",
+        )
+        .bind(key.stable_id())
+        .bind(window.as_ref().map(|value| value.0.as_str()))
+        .bind(window.as_ref().map(|value| value.1.as_str()))
+        .bind(excluded_intent_id)
+        .fetch_one(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load task board admission usage: {error}")))?;
+        usage.push(TaskBoardAdmissionUsage {
+            kind: requirement.kind,
+            scope: requirement.scope.clone(),
+            consumed: u64::try_from(consumed).map_err(|error| {
+                db_error(format!("convert task board admission usage: {error}"))
+            })?,
+            window_seconds: requirement.window_seconds,
+            available_at: window.map(|value| value.1),
+        });
+    }
+    Ok(usage)
+}
+
+async fn release_expired_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    evaluated_at: &str,
+) -> Result<(), CliError> {
+    query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'released', expires_at = NULL, released_at = ?1
+         WHERE state = 'reserved' AND datetime(expires_at) <= datetime(?1)",
+    )
+    .bind(evaluated_at)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("release expired task board admission: {error}")))?;
+    Ok(())
+}
+
+pub(super) async fn persist_admission_snapshot_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+    intent_id: Option<&str>,
+    snapshot: &mut TaskBoardDispatchAdmissionSnapshot,
+) -> Result<(), CliError> {
+    release_reserved_admission_in_tx(transaction, intent_id).await?;
+    supersede_current_admission_in_tx(transaction, item_id, intent_id).await?;
+    snapshot.generation = next_admission_generation(transaction, item_id).await?;
+    snapshot.decision_id = format!("admission-decision-{}", Uuid::new_v4().simple());
+    insert_decision(transaction, item_id, intent_id, snapshot).await?;
+    if snapshot.is_allowed() {
+        let intent_id = intent_id.ok_or_else(|| {
+            db_error("allowed task board admission decision requires a dispatch intent")
+        })?;
+        insert_ledger(transaction, item_id, intent_id, snapshot).await?;
+    }
+    Ok(())
+}
+
+pub(super) async fn clear_current_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+    intent_id: Option<&str>,
+) -> Result<(), CliError> {
+    release_reserved_admission_in_tx(transaction, intent_id).await?;
+    supersede_current_admission_in_tx(transaction, item_id, intent_id).await
+}
+
+pub(super) async fn release_reserved_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: Option<&str>,
+) -> Result<(), CliError> {
+    let Some(intent_id) = intent_id else {
+        return Ok(());
+    };
+    let now = utc_now();
+    query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'released', expires_at = NULL, released_at = ?2
+         WHERE intent_id = ?1 AND state = 'reserved'",
+    )
+    .bind(intent_id)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("release task board admission reservation: {error}")))?;
+    Ok(())
+}
+
+async fn supersede_current_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+    intent_id: Option<&str>,
+) -> Result<(), CliError> {
+    let now = utc_now();
+    query(
+        "UPDATE task_board_dispatch_admission_decisions
+         SET is_current = 0, superseded_at = ?3
+         WHERE is_current = 1 AND item_id = ?1
+           AND (intent_id IS NULL OR intent_id = ?2)",
+    )
+    .bind(item_id)
+    .bind(intent_id)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("supersede task board admission decision: {error}")))?;
+    Ok(())
+}
+
+async fn next_admission_generation(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+) -> Result<i64, CliError> {
+    query_scalar::<_, i64>(
+        "SELECT COALESCE(MAX(generation), 0) + 1
+         FROM task_board_dispatch_admission_decisions WHERE item_id = ?1",
+    )
+    .bind(item_id)
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("allocate task board admission generation: {error}")))
+}
+
+async fn insert_decision(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+    intent_id: Option<&str>,
+    snapshot: &TaskBoardDispatchAdmissionSnapshot,
+) -> Result<(), CliError> {
+    let policy_json = json_text(&snapshot.policy, "policy")?;
+    let context_json = json_text(&snapshot.context, "context")?;
+    let requirements_json = json_text(&snapshot.requirements, "requirements")?;
+    let blockers_json = json_text(&snapshot.blockers, "blockers")?;
+    query(
+        "INSERT INTO task_board_dispatch_admission_decisions (
+            decision_id, intent_id, generation, item_id, item_revision,
+            settings_revision, decision, policy_json, context_json,
+            requirements_json, blockers_json, launch_profile, evaluated_at,
+            next_available_at, is_current, created_at
+         ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, 1, ?15
+         )",
+    )
+    .bind(&snapshot.decision_id)
+    .bind(intent_id)
+    .bind(snapshot.generation)
+    .bind(item_id)
+    .bind(snapshot.item_revision)
+    .bind(snapshot.settings_revision)
+    .bind(decision_name(snapshot.decision))
+    .bind(policy_json)
+    .bind(context_json)
+    .bind(requirements_json)
+    .bind(blockers_json)
+    .bind(snapshot.launch_capability.map(launch_profile_name))
+    .bind(&snapshot.evaluated_at)
+    .bind(snapshot.next_available_at.as_deref())
+    .bind(utc_now())
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("insert task board admission decision: {error}")))?;
+    Ok(())
+}
+
+async fn insert_ledger(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+    intent_id: &str,
+    snapshot: &TaskBoardDispatchAdmissionSnapshot,
+) -> Result<(), CliError> {
+    let expires_at = offset_time(&snapshot.evaluated_at, ADMISSION_RESERVATION_SECONDS)?;
+    for requirement in &snapshot.requirements {
+        let key = canonical_admission_requirement_key(requirement)
+            .map_err(|error| db_error(format!("key task board admission ledger: {error}")))?;
+        let window = ledger_window(requirement, &snapshot.evaluated_at)?;
+        let amount = ledger_amount(requirement)?;
+        query(
+            "INSERT INTO task_board_dispatch_admission_ledger (
+                ledger_id, decision_id, decision, intent_id, generation, item_id,
+                canonical_key, kind, scope, amount, limit_value,
+                window_started_at, window_ends_at, state, expires_at, reserved_at
+             ) VALUES (
+                ?1, ?2, 'allowed', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+                ?11, ?12, 'reserved', ?13, ?14
+             )",
+        )
+        .bind(format!("admission-ledger-{}", Uuid::new_v4().simple()))
+        .bind(&snapshot.decision_id)
+        .bind(intent_id)
+        .bind(snapshot.generation)
+        .bind(item_id)
+        .bind(key.stable_id())
+        .bind(kind_name(requirement.kind))
+        .bind(&requirement.scope)
+        .bind(amount)
+        .bind(to_i64(requirement.limit, "limit")?)
+        .bind(window.as_ref().map(|value| value.0.as_str()))
+        .bind(window.as_ref().map(|value| value.1.as_str()))
+        .bind(&expires_at)
+        .bind(&snapshot.evaluated_at)
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("insert task board admission ledger: {error}")))?;
+    }
+    Ok(())
+}
+
+fn ledger_window(
+    requirement: &TaskBoardAdmissionRequirement,
+    evaluated_at: &str,
+) -> Result<Option<(String, String)>, CliError> {
+    if requirement.kind == TaskBoardAdmissionRequirementKind::Concurrency {
+        return Ok(None);
+    }
+    let seconds = requirement
+        .window_seconds
+        .ok_or_else(|| db_error("windowed task board admission has no duration"))?;
+    let seconds = to_i64(seconds, "window")?;
+    if requirement.kind == TaskBoardAdmissionRequirementKind::TimeWindow {
+        let start = requirement
+            .available_at
+            .as_deref()
+            .ok_or_else(|| db_error("time-window task board admission has no start"))?;
+        return Ok(Some((start.to_string(), offset_time(start, seconds)?)));
+    }
+    let evaluated_at = parse_time(evaluated_at)?;
+    let started_at = evaluated_at.timestamp().div_euclid(seconds) * seconds;
+    let start = DateTime::<Utc>::from_timestamp(started_at, 0)
+        .ok_or_else(|| db_error("task board admission window start overflow"))?;
+    let end = start
+        .checked_add_signed(Duration::seconds(seconds))
+        .ok_or_else(|| db_error("task board admission window end overflow"))?;
+    Ok(Some((canonical_time(start), canonical_time(end))))
+}
+
+fn ledger_amount(requirement: &TaskBoardAdmissionRequirement) -> Result<i64, CliError> {
+    if requirement.kind == TaskBoardAdmissionRequirementKind::TimeWindow {
+        return Ok(0);
+    }
+    to_i64(
+        requirement
+            .reservation
+            .ok_or_else(|| db_error("task board admission has no reservation amount"))?,
+        "reservation",
+    )
+}
+
+fn offset_time(value: &str, seconds: i64) -> Result<String, CliError> {
+    parse_time(value)?
+        .checked_add_signed(Duration::seconds(seconds))
+        .map(canonical_time)
+        .ok_or_else(|| db_error("task board admission timestamp overflow"))
+}
+
+fn parse_time(value: &str) -> Result<DateTime<Utc>, CliError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| db_error(format!("parse task board admission timestamp: {error}")))
+}
+
+fn canonical_time(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn json_text(value: &impl serde::Serialize, label: &str) -> Result<String, CliError> {
+    serde_json::to_string(value)
+        .map_err(|error| db_error(format!("serialize task board admission {label}: {error}")))
+}
+
+fn to_i64(value: u64, label: &str) -> Result<i64, CliError> {
+    i64::try_from(value)
+        .map_err(|error| db_error(format!("convert task board admission {label}: {error}")))
+}
+
+const fn decision_name(decision: TaskBoardAdmissionDecision) -> &'static str {
+    match decision {
+        TaskBoardAdmissionDecision::Allowed => "allowed",
+        TaskBoardAdmissionDecision::Deferred => "deferred",
+        TaskBoardAdmissionDecision::Rejected => "rejected",
+    }
+}
+
+const fn launch_profile_name(capability: TaskBoardLaunchCapability) -> &'static str {
+    match capability {
+        TaskBoardLaunchCapability::ReportReadOnly => "read_only",
+        TaskBoardLaunchCapability::WorkspaceWrite => "workspace_write",
+    }
+}
+
+const fn kind_name(kind: TaskBoardAdmissionRequirementKind) -> &'static str {
+    match kind {
+        TaskBoardAdmissionRequirementKind::Concurrency => "concurrency",
+        TaskBoardAdmissionRequirementKind::Rate => "rate",
+        TaskBoardAdmissionRequirementKind::TimeWindow => "time_window",
+        TaskBoardAdmissionRequirementKind::TokenBudget => "token_budget",
+        TaskBoardAdmissionRequirementKind::MonetaryBudget => "monetary_budget",
+    }
+}

--- a/src/daemon/db/task_board/aggregates.rs
+++ b/src/daemon/db/task_board/aggregates.rs
@@ -15,6 +15,17 @@ use crate::task_board::{
     Machine, TaskBoardGitRuntimeConfig, TaskBoardOrchestratorSettings, TaskBoardOrchestratorState,
 };
 
+pub(super) struct TaskBoardOrchestratorSettingsMutation {
+    pub(super) row_revision: i64,
+    pub(super) change_revision: i64,
+}
+
+pub(crate) struct TaskBoardOrchestratorSettingsSnapshot {
+    pub(crate) settings: TaskBoardOrchestratorSettings,
+    pub(crate) row_revision: i64,
+    pub(crate) change_revision: i64,
+}
+
 impl AsyncDaemonDb {
     pub(crate) async fn task_board_machines(&self) -> Result<Vec<Machine>, CliError> {
         let rows = query_as::<_, MachineRow>(
@@ -128,13 +139,30 @@ impl AsyncDaemonDb {
     pub(crate) async fn task_board_orchestrator_settings(
         &self,
     ) -> Result<TaskBoardOrchestratorSettings, CliError> {
-        load_singleton_json(
-            self,
-            "SELECT settings_json FROM task_board_orchestrator_settings WHERE singleton = 1",
-            "task board orchestrator settings",
+        self.task_board_orchestrator_settings_snapshot()
+            .await
+            .map(|snapshot| snapshot.settings)
+    }
+
+    pub(crate) async fn task_board_orchestrator_settings_snapshot(
+        &self,
+    ) -> Result<TaskBoardOrchestratorSettingsSnapshot, CliError> {
+        let (settings_json, row_revision, change_revision) = query_as::<_, (String, i64, i64)>(
+            "SELECT settings.settings_json, settings.revision,
+                        COALESCE(changes.change_seq, 0)
+                 FROM task_board_orchestrator_settings AS settings
+                 LEFT JOIN change_tracking AS changes ON changes.scope = ?1
+                 WHERE settings.singleton = 1",
         )
+        .bind(ORCHESTRATOR_CHANGE_SCOPE)
+        .fetch_one(self.pool())
         .await
-        .map(Option::unwrap_or_default)
+        .map_err(|error| db_error(format!("load orchestrator settings: {error}")))?;
+        Ok(TaskBoardOrchestratorSettingsSnapshot {
+            settings: parse_json(&settings_json, "task board orchestrator settings")?,
+            row_revision,
+            change_revision,
+        })
     }
 
     pub(crate) async fn replace_task_board_orchestrator_settings(
@@ -149,7 +177,7 @@ impl AsyncDaemonDb {
             .commit()
             .await
             .map_err(|error| db_error(format!("commit orchestrator settings: {error}")))?;
-        Ok(revision)
+        Ok(revision.change_revision)
     }
 
     pub(crate) async fn task_board_orchestrator_state(
@@ -240,7 +268,7 @@ impl AsyncDaemonDb {
 pub(super) async fn replace_orchestrator_settings_in_tx(
     transaction: &mut Transaction<'_, Sqlite>,
     settings: &TaskBoardOrchestratorSettings,
-) -> Result<i64, CliError> {
+) -> Result<TaskBoardOrchestratorSettingsMutation, CliError> {
     query(
         "INSERT INTO task_board_orchestrator_settings (
             singleton, settings_json, revision, updated_at
@@ -254,7 +282,18 @@ pub(super) async fn replace_orchestrator_settings_in_tx(
     .execute(transaction.as_mut())
     .await
     .map_err(|error| db_error(format!("save orchestrator settings: {error}")))?;
-    bump_change_in_tx(transaction, ORCHESTRATOR_CHANGE_SCOPE).await
+    let row_revision = query_as::<_, (i64,)>(
+        "SELECT revision FROM task_board_orchestrator_settings WHERE singleton = 1",
+    )
+    .fetch_one(transaction.as_mut())
+    .await
+    .map(|row| row.0)
+    .map_err(|error| db_error(format!("read orchestrator settings revision: {error}")))?;
+    let change_revision = bump_change_in_tx(transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
+    Ok(TaskBoardOrchestratorSettingsMutation {
+        row_revision,
+        change_revision,
+    })
 }
 
 pub(super) async fn upsert_machine_in_tx(

--- a/src/daemon/db/task_board/dispatch_intents.rs
+++ b/src/daemon/db/task_board/dispatch_intents.rs
@@ -2,8 +2,10 @@ use sqlx::{Sqlite, Transaction, query, query_as};
 use uuid::Uuid;
 
 use super::ITEMS_CHANGE_SCOPE;
+use super::admission_lifecycle::{
+    TaskBoardAdmissionCheck, commit_dispatch_admission_in_tx, revalidate_dispatch_admission_in_tx,
+};
 use super::items::{bump_change_in_tx, load_item_in_tx, replace_item_in_tx};
-use crate::daemon::db::policy::restore_consumed_approval_grant_in_tx_at;
 use crate::daemon::db::{AsyncDaemonDb, CliError, CliErrorKind, db_error, utc_now};
 use crate::infra::io;
 use crate::task_board::dispatch::DispatchLifecycle;
@@ -11,12 +13,24 @@ use crate::task_board::{DispatchAppliedTask, TaskBoardStatus, TaskBoardWorkflowS
 
 const CLAIM_LEASE_SECONDS: i64 = 30;
 
+#[path = "dispatch_intents_helpers.rs"]
+mod helpers;
+use helpers::refuse_pending_admission_in_tx;
+
+#[derive(Debug)]
+pub(crate) enum TaskBoardDispatchClaimAction {
+    Start,
+    Recover,
+    Compensate { reason: String },
+}
+
 #[derive(Debug)]
 pub(crate) struct ClaimedTaskBoardDispatch {
     pub(crate) intent_id: String,
     pub(crate) claim_token: String,
     pub(crate) applied: DispatchAppliedTask,
     pub(crate) consumed_approval_grant_id: Option<String>,
+    pub(crate) action: TaskBoardDispatchClaimAction,
 }
 
 impl AsyncDaemonDb {
@@ -90,34 +104,84 @@ impl AsyncDaemonDb {
         let mut transaction = self
             .begin_immediate_transaction("task board dispatch claim")
             .await?;
-        release_expired_claims(&mut transaction).await?;
-        let Some((intent_id, payload_json, consumed_approval_grant_id)) =
-            query_as::<_, (String, String, Option<String>)>(
-                "SELECT intent_id, payload_json, consumed_approval_grant_id
+        let Some((
+            intent_id,
+            payload_json,
+            consumed_approval_grant_id,
+            prior_status,
+            compensation_pending,
+            last_error,
+        )) = query_as::<_, (String, String, Option<String>, String, bool, Option<String>)>(
+            "SELECT intent_id, payload_json, consumed_approval_grant_id,
+                        status, compensation_pending, last_error
                  FROM task_board_dispatch_intents
-                 WHERE item_id = ?1 AND status = 'pending'
-                   AND datetime(available_at) <= datetime('now')
+                 WHERE item_id = ?1
+                   AND (
+                       (status = 'pending' AND datetime(available_at) <= datetime('now'))
+                       OR (status = 'starting'
+                           AND datetime(claimed_at) <= datetime('now', ?2))
+                   )
                  ORDER BY created_at, intent_id LIMIT 1",
-            )
-            .bind(board_item_id)
-            .fetch_optional(transaction.as_mut())
-            .await
-            .map_err(|error| db_error(format!("load pending task board dispatch: {error}")))?
+        )
+        .bind(board_item_id)
+        .bind(format!("-{CLAIM_LEASE_SECONDS} seconds"))
+        .fetch_optional(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load pending task board dispatch: {error}")))?
         else {
             transaction.commit().await.map_err(|error| {
                 db_error(format!("commit empty task board dispatch claim: {error}"))
             })?;
             return Ok(None);
         };
+        let applied = decode_applied(&payload_json)?;
+        let action = if compensation_pending {
+            TaskBoardDispatchClaimAction::Compensate {
+                reason: last_error
+                    .filter(|reason| !reason.is_empty())
+                    .ok_or_else(|| db_error("compensating task board dispatch has no reason"))?,
+            }
+        } else if prior_status == "starting" {
+            // A reclaimed `starting` claim can already own the deterministic
+            // worker. Its recovery path must probe that identity before current
+            // item or policy state is allowed to reject the intent.
+            TaskBoardDispatchClaimAction::Recover
+        } else {
+            if let Err(error) = validate_pending_dispatch(
+                &mut transaction,
+                board_item_id,
+                &intent_id,
+                &applied,
+                consumed_approval_grant_id.as_deref(),
+            )
+            .await
+            {
+                transaction.commit().await.map_err(|commit_error| {
+                    db_error(format!(
+                        "commit refused task board worker claim: {commit_error}"
+                    ))
+                })?;
+                return Err(error);
+            }
+            TaskBoardDispatchClaimAction::Start
+        };
         let claim_token = format!("dispatch-claim-{}", Uuid::new_v4().simple());
         let changed = query(
             "UPDATE task_board_dispatch_intents SET status = 'starting', attempts = attempts + 1,
              claim_token = ?2, claimed_at = ?3, updated_at = ?3
-             WHERE intent_id = ?1 AND status = 'pending'",
+             WHERE intent_id = ?1 AND compensation_pending = ?4
+               AND (
+                   (?5 = 'pending' AND status = 'pending')
+                   OR (?5 = 'starting' AND status = 'starting'
+                       AND datetime(claimed_at) <= datetime('now', ?6))
+               )",
         )
         .bind(&intent_id)
         .bind(&claim_token)
         .bind(utc_now())
+        .bind(compensation_pending)
+        .bind(&prior_status)
+        .bind(format!("-{CLAIM_LEASE_SECONDS} seconds"))
         .execute(transaction.as_mut())
         .await
         .map_err(|error| db_error(format!("claim task board dispatch: {error}")))?
@@ -132,8 +196,9 @@ impl AsyncDaemonDb {
         Ok(Some(ClaimedTaskBoardDispatch {
             intent_id,
             claim_token,
-            applied: decode_applied(&payload_json)?,
+            applied,
             consumed_approval_grant_id,
+            action,
         }))
     }
 
@@ -163,6 +228,7 @@ impl AsyncDaemonDb {
         &self,
         intent_id: &str,
         claim_token: &str,
+        managed_worker_id: &str,
     ) -> Result<crate::task_board::TaskBoardItem, CliError> {
         let mut transaction = self
             .begin_immediate_transaction("task board dispatch completion")
@@ -175,19 +241,24 @@ impl AsyncDaemonDb {
         let still_linked = item.session_id.as_deref() == Some(session_id.as_str())
             && item.work_item_id.as_deref() == Some(work_item_id.as_str())
             && item.workflow.execution_id.as_deref() == Some(execution_id.as_str());
-        if still_linked {
-            item.workflow.status = TaskBoardWorkflowStatus::Running;
-            item.workflow.current_step_id = Some("worker_running".to_string());
-            item.workflow.last_error = None;
-            item.updated_at = utc_now();
-            replace_item_in_tx(&mut transaction, &item, revision + 1).await?;
-            bump_change_in_tx(&mut transaction, ITEMS_CHANGE_SCOPE).await?;
+        if !still_linked {
+            return Err(db_error(format!(
+                "task board dispatch intent '{intent_id}' no longer matches its item linkage"
+            )));
         }
+        ensure_dispatch_item_startable(&item, &session_id, &work_item_id, Some(&execution_id))?;
+        item.workflow.status = TaskBoardWorkflowStatus::Running;
+        item.workflow.current_step_id = Some("worker_running".to_string());
+        item.workflow.last_error = None;
+        item.updated_at = utc_now();
+        replace_item_in_tx(&mut transaction, &item, revision + 1).await?;
+        bump_change_in_tx(&mut transaction, ITEMS_CHANGE_SCOPE).await?;
         let now = utc_now();
         let changed = query(
             "UPDATE task_board_dispatch_intents SET status = 'completed', last_error = NULL,
              claim_token = NULL, claimed_at = NULL, updated_at = ?3, completed_at = ?3
-             WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'",
+             WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'
+               AND compensation_pending = 0",
         )
         .bind(intent_id)
         .bind(claim_token)
@@ -201,67 +272,77 @@ impl AsyncDaemonDb {
                 "task board dispatch intent '{intent_id}' is not claimed"
             )));
         }
+        commit_dispatch_admission_in_tx(&mut transaction, intent_id, managed_worker_id).await?;
         transaction
             .commit()
             .await
             .map_err(|error| db_error(format!("commit task board dispatch completion: {error}")))?;
         Ok(item)
     }
+}
 
-    /// Atomically mark worker startup failed and make the item dispatchable again.
-    #[expect(
-        clippy::cognitive_complexity,
-        reason = "dispatch failure must keep item rollback and intent completion atomic"
-    )]
-    pub(crate) async fn fail_task_board_dispatch(
-        &self,
-        intent_id: &str,
-        claim_token: &str,
-        consumed_approval_grant_id: Option<&str>,
-        reason: &str,
-    ) -> Result<(), CliError> {
-        let mut transaction = self
-            .begin_immediate_transaction("task board dispatch failure")
-            .await?;
-        let (item_id, session_id, work_item_id, execution_id) =
-            claimed_intent_identity(&mut transaction, intent_id, claim_token).await?;
-        if let Some(grant_id) = consumed_approval_grant_id {
-            restore_consumed_approval_grant_in_tx_at(transaction.as_mut(), grant_id, &utc_now())
-                .await?;
-        }
-        let (mut item, revision) = load_item_in_tx(&mut transaction, &item_id)
-            .await?
-            .ok_or_else(|| db_error(format!("task-board item '{item_id}' not found")))?;
-        let still_linked = item.session_id.as_deref() == Some(session_id.as_str())
-            && item.work_item_id.as_deref() == Some(work_item_id.as_str())
-            && item.workflow.execution_id.as_deref() == Some(execution_id.as_str());
-        if still_linked {
-            item.workflow.status = TaskBoardWorkflowStatus::Failed;
-            item.workflow.current_step_id = Some("worker_spawn".to_string());
-            item.workflow.last_error = Some(reason.to_string());
-            item.status = TaskBoardStatus::Todo;
-            item.session_id = None;
-            item.work_item_id = None;
-            item.updated_at = utc_now();
-            replace_item_in_tx(&mut transaction, &item, revision + 1).await?;
-            bump_change_in_tx(&mut transaction, ITEMS_CHANGE_SCOPE).await?;
-        }
-        query(
-            "UPDATE task_board_dispatch_intents SET status = 'failed', last_error = ?3,
-             claim_token = NULL, claimed_at = NULL, updated_at = ?4, completed_at = ?4
-             WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'",
+async fn validate_pending_dispatch(
+    transaction: &mut Transaction<'_, Sqlite>,
+    board_item_id: &str,
+    intent_id: &str,
+    applied: &DispatchAppliedTask,
+    consumed_approval_grant_id: Option<&str>,
+) -> Result<(), CliError> {
+    let (item, item_revision) = load_item_in_tx(transaction, board_item_id)
+        .await?
+        .ok_or_else(|| db_error(format!("task-board item '{board_item_id}' not found")))?;
+    if let Err(error) = ensure_dispatch_item_startable(
+        &item,
+        &applied.session_id,
+        &applied.work_item_id,
+        applied.item.workflow.execution_id.as_deref(),
+    ) {
+        refuse_pending_admission_in_tx(
+            transaction,
+            intent_id,
+            applied,
+            consumed_approval_grant_id,
+            &error.to_string(),
         )
-        .bind(intent_id)
-        .bind(claim_token)
-        .bind(reason)
-        .bind(utc_now())
-        .execute(transaction.as_mut())
-        .await
-        .map_err(|error| db_error(format!("fail task board dispatch: {error}")))?;
-        transaction
-            .commit()
-            .await
-            .map_err(|error| db_error(format!("commit task board dispatch failure: {error}")))
+        .await?;
+        return Err(error);
+    }
+    if let TaskBoardAdmissionCheck::Blocked(admission) =
+        revalidate_dispatch_admission_in_tx(transaction, intent_id, &item, item_revision).await?
+    {
+        refuse_pending_admission_in_tx(
+            transaction,
+            intent_id,
+            applied,
+            consumed_approval_grant_id,
+            &admission.refusal_message(),
+        )
+        .await?;
+        return Err(CliErrorKind::invalid_transition(admission.refusal_message()).into());
+    }
+    Ok(())
+}
+
+pub(super) fn ensure_dispatch_item_startable(
+    item: &crate::task_board::TaskBoardItem,
+    session_id: &str,
+    work_item_id: &str,
+    execution_id: Option<&str>,
+) -> Result<(), CliError> {
+    let matches = !item.is_deleted()
+        && item.status == TaskBoardStatus::InProgress
+        && item.workflow.status == TaskBoardWorkflowStatus::Running
+        && item.session_id.as_deref() == Some(session_id)
+        && item.work_item_id.as_deref() == Some(work_item_id)
+        && item.workflow.execution_id.as_deref() == execution_id;
+    if matches {
+        Ok(())
+    } else {
+        Err(CliErrorKind::invalid_transition(format!(
+            "task-board item '{}' is no longer startable for its claimed dispatch",
+            item.id
+        ))
+        .into())
     }
 }
 
@@ -333,24 +414,6 @@ async fn insert_intent(
     Ok(())
 }
 
-async fn release_expired_claims(transaction: &mut Transaction<'_, Sqlite>) -> Result<(), CliError> {
-    query(
-        "UPDATE task_board_dispatch_intents SET status = 'pending', claim_token = NULL,
-         claimed_at = NULL, updated_at = ?1
-         WHERE status = 'starting' AND datetime(claimed_at) <= datetime('now', ?2)",
-    )
-    .bind(utc_now())
-    .bind(format!("-{CLAIM_LEASE_SECONDS} seconds"))
-    .execute(transaction.as_mut())
-    .await
-    .map_err(|error| {
-        db_error(format!(
-            "release expired task board dispatch claims: {error}"
-        ))
-    })?;
-    Ok(())
-}
-
 async fn claimed_intent_identity(
     transaction: &mut Transaction<'_, Sqlite>,
     intent_id: &str,
@@ -359,7 +422,8 @@ async fn claimed_intent_identity(
     query_as::<_, (String, String, String, String)>(
         "SELECT item_id, session_id, work_item_id, workflow_execution_id
          FROM task_board_dispatch_intents
-         WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'",
+         WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'
+           AND compensation_pending = 0",
     )
     .bind(intent_id)
     .bind(claim_token)

--- a/src/daemon/db/task_board/dispatch_intents_helpers.rs
+++ b/src/daemon/db/task_board/dispatch_intents_helpers.rs
@@ -1,0 +1,340 @@
+use sqlx::{Sqlite, Transaction, query, query_as, query_scalar};
+
+use super::super::ITEMS_CHANGE_SCOPE;
+use super::super::admission_lifecycle::{
+    commit_compensating_dispatch_admission_in_tx, finalize_compensating_dispatch_admission_in_tx,
+    release_dispatch_admission_in_tx, renew_frozen_dispatch_admission_in_tx,
+};
+use super::super::items::{bump_change_in_tx, load_item_in_tx, replace_item_in_tx};
+use crate::daemon::db::policy::restore_consumed_approval_grant_in_tx_at;
+use crate::daemon::db::{AsyncDaemonDb, CliError, db_error, utc_now};
+use crate::task_board::{
+    DispatchAppliedTask, TaskBoardItem, TaskBoardStatus, TaskBoardWorkflowStatus,
+};
+
+pub(super) async fn refuse_pending_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    applied: &DispatchAppliedTask,
+    consumed_approval_grant_id: Option<&str>,
+    reason: &str,
+) -> Result<(), CliError> {
+    if let Some(grant_id) = consumed_approval_grant_id {
+        restore_consumed_approval_grant_in_tx_at(transaction.as_mut(), grant_id, &utc_now())
+            .await?;
+    }
+    let (mut item, revision) = load_item_in_tx(transaction, &applied.board_item_id)
+        .await?
+        .ok_or_else(|| {
+            db_error(format!(
+                "task-board item '{}' not found",
+                applied.board_item_id
+            ))
+        })?;
+    let still_linked = item.session_id.as_deref() == Some(applied.session_id.as_str())
+        && item.work_item_id.as_deref() == Some(applied.work_item_id.as_str());
+    if still_linked && dispatch_item_can_be_rolled_back(&item) {
+        item.workflow.status = TaskBoardWorkflowStatus::Failed;
+        item.workflow.current_step_id = Some("admission".to_string());
+        item.workflow.last_error = Some(reason.to_string());
+        item.status = TaskBoardStatus::Todo;
+        item.session_id = None;
+        item.work_item_id = None;
+        item.updated_at = utc_now();
+        replace_item_in_tx(transaction, &item, revision + 1).await?;
+        bump_change_in_tx(transaction, ITEMS_CHANGE_SCOPE).await?;
+    }
+    let now = utc_now();
+    query(
+        "UPDATE task_board_dispatch_intents
+         SET status = 'failed', last_error = ?2, completed_at = ?3, updated_at = ?3
+         WHERE intent_id = ?1 AND status = 'pending'",
+    )
+    .bind(intent_id)
+    .bind(reason)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("refuse task board worker admission: {error}")))?;
+    release_dispatch_admission_in_tx(transaction, intent_id).await?;
+    Ok(())
+}
+
+pub(super) fn dispatch_item_can_be_rolled_back(item: &TaskBoardItem) -> bool {
+    !item.is_deleted()
+        && item.status == TaskBoardStatus::InProgress
+        && item.workflow.status == TaskBoardWorkflowStatus::Running
+}
+
+impl AsyncDaemonDb {
+    pub(crate) async fn begin_task_board_dispatch_compensation(
+        &self,
+        intent_id: &str,
+        claim_token: &str,
+        managed_worker_id: &str,
+        reason: &str,
+    ) -> Result<(), CliError> {
+        if reason.is_empty() {
+            return Err(db_error("task board dispatch compensation reason is empty"));
+        }
+        let mut transaction = self
+            .begin_immediate_transaction("task board dispatch compensation")
+            .await?;
+        let now = utc_now();
+        let changed = query(
+            "UPDATE task_board_dispatch_intents
+             SET compensation_pending = 1, last_error = ?3,
+                 claimed_at = ?4, updated_at = ?4
+             WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'
+               AND compensation_pending = 0",
+        )
+        .bind(intent_id)
+        .bind(claim_token)
+        .bind(reason)
+        .bind(now)
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("begin task board dispatch compensation: {error}")))?
+        .rows_affected();
+        if changed != 1 {
+            return Err(lost_claim(intent_id));
+        }
+        commit_compensating_dispatch_admission_in_tx(
+            &mut transaction,
+            intent_id,
+            managed_worker_id,
+        )
+        .await?;
+        transaction.commit().await.map_err(|error| {
+            db_error(format!(
+                "commit task board dispatch compensation marker: {error}"
+            ))
+        })
+    }
+
+    pub(crate) async fn task_board_dispatch_is_completed(
+        &self,
+        applied: &DispatchAppliedTask,
+    ) -> Result<bool, CliError> {
+        self.task_board_dispatch_has_status(applied, "completed")
+            .await
+    }
+
+    pub(crate) async fn task_board_dispatch_is_held(
+        &self,
+        applied: &DispatchAppliedTask,
+    ) -> Result<bool, CliError> {
+        self.task_board_dispatch_has_status(applied, "held").await
+    }
+
+    async fn task_board_dispatch_has_status(
+        &self,
+        applied: &DispatchAppliedTask,
+        status: &str,
+    ) -> Result<bool, CliError> {
+        let Some(execution_id) = applied.item.workflow.execution_id.as_deref() else {
+            return Ok(false);
+        };
+        query_scalar::<_, bool>(
+            "SELECT EXISTS(
+                 SELECT 1 FROM task_board_dispatch_intents
+                 WHERE item_id = ?1 AND session_id = ?2 AND work_item_id = ?3
+                   AND workflow_execution_id = ?4 AND status = ?5
+             )",
+        )
+        .bind(&applied.board_item_id)
+        .bind(&applied.session_id)
+        .bind(&applied.work_item_id)
+        .bind(execution_id)
+        .bind(status)
+        .fetch_one(self.pool())
+        .await
+        .map_err(|error| db_error(format!("check task board dispatch status: {error}")))
+    }
+
+    pub(crate) async fn renew_task_board_dispatch_claim(
+        &self,
+        intent_id: &str,
+        claim_token: &str,
+    ) -> Result<(), CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board dispatch claim renewal")
+            .await?;
+        let compensation_pending = query_scalar::<_, bool>(
+            "SELECT compensation_pending FROM task_board_dispatch_intents
+             WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'",
+        )
+        .bind(intent_id)
+        .bind(claim_token)
+        .fetch_optional(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("load task board dispatch claim: {error}")))?
+        .ok_or_else(|| lost_claim(intent_id))?;
+        let changed = query(
+            "UPDATE task_board_dispatch_intents
+             SET claimed_at = ?3, updated_at = ?3
+             WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'",
+        )
+        .bind(intent_id)
+        .bind(claim_token)
+        .bind(utc_now())
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("renew task board dispatch claim: {error}")))?
+        .rows_affected();
+        if changed != 1 {
+            return Err(lost_claim(intent_id));
+        }
+        if !compensation_pending {
+            renew_frozen_dispatch_admission_in_tx(&mut transaction, intent_id).await?;
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit task board dispatch renewal: {error}")))
+    }
+
+    pub(crate) async fn fail_task_board_dispatch(
+        &self,
+        intent_id: &str,
+        claim_token: &str,
+        consumed_approval_grant_id: Option<&str>,
+        reason: &str,
+    ) -> Result<(), CliError> {
+        self.finish_failed_task_board_dispatch(
+            intent_id,
+            claim_token,
+            consumed_approval_grant_id,
+            None,
+            reason,
+            false,
+        )
+        .await
+    }
+
+    pub(crate) async fn finalize_task_board_dispatch_compensation(
+        &self,
+        intent_id: &str,
+        claim_token: &str,
+        consumed_approval_grant_id: Option<&str>,
+        managed_worker_id: &str,
+        reason: &str,
+    ) -> Result<(), CliError> {
+        self.finish_failed_task_board_dispatch(
+            intent_id,
+            claim_token,
+            consumed_approval_grant_id,
+            Some(managed_worker_id),
+            reason,
+            true,
+        )
+        .await
+    }
+
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "dispatch failure keeps item rollback and intent completion atomic"
+    )]
+    async fn finish_failed_task_board_dispatch(
+        &self,
+        intent_id: &str,
+        claim_token: &str,
+        consumed_approval_grant_id: Option<&str>,
+        managed_worker_id: Option<&str>,
+        reason: &str,
+        expected_compensation: bool,
+    ) -> Result<(), CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board dispatch failure")
+            .await?;
+        let (item_id, session_id, work_item_id, execution_id) = claimed_intent_identity(
+            &mut transaction,
+            intent_id,
+            claim_token,
+            expected_compensation,
+        )
+        .await?;
+        if let Some(grant_id) = consumed_approval_grant_id {
+            restore_consumed_approval_grant_in_tx_at(transaction.as_mut(), grant_id, &utc_now())
+                .await?;
+        }
+        let (mut item, revision) = load_item_in_tx(&mut transaction, &item_id)
+            .await?
+            .ok_or_else(|| db_error(format!("task-board item '{item_id}' not found")))?;
+        let still_linked = item.session_id.as_deref() == Some(session_id.as_str())
+            && item.work_item_id.as_deref() == Some(work_item_id.as_str())
+            && item.workflow.execution_id.as_deref() == Some(execution_id.as_str());
+        if still_linked && dispatch_item_can_be_rolled_back(&item) {
+            item.workflow.status = TaskBoardWorkflowStatus::Failed;
+            item.workflow.current_step_id = Some("worker_spawn".to_string());
+            item.workflow.last_error = Some(reason.to_string());
+            item.status = TaskBoardStatus::Todo;
+            item.session_id = None;
+            item.work_item_id = None;
+            item.updated_at = utc_now();
+            replace_item_in_tx(&mut transaction, &item, revision + 1).await?;
+            bump_change_in_tx(&mut transaction, ITEMS_CHANGE_SCOPE).await?;
+        }
+        let now = utc_now();
+        let changed = query(
+            "UPDATE task_board_dispatch_intents
+             SET status = 'failed', last_error = ?3, compensation_pending = 0,
+                 claim_token = NULL, claimed_at = NULL, updated_at = ?4, completed_at = ?4
+             WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'
+               AND compensation_pending = ?5",
+        )
+        .bind(intent_id)
+        .bind(claim_token)
+        .bind(reason)
+        .bind(now)
+        .bind(expected_compensation)
+        .execute(transaction.as_mut())
+        .await
+        .map_err(|error| db_error(format!("fail task board dispatch: {error}")))?
+        .rows_affected();
+        if changed != 1 {
+            return Err(lost_claim(intent_id));
+        }
+        if let Some(managed_worker_id) = managed_worker_id {
+            finalize_compensating_dispatch_admission_in_tx(
+                &mut transaction,
+                intent_id,
+                managed_worker_id,
+            )
+            .await?;
+        } else {
+            release_dispatch_admission_in_tx(&mut transaction, intent_id).await?;
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit task board dispatch failure: {error}")))
+    }
+}
+
+async fn claimed_intent_identity(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    claim_token: &str,
+    compensation_pending: bool,
+) -> Result<(String, String, String, String), CliError> {
+    query_as::<_, (String, String, String, String)>(
+        "SELECT item_id, session_id, work_item_id, workflow_execution_id
+         FROM task_board_dispatch_intents
+         WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'starting'
+           AND compensation_pending = ?3",
+    )
+    .bind(intent_id)
+    .bind(claim_token)
+    .bind(compensation_pending)
+    .fetch_optional(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load claimed task board dispatch: {error}")))?
+    .ok_or_else(|| lost_claim(intent_id))
+}
+
+fn lost_claim(intent_id: &str) -> CliError {
+    db_error(format!(
+        "task board dispatch intent '{intent_id}' lost its claim"
+    ))
+}

--- a/src/daemon/db/task_board/dispatch_preparations.rs
+++ b/src/daemon/db/task_board/dispatch_preparations.rs
@@ -1,19 +1,28 @@
 use serde::{Deserialize, Serialize};
-use sqlx::{Sqlite, Transaction, query, query_as};
+use sqlx::{query, query_as};
 use uuid::Uuid;
 
 use super::ITEMS_CHANGE_SCOPE;
+use super::admission::{TaskBoardDispatchAdmissionSnapshot, evaluate_dispatch_admission_in_tx};
+use super::admission_lifecycle::{
+    TaskBoardAdmissionCheck, renew_dispatch_admission_in_tx, revalidate_dispatch_admission_in_tx,
+};
+use super::admission_reservations::persist_admission_snapshot_in_tx;
 use super::items::{bump_change_in_tx, load_item_in_tx, replace_item_in_tx};
 use crate::daemon::db::policy::consume_approval_grant_in_tx;
 use crate::daemon::db::{AsyncDaemonDb, CliError, db_error, utc_now};
 use crate::infra::io;
-use crate::session::types::TaskSeverity;
-use crate::task_board::{
-    DispatchAppliedTask, DispatchPlan, SessionIntent, TaskBoardItem, TaskBoardPriority,
-    TaskBoardStatus, TaskBoardWorkflowStatus,
-};
+use crate::task_board::{DispatchAppliedTask, DispatchPlan, SessionIntent};
 
 const PREPARATION_LEASE_SECONDS: i64 = 30;
+
+#[path = "dispatch_preparations_helpers.rs"]
+mod helpers;
+use helpers::{
+    active_reservation, apply_preparation_to_item, decode_preparation, ensure_preparation_claim,
+    fail_preparation_admission_in_tx, insert_preparation, release_expired_preparations,
+    validate_reservable_item,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct TaskBoardDispatchPreparation {
@@ -42,6 +51,7 @@ pub(crate) enum ReservedTaskBoardDispatch {
         preparation: TaskBoardDispatchPreparation,
     },
     Applied(DispatchAppliedTask),
+    Blocked(TaskBoardDispatchAdmissionSnapshot),
 }
 
 impl AsyncDaemonDb {
@@ -67,7 +77,7 @@ impl AsyncDaemonDb {
             })?;
             return Ok(reserved);
         }
-        let (item, _) = load_item_in_tx(&mut transaction, &plan.board_item_id)
+        let (item, item_revision) = load_item_in_tx(&mut transaction, &plan.board_item_id)
             .await?
             .ok_or_else(|| {
                 db_error(format!(
@@ -76,6 +86,22 @@ impl AsyncDaemonDb {
                 ))
             })?;
         validate_reservable_item(&item, plan)?;
+        let mut admission =
+            evaluate_dispatch_admission_in_tx(&mut transaction, &item, item_revision, None).await?;
+        if admission.as_ref().is_some_and(|value| !value.is_allowed()) {
+            let mut admission = admission.take().expect("checked task board admission");
+            persist_admission_snapshot_in_tx(
+                &mut transaction,
+                &plan.board_item_id,
+                None,
+                &mut admission,
+            )
+            .await?;
+            transaction.commit().await.map_err(|error| {
+                db_error(format!("commit refused task board admission: {error}"))
+            })?;
+            return Ok(ReservedTaskBoardDispatch::Blocked(admission));
+        }
         let intent_id = format!("dispatch-intent-{}", Uuid::new_v4().simple());
         let workflow_execution_id = format!("workflow-{}", Uuid::new_v4().simple());
         let session_id = match &plan.session {
@@ -93,6 +119,15 @@ impl AsyncDaemonDb {
             hold_worker,
         };
         insert_preparation(&mut transaction, &intent_id, &preparation).await?;
+        if let Some(mut admission) = admission {
+            persist_admission_snapshot_in_tx(
+                &mut transaction,
+                &plan.board_item_id,
+                Some(&intent_id),
+                &mut admission,
+            )
+            .await?;
+        }
         transaction.commit().await.map_err(|error| {
             db_error(format!("commit task board dispatch reservation: {error}"))
         })?;
@@ -127,6 +162,34 @@ impl AsyncDaemonDb {
             })?;
             return Ok(None);
         };
+        let preparation = decode_preparation(&payload)?;
+        let (item, item_revision) = load_item_in_tx(&mut transaction, &preparation.board_item_id)
+            .await?
+            .ok_or_else(|| {
+                db_error(format!(
+                    "task-board item '{}' not found",
+                    preparation.board_item_id
+                ))
+            })?;
+        validate_reservable_item(&item, &preparation.plan)?;
+        if let TaskBoardAdmissionCheck::Blocked(admission) =
+            revalidate_dispatch_admission_in_tx(&mut transaction, intent_id, &item, item_revision)
+                .await?
+        {
+            fail_preparation_admission_in_tx(
+                &mut transaction,
+                intent_id,
+                &admission.refusal_message(),
+            )
+            .await?;
+            transaction.commit().await.map_err(|error| {
+                db_error(format!("commit refused task board preparation: {error}"))
+            })?;
+            return Err(crate::errors::CliErrorKind::invalid_transition(
+                admission.refusal_message(),
+            )
+            .into());
+        }
         let claim_token = format!("dispatch-prepare-{}", Uuid::new_v4().simple());
         query(
             "UPDATE task_board_dispatch_intents
@@ -147,7 +210,7 @@ impl AsyncDaemonDb {
         Ok(Some(ClaimedTaskBoardDispatchPreparation {
             intent_id: intent_id.to_string(),
             claim_token,
-            preparation: decode_preparation(&payload)?,
+            preparation,
         }))
     }
 
@@ -177,6 +240,9 @@ impl AsyncDaemonDb {
         &self,
         claim: &ClaimedTaskBoardDispatchPreparation,
     ) -> Result<(), CliError> {
+        let mut transaction = self
+            .begin_immediate_transaction("task board dispatch preparation renewal")
+            .await?;
         let changed = query(
             "UPDATE task_board_dispatch_intents
              SET claimed_at = ?3, updated_at = ?3
@@ -185,18 +251,21 @@ impl AsyncDaemonDb {
         .bind(&claim.intent_id)
         .bind(&claim.claim_token)
         .bind(utc_now())
-        .execute(self.pool())
+        .execute(transaction.as_mut())
         .await
         .map_err(|error| db_error(format!("renew task board preparation: {error}")))?
         .rows_affected();
-        if changed == 1 {
-            Ok(())
-        } else {
-            Err(db_error(format!(
+        if changed != 1 {
+            return Err(db_error(format!(
                 "task board preparation '{}' lost its claim",
                 claim.intent_id
-            )))
+            )));
         }
+        renew_dispatch_admission_in_tx(&mut transaction, &claim.intent_id).await?;
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(format!("commit task board preparation renewal: {error}")))
     }
 
     /// Atomically link a prepared session task and expose it for worker startup.
@@ -224,33 +293,7 @@ impl AsyncDaemonDb {
                 ))
             })?;
         validate_reservable_item(&item, &preparation.plan)?;
-        item.workflow.execution_id = Some(preparation.workflow_execution_id.clone());
-        item.workflow.branch = Some(branch.to_string());
-        item.workflow.worktree = Some(worktree.to_string());
-        item.workflow.status = TaskBoardWorkflowStatus::Running;
-        item.workflow.current_step_id = Some(
-            if preparation.hold_worker {
-                "awaiting_delivery"
-            } else {
-                "dispatch"
-            }
-            .to_string(),
-        );
-        item.workflow.attempts = item.workflow.attempts.saturating_add(1);
-        // Record the real recorded-decision id from evaluation so the workflow
-        // trace correlates with the decision feed. Fall back to a minted trace
-        // id only when the built-in fallback gate decided (no recorded id).
-        item.workflow.push_policy_trace_id(
-            preparation
-                .plan
-                .policy_decision_id
-                .clone()
-                .unwrap_or_else(|| format!("policy-trace-{}", Uuid::new_v4().simple())),
-        );
-        item.status = TaskBoardStatus::InProgress;
-        item.session_id = Some(preparation.session_id.clone());
-        item.work_item_id = Some(preparation.work_item_id.clone());
-        item.updated_at = utc_now();
+        apply_preparation_to_item(&mut item, preparation, branch, worktree);
         replace_item_in_tx(&mut transaction, &item, revision + 1).await?;
         // Immediate dispatch consumes its one-shot grant with publication.
         // Step-mode dispatch deliberately keeps the grant live while held;
@@ -335,143 +378,4 @@ impl AsyncDaemonDb {
             )))
         }
     }
-}
-
-async fn active_reservation(
-    transaction: &mut Transaction<'_, Sqlite>,
-    item_id: &str,
-) -> Result<Option<ReservedTaskBoardDispatch>, CliError> {
-    let row = query_as::<_, (String, String, String)>(
-        "SELECT intent_id, status, payload_json FROM task_board_dispatch_intents
-         WHERE item_id = ?1
-           AND status IN ('preparing', 'preparing_claimed', 'held', 'pending', 'starting')
-         ORDER BY created_at DESC LIMIT 1",
-    )
-    .bind(item_id)
-    .fetch_optional(transaction.as_mut())
-    .await
-    .map_err(|error| db_error(format!("load active task board reservation: {error}")))?;
-    row.map(|(intent_id, status, payload)| {
-        if matches!(status.as_str(), "preparing" | "preparing_claimed") {
-            Ok(ReservedTaskBoardDispatch::Preparing {
-                intent_id,
-                preparation: decode_preparation(&payload)?,
-            })
-        } else {
-            serde_json::from_str(&payload)
-                .map(ReservedTaskBoardDispatch::Applied)
-                .map_err(|error| db_error(format!("decode active task board dispatch: {error}")))
-        }
-    })
-    .transpose()
-}
-
-async fn insert_preparation(
-    transaction: &mut Transaction<'_, Sqlite>,
-    intent_id: &str,
-    preparation: &TaskBoardDispatchPreparation,
-) -> Result<(), CliError> {
-    let payload = serde_json::to_string(preparation)
-        .map_err(|error| db_error(format!("serialize task board preparation: {error}")))?;
-    let now = utc_now();
-    query(
-        "INSERT INTO task_board_dispatch_intents (
-            intent_id, item_id, session_id, work_item_id, workflow_execution_id, payload_json,
-            status, attempts, available_at, created_at, updated_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'preparing', 0, ?7, ?7, ?7)",
-    )
-    .bind(intent_id)
-    .bind(&preparation.board_item_id)
-    .bind(&preparation.session_id)
-    .bind(&preparation.work_item_id)
-    .bind(&preparation.workflow_execution_id)
-    .bind(payload)
-    .bind(now)
-    .execute(transaction.as_mut())
-    .await
-    .map_err(|error| db_error(format!("insert task board preparation: {error}")))?;
-    Ok(())
-}
-
-async fn release_expired_preparations(
-    transaction: &mut Transaction<'_, Sqlite>,
-) -> Result<(), CliError> {
-    query(
-        "UPDATE task_board_dispatch_intents
-         SET status = 'preparing', claim_token = NULL, claimed_at = NULL, updated_at = ?1
-         WHERE status = 'preparing_claimed'
-           AND datetime(claimed_at) <= datetime('now', ?2)",
-    )
-    .bind(utc_now())
-    .bind(format!("-{PREPARATION_LEASE_SECONDS} seconds"))
-    .execute(transaction.as_mut())
-    .await
-    .map_err(|error| db_error(format!("release expired task board preparations: {error}")))?;
-    Ok(())
-}
-
-async fn ensure_preparation_claim(
-    transaction: &mut Transaction<'_, Sqlite>,
-    claim: &ClaimedTaskBoardDispatchPreparation,
-) -> Result<(), CliError> {
-    let exists = query_as::<_, (i64,)>(
-        "SELECT COUNT(*) FROM task_board_dispatch_intents
-         WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'preparing_claimed'",
-    )
-    .bind(&claim.intent_id)
-    .bind(&claim.claim_token)
-    .fetch_one(transaction.as_mut())
-    .await
-    .map_err(|error| db_error(format!("verify task board preparation claim: {error}")))?
-    .0;
-    if exists == 1 {
-        Ok(())
-    } else {
-        Err(db_error(format!(
-            "task board preparation '{}' is not claimed",
-            claim.intent_id
-        )))
-    }
-}
-
-fn validate_reservable_item(item: &TaskBoardItem, plan: &DispatchPlan) -> Result<(), CliError> {
-    let body = item.body.trim();
-    let body = (!body.is_empty()).then_some(body);
-    let session_matches = match &plan.session {
-        SessionIntent::Existing { session_id } => item.session_id.as_deref() == Some(session_id),
-        SessionIntent::Create { .. } => item.session_id.is_none(),
-    };
-    let matches_plan = item.id == plan.board_item_id
-        && item.title == plan.task.title
-        && body == plan.task.context.as_deref()
-        && dispatch_severity(item.priority) == plan.task.severity
-        && item.planning.summary == plan.task.suggested_fix
-        && item.tags == plan.task.tags
-        && item.external_refs == plan.task.external_refs
-        && item.status == TaskBoardStatus::Todo
-        && session_matches
-        && item.work_item_id.is_none()
-        && !item.is_deleted();
-    if matches_plan {
-        Ok(())
-    } else {
-        Err(db_error(format!(
-            "task-board item '{}' changed before dispatch reservation",
-            plan.board_item_id
-        )))
-    }
-}
-
-const fn dispatch_severity(priority: TaskBoardPriority) -> TaskSeverity {
-    match priority {
-        TaskBoardPriority::Low => TaskSeverity::Low,
-        TaskBoardPriority::Medium => TaskSeverity::Medium,
-        TaskBoardPriority::High => TaskSeverity::High,
-        TaskBoardPriority::Critical => TaskSeverity::Critical,
-    }
-}
-
-fn decode_preparation(payload: &str) -> Result<TaskBoardDispatchPreparation, CliError> {
-    serde_json::from_str(payload)
-        .map_err(|error| db_error(format!("decode task board preparation: {error}")))
 }

--- a/src/daemon/db/task_board/dispatch_preparations_helpers.rs
+++ b/src/daemon/db/task_board/dispatch_preparations_helpers.rs
@@ -1,0 +1,210 @@
+use sqlx::{Sqlite, Transaction, query, query_as};
+use uuid::Uuid;
+
+use super::{
+    ClaimedTaskBoardDispatchPreparation, PREPARATION_LEASE_SECONDS, ReservedTaskBoardDispatch,
+    TaskBoardDispatchPreparation,
+};
+use crate::daemon::db::{CliError, db_error, utc_now};
+use crate::session::types::TaskSeverity;
+use crate::task_board::{
+    DispatchPlan, SessionIntent, TaskBoardItem, TaskBoardPriority, TaskBoardStatus,
+    TaskBoardWorkflowStatus,
+};
+
+pub(super) fn apply_preparation_to_item(
+    item: &mut TaskBoardItem,
+    preparation: &TaskBoardDispatchPreparation,
+    branch: &str,
+    worktree: &str,
+) {
+    item.workflow.execution_id = Some(preparation.workflow_execution_id.clone());
+    item.workflow.branch = Some(branch.to_string());
+    item.workflow.worktree = Some(worktree.to_string());
+    item.workflow.status = TaskBoardWorkflowStatus::Running;
+    item.workflow.current_step_id = Some(
+        if preparation.hold_worker {
+            "awaiting_delivery"
+        } else {
+            "dispatch"
+        }
+        .to_string(),
+    );
+    item.workflow.attempts = item.workflow.attempts.saturating_add(1);
+    // Record the real recorded-decision id from evaluation so the workflow
+    // trace correlates with the decision feed. Fall back to a minted trace id
+    // only when the built-in fallback gate decided (no recorded id).
+    item.workflow.push_policy_trace_id(
+        preparation
+            .plan
+            .policy_decision_id
+            .clone()
+            .unwrap_or_else(|| format!("policy-trace-{}", Uuid::new_v4().simple())),
+    );
+    item.status = TaskBoardStatus::InProgress;
+    item.session_id = Some(preparation.session_id.clone());
+    item.work_item_id = Some(preparation.work_item_id.clone());
+    item.updated_at = utc_now();
+}
+
+pub(super) async fn fail_preparation_admission_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    reason: &str,
+) -> Result<(), CliError> {
+    let now = utc_now();
+    query(
+        "UPDATE task_board_dispatch_intents
+         SET status = 'failed', last_error = ?2, completed_at = ?3, updated_at = ?3
+         WHERE intent_id = ?1 AND status IN ('preparing', 'preparing_claimed')",
+    )
+    .bind(intent_id)
+    .bind(reason)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("refuse task board preparation admission: {error}")))?;
+    Ok(())
+}
+
+pub(super) async fn active_reservation(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+) -> Result<Option<ReservedTaskBoardDispatch>, CliError> {
+    let row = query_as::<_, (String, String, String)>(
+        "SELECT intent_id, status, payload_json FROM task_board_dispatch_intents
+         WHERE item_id = ?1
+           AND status IN ('preparing', 'preparing_claimed', 'held', 'pending', 'starting')
+         ORDER BY created_at DESC LIMIT 1",
+    )
+    .bind(item_id)
+    .fetch_optional(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load active task board reservation: {error}")))?;
+    row.map(|(intent_id, status, payload)| {
+        if matches!(status.as_str(), "preparing" | "preparing_claimed") {
+            Ok(ReservedTaskBoardDispatch::Preparing {
+                intent_id,
+                preparation: decode_preparation(&payload)?,
+            })
+        } else {
+            serde_json::from_str(&payload)
+                .map(ReservedTaskBoardDispatch::Applied)
+                .map_err(|error| db_error(format!("decode active task board dispatch: {error}")))
+        }
+    })
+    .transpose()
+}
+
+pub(super) async fn insert_preparation(
+    transaction: &mut Transaction<'_, Sqlite>,
+    intent_id: &str,
+    preparation: &TaskBoardDispatchPreparation,
+) -> Result<(), CliError> {
+    let payload = serde_json::to_string(preparation)
+        .map_err(|error| db_error(format!("serialize task board preparation: {error}")))?;
+    let now = utc_now();
+    query(
+        "INSERT INTO task_board_dispatch_intents (
+            intent_id, item_id, session_id, work_item_id, workflow_execution_id, payload_json,
+            status, attempts, available_at, created_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'preparing', 0, ?7, ?7, ?7)",
+    )
+    .bind(intent_id)
+    .bind(&preparation.board_item_id)
+    .bind(&preparation.session_id)
+    .bind(&preparation.work_item_id)
+    .bind(&preparation.workflow_execution_id)
+    .bind(payload)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("insert task board preparation: {error}")))?;
+    Ok(())
+}
+
+pub(super) async fn release_expired_preparations(
+    transaction: &mut Transaction<'_, Sqlite>,
+) -> Result<(), CliError> {
+    query(
+        "UPDATE task_board_dispatch_intents
+         SET status = 'preparing', claim_token = NULL, claimed_at = NULL, updated_at = ?1
+         WHERE status = 'preparing_claimed'
+           AND datetime(claimed_at) <= datetime('now', ?2)",
+    )
+    .bind(utc_now())
+    .bind(format!("-{PREPARATION_LEASE_SECONDS} seconds"))
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("release expired task board preparations: {error}")))?;
+    Ok(())
+}
+
+pub(super) async fn ensure_preparation_claim(
+    transaction: &mut Transaction<'_, Sqlite>,
+    claim: &ClaimedTaskBoardDispatchPreparation,
+) -> Result<(), CliError> {
+    let exists = query_as::<_, (i64,)>(
+        "SELECT COUNT(*) FROM task_board_dispatch_intents
+         WHERE intent_id = ?1 AND claim_token = ?2 AND status = 'preparing_claimed'",
+    )
+    .bind(&claim.intent_id)
+    .bind(&claim.claim_token)
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("verify task board preparation claim: {error}")))?
+    .0;
+    if exists == 1 {
+        Ok(())
+    } else {
+        Err(db_error(format!(
+            "task board preparation '{}' is not claimed",
+            claim.intent_id
+        )))
+    }
+}
+
+pub(super) fn validate_reservable_item(
+    item: &TaskBoardItem,
+    plan: &DispatchPlan,
+) -> Result<(), CliError> {
+    let body = item.body.trim();
+    let body = (!body.is_empty()).then_some(body);
+    let session_matches = match &plan.session {
+        SessionIntent::Existing { session_id } => item.session_id.as_deref() == Some(session_id),
+        SessionIntent::Create { .. } => item.session_id.is_none(),
+    };
+    let matches_plan = item.id == plan.board_item_id
+        && item.title == plan.task.title
+        && body == plan.task.context.as_deref()
+        && dispatch_severity(item.priority) == plan.task.severity
+        && item.planning.summary == plan.task.suggested_fix
+        && item.tags == plan.task.tags
+        && item.external_refs == plan.task.external_refs
+        && item.status == TaskBoardStatus::Todo
+        && session_matches
+        && item.work_item_id.is_none()
+        && !item.is_deleted();
+    if matches_plan {
+        Ok(())
+    } else {
+        Err(db_error(format!(
+            "task-board item '{}' changed before dispatch reservation",
+            plan.board_item_id
+        )))
+    }
+}
+
+const fn dispatch_severity(priority: TaskBoardPriority) -> TaskSeverity {
+    match priority {
+        TaskBoardPriority::Low => TaskSeverity::Low,
+        TaskBoardPriority::Medium => TaskSeverity::Medium,
+        TaskBoardPriority::High => TaskSeverity::High,
+        TaskBoardPriority::Critical => TaskSeverity::Critical,
+    }
+}
+
+pub(super) fn decode_preparation(payload: &str) -> Result<TaskBoardDispatchPreparation, CliError> {
+    serde_json::from_str(payload)
+        .map_err(|error| db_error(format!("decode task board preparation: {error}")))
+}

--- a/src/daemon/db/task_board/held_dispatch.rs
+++ b/src/daemon/db/task_board/held_dispatch.rs
@@ -1,8 +1,12 @@
-use sqlx::{SqliteConnection, query, query_as};
+use sqlx::{Sqlite, SqliteConnection, Transaction, query, query_as};
 use uuid::Uuid;
 
 use super::ITEMS_CHANGE_SCOPE;
-use super::dispatch_intents::{ClaimedTaskBoardDispatch, decode_applied};
+use super::admission_lifecycle::{TaskBoardAdmissionCheck, revalidate_dispatch_admission_in_tx};
+use super::dispatch_intents::{
+    ClaimedTaskBoardDispatch, TaskBoardDispatchClaimAction, decode_applied,
+    ensure_dispatch_item_startable,
+};
 use super::items::{bump_change_in_tx, load_item_in_tx, replace_item_in_tx};
 use crate::daemon::db::policy::{
     consume_approval_grant_in_tx_at, live_approval_grant_in_tx_at, load_workspace_in_tx,
@@ -11,8 +15,9 @@ use crate::daemon::db::{AsyncDaemonDb, CliError, CliErrorKind, db_error, utc_now
 use crate::infra::io;
 use crate::task_board::policy_graph::PolicyCanvasWorkspace;
 use crate::task_board::{
-    DispatchAppliedTask, PolicyAction, SpawnGateSwitches, TaskBoardHeldDispatchItem,
-    TaskBoardHeldDispatchSummary, consumed_grant_id, dispatch_policy_from_graph,
+    DispatchAppliedTask, PolicyAction, PolicyDecision, SpawnGateSwitches,
+    TaskBoardHeldDispatchItem, TaskBoardHeldDispatchSummary, TaskBoardItem, consumed_grant_id,
+    dispatch_policy_from_graph,
 };
 
 #[derive(Debug)]
@@ -87,52 +92,39 @@ impl AsyncDaemonDb {
             .await?
             .ok_or_else(|| db_error(format!("task-board item '{board_item_id}' not found")))?;
         ensure_held_linkage(&applied, &item)?;
-        let now = utc_now();
-        let workspace = load_workspace_in_tx(&mut transaction).await?;
-        let switches = spawn_gate_switches(workspace.as_ref());
-        let live_policy = workspace
-            .as_ref()
-            .and_then(|workspace| workspace.active_live_canvas())
-            .map(|(canvas, graph)| (canvas.id.as_str(), graph));
-        let grant = match live_policy {
-            Some((_, graph)) => {
-                live_approval_grant_in_tx_at(
-                    transaction.as_mut(),
-                    board_item_id,
-                    PolicyAction::SpawnAgent,
-                    graph.revision,
-                    &now,
-                )
-                .await?
-            }
-            None => None,
-        };
-        let (decision, decision_id) = dispatch_policy_from_graph(
+        ensure_dispatch_item_startable(
             &item,
-            live_policy,
-            Some(now.clone()),
-            switches,
-            grant.as_ref(),
-        );
-        if !decision.is_allow() {
+            &applied.session_id,
+            &applied.work_item_id,
+            applied.item.workflow.execution_id.as_deref(),
+        )?;
+        if let TaskBoardAdmissionCheck::Blocked(admission) =
+            revalidate_dispatch_admission_in_tx(&mut transaction, &intent_id, &item, revision)
+                .await?
+        {
             transaction.commit().await.map_err(|error| {
-                db_error(format!("commit denied held task board delivery: {error}"))
+                db_error(format!("commit refused held task board admission: {error}"))
             })?;
-            return Err(CliErrorKind::invalid_transition(format!(
-                "current spawn policy refused held delivery: {decision:?}"
-            ))
-            .into());
+            return Err(CliErrorKind::invalid_transition(admission.refusal_message()).into());
         }
-        let consumed_approval_grant_id = consumed_grant_id(grant.as_ref(), &decision);
-        if let Some(grant_id) = consumed_approval_grant_id.as_deref() {
-            let consumed =
-                consume_approval_grant_in_tx_at(transaction.as_mut(), grant_id, &now).await?;
-            if !consumed {
-                return Err(db_error(format!(
-                    "approval grant expired or was consumed during delivery (grant '{grant_id}')"
-                )));
+        let now = utc_now();
+        let authorization =
+            authorize_held_delivery(&mut transaction, board_item_id, &item, &now).await?;
+        let (decision_id, consumed_approval_grant_id) = match authorization {
+            HeldDeliveryAuthorization::Allowed {
+                decision_id,
+                consumed_approval_grant_id,
+            } => (decision_id, consumed_approval_grant_id),
+            HeldDeliveryAuthorization::Refused(decision) => {
+                transaction.commit().await.map_err(|error| {
+                    db_error(format!("commit denied held task board delivery: {error}"))
+                })?;
+                return Err(CliErrorKind::invalid_transition(format!(
+                    "current spawn policy refused held delivery: {decision:?}"
+                ))
+                .into());
             }
-        }
+        };
         item.workflow.current_step_id = Some("dispatch".to_string());
         item.workflow.last_error = None;
         if let Some(decision_id) = decision_id {
@@ -169,8 +161,67 @@ impl AsyncDaemonDb {
             claim_token,
             applied,
             consumed_approval_grant_id,
+            action: TaskBoardDispatchClaimAction::Start,
         })
     }
+}
+
+enum HeldDeliveryAuthorization {
+    Allowed {
+        decision_id: Option<String>,
+        consumed_approval_grant_id: Option<String>,
+    },
+    Refused(PolicyDecision),
+}
+
+async fn authorize_held_delivery(
+    transaction: &mut Transaction<'_, Sqlite>,
+    board_item_id: &str,
+    item: &TaskBoardItem,
+    now: &str,
+) -> Result<HeldDeliveryAuthorization, CliError> {
+    let workspace = load_workspace_in_tx(transaction).await?;
+    let switches = spawn_gate_switches(workspace.as_ref());
+    let live_policy = workspace
+        .as_ref()
+        .and_then(|workspace| workspace.active_live_canvas())
+        .map(|(canvas, graph)| (canvas.id.as_str(), graph));
+    let grant = match live_policy {
+        Some((_, graph)) => {
+            live_approval_grant_in_tx_at(
+                transaction.as_mut(),
+                board_item_id,
+                PolicyAction::SpawnAgent,
+                graph.revision,
+                now,
+            )
+            .await?
+        }
+        None => None,
+    };
+    let (decision, decision_id) = dispatch_policy_from_graph(
+        item,
+        live_policy,
+        Some(now.to_string()),
+        switches,
+        grant.as_ref(),
+    );
+    if !decision.is_allow() {
+        return Ok(HeldDeliveryAuthorization::Refused(decision));
+    }
+    let consumed_approval_grant_id = consumed_grant_id(grant.as_ref(), &decision);
+    if let Some(grant_id) = consumed_approval_grant_id.as_deref() {
+        let consumed = consume_approval_grant_in_tx_at(transaction.as_mut(), grant_id, now).await?;
+        if !consumed {
+            return Err(db_error(format!(
+                "approval grant expired or was consumed during delivery (grant '{grant_id}')"
+            )));
+        }
+    }
+    Ok(HeldDeliveryAuthorization::Allowed {
+        decision_id,
+        consumed_approval_grant_id,
+    })
 }
 
 async fn load_held_delivery(

--- a/src/daemon/db/task_board/held_dispatch_tests.rs
+++ b/src/daemon/db/task_board/held_dispatch_tests.rs
@@ -81,6 +81,7 @@ async fn held_fixture() -> HeldFixture {
     let intent_id = match reserved {
         ReservedTaskBoardDispatch::Preparing { intent_id, .. } => intent_id,
         ReservedTaskBoardDispatch::Applied(_) => panic!("fresh item already applied"),
+        ReservedTaskBoardDispatch::Blocked(_) => panic!("default admission blocked reservation"),
     };
     let preparation = db
         .claim_task_board_dispatch_preparation(&intent_id)
@@ -172,7 +173,7 @@ async fn held_delivery_rechecks_kill_switch_then_advances_worker_state() {
     );
     let completed = fixture
         .db
-        .complete_task_board_dispatch(&claim.intent_id, &claim.claim_token)
+        .complete_task_board_dispatch(&claim.intent_id, &claim.claim_token, "codex-held-test")
         .await
         .expect("complete start");
     assert_eq!(completed.workflow.status, TaskBoardWorkflowStatus::Running);

--- a/src/daemon/db/task_board/imports.rs
+++ b/src/daemon/db/task_board/imports.rs
@@ -183,16 +183,21 @@ async fn insert_singletons(
     snapshot: &LegacyTaskBoardSnapshot,
     runtime_config: &TaskBoardGitRuntimeConfig,
 ) -> Result<(), CliError> {
-    query(
-        "INSERT INTO task_board_orchestrator_settings (
-        singleton, settings_json, revision, updated_at
-    ) VALUES (1, ?1, 1, ?2)",
+    let settings_update = query(
+        "UPDATE task_board_orchestrator_settings
+         SET settings_json = ?1, revision = 1, updated_at = ?2
+         WHERE singleton = 1",
     )
     .bind(to_json(&snapshot.settings, "orchestrator settings")?)
     .bind(utc_now())
     .execute(transaction.as_mut())
     .await
     .map_err(|error| db_error(format!("import orchestrator settings: {error}")))?;
+    if settings_update.rows_affected() != 1 {
+        return Err(db_error(
+            "import orchestrator settings: seeded singleton is missing",
+        ));
+    }
     query(
         "INSERT INTO task_board_orchestrator_state (
         singleton, state_json, enabled, running, revision, updated_at

--- a/src/daemon/db/task_board/item_estimate_tests.rs
+++ b/src/daemon/db/task_board/item_estimate_tests.rs
@@ -1,0 +1,101 @@
+use sqlx::query;
+use tempfile::{TempDir, tempdir};
+
+use crate::daemon::db::AsyncDaemonDb;
+use crate::task_board::TaskBoardItem;
+use crate::task_board::types::MAX_TASK_BOARD_ESTIMATE;
+
+#[tokio::test]
+async fn estimates_round_trip_at_both_storage_boundaries_and_clear() {
+    let (_dir, db) = connect().await;
+    let mut item = item("task-estimate-round-trip");
+    item.estimated_tokens = Some(1);
+    item.estimated_cost_microusd = Some(MAX_TASK_BOARD_ESTIMATE);
+
+    let created = db.create_task_board_item(item).await.expect("create item");
+    assert_eq!(created.item_revision, 1);
+    assert_eq!(created.item.estimated_tokens, Some(1));
+    assert_eq!(
+        created.item.estimated_cost_microusd,
+        Some(MAX_TASK_BOARD_ESTIMATE)
+    );
+
+    let updated = db
+        .update_task_board_item("task-estimate-round-trip", |current| {
+            current.estimated_tokens = None;
+            current.estimated_cost_microusd = Some(1);
+            Ok(true)
+        })
+        .await
+        .expect("update item")
+        .expect("mutation");
+    assert_eq!(updated.item_revision, 2);
+    assert_eq!(updated.item.estimated_tokens, None);
+    assert_eq!(updated.item.estimated_cost_microusd, Some(1));
+}
+
+#[tokio::test]
+async fn invalid_estimate_update_leaves_item_and_revision_unchanged() {
+    let (_dir, db) = connect().await;
+    db.create_task_board_item(item("task-estimate-invalid"))
+        .await
+        .expect("create item");
+
+    let error = db
+        .update_task_board_item("task-estimate-invalid", |current| {
+            current.estimated_tokens = Some(0);
+            Ok(true)
+        })
+        .await
+        .expect_err("zero estimate must fail");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+
+    let snapshot = db
+        .task_board_item_snapshot("task-estimate-invalid")
+        .await
+        .expect("unchanged snapshot");
+    assert_eq!(snapshot.item_revision, 1);
+    assert_eq!(snapshot.item.estimated_tokens, None);
+}
+
+#[tokio::test]
+async fn corrupt_negative_estimate_fails_closed_during_mapping() {
+    let (_dir, db) = connect().await;
+    db.create_task_board_item(item("task-estimate-corrupt"))
+        .await
+        .expect("create item");
+    let mut connection = db.pool().acquire().await.expect("acquire connection");
+    query("PRAGMA ignore_check_constraints = ON")
+        .execute(&mut *connection)
+        .await
+        .expect("disable checks for corruption fixture");
+    query("UPDATE task_board_items SET estimated_tokens = -1 WHERE item_id = ?1")
+        .bind("task-estimate-corrupt")
+        .execute(&mut *connection)
+        .await
+        .expect("inject corrupt estimate");
+    drop(connection);
+
+    let error = db
+        .task_board_item("task-estimate-corrupt")
+        .await
+        .expect_err("negative estimate must fail mapping");
+    assert_eq!(error.code(), "WORKFLOW_IO");
+}
+
+async fn connect() -> (TempDir, AsyncDaemonDb) {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("open db");
+    (dir, db)
+}
+
+fn item(id: &str) -> TaskBoardItem {
+    TaskBoardItem::new(
+        id.to_owned(),
+        "Bounded estimate".to_owned(),
+        "Body".to_owned(),
+        "2026-07-17T10:00:00Z".to_owned(),
+    )
+}

--- a/src/daemon/db/task_board/items.rs
+++ b/src/daemon/db/task_board/items.rs
@@ -3,6 +3,9 @@ use std::collections::BTreeMap;
 use sqlx::{Sqlite, Transaction, query, query_as, query_scalar};
 
 use super::ITEMS_CHANGE_SCOPE;
+use super::admission_lifecycle::{
+    ensure_item_admission_can_terminate_in_tx, release_item_admission_in_tx,
+};
 use super::mapper::{item_from_rows, label, to_json};
 use super::rows::{ExternalRefRow, ItemRow};
 use crate::daemon::db::{AsyncDaemonDb, CliError, db_error, utc_now};
@@ -10,6 +13,13 @@ use crate::errors::CliErrorKind;
 use crate::infra::io;
 use crate::task_board::types::{CURRENT_TASK_BOARD_ITEM_VERSION, MAX_TASK_BOARD_ESTIMATE};
 use crate::task_board::{TaskBoardItem, TaskBoardStatus};
+
+#[path = "items_lifecycle.rs"]
+mod lifecycle;
+use lifecycle::{
+    cancel_prestart_dispatch_for_terminal_item_in_tx, ensure_estimates_are_editable_in_tx,
+    task_board_item_is_terminal,
+};
 
 const SELECT_ITEM: &str = "SELECT * FROM task_board_items WHERE item_id = ?1";
 const SELECT_REFS: &str = "SELECT item_id, position, provider, external_id, url, sync_state_json
@@ -159,6 +169,8 @@ impl AsyncDaemonDb {
         let (mut item, revision) = load_item_in_tx(&mut transaction, item_id)
             .await?
             .ok_or_else(|| db_error(format!("task-board item '{item_id}' not found")))?;
+        let prior_estimates = (item.estimated_tokens, item.estimated_cost_microusd);
+        let prior_workflow_status = item.workflow.status;
         if !mutate(&mut item)? {
             transaction
                 .commit()
@@ -172,9 +184,18 @@ impl AsyncDaemonDb {
                 item.id
             )));
         }
+        if prior_estimates != (item.estimated_tokens, item.estimated_cost_microusd) {
+            ensure_estimates_are_editable_in_tx(&mut transaction, item_id, prior_workflow_status)
+                .await?;
+        }
         validate_item(&item)?;
         item.status = item.status.canonical_persisted_status();
         item.updated_at = utc_now();
+        if task_board_item_is_terminal(&item) {
+            ensure_item_admission_can_terminate_in_tx(&mut transaction, item_id).await?;
+            cancel_prestart_dispatch_for_terminal_item_in_tx(&mut transaction, item_id).await?;
+            release_item_admission_in_tx(&mut transaction, item_id).await?;
+        }
         replace_item_in_tx(&mut transaction, &item, revision + 1).await?;
         let change_revision = bump_change_in_tx(&mut transaction, ITEMS_CHANGE_SCOPE).await?;
         transaction

--- a/src/daemon/db/task_board/items.rs
+++ b/src/daemon/db/task_board/items.rs
@@ -8,7 +8,7 @@ use super::rows::{ExternalRefRow, ItemRow};
 use crate::daemon::db::{AsyncDaemonDb, CliError, db_error, utc_now};
 use crate::errors::CliErrorKind;
 use crate::infra::io;
-use crate::task_board::types::CURRENT_TASK_BOARD_ITEM_VERSION;
+use crate::task_board::types::{CURRENT_TASK_BOARD_ITEM_VERSION, MAX_TASK_BOARD_ESTIMATE};
 use crate::task_board::{TaskBoardItem, TaskBoardStatus};
 
 const SELECT_ITEM: &str = "SELECT * FROM task_board_items WHERE item_id = ?1";
@@ -231,10 +231,11 @@ pub(super) async fn insert_item_in_tx(
         "INSERT INTO task_board_items (
         item_id, schema_version, title, body, status, priority, tags_json, project_id,
         target_project_types_json, agent_mode, workflow_kind, execution_repository,
-        imported_from_provider, planning_json, workflow_json, session_id, work_item_id,
-        usage_json, created_at, updated_at, deleted_at, revision
+        estimated_tokens, estimated_cost_microusd, imported_from_provider, planning_json,
+        workflow_json, session_id, work_item_id, usage_json, created_at, updated_at,
+        deleted_at, revision
     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-        ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)",
+        ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)",
     )
     .bind(&item.id)
     .bind(i64::from(item.schema_version))
@@ -251,6 +252,14 @@ pub(super) async fn insert_item_in_tx(
     .bind(label(item.agent_mode, "task board agent mode")?)
     .bind(label(item.workflow_kind, "task board workflow kind")?)
     .bind(&item.execution_repository)
+    .bind(optional_u64_as_i64(
+        item.estimated_tokens,
+        "task board estimated tokens",
+    )?)
+    .bind(optional_u64_as_i64(
+        item.estimated_cost_microusd,
+        "task board estimated cost",
+    )?)
     .bind(
         item.imported_from_provider
             .map(|provider| label(provider, "task board imported provider"))
@@ -282,9 +291,10 @@ pub(super) async fn replace_item_in_tx(
         schema_version = ?2, title = ?3, body = ?4, status = ?5, priority = ?6,
         tags_json = ?7, project_id = ?8, target_project_types_json = ?9,
         agent_mode = ?10, workflow_kind = ?11, execution_repository = ?12,
-        imported_from_provider = ?13, planning_json = ?14, workflow_json = ?15,
-        session_id = ?16, work_item_id = ?17, usage_json = ?18, created_at = ?19,
-        updated_at = ?20, deleted_at = ?21, revision = ?22
+        estimated_tokens = ?13, estimated_cost_microusd = ?14,
+        imported_from_provider = ?15, planning_json = ?16, workflow_json = ?17,
+        session_id = ?18, work_item_id = ?19, usage_json = ?20, created_at = ?21,
+        updated_at = ?22, deleted_at = ?23, revision = ?24
         WHERE item_id = ?1",
     )
     .bind(&item.id)
@@ -302,6 +312,14 @@ pub(super) async fn replace_item_in_tx(
     .bind(label(item.agent_mode, "task board agent mode")?)
     .bind(label(item.workflow_kind, "task board workflow kind")?)
     .bind(&item.execution_repository)
+    .bind(optional_u64_as_i64(
+        item.estimated_tokens,
+        "task board estimated tokens",
+    )?)
+    .bind(optional_u64_as_i64(
+        item.estimated_cost_microusd,
+        "task board estimated cost",
+    )?)
     .bind(
         item.imported_from_provider
             .map(|provider| label(provider, "task board imported provider"))
@@ -393,7 +411,27 @@ fn validate_item(item: &TaskBoardItem) -> Result<(), CliError> {
         ))
         .into());
     }
+    if item
+        .estimated_tokens
+        .is_some_and(|value| !(1..=MAX_TASK_BOARD_ESTIMATE).contains(&value))
+    {
+        return Err(db_error("task-board estimated tokens are out of range"));
+    }
+    if item
+        .estimated_cost_microusd
+        .is_some_and(|value| !(1..=MAX_TASK_BOARD_ESTIMATE).contains(&value))
+    {
+        return Err(db_error("task-board estimated cost is out of range"));
+    }
     Ok(())
+}
+
+fn optional_u64_as_i64(value: Option<u64>, context: &str) -> Result<Option<i64>, CliError> {
+    value
+        .map(|value| {
+            i64::try_from(value).map_err(|error| db_error(format!("store {context}: {error}")))
+        })
+        .transpose()
 }
 
 fn sort_items(items: &mut [TaskBoardItem]) {

--- a/src/daemon/db/task_board/items.rs
+++ b/src/daemon/db/task_board/items.rs
@@ -170,7 +170,6 @@ impl AsyncDaemonDb {
             .await?
             .ok_or_else(|| db_error(format!("task-board item '{item_id}' not found")))?;
         let prior_estimates = (item.estimated_tokens, item.estimated_cost_microusd);
-        let prior_workflow_status = item.workflow.status;
         if !mutate(&mut item)? {
             transaction
                 .commit()
@@ -185,8 +184,7 @@ impl AsyncDaemonDb {
             )));
         }
         if prior_estimates != (item.estimated_tokens, item.estimated_cost_microusd) {
-            ensure_estimates_are_editable_in_tx(&mut transaction, item_id, prior_workflow_status)
-                .await?;
+            ensure_estimates_are_editable_in_tx(&mut transaction, item_id).await?;
         }
         validate_item(&item)?;
         item.status = item.status.canonical_persisted_status();

--- a/src/daemon/db/task_board/items_lifecycle.rs
+++ b/src/daemon/db/task_board/items_lifecycle.rs
@@ -8,23 +8,15 @@ use crate::task_board::{TaskBoardItem, TaskBoardStatus, TaskBoardWorkflowStatus}
 pub(super) async fn ensure_estimates_are_editable_in_tx(
     transaction: &mut Transaction<'_, Sqlite>,
     item_id: &str,
-    workflow_status: TaskBoardWorkflowStatus,
 ) -> Result<(), CliError> {
     let started = query_scalar::<_, bool>(
         "SELECT EXISTS(
              SELECT 1 FROM task_board_dispatch_intents
              WHERE item_id = ?1
-               AND (
-                   status = 'starting'
-                   OR (status = 'completed' AND ?2 = 1)
-               )
+               AND status IN ('starting', 'completed')
          )",
     )
     .bind(item_id)
-    .bind(i64::from(matches!(
-        workflow_status,
-        TaskBoardWorkflowStatus::Running
-    )))
     .fetch_one(transaction.as_mut())
     .await
     .map_err(|error| db_error(format!("check task board estimate freeze: {error}")))?;

--- a/src/daemon/db/task_board/items_lifecycle.rs
+++ b/src/daemon/db/task_board/items_lifecycle.rs
@@ -1,0 +1,100 @@
+use sqlx::{Sqlite, Transaction, query, query_as, query_scalar};
+
+use crate::daemon::db::policy::restore_consumed_approval_grant_in_tx_at;
+use crate::daemon::db::{CliError, db_error, utc_now};
+use crate::errors::CliErrorKind;
+use crate::task_board::{TaskBoardItem, TaskBoardStatus, TaskBoardWorkflowStatus};
+
+pub(super) async fn ensure_estimates_are_editable_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+    workflow_status: TaskBoardWorkflowStatus,
+) -> Result<(), CliError> {
+    let started = query_scalar::<_, bool>(
+        "SELECT EXISTS(
+             SELECT 1 FROM task_board_dispatch_intents
+             WHERE item_id = ?1
+               AND (
+                   status = 'starting'
+                   OR (status = 'completed' AND ?2 = 1)
+               )
+         )",
+    )
+    .bind(item_id)
+    .bind(i64::from(matches!(
+        workflow_status,
+        TaskBoardWorkflowStatus::Running
+    )))
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("check task board estimate freeze: {error}")))?;
+    if started {
+        return Err(CliErrorKind::invalid_transition(format!(
+            "task-board estimates for item '{item_id}' are frozen after worker start"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+pub(super) async fn cancel_prestart_dispatch_for_terminal_item_in_tx(
+    transaction: &mut Transaction<'_, Sqlite>,
+    item_id: &str,
+) -> Result<(), CliError> {
+    let claimed = query_scalar::<_, bool>(
+        "SELECT EXISTS(
+             SELECT 1 FROM task_board_dispatch_intents
+             WHERE item_id = ?1 AND status IN ('preparing_claimed', 'starting')
+         )",
+    )
+    .bind(item_id)
+    .fetch_one(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("check claimed task board dispatch: {error}")))?;
+    if claimed {
+        return Err(CliErrorKind::invalid_transition(format!(
+            "task-board item '{item_id}' cannot become terminal while its dispatch is claimed"
+        ))
+        .into());
+    }
+
+    let grants = query_as::<_, (Option<String>,)>(
+        "SELECT consumed_approval_grant_id
+         FROM task_board_dispatch_intents
+         WHERE item_id = ?1 AND status IN ('preparing', 'held', 'pending')",
+    )
+    .bind(item_id)
+    .fetch_all(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("load cancellable task board dispatch: {error}")))?;
+    let now = utc_now();
+    for (grant_id,) in grants {
+        if let Some(grant_id) = grant_id {
+            restore_consumed_approval_grant_in_tx_at(transaction.as_mut(), &grant_id, &now).await?;
+        }
+    }
+    query(
+        "UPDATE task_board_dispatch_intents
+         SET status = 'failed', claim_token = NULL, claimed_at = NULL,
+             last_error = 'item became terminal before worker start',
+             updated_at = ?2, completed_at = ?2
+         WHERE item_id = ?1 AND status IN ('preparing', 'held', 'pending')",
+    )
+    .bind(item_id)
+    .bind(now)
+    .execute(transaction.as_mut())
+    .await
+    .map_err(|error| db_error(format!("cancel pre-start task board dispatch: {error}")))?;
+    Ok(())
+}
+
+pub(super) fn task_board_item_is_terminal(item: &TaskBoardItem) -> bool {
+    item.is_deleted()
+        || matches!(item.status, TaskBoardStatus::Done | TaskBoardStatus::Failed)
+        || matches!(
+            item.workflow.status,
+            TaskBoardWorkflowStatus::Completed
+                | TaskBoardWorkflowStatus::Failed
+                | TaskBoardWorkflowStatus::Cancelled
+        )
+}

--- a/src/daemon/db/task_board/mapper.rs
+++ b/src/daemon/db/task_board/mapper.rs
@@ -30,6 +30,11 @@ pub(super) fn item_from_rows(
             agent_mode: parse_label(&row.agent_mode, "task board agent mode")?,
             workflow_kind: parse_label(&row.workflow_kind, "task board workflow kind")?,
             execution_repository: row.execution_repository,
+            estimated_tokens: optional_u64(row.estimated_tokens, "task board estimated tokens")?,
+            estimated_cost_microusd: optional_u64(
+                row.estimated_cost_microusd,
+                "task board estimated cost",
+            )?,
             external_refs: external_refs
                 .into_iter()
                 .map(external_ref_from_row)
@@ -95,4 +100,12 @@ pub(super) fn label<T: Serialize>(value: T, context: &str) -> Result<String, Cli
 fn parse_label<T: DeserializeOwned>(value: &str, context: &str) -> Result<T, CliError> {
     serde_json::from_value(Value::String(value.to_owned()))
         .map_err(|error| db_error(format!("parse {context}: {error}")))
+}
+
+fn optional_u64(value: Option<i64>, context: &str) -> Result<Option<u64>, CliError> {
+    value
+        .map(|value| {
+            u64::try_from(value).map_err(|error| db_error(format!("parse {context}: {error}")))
+        })
+        .transpose()
 }

--- a/src/daemon/db/task_board/mod.rs
+++ b/src/daemon/db/task_board/mod.rs
@@ -21,6 +21,8 @@ mod rows;
 mod scheduler;
 
 #[cfg(test)]
+mod item_estimate_tests;
+#[cfg(test)]
 mod provider_external_create_finalize_tests;
 #[cfg(test)]
 mod provider_external_create_follow_up_tests;

--- a/src/daemon/db/task_board/mod.rs
+++ b/src/daemon/db/task_board/mod.rs
@@ -1,5 +1,10 @@
 //! Canonical `SQLite` persistence for Task Board domain state.
 
+mod admission;
+mod admission_lifecycle;
+mod admission_recovery;
+mod admission_reservations;
+pub(super) use admission_lifecycle::release_managed_worker_admission_in_tx;
 mod aggregates;
 mod dispatch_intents;
 mod dispatch_preparations;
@@ -47,7 +52,10 @@ mod provider_sync_renewal_tests;
 #[cfg(test)]
 mod provider_sync_tests;
 
-pub(crate) use dispatch_intents::ClaimedTaskBoardDispatch;
+pub(crate) use admission_recovery::{
+    TaskBoardAdmissionMissingRunRecovery, TaskBoardAdmissionWorkerRecovery,
+};
+pub(crate) use dispatch_intents::{ClaimedTaskBoardDispatch, TaskBoardDispatchClaimAction};
 pub(crate) use dispatch_preparations::{
     ClaimedTaskBoardDispatchPreparation, ReservedTaskBoardDispatch,
 };

--- a/src/daemon/db/task_board/rows.rs
+++ b/src/daemon/db/task_board/rows.rs
@@ -14,6 +14,8 @@ pub(super) struct ItemRow {
     pub(super) agent_mode: String,
     pub(super) workflow_kind: String,
     pub(super) execution_repository: Option<String>,
+    pub(super) estimated_tokens: Option<i64>,
+    pub(super) estimated_cost_microusd: Option<i64>,
     pub(super) imported_from_provider: Option<String>,
     pub(super) planning_json: String,
     pub(super) workflow_json: String,

--- a/src/daemon/db/task_board/scheduler/control.rs
+++ b/src/daemon/db/task_board/scheduler/control.rs
@@ -171,10 +171,8 @@ impl AsyncDaemonDb {
         if changed == 1 {
             bump_change_in_tx(&mut transaction, ORCHESTRATOR_CHANGE_SCOPE).await?;
             if desired_mode == TaskBoardAutomationDesiredMode::Continuous {
-                let revision = u64::try_from(revision).map_err(|error| {
-                    db_error(format!(
-                        "convert task board settings change revision: {error}"
-                    ))
+                let revision = u64::try_from(revision.row_revision).map_err(|error| {
+                    db_error(format!("convert task board settings row revision: {error}"))
                 })?;
                 super::wake::enqueue_in_tx(
                     &mut transaction,
@@ -195,7 +193,7 @@ impl AsyncDaemonDb {
                 "commit task board automation settings update: {error}"
             ))
         })?;
-        Ok(revision)
+        Ok(revision.row_revision)
     }
 
     pub(crate) async fn stop_task_board_automation(

--- a/src/daemon/db/task_board/scheduler/status_atomicity_tests.rs
+++ b/src/daemon/db/task_board/scheduler/status_atomicity_tests.rs
@@ -182,9 +182,9 @@ async fn ready_database() -> AsyncDaemonDb {
         serde_json::to_string(&crate::task_board::TaskBoardOrchestratorSettings::default())
             .expect("serialize settings");
     query(
-        "INSERT INTO task_board_orchestrator_settings
-            (singleton, settings_json, revision, updated_at)
-         VALUES (1, ?1, 1, ?2)",
+        "UPDATE task_board_orchestrator_settings
+         SET settings_json = ?1, revision = 1, updated_at = ?2
+         WHERE singleton = 1",
     )
     .bind(settings)
     .bind(timestamp(Utc::now()))

--- a/src/daemon/db/tests/async_pool.rs
+++ b/src/daemon/db/tests/async_pool.rs
@@ -26,7 +26,7 @@ async fn connect_reads_current_schema_version() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=32).collect::<Vec<i64>>()
+        (1..=33).collect::<Vec<i64>>()
     );
 }
 
@@ -51,7 +51,7 @@ async fn connect_bootstraps_empty_database_with_sqlx_migrations() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=32).collect::<Vec<i64>>()
+        (1..=33).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -143,7 +143,7 @@ async fn connect_migrates_legacy_schema_before_opening_pool() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=32).collect::<Vec<i64>>()
+        (1..=33).collect::<Vec<i64>>()
     );
 }
 
@@ -187,7 +187,7 @@ async fn connect_preserves_existing_db_when_baseline_checksum_drifted() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=32).collect::<Vec<i64>>()
+        (1..=33).collect::<Vec<i64>>()
     );
 }
 
@@ -246,7 +246,7 @@ async fn connect_accepts_v22_db_with_recorded_policy_snapshot_migration() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=32).collect::<Vec<i64>>()
+        (1..=33).collect::<Vec<i64>>()
     );
     let policy_workspace_columns =
         query_scalar::<_, String>("SELECT name FROM pragma_table_info('policy_workspace')")
@@ -279,7 +279,7 @@ async fn connect_seeds_v18_sqlx_ledger_when_sync_schema_already_applied() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=32).collect::<Vec<i64>>()
+        (1..=33).collect::<Vec<i64>>()
     );
 }
 
@@ -369,7 +369,7 @@ async fn connect_repairs_v8_active_sessions_without_leader_before_opening_pool()
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=32).collect::<Vec<i64>>()
+        (1..=33).collect::<Vec<i64>>()
     );
     drop(async_db);
 

--- a/src/daemon/db/tests/async_pool_migrations.rs
+++ b/src/daemon/db/tests/async_pool_migrations.rs
@@ -183,7 +183,7 @@ fn shipped_daemon_async_migration_checksums_remain_stable() {
         ),
         (
             "0033_daemon_v39_task_board_policy_admission.sql",
-            "AB6A259007355E6F6E1FCE4356345D0778F043AE3648F91005A0931E168646B6CBA088C765BD677B36875E655B71489F",
+            "91742D2F0BCDF2830FB7720DFE53675C83DAD8B9575B653E0A558A31C6C3C11A60A687CE621E20B069040ACDD351294D",
         ),
     ];
     let migrations_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/daemon/db/migrations");

--- a/src/daemon/db/tests/async_pool_migrations.rs
+++ b/src/daemon/db/tests/async_pool_migrations.rs
@@ -74,7 +74,7 @@ async fn connect_upgrades_applied_original_v34_migration() {
     );
     assert_eq!(
         applied_migration_versions(&async_db).await,
-        (1..=32).collect::<Vec<i64>>()
+        (1..=33).collect::<Vec<i64>>()
     );
     let requires_live = query_scalar::<_, bool>(
         "SELECT spawn_requires_live_policy FROM policy_workspace WHERE singleton = 1",
@@ -180,6 +180,10 @@ fn shipped_daemon_async_migration_checksums_remain_stable() {
         (
             "0032_daemon_v38_task_board_external_create_intents.sql",
             "C7D2FB56584DD8D1DE324D944A13B1B5F73F1DE76A78A36E12F9C2CB4485E6B437AA03C5214D8B1DF13743276318FB3E",
+        ),
+        (
+            "0033_daemon_v39_task_board_policy_admission.sql",
+            "AB6A259007355E6F6E1FCE4356345D0778F043AE3648F91005A0931E168646B6CBA088C765BD677B36875E655B71489F",
         ),
     ];
     let migrations_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/daemon/db/migrations");

--- a/src/daemon/db/tests/mod.rs
+++ b/src/daemon/db/tests/mod.rs
@@ -32,6 +32,7 @@ mod schema;
 mod schema_backfill;
 mod schema_migrations;
 mod schema_shape_repairs;
+mod schema_shape_repairs_admission;
 mod schema_shape_repairs_wake_events;
 mod signals;
 mod sync;

--- a/src/daemon/db/tests/schema.rs
+++ b/src/daemon/db/tests/schema.rs
@@ -139,6 +139,8 @@ fn all_tables_exist() {
         "task_checkpoints",
         "tasks",
         "task_board_dispatch_intents",
+        "task_board_dispatch_admission_decisions",
+        "task_board_dispatch_admission_ledger",
         "task_board_admission_leases",
         "task_board_execution_attempts",
         "task_board_execution_hosts",

--- a/src/daemon/db/tests/schema_shape_repairs_admission.rs
+++ b/src/daemon/db/tests/schema_shape_repairs_admission.rs
@@ -1,0 +1,66 @@
+use tempfile::tempdir;
+
+use super::*;
+
+#[tokio::test]
+async fn async_connect_repairs_missing_orchestrator_settings_singleton() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    let deleted = sync_db
+        .connection()
+        .execute(
+            "DELETE FROM task_board_orchestrator_settings WHERE singleton = 1",
+            [],
+        )
+        .expect("delete orchestrator settings singleton");
+    assert_eq!(deleted, 1);
+    drop(sync_db);
+
+    let async_db = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect("repair orchestrator settings singleton");
+    let (settings_json, revision): (String, i64) = sqlx::query_as(
+        "SELECT settings_json, revision
+         FROM task_board_orchestrator_settings WHERE singleton = 1",
+    )
+    .fetch_one(async_db.pool())
+    .await
+    .expect("read repaired orchestrator settings");
+
+    assert_eq!(
+        settings_json,
+        r#"{"admission_policy":{"limits":[],"windows":[]}}"#
+    );
+    assert_eq!(revision, 1);
+    assert_eq!(
+        async_db.schema_version().await.expect("schema version"),
+        SCHEMA_VERSION
+    );
+}
+
+#[tokio::test]
+async fn async_connect_repairs_missing_dispatch_compensation_marker() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("harness.db");
+    let sync_db = DaemonDb::open(&db_path).expect("open sync daemon db");
+    sync_db
+        .connection()
+        .execute_batch("ALTER TABLE task_board_dispatch_intents DROP COLUMN compensation_pending")
+        .expect("remove compensation marker");
+    drop(sync_db);
+
+    let async_db = AsyncDaemonDb::connect(&db_path)
+        .await
+        .expect("repair dispatch compensation marker");
+    let column: (String, i64, Option<String>) = sqlx::query_as(
+        "SELECT type, \"notnull\", dflt_value
+         FROM pragma_table_xinfo('task_board_dispatch_intents')
+         WHERE name = 'compensation_pending'",
+    )
+    .fetch_one(async_db.pool())
+    .await
+    .expect("read repaired compensation marker");
+
+    assert_eq!(column, ("INTEGER".to_string(), 1, Some("0".to_string())));
+}

--- a/src/daemon/db/tests/task_board.rs
+++ b/src/daemon/db/tests/task_board.rs
@@ -14,8 +14,14 @@ use crate::task_board::{
     TaskBoardOrchestratorSettings, TaskBoardOrchestratorState, TaskBoardStatus,
 };
 
+mod admission_compensation;
+mod admission_dispatch;
+mod admission_evidence;
+mod admission_lifecycle_tests;
 mod dispatch;
+mod dispatch_claims;
 mod imports;
+mod terminal_dispatch_lifecycle;
 
 #[tokio::test]
 async fn task_board_instance_identity_is_stable_per_database() {

--- a/src/daemon/db/tests/task_board.rs
+++ b/src/daemon/db/tests/task_board.rs
@@ -203,6 +203,13 @@ async fn task_board_singletons_and_machine_registry_round_trip() {
     db.replace_task_board_orchestrator_settings(&settings)
         .await
         .expect("save settings");
+    let settings_snapshot = db
+        .task_board_orchestrator_settings_snapshot()
+        .await
+        .expect("load settings snapshot");
+    assert_eq!(settings_snapshot.settings, settings);
+    assert_eq!(settings_snapshot.row_revision, 2);
+    assert!(settings_snapshot.change_revision > 0);
     assert_eq!(
         db.task_board_orchestrator_settings()
             .await

--- a/src/daemon/db/tests/task_board/admission_compensation.rs
+++ b/src/daemon/db/tests/task_board/admission_compensation.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use crate::task_board::{
+    AgentMode, SpawnGateSwitches, TaskBoardItem, build_dispatch_plans_with_policy,
+};
+
+use super::admission_dispatch::{
+    admission_policy, configure_policy, ledger_kind_state, preparing_intent, test_db,
+};
+
+#[tokio::test]
+async fn missing_worker_compensation_commits_usage_and_releases_concurrency() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let mut item = TaskBoardItem::new(
+        "admission-compensated-start".to_string(),
+        "Compensated admission".to_string(),
+        "Body".to_string(),
+        "2026-07-17T10:00:00Z".to_string(),
+    );
+    item.agent_mode = AgentMode::Headless;
+    db.create_task_board_item(item).await.expect("create item");
+    let item = db
+        .task_board_item("admission-compensated-start")
+        .await
+        .expect("load item");
+    let plan = build_dispatch_plans_with_policy(
+        &[item],
+        None,
+        None,
+        SpawnGateSwitches::default(),
+        &HashMap::new(),
+    )
+    .remove(0);
+    let intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve dispatch"),
+    );
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete preparation");
+    let claim = db
+        .claim_task_board_dispatch("admission-compensated-start")
+        .await
+        .expect("claim dispatch")
+        .expect("pending dispatch");
+    let worker_id = "codex-admission-compensated-start";
+    db.begin_task_board_dispatch_compensation(
+        &intent,
+        &claim.claim_token,
+        worker_id,
+        "dispatch completion failed",
+    )
+    .await
+    .expect("persist compensation marker");
+
+    db.finalize_task_board_dispatch_compensation(
+        &intent,
+        &claim.claim_token,
+        claim.consumed_approval_grant_id.as_deref(),
+        worker_id,
+        "dispatch completion failed",
+    )
+    .await
+    .expect("finalize stopped worker compensation");
+
+    assert_eq!(
+        ledger_kind_state(&db, &intent, "concurrency").await,
+        "released"
+    );
+    assert_eq!(ledger_kind_state(&db, &intent, "rate").await, "committed");
+}

--- a/src/daemon/db/tests/task_board/admission_dispatch.rs
+++ b/src/daemon/db/tests/task_board/admission_dispatch.rs
@@ -1,0 +1,518 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::{Arc, OnceLock};
+
+use tempfile::{TempDir, tempdir};
+use tokio::sync::broadcast;
+
+use crate::daemon::codex_controller::CodexControllerHandle;
+use crate::daemon::db::{AsyncDaemonDb, DaemonDb, ReservedTaskBoardDispatch};
+use crate::daemon::protocol::{CodexRunStatus, StreamEvent};
+use crate::task_board::{
+    AgentMode, DispatchPlan, SpawnGateSwitches, TaskBoardAdmissionDecision,
+    TaskBoardAutomationPolicy, TaskBoardItem, TaskBoardLaunchCapability, TaskBoardPolicyLimit,
+    TaskBoardPolicyScope, build_dispatch_plans_with_policy,
+};
+
+#[tokio::test]
+async fn admission_reservation_is_all_or_none_and_idempotent() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let first = create_plan(&db, "admission-first", AgentMode::Headless).await;
+    let second = create_plan(&db, "admission-second", AgentMode::Headless).await;
+
+    let first = db
+        .reserve_task_board_dispatch(&first, "control-plane", Some("/tmp/project"), false)
+        .await
+        .expect("reserve first dispatch");
+    let first_intent = preparing_intent(first);
+    let repeated = db
+        .reserve_task_board_dispatch(
+            &create_plan_for_existing(&db, "admission-first").await,
+            "control-plane",
+            Some("/tmp/project"),
+            false,
+        )
+        .await
+        .expect("repeat first dispatch");
+    assert_eq!(preparing_intent(repeated), first_intent);
+    assert_eq!(ledger_count(&db, "admission-first").await, 2);
+
+    let blocked = db
+        .reserve_task_board_dispatch(&second, "control-plane", Some("/tmp/project"), false)
+        .await
+        .expect("evaluate second dispatch");
+    let ReservedTaskBoardDispatch::Blocked(snapshot) = blocked else {
+        panic!("second dispatch exceeded concurrency but was not blocked");
+    };
+    assert_eq!(snapshot.decision, TaskBoardAdmissionDecision::Deferred);
+    assert_eq!(ledger_count(&db, "admission-second").await, 0);
+    assert_eq!(active_intent_count(&db, "admission-second").await, 0);
+}
+
+#[tokio::test]
+async fn preparation_renewal_rejects_a_partial_admission_ledger() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let plan = create_plan(&db, "admission-partial-renewal", AgentMode::Headless).await;
+    let intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve dispatch"),
+    );
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    sqlx::query(
+        "DELETE FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND kind = 'rate' AND state = 'reserved'",
+    )
+    .bind(&intent)
+    .execute(db.pool())
+    .await
+    .expect("remove one reserved requirement");
+
+    let error = db
+        .renew_task_board_dispatch_preparation(&preparation)
+        .await
+        .expect_err("partial admission ledger must not renew");
+
+    assert!(
+        error
+            .to_string()
+            .contains("found 1 valid reserved ledger rows, expected 2")
+    );
+}
+
+#[tokio::test]
+async fn admission_revalidates_then_commits_and_releases_concurrency() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let plan = create_plan(&db, "admission-start", AgentMode::Headless).await;
+    let intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve dispatch"),
+    );
+
+    configure_policy(&db, admission_policy(2)).await;
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    assert_eq!(current_generation(&db, &intent).await, 2);
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete preparation");
+    let claim = db
+        .claim_task_board_dispatch("admission-start")
+        .await
+        .expect("claim dispatch")
+        .expect("pending dispatch");
+    assert_eq!(current_generation(&db, &intent).await, 3);
+    let error = db
+        .update_task_board_item("admission-start", |item| {
+            item.estimated_tokens = Some(10);
+            Ok(true)
+        })
+        .await
+        .expect_err("worker claim must freeze estimate edits");
+    assert!(error.to_string().contains("frozen after worker start"));
+    assert_eq!(
+        db.task_board_item("admission-start")
+            .await
+            .expect("reload frozen item")
+            .estimated_tokens,
+        None
+    );
+    db.validate_task_board_dispatch_admission_start(
+        &intent,
+        &claim.claim_token,
+        Some(TaskBoardLaunchCapability::WorkspaceWrite),
+    )
+    .await
+    .expect("validate launch");
+    db.complete_task_board_dispatch(&intent, &claim.claim_token, "codex-admission-start")
+        .await
+        .expect("commit launch");
+    assert_eq!(ledger_state_count(&db, &intent, "committed").await, 2);
+    let error = db
+        .update_task_board_item("admission-start", |item| {
+            item.status = crate::task_board::TaskBoardStatus::Done;
+            Ok(true)
+        })
+        .await
+        .expect_err("active worker must prevent terminal item mutation");
+    assert!(error.to_string().contains("managed worker is active"));
+
+    assert!(
+        db.release_task_board_admission_for_managed_worker("codex-admission-start")
+            .await
+            .expect("release terminal worker")
+    );
+    assert_eq!(
+        ledger_kind_state(&db, &intent, "concurrency").await,
+        "released"
+    );
+    assert_eq!(ledger_kind_state(&db, &intent, "rate").await, "committed");
+    db.update_task_board_item("admission-start", |item| {
+        item.status = crate::task_board::TaskBoardStatus::Done;
+        Ok(true)
+    })
+    .await
+    .expect("terminal item update after worker release");
+}
+
+#[tokio::test]
+async fn configured_admission_rejects_unenforceable_interactive_launch() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let plan = create_plan(&db, "admission-interactive", AgentMode::Interactive).await;
+
+    let outcome = db
+        .reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+        .await
+        .expect("evaluate interactive dispatch");
+    let ReservedTaskBoardDispatch::Blocked(snapshot) = outcome else {
+        panic!("configured interactive dispatch was not rejected");
+    };
+    assert_eq!(snapshot.decision, TaskBoardAdmissionDecision::Rejected);
+    assert_eq!(active_intent_count(&db, "admission-interactive").await, 0);
+}
+
+#[tokio::test]
+async fn default_empty_admission_rejects_unenforceable_interactive_launch() {
+    let db = test_db().await;
+    let plan = create_plan(&db, "admission-interactive-empty", AgentMode::Interactive).await;
+
+    let outcome = db
+        .reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+        .await
+        .expect("evaluate interactive dispatch");
+    let ReservedTaskBoardDispatch::Blocked(snapshot) = outcome else {
+        panic!("default-empty policy allowed an unenforceable interactive dispatch");
+    };
+    assert_eq!(snapshot.decision, TaskBoardAdmissionDecision::Rejected);
+    assert_eq!(
+        active_intent_count(&db, "admission-interactive-empty").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn terminal_item_cancels_unclaimed_dispatch_but_rejects_a_claimed_one() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let plan = create_plan(&db, "admission-terminal", AgentMode::Headless).await;
+    let first_intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve first dispatch"),
+    );
+
+    db.update_task_board_item("admission-terminal", |item| {
+        item.status = crate::task_board::TaskBoardStatus::Done;
+        Ok(true)
+    })
+    .await
+    .expect("terminal mutation cancels an unclaimed dispatch");
+    assert_eq!(active_intent_count(&db, "admission-terminal").await, 0);
+
+    db.update_task_board_item("admission-terminal", |item| {
+        item.status = crate::task_board::TaskBoardStatus::Todo;
+        Ok(true)
+    })
+    .await
+    .expect("reopen item");
+    let second_intent = preparing_intent(
+        db.reserve_task_board_dispatch(
+            &create_plan_for_existing(&db, "admission-terminal").await,
+            "control-plane",
+            Some("/tmp/project"),
+            false,
+        )
+        .await
+        .expect("reserve fresh dispatch"),
+    );
+    assert_ne!(first_intent, second_intent);
+    db.claim_task_board_dispatch_preparation(&second_intent)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+
+    let error = db
+        .delete_task_board_item("admission-terminal")
+        .await
+        .expect_err("claimed preparation must fence deletion");
+    assert!(error.to_string().contains("dispatch is claimed"));
+    assert_eq!(active_intent_count(&db, "admission-terminal").await, 1);
+}
+
+#[tokio::test]
+async fn terminal_run_before_dispatch_commit_releases_only_concurrency() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let plan = create_plan(&db, "admission-fast-terminal", AgentMode::Headless).await;
+    let intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve dispatch"),
+    );
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete preparation");
+    let claim = db
+        .claim_task_board_dispatch("admission-fast-terminal")
+        .await
+        .expect("claim dispatch")
+        .expect("pending dispatch");
+    let worker_id = "codex-admission-fast-terminal";
+    let mut run = super::super::sample_codex_run(worker_id, "2026-07-17T10:00:00Z");
+    run.status = CodexRunStatus::Completed;
+    db.save_codex_run(&run).await.expect("save terminal run");
+
+    db.complete_task_board_dispatch(&intent, &claim.claim_token, worker_id)
+        .await
+        .expect("commit terminal launch evidence");
+
+    assert_eq!(
+        ledger_kind_state(&db, &intent, "concurrency").await,
+        "released"
+    );
+    assert_eq!(ledger_kind_state(&db, &intent, "rate").await, "committed");
+}
+
+#[tokio::test]
+async fn startup_reconciliation_releases_orphaned_codex_concurrency() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let plan = create_plan(&db, "admission-restart", AgentMode::Headless).await;
+    let intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve dispatch"),
+    );
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete preparation");
+    let claim = db
+        .claim_task_board_dispatch("admission-restart")
+        .await
+        .expect("claim dispatch")
+        .expect("pending dispatch");
+    let worker_id = format!("codex-{intent}");
+    let run = super::super::sample_codex_run(&worker_id, "2026-07-17T10:00:00Z");
+    db.save_codex_run(&run).await.expect("save active run");
+    db.complete_task_board_dispatch(&intent, &claim.claim_token, &worker_id)
+        .await
+        .expect("commit worker admission");
+    let before_recovery = db
+        .current_change_sequence()
+        .await
+        .expect("load change sequence");
+
+    let reopened = Arc::new(
+        AsyncDaemonDb::connect(&db._directory.path().join("harness.db"))
+            .await
+            .expect("reopen async db"),
+    );
+    let (sender, _) = broadcast::channel::<StreamEvent>(8);
+    let async_db_slot = Arc::new(OnceLock::new());
+    async_db_slot
+        .set(reopened.clone())
+        .expect("install reopened async db");
+    let controller = CodexControllerHandle::new_with_async_db(
+        sender,
+        Arc::new(OnceLock::new()),
+        async_db_slot,
+        false,
+    );
+    controller
+        .reconcile_task_board_admission_workers_after_restart()
+        .await
+        .expect("reconcile orphaned worker admission");
+
+    let reconciled = reopened
+        .codex_run(&worker_id)
+        .await
+        .expect("load reconciled run")
+        .expect("persisted run");
+    assert_eq!(reconciled.status, CodexRunStatus::Failed);
+    assert_eq!(
+        ledger_kind_state(&reopened, &intent, "concurrency").await,
+        "released"
+    );
+    assert_eq!(
+        ledger_kind_state(&reopened, &intent, "rate").await,
+        "committed"
+    );
+    assert!(
+        reopened
+            .current_change_sequence()
+            .await
+            .expect("load recovered change sequence")
+            > before_recovery
+    );
+}
+
+pub(super) struct TestDb {
+    db: AsyncDaemonDb,
+    _directory: TempDir,
+}
+
+impl Deref for TestDb {
+    type Target = AsyncDaemonDb;
+
+    fn deref(&self) -> &Self::Target {
+        &self.db
+    }
+}
+
+pub(super) async fn test_db() -> TestDb {
+    let directory = tempdir().expect("tempdir");
+    let path = directory.path().join("harness.db");
+    let sync_db = DaemonDb::open(&path).expect("open sync db");
+    let project = super::super::sample_project();
+    sync_db.sync_project(&project).expect("sync project");
+    let session = super::super::sample_session_state();
+    sync_db
+        .sync_session(&project.project_id, &session)
+        .expect("sync session");
+    drop(sync_db);
+    let db = AsyncDaemonDb::connect(&path).await.expect("open db");
+    TestDb {
+        db,
+        _directory: directory,
+    }
+}
+
+pub(super) fn admission_policy(concurrency_limit: u64) -> TaskBoardAutomationPolicy {
+    TaskBoardAutomationPolicy {
+        limits: vec![
+            TaskBoardPolicyLimit::Concurrency {
+                scope: TaskBoardPolicyScope::Global,
+                limit: concurrency_limit,
+                reservation: 1,
+            },
+            TaskBoardPolicyLimit::Rate {
+                scope: TaskBoardPolicyScope::Global,
+                limit: 100,
+                window_seconds: 3_600,
+                reservation: 1,
+            },
+        ],
+        windows: Vec::new(),
+    }
+}
+
+pub(super) async fn configure_policy(db: &AsyncDaemonDb, policy: TaskBoardAutomationPolicy) {
+    let mut settings = db
+        .task_board_orchestrator_settings()
+        .await
+        .expect("load settings");
+    settings.admission_policy = policy;
+    db.replace_task_board_orchestrator_settings(&settings)
+        .await
+        .expect("save settings");
+}
+
+async fn create_plan(db: &AsyncDaemonDb, item_id: &str, mode: AgentMode) -> DispatchPlan {
+    let mut item = TaskBoardItem::new(
+        item_id.to_string(),
+        "Admission dispatch".to_string(),
+        "Body".to_string(),
+        "2026-07-17T10:00:00Z".to_string(),
+    );
+    item.agent_mode = mode;
+    db.create_task_board_item(item).await.expect("create item");
+    create_plan_for_existing(db, item_id).await
+}
+
+async fn create_plan_for_existing(db: &AsyncDaemonDb, item_id: &str) -> DispatchPlan {
+    let item = db.task_board_item(item_id).await.expect("load item");
+    build_dispatch_plans_with_policy(
+        &[item],
+        None,
+        None,
+        SpawnGateSwitches::default(),
+        &HashMap::new(),
+    )
+    .remove(0)
+}
+
+pub(super) fn preparing_intent(outcome: ReservedTaskBoardDispatch) -> String {
+    match outcome {
+        ReservedTaskBoardDispatch::Preparing { intent_id, .. } => intent_id,
+        ReservedTaskBoardDispatch::Applied(_) => panic!("new reservation was already applied"),
+        ReservedTaskBoardDispatch::Blocked(_) => panic!("reservation was unexpectedly blocked"),
+    }
+}
+
+async fn ledger_count(db: &AsyncDaemonDb, item_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM task_board_dispatch_admission_ledger WHERE item_id = ?1",
+    )
+    .bind(item_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("count ledger")
+}
+
+async fn active_intent_count(db: &AsyncDaemonDb, item_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM task_board_dispatch_intents
+         WHERE item_id = ?1 AND status IN ('preparing', 'preparing_claimed', 'held', 'pending', 'starting')",
+    )
+    .bind(item_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("count active intents")
+}
+
+async fn current_generation(db: &AsyncDaemonDb, intent_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT generation FROM task_board_dispatch_admission_decisions
+         WHERE intent_id = ?1 AND is_current = 1",
+    )
+    .bind(intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load generation")
+}
+
+async fn ledger_state_count(db: &AsyncDaemonDb, intent_id: &str, state: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND state = ?2",
+    )
+    .bind(intent_id)
+    .bind(state)
+    .fetch_one(db.pool())
+    .await
+    .expect("count ledger state")
+}
+
+pub(super) async fn ledger_kind_state(db: &AsyncDaemonDb, intent_id: &str, kind: &str) -> String {
+    sqlx::query_scalar(
+        "SELECT state FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND kind = ?2 ORDER BY generation DESC LIMIT 1",
+    )
+    .bind(intent_id)
+    .bind(kind)
+    .fetch_one(db.pool())
+    .await
+    .expect("load ledger state")
+}

--- a/src/daemon/db/tests/task_board/admission_dispatch.rs
+++ b/src/daemon/db/tests/task_board/admission_dispatch.rs
@@ -5,13 +5,16 @@ use std::sync::{Arc, OnceLock};
 use tempfile::{TempDir, tempdir};
 use tokio::sync::broadcast;
 
+#[path = "admission_dispatch_estimate_freeze.rs"]
+mod estimate_freeze_tests;
+
 use crate::daemon::codex_controller::CodexControllerHandle;
 use crate::daemon::db::{AsyncDaemonDb, DaemonDb, ReservedTaskBoardDispatch};
 use crate::daemon::protocol::{CodexRunStatus, StreamEvent};
 use crate::task_board::{
     AgentMode, DispatchPlan, SpawnGateSwitches, TaskBoardAdmissionDecision,
-    TaskBoardAutomationPolicy, TaskBoardItem, TaskBoardLaunchCapability, TaskBoardPolicyLimit,
-    TaskBoardPolicyScope, build_dispatch_plans_with_policy,
+    TaskBoardAutomationPolicy, TaskBoardItem, TaskBoardPolicyLimit, TaskBoardPolicyScope,
+    build_dispatch_plans_with_policy,
 };
 
 #[tokio::test]
@@ -84,86 +87,6 @@ async fn preparation_renewal_rejects_a_partial_admission_ledger() {
             .to_string()
             .contains("found 1 valid reserved ledger rows, expected 2")
     );
-}
-
-#[tokio::test]
-async fn admission_revalidates_then_commits_and_releases_concurrency() {
-    let db = test_db().await;
-    configure_policy(&db, admission_policy(1)).await;
-    let plan = create_plan(&db, "admission-start", AgentMode::Headless).await;
-    let intent = preparing_intent(
-        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
-            .await
-            .expect("reserve dispatch"),
-    );
-
-    configure_policy(&db, admission_policy(2)).await;
-    let preparation = db
-        .claim_task_board_dispatch_preparation(&intent)
-        .await
-        .expect("claim preparation")
-        .expect("pending preparation");
-    assert_eq!(current_generation(&db, &intent).await, 2);
-    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
-        .await
-        .expect("complete preparation");
-    let claim = db
-        .claim_task_board_dispatch("admission-start")
-        .await
-        .expect("claim dispatch")
-        .expect("pending dispatch");
-    assert_eq!(current_generation(&db, &intent).await, 3);
-    let error = db
-        .update_task_board_item("admission-start", |item| {
-            item.estimated_tokens = Some(10);
-            Ok(true)
-        })
-        .await
-        .expect_err("worker claim must freeze estimate edits");
-    assert!(error.to_string().contains("frozen after worker start"));
-    assert_eq!(
-        db.task_board_item("admission-start")
-            .await
-            .expect("reload frozen item")
-            .estimated_tokens,
-        None
-    );
-    db.validate_task_board_dispatch_admission_start(
-        &intent,
-        &claim.claim_token,
-        Some(TaskBoardLaunchCapability::WorkspaceWrite),
-    )
-    .await
-    .expect("validate launch");
-    db.complete_task_board_dispatch(&intent, &claim.claim_token, "codex-admission-start")
-        .await
-        .expect("commit launch");
-    assert_eq!(ledger_state_count(&db, &intent, "committed").await, 2);
-    let error = db
-        .update_task_board_item("admission-start", |item| {
-            item.status = crate::task_board::TaskBoardStatus::Done;
-            Ok(true)
-        })
-        .await
-        .expect_err("active worker must prevent terminal item mutation");
-    assert!(error.to_string().contains("managed worker is active"));
-
-    assert!(
-        db.release_task_board_admission_for_managed_worker("codex-admission-start")
-            .await
-            .expect("release terminal worker")
-    );
-    assert_eq!(
-        ledger_kind_state(&db, &intent, "concurrency").await,
-        "released"
-    );
-    assert_eq!(ledger_kind_state(&db, &intent, "rate").await, "committed");
-    db.update_task_board_item("admission-start", |item| {
-        item.status = crate::task_board::TaskBoardStatus::Done;
-        Ok(true)
-    })
-    .await
-    .expect("terminal item update after worker release");
 }
 
 #[tokio::test]

--- a/src/daemon/db/tests/task_board/admission_dispatch_estimate_freeze.rs
+++ b/src/daemon/db/tests/task_board/admission_dispatch_estimate_freeze.rs
@@ -1,0 +1,155 @@
+use super::{
+    admission_policy, configure_policy, create_plan, current_generation, ledger_kind_state,
+    ledger_state_count, preparing_intent, test_db,
+};
+use crate::task_board::{
+    AgentMode, TaskBoardLaunchCapability, TaskBoardStatus, TaskBoardWorkflowStatus,
+};
+
+#[tokio::test]
+async fn admission_revalidates_then_commits_and_releases_concurrency() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let plan = create_plan(&db, "admission-start", AgentMode::Headless).await;
+    let intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve dispatch"),
+    );
+
+    configure_policy(&db, admission_policy(2)).await;
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    assert_eq!(current_generation(&db, &intent).await, 2);
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete preparation");
+    let claim = db
+        .claim_task_board_dispatch("admission-start")
+        .await
+        .expect("claim dispatch")
+        .expect("pending dispatch");
+    assert_eq!(current_generation(&db, &intent).await, 3);
+    let error = db
+        .update_task_board_item("admission-start", |item| {
+            item.estimated_tokens = Some(10);
+            Ok(true)
+        })
+        .await
+        .expect_err("worker claim must freeze estimate edits");
+    assert!(error.to_string().contains("frozen after worker start"));
+    assert_eq!(
+        db.task_board_item("admission-start")
+            .await
+            .expect("reload frozen item")
+            .estimated_tokens,
+        None
+    );
+    db.validate_task_board_dispatch_admission_start(
+        &intent,
+        &claim.claim_token,
+        Some(TaskBoardLaunchCapability::WorkspaceWrite),
+    )
+    .await
+    .expect("validate launch");
+    db.complete_task_board_dispatch(&intent, &claim.claim_token, "codex-admission-start")
+        .await
+        .expect("commit launch");
+    assert_eq!(ledger_state_count(&db, &intent, "committed").await, 2);
+    let error = db
+        .update_task_board_item("admission-start", |item| {
+            item.status = TaskBoardStatus::Done;
+            Ok(true)
+        })
+        .await
+        .expect_err("active worker must prevent terminal item mutation");
+    assert!(error.to_string().contains("managed worker is active"));
+
+    assert!(
+        db.release_task_board_admission_for_managed_worker("codex-admission-start")
+            .await
+            .expect("release terminal worker")
+    );
+    assert_eq!(
+        ledger_kind_state(&db, &intent, "concurrency").await,
+        "released"
+    );
+    assert_eq!(ledger_kind_state(&db, &intent, "rate").await, "committed");
+    db.update_task_board_item("admission-start", |item| {
+        item.status = TaskBoardStatus::Done;
+        Ok(true)
+    })
+    .await
+    .expect("terminal item update after worker release");
+}
+
+#[tokio::test]
+async fn estimates_remain_frozen_after_started_worker_becomes_terminal() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(1)).await;
+    let plan = create_plan(&db, "admission-terminal-estimate", AgentMode::Headless).await;
+    let intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve dispatch"),
+    );
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete preparation");
+    let claim = db
+        .claim_task_board_dispatch("admission-terminal-estimate")
+        .await
+        .expect("claim dispatch")
+        .expect("pending dispatch");
+    db.validate_task_board_dispatch_admission_start(
+        &intent,
+        &claim.claim_token,
+        Some(TaskBoardLaunchCapability::WorkspaceWrite),
+    )
+    .await
+    .expect("validate launch");
+    let worker_id = "codex-admission-terminal-estimate";
+    db.complete_task_board_dispatch(&intent, &claim.claim_token, worker_id)
+        .await
+        .expect("complete dispatch");
+    assert!(
+        db.release_task_board_admission_for_managed_worker(worker_id)
+            .await
+            .expect("release worker admission")
+    );
+    db.update_task_board_item("admission-terminal-estimate", |item| {
+        item.status = TaskBoardStatus::Done;
+        item.workflow.status = TaskBoardWorkflowStatus::Completed;
+        Ok(true)
+    })
+    .await
+    .expect("make item terminal");
+    let before = db
+        .task_board_item_snapshot("admission-terminal-estimate")
+        .await
+        .expect("load terminal item");
+
+    let error = db
+        .update_task_board_item("admission-terminal-estimate", |item| {
+            item.estimated_tokens = Some(10);
+            Ok(true)
+        })
+        .await
+        .expect_err("started worker must freeze terminal item estimates");
+
+    assert!(error.to_string().contains("frozen after worker start"));
+    let after = db
+        .task_board_item_snapshot("admission-terminal-estimate")
+        .await
+        .expect("reload terminal item");
+    assert_eq!(after.item_revision, before.item_revision);
+    assert_eq!(after.item.estimated_tokens, before.item.estimated_tokens);
+}

--- a/src/daemon/db/tests/task_board/admission_evidence.rs
+++ b/src/daemon/db/tests/task_board/admission_evidence.rs
@@ -1,0 +1,329 @@
+use std::collections::HashMap;
+
+use crate::daemon::db::{AsyncDaemonDb, ReservedTaskBoardDispatch};
+use crate::task_board::{
+    AgentMode, SpawnGateSwitches, TaskBoardAutomationPolicy, TaskBoardItem,
+    TaskBoardLaunchCapability, TaskBoardPolicyLimit, TaskBoardPolicyScope, TaskBoardStatus,
+    build_dispatch_plans_with_policy,
+};
+
+use super::admission_dispatch::{configure_policy, preparing_intent, test_db};
+
+#[tokio::test]
+async fn compensation_survives_reservation_horizon_and_retry_with_exact_usage() {
+    let db = test_db().await;
+    configure_policy(&db, finite_policy(1)).await;
+    let intent = reserve_item(&db, "compensation-evidence", Some((400, 75_000))).await;
+    prepare_dispatch(&db, &intent).await;
+    let claim = db
+        .claim_task_board_dispatch("compensation-evidence")
+        .await
+        .expect("claim dispatch")
+        .expect("pending dispatch");
+    let worker_id = format!("codex-{intent}");
+
+    db.begin_task_board_dispatch_compensation(
+        &intent,
+        &claim.claim_token,
+        &worker_id,
+        "worker start outcome requires compensation",
+    )
+    .await
+    .expect("commit compensation evidence before stop");
+    age_committed_evidence_and_claim(&db, &intent).await;
+
+    let blocked = db
+        .reserve_task_board_dispatch(
+            &create_plan(&db, "compensation-capacity", Some((1, 1))).await,
+            "control-plane",
+            Some("/tmp/project"),
+            false,
+        )
+        .await
+        .expect("evaluate capacity while compensation is pending");
+    assert!(matches!(blocked, ReservedTaskBoardDispatch::Blocked(_)));
+    assert_exact_committed_evidence(&db, &intent, &worker_id).await;
+
+    let retry = db
+        .claim_next_task_board_dispatch()
+        .await
+        .expect("reclaim expired compensation")
+        .expect("compensation remains retryable");
+    assert_eq!(retry.intent_id, intent);
+    db.finalize_task_board_dispatch_compensation(
+        &retry.intent_id,
+        &retry.claim_token,
+        retry.consumed_approval_grant_id.as_deref(),
+        &worker_id,
+        "worker start outcome requires compensation",
+    )
+    .await
+    .expect("finalize compensation after stop proof");
+
+    assert_eq!(ledger_state(&db, &intent, "concurrency").await, "released");
+    for kind in ["rate", "token_budget", "monetary_budget"] {
+        assert_eq!(ledger_state(&db, &intent, kind).await, "committed");
+    }
+}
+
+#[tokio::test]
+async fn refused_pending_intent_releases_capacity_in_the_same_transaction() {
+    let db = test_db().await;
+    configure_policy(&db, finite_policy(1)).await;
+    let intent = reserve_item(&db, "refused-pending", Some((400, 75_000))).await;
+    prepare_dispatch(&db, &intent).await;
+    db.update_task_board_item("refused-pending", |item| {
+        item.status = TaskBoardStatus::Todo;
+        Ok(true)
+    })
+    .await
+    .expect("make pending item no longer startable");
+
+    let error = db
+        .claim_task_board_dispatch("refused-pending")
+        .await
+        .expect_err("no-longer-startable dispatch must be refused");
+    assert!(error.to_string().contains("no longer startable"));
+    assert_eq!(intent_status(&db, &intent).await, "failed");
+    assert_eq!(active_ledger_rows(&db, &intent).await, 0);
+
+    let next = reserve_item(&db, "refused-capacity-reuse", Some((1, 1))).await;
+    assert!(!next.is_empty());
+}
+
+#[tokio::test]
+async fn claim_to_start_policy_drift_commits_the_blocked_evidence() {
+    let db = test_db().await;
+    configure_policy(&db, finite_policy(2)).await;
+    let first = reserve_item(&db, "start-drift-first", Some((400, 75_000))).await;
+    let second = reserve_item(&db, "start-drift-second", Some((400, 75_000))).await;
+    prepare_dispatch(&db, &first).await;
+    prepare_dispatch(&db, &second).await;
+    let first_claim = db
+        .claim_task_board_dispatch("start-drift-first")
+        .await
+        .expect("claim first")
+        .expect("first pending dispatch");
+    let second_claim = db
+        .claim_task_board_dispatch("start-drift-second")
+        .await
+        .expect("claim second")
+        .expect("second pending dispatch");
+    db.complete_task_board_dispatch(
+        &second,
+        &second_claim.claim_token,
+        &format!("codex-{second}"),
+    )
+    .await
+    .expect("commit competing worker admission");
+    let prior_generation = current_intent_generation(&db, &first).await;
+    configure_policy(&db, finite_policy(1)).await;
+    let settings_revision = settings_revision(&db).await;
+
+    let error = db
+        .validate_task_board_dispatch_admission_start(
+            &first,
+            &first_claim.claim_token,
+            Some(TaskBoardLaunchCapability::WorkspaceWrite),
+        )
+        .await
+        .expect_err("new policy must block the first worker start");
+    assert!(error.to_string().contains("admission deferred"));
+
+    let (decision, intent_id, generation, recorded_revision, blockers): (
+        String,
+        Option<String>,
+        i64,
+        i64,
+        String,
+    ) = sqlx::query_as(
+        "SELECT decision, intent_id, generation, settings_revision, blockers_json
+         FROM task_board_dispatch_admission_decisions
+         WHERE item_id = 'start-drift-first' AND is_current = 1",
+    )
+    .fetch_one(db.pool())
+    .await
+    .expect("load persisted blocked decision");
+    assert_eq!(decision, "deferred");
+    assert!(intent_id.is_none());
+    assert!(generation > prior_generation);
+    assert_eq!(recorded_revision, settings_revision);
+    assert_ne!(blockers, "[]");
+    assert_eq!(active_ledger_rows(&db, &first).await, 0);
+}
+
+fn finite_policy(concurrency_limit: u64) -> TaskBoardAutomationPolicy {
+    TaskBoardAutomationPolicy {
+        limits: vec![
+            TaskBoardPolicyLimit::Concurrency {
+                scope: TaskBoardPolicyScope::Global,
+                limit: concurrency_limit,
+                reservation: 1,
+            },
+            TaskBoardPolicyLimit::Rate {
+                scope: TaskBoardPolicyScope::Global,
+                limit: 100,
+                window_seconds: 3_600,
+                reservation: 1,
+            },
+            TaskBoardPolicyLimit::TokenBudget {
+                scope: TaskBoardPolicyScope::Global,
+                limit: 10_000,
+                window_seconds: 3_600,
+            },
+            TaskBoardPolicyLimit::MonetaryBudget {
+                scope: TaskBoardPolicyScope::Global,
+                limit_microusd: 1_000_000,
+                window_seconds: 3_600,
+            },
+        ],
+        windows: Vec::new(),
+    }
+}
+
+async fn reserve_item(db: &AsyncDaemonDb, item_id: &str, estimates: Option<(u64, u64)>) -> String {
+    preparing_intent(
+        db.reserve_task_board_dispatch(
+            &create_plan(db, item_id, estimates).await,
+            "control-plane",
+            Some("/tmp/project"),
+            false,
+        )
+        .await
+        .expect("reserve dispatch"),
+    )
+}
+
+async fn create_plan(
+    db: &AsyncDaemonDb,
+    item_id: &str,
+    estimates: Option<(u64, u64)>,
+) -> crate::task_board::DispatchPlan {
+    let mut item = TaskBoardItem::new(
+        item_id.to_string(),
+        "Admission evidence".to_string(),
+        "Body".to_string(),
+        "2026-07-17T10:00:00Z".to_string(),
+    );
+    item.agent_mode = AgentMode::Headless;
+    if let Some((tokens, cost)) = estimates {
+        item.estimated_tokens = Some(tokens);
+        item.estimated_cost_microusd = Some(cost);
+    }
+    db.create_task_board_item(item).await.expect("create item");
+    let item = db.task_board_item(item_id).await.expect("load item");
+    build_dispatch_plans_with_policy(
+        &[item],
+        None,
+        None,
+        SpawnGateSwitches::default(),
+        &HashMap::new(),
+    )
+    .remove(0)
+}
+
+async fn prepare_dispatch(db: &AsyncDaemonDb, intent_id: &str) {
+    let preparation = db
+        .claim_task_board_dispatch_preparation(intent_id)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete preparation");
+}
+
+async fn age_committed_evidence_and_claim(db: &AsyncDaemonDb, intent_id: &str) {
+    sqlx::query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET reserved_at = '2000-01-01T00:00:00Z', committed_at = '2000-01-01T00:00:01Z'
+         WHERE intent_id = ?1 AND state = 'committed'",
+    )
+    .bind(intent_id)
+    .execute(db.pool())
+    .await
+    .expect("age committed admission evidence beyond reservation horizon");
+    sqlx::query(
+        "UPDATE task_board_dispatch_intents SET claimed_at = '2000-01-01T00:00:00Z'
+         WHERE intent_id = ?1",
+    )
+    .bind(intent_id)
+    .execute(db.pool())
+    .await
+    .expect("age compensation claim for retry");
+}
+
+async fn assert_exact_committed_evidence(db: &AsyncDaemonDb, intent_id: &str, worker_id: &str) {
+    let rows = sqlx::query_as::<_, (String, i64, String, String, Option<String>)>(
+        "SELECT kind, amount, state, managed_worker_id, expires_at
+         FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND state = 'committed' ORDER BY kind",
+    )
+    .bind(intent_id)
+    .fetch_all(db.pool())
+    .await
+    .expect("load exact compensation evidence");
+    let expected = [
+        ("concurrency", 1),
+        ("monetary_budget", 75_000),
+        ("rate", 1),
+        ("token_budget", 400),
+    ];
+    assert_eq!(rows.len(), expected.len());
+    for (row, (kind, amount)) in rows.iter().zip(expected) {
+        assert_eq!(row.0, kind);
+        assert_eq!(row.1, amount);
+        assert_eq!(row.2, "committed");
+        assert_eq!(row.3, worker_id);
+        assert!(row.4.is_none());
+    }
+}
+
+async fn ledger_state(db: &AsyncDaemonDb, intent_id: &str, kind: &str) -> String {
+    sqlx::query_scalar(
+        "SELECT state FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND kind = ?2 ORDER BY generation DESC LIMIT 1",
+    )
+    .bind(intent_id)
+    .bind(kind)
+    .fetch_one(db.pool())
+    .await
+    .expect("load ledger state")
+}
+
+async fn active_ledger_rows(db: &AsyncDaemonDb, intent_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND state IN ('reserved', 'committed')",
+    )
+    .bind(intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("count active ledger rows")
+}
+
+async fn intent_status(db: &AsyncDaemonDb, intent_id: &str) -> String {
+    sqlx::query_scalar("SELECT status FROM task_board_dispatch_intents WHERE intent_id = ?1")
+        .bind(intent_id)
+        .fetch_one(db.pool())
+        .await
+        .expect("load intent status")
+}
+
+async fn current_intent_generation(db: &AsyncDaemonDb, intent_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT generation FROM task_board_dispatch_admission_decisions
+         WHERE intent_id = ?1 AND is_current = 1",
+    )
+    .bind(intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load current intent generation")
+}
+
+async fn settings_revision(db: &AsyncDaemonDb) -> i64 {
+    sqlx::query_scalar("SELECT revision FROM task_board_orchestrator_settings WHERE singleton = 1")
+        .fetch_one(db.pool())
+        .await
+        .expect("load settings revision")
+}

--- a/src/daemon/db/tests/task_board/admission_lifecycle_tests.rs
+++ b/src/daemon/db/tests/task_board/admission_lifecycle_tests.rs
@@ -1,0 +1,504 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use chrono::{Duration, Timelike, Utc};
+use tempfile::{TempDir, tempdir};
+
+use crate::daemon::db::{AsyncDaemonDb, DaemonDb, ReservedTaskBoardDispatch};
+use crate::task_board::{
+    AgentMode, DispatchPlan, SpawnGateSwitches, TaskBoardAdmissionRequirement,
+    TaskBoardAutomationPolicy, TaskBoardItem, TaskBoardLaunchCapability,
+    TaskBoardOutsideWindowAction, TaskBoardPolicyLimit, TaskBoardPolicyScope,
+    TaskBoardPolicyWeekday, TaskBoardPolicyWindow, build_dispatch_plans_with_policy,
+    canonical_admission_requirement_key,
+};
+
+#[tokio::test]
+async fn configured_policy_rejects_missing_decision_and_ledger_evidence() {
+    let db = test_db().await;
+    configure_policy(&db, concurrency_policy()).await;
+
+    let renewal_intent = reserve(&db, "admission-missing-renewal", None).await;
+    let renewal_claim = db
+        .claim_task_board_dispatch_preparation(&renewal_intent)
+        .await
+        .expect("claim renewal preparation")
+        .expect("pending renewal preparation");
+    delete_admission_evidence(&db, &renewal_intent).await;
+    let renewal_error = db
+        .renew_task_board_dispatch_preparation(&renewal_claim)
+        .await
+        .expect_err("configured renewal without evidence must fail");
+    assert!(
+        renewal_error
+            .to_string()
+            .contains("without a current allowed decision under the configured policy")
+    );
+
+    let commit_intent = reserve(&db, "admission-missing-commit", None).await;
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&commit_intent)
+        .await
+        .expect("claim commit preparation")
+        .expect("pending commit preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete commit preparation");
+    let dispatch = db
+        .claim_task_board_dispatch("admission-missing-commit")
+        .await
+        .expect("claim commit dispatch")
+        .expect("pending commit dispatch");
+    delete_admission_evidence(&db, &commit_intent).await;
+    let commit_error = db
+        .complete_task_board_dispatch(
+            &commit_intent,
+            &dispatch.claim_token,
+            "codex-missing-admission",
+        )
+        .await
+        .expect_err("configured commit without evidence must fail");
+    assert!(
+        commit_error
+            .to_string()
+            .contains("without a current allowed decision under the configured policy")
+    );
+}
+
+#[tokio::test]
+async fn empty_policy_preserves_evidenceless_renewal_and_commit() {
+    let db = test_db().await;
+    configure_policy(&db, TaskBoardAutomationPolicy::default()).await;
+    let intent = reserve(&db, "admission-empty-policy", None).await;
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim empty-policy preparation")
+        .expect("pending empty-policy preparation");
+
+    db.renew_task_board_dispatch_preparation(&preparation)
+        .await
+        .expect("renew empty-policy preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete empty-policy preparation");
+    let dispatch = db
+        .claim_task_board_dispatch("admission-empty-policy")
+        .await
+        .expect("claim empty-policy dispatch")
+        .expect("pending empty-policy dispatch");
+    db.renew_task_board_dispatch_claim(&intent, &dispatch.claim_token)
+        .await
+        .expect("renew empty-policy worker claim");
+    db.complete_task_board_dispatch(&intent, &dispatch.claim_token, "codex-empty-policy")
+        .await
+        .expect("commit empty-policy dispatch");
+}
+
+#[tokio::test]
+async fn renewal_recompiles_a_closed_time_window_reservation() {
+    let db = test_db().await;
+    configure_policy(&db, active_time_window_policy()).await;
+    let intent = reserve(&db, "admission-window-rollover", None).await;
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim window preparation")
+        .expect("pending window preparation");
+    let initial_generation = current_generation(&db, &intent).await;
+    let stale_end = make_time_window_stale(&db, &intent).await;
+
+    db.renew_task_board_dispatch_preparation(&preparation)
+        .await
+        .expect("recompile closed time window");
+
+    assert!(current_generation(&db, &intent).await > initial_generation);
+    let (start, end) = current_window(&db, &intent, "time_window").await;
+    let now = Utc::now();
+    assert!(start <= now && now < end);
+    assert_ne!(end, stale_end);
+}
+
+#[tokio::test]
+async fn claim_heartbeat_and_commit_keep_the_frozen_start_authorization() {
+    let db = test_db().await;
+    configure_policy(&db, active_time_window_policy()).await;
+    let intent = reserve(&db, "admission-authorized-window", None).await;
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim authorized preparation")
+        .expect("pending authorized preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete authorized preparation");
+    let dispatch = db
+        .claim_task_board_dispatch("admission-authorized-window")
+        .await
+        .expect("claim authorized dispatch")
+        .expect("pending authorized dispatch");
+    db.validate_task_board_dispatch_admission_start(
+        &intent,
+        &dispatch.claim_token,
+        Some(TaskBoardLaunchCapability::WorkspaceWrite),
+    )
+    .await
+    .expect("authorize worker start");
+    let authorized_generation = current_generation(&db, &intent).await;
+    let authorized_window_end = make_time_window_stale(&db, &intent).await;
+
+    db.renew_task_board_dispatch_claim(&intent, &dispatch.claim_token)
+        .await
+        .expect("renew frozen worker claim");
+
+    assert_eq!(
+        current_generation(&db, &intent).await,
+        authorized_generation
+    );
+    assert_eq!(
+        current_window(&db, &intent, "time_window").await.1,
+        authorized_window_end
+    );
+
+    db.complete_task_board_dispatch(&intent, &dispatch.claim_token, "codex-authorized-window")
+        .await
+        .expect("commit frozen authorized reservation");
+
+    assert_eq!(
+        current_generation(&db, &intent).await,
+        authorized_generation
+    );
+    assert_eq!(current_ledger_state(&db, &intent).await, "committed");
+}
+
+#[tokio::test]
+async fn worker_claim_renewal_rejects_orphaned_admission_ledger() {
+    let db = test_db().await;
+    configure_policy(&db, concurrency_policy()).await;
+    let intent = reserve(&db, "admission-orphaned-ledger", None).await;
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim orphan preparation")
+        .expect("pending orphan preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete orphan preparation");
+    let dispatch = db
+        .claim_task_board_dispatch("admission-orphaned-ledger")
+        .await
+        .expect("claim orphan dispatch")
+        .expect("pending orphan dispatch");
+    sqlx::query(
+        "UPDATE task_board_dispatch_admission_decisions
+         SET is_current = 0, superseded_at = created_at
+         WHERE intent_id = ?1 AND is_current = 1",
+    )
+    .bind(&intent)
+    .execute(db.pool())
+    .await
+    .expect("orphan reserved ledger evidence");
+
+    let error = db
+        .renew_task_board_dispatch_claim(&intent, &dispatch.claim_token)
+        .await
+        .expect_err("orphaned worker admission evidence must fail closed");
+    assert!(
+        error
+            .to_string()
+            .contains("reserved ledger rows without a current allowed decision")
+    );
+}
+
+#[tokio::test]
+async fn renewal_recompiles_rate_token_and_cost_bucket_rollover() {
+    let db = test_db().await;
+    configure_policy(&db, windowed_budget_policy()).await;
+    let intent = reserve(&db, "admission-budget-rollover", Some((40, 75_000))).await;
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim budget preparation")
+        .expect("pending budget preparation");
+    let initial_generation = current_generation(&db, &intent).await;
+    shift_current_buckets_back(&db, &intent).await;
+
+    db.renew_task_board_dispatch_preparation(&preparation)
+        .await
+        .expect("recompile stale budget buckets");
+
+    assert!(current_generation(&db, &intent).await > initial_generation);
+    for kind in ["rate", "token_budget", "monetary_budget"] {
+        let (start, end) = current_window(&db, &intent, kind).await;
+        let now = Utc::now();
+        assert!(start <= now && now < end, "stale {kind} bucket survived");
+    }
+}
+
+struct TestDb {
+    db: AsyncDaemonDb,
+    _directory: TempDir,
+}
+
+impl Deref for TestDb {
+    type Target = AsyncDaemonDb;
+
+    fn deref(&self) -> &Self::Target {
+        &self.db
+    }
+}
+
+async fn test_db() -> TestDb {
+    let directory = tempdir().expect("tempdir");
+    let path = directory.path().join("harness.db");
+    let sync_db = DaemonDb::open(&path).expect("open sync db");
+    let project = super::super::sample_project();
+    sync_db.sync_project(&project).expect("sync project");
+    let session = super::super::sample_session_state();
+    sync_db
+        .sync_session(&project.project_id, &session)
+        .expect("sync session");
+    drop(sync_db);
+    TestDb {
+        db: AsyncDaemonDb::connect(&path).await.expect("open db"),
+        _directory: directory,
+    }
+}
+
+async fn configure_policy(db: &AsyncDaemonDb, policy: TaskBoardAutomationPolicy) {
+    let mut settings = db
+        .task_board_orchestrator_settings()
+        .await
+        .expect("load settings");
+    settings.admission_policy = policy;
+    db.replace_task_board_orchestrator_settings(&settings)
+        .await
+        .expect("save settings");
+}
+
+async fn reserve(db: &AsyncDaemonDb, item_id: &str, estimates: Option<(u64, u64)>) -> String {
+    let mut item = TaskBoardItem::new(
+        item_id.to_string(),
+        "Admission lifecycle".to_string(),
+        "Body".to_string(),
+        "2026-07-17T10:00:00Z".to_string(),
+    );
+    item.agent_mode = AgentMode::Headless;
+    if let Some((tokens, cost)) = estimates {
+        item.estimated_tokens = Some(tokens);
+        item.estimated_cost_microusd = Some(cost);
+    }
+    db.create_task_board_item(item).await.expect("create item");
+    let plan = dispatch_plan(db, item_id).await;
+    match db
+        .reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+        .await
+        .expect("reserve dispatch")
+    {
+        ReservedTaskBoardDispatch::Preparing { intent_id, .. } => intent_id,
+        ReservedTaskBoardDispatch::Applied(_) => panic!("new reservation already applied"),
+        ReservedTaskBoardDispatch::Blocked(value) => {
+            panic!(
+                "reservation unexpectedly blocked: {}",
+                value.refusal_message()
+            )
+        }
+    }
+}
+
+async fn dispatch_plan(db: &AsyncDaemonDb, item_id: &str) -> DispatchPlan {
+    let item = db.task_board_item(item_id).await.expect("load item");
+    build_dispatch_plans_with_policy(
+        &[item],
+        None,
+        None,
+        SpawnGateSwitches::default(),
+        &HashMap::new(),
+    )
+    .remove(0)
+}
+
+fn concurrency_policy() -> TaskBoardAutomationPolicy {
+    TaskBoardAutomationPolicy {
+        limits: vec![TaskBoardPolicyLimit::Concurrency {
+            scope: TaskBoardPolicyScope::Global,
+            limit: 1,
+            reservation: 1,
+        }],
+        windows: Vec::new(),
+    }
+}
+
+fn active_time_window_policy() -> TaskBoardAutomationPolicy {
+    let now = Utc::now();
+    let start = now - Duration::minutes(2);
+    let end = now + Duration::minutes(2);
+    TaskBoardAutomationPolicy {
+        limits: Vec::new(),
+        windows: vec![TaskBoardPolicyWindow {
+            scope: TaskBoardPolicyScope::Global,
+            timezone: "UTC".to_string(),
+            weekdays: all_weekdays(),
+            start_time: format!("{:02}:{:02}", start.hour(), start.minute()),
+            end_time: format!("{:02}:{:02}", end.hour(), end.minute()),
+            outside_action: TaskBoardOutsideWindowAction::Deny,
+        }],
+    }
+}
+
+fn all_weekdays() -> Vec<TaskBoardPolicyWeekday> {
+    use TaskBoardPolicyWeekday::{Friday, Monday, Saturday, Sunday, Thursday, Tuesday, Wednesday};
+    vec![
+        Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday,
+    ]
+}
+
+fn windowed_budget_policy() -> TaskBoardAutomationPolicy {
+    TaskBoardAutomationPolicy {
+        limits: vec![
+            TaskBoardPolicyLimit::Rate {
+                scope: TaskBoardPolicyScope::Global,
+                limit: 10,
+                window_seconds: 60,
+                reservation: 1,
+            },
+            TaskBoardPolicyLimit::TokenBudget {
+                scope: TaskBoardPolicyScope::Global,
+                limit: 1_000,
+                window_seconds: 60,
+            },
+            TaskBoardPolicyLimit::MonetaryBudget {
+                scope: TaskBoardPolicyScope::Global,
+                limit_microusd: 1_000_000,
+                window_seconds: 60,
+            },
+        ],
+        windows: Vec::new(),
+    }
+}
+
+async fn delete_admission_evidence(db: &AsyncDaemonDb, intent_id: &str) {
+    sqlx::query("DELETE FROM task_board_dispatch_admission_ledger WHERE intent_id = ?1")
+        .bind(intent_id)
+        .execute(db.pool())
+        .await
+        .expect("delete ledger evidence");
+    sqlx::query("DELETE FROM task_board_dispatch_admission_decisions WHERE intent_id = ?1")
+        .bind(intent_id)
+        .execute(db.pool())
+        .await
+        .expect("delete decision evidence");
+}
+
+async fn current_generation(db: &AsyncDaemonDb, intent_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT generation FROM task_board_dispatch_admission_decisions
+         WHERE intent_id = ?1 AND is_current = 1",
+    )
+    .bind(intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load current generation")
+}
+
+async fn current_ledger_state(db: &AsyncDaemonDb, intent_id: &str) -> String {
+    sqlx::query_scalar(
+        "SELECT state FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND state != 'released'",
+    )
+    .bind(intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load current ledger state")
+}
+
+async fn make_time_window_stale(db: &AsyncDaemonDb, intent_id: &str) -> chrono::DateTime<Utc> {
+    let (decision_id, requirements_json): (String, String) = sqlx::query_as(
+        "SELECT decision_id, requirements_json
+         FROM task_board_dispatch_admission_decisions
+         WHERE intent_id = ?1 AND is_current = 1",
+    )
+    .bind(intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load time-window decision");
+    let mut requirements: Vec<TaskBoardAdmissionRequirement> =
+        serde_json::from_str(&requirements_json).expect("decode requirements");
+    let requirement = requirements.first_mut().expect("time-window requirement");
+    let start = chrono::DateTime::parse_from_rfc3339(
+        requirement.available_at.as_deref().expect("window start"),
+    )
+    .expect("parse window start")
+    .with_timezone(&Utc)
+        - Duration::days(1);
+    requirement.available_at = Some(start.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+    let end = start
+        + Duration::seconds(
+            i64::try_from(requirement.window_seconds.expect("window duration"))
+                .expect("persisted duration"),
+        );
+    let key = canonical_admission_requirement_key(requirement)
+        .expect("canonical stale requirement")
+        .stable_id();
+    sqlx::query(
+        "UPDATE task_board_dispatch_admission_decisions SET requirements_json = ?2
+         WHERE decision_id = ?1",
+    )
+    .bind(&decision_id)
+    .bind(serde_json::to_string(&requirements).expect("encode stale requirements"))
+    .execute(db.pool())
+    .await
+    .expect("update stale decision");
+    sqlx::query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET canonical_key = ?2, window_started_at = ?3, window_ends_at = ?4
+         WHERE decision_id = ?1",
+    )
+    .bind(&decision_id)
+    .bind(key)
+    .bind(start.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+    .bind(end.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+    .execute(db.pool())
+    .await
+    .expect("update stale ledger window");
+    end
+}
+
+async fn shift_current_buckets_back(db: &AsyncDaemonDb, intent_id: &str) {
+    sqlx::query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET window_started_at = strftime('%Y-%m-%dT%H:%M:%SZ', window_started_at, '-60 seconds'),
+             window_ends_at = strftime('%Y-%m-%dT%H:%M:%SZ', window_ends_at, '-60 seconds')
+         WHERE intent_id = ?1 AND kind IN ('rate', 'token_budget', 'monetary_budget')
+           AND state = 'reserved'",
+    )
+    .bind(intent_id)
+    .execute(db.pool())
+    .await
+    .expect("shift admission buckets");
+}
+
+async fn current_window(
+    db: &AsyncDaemonDb,
+    intent_id: &str,
+    kind: &str,
+) -> (chrono::DateTime<Utc>, chrono::DateTime<Utc>) {
+    let (start, end): (String, String) = sqlx::query_as(
+        "SELECT window_started_at, window_ends_at
+         FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 AND kind = ?2 AND state = 'reserved'",
+    )
+    .bind(intent_id)
+    .bind(kind)
+    .fetch_one(db.pool())
+    .await
+    .expect("load current admission window");
+    (
+        chrono::DateTime::parse_from_rfc3339(&start)
+            .expect("parse current window start")
+            .with_timezone(&Utc),
+        chrono::DateTime::parse_from_rfc3339(&end)
+            .expect("parse current window end")
+            .with_timezone(&Utc),
+    )
+}

--- a/src/daemon/db/tests/task_board/dispatch.rs
+++ b/src/daemon/db/tests/task_board/dispatch.rs
@@ -67,10 +67,13 @@ async fn task_board_dispatch_intents_survive_until_worker_outcome() {
         .expect("reclaim dispatch")
         .expect("expired dispatch");
     assert_ne!(reclaimed.claim_token, claim.claim_token);
-    db.complete_task_board_dispatch(&reclaimed.intent_id, &reclaimed.claim_token)
-        .await
-        .expect("complete dispatch");
-
+    db.complete_task_board_dispatch(
+        &reclaimed.intent_id,
+        &reclaimed.claim_token,
+        "codex-reclaimed-test",
+    )
+    .await
+    .expect("complete dispatch");
     let failed = db
         .task_board_item("task-dispatch-failed")
         .await
@@ -154,6 +157,7 @@ async fn task_board_dispatch_reservation_precedes_links_and_is_reclaimable() {
             preparation,
         } => (intent_id, preparation),
         ReservedTaskBoardDispatch::Applied(_) => panic!("new reservation was already applied"),
+        ReservedTaskBoardDispatch::Blocked(_) => panic!("default admission blocked reservation"),
     };
     assert_eq!(preparation.board_item_id, "task-dispatch-reserved");
     let still_todo = db
@@ -264,7 +268,6 @@ async fn existing_session_without_work_item_is_reservable() {
     let reserved = db
         .reserve_task_board_dispatch(&plan, "control-plane", None, false)
         .await;
-
     assert!(
         reserved.is_ok(),
         "existing session without work item should reserve: {reserved:?}"
@@ -467,6 +470,7 @@ async fn approved_grant_is_consumed_at_reservation() {
     let intent_id = match reserved {
         ReservedTaskBoardDispatch::Preparing { intent_id, .. } => intent_id,
         ReservedTaskBoardDispatch::Applied(_) => panic!("new reservation was already applied"),
+        ReservedTaskBoardDispatch::Blocked(_) => panic!("default admission blocked reservation"),
     };
     let claim = db
         .claim_task_board_dispatch_preparation(&intent_id)

--- a/src/daemon/db/tests/task_board/dispatch_claims.rs
+++ b/src/daemon/db/tests/task_board/dispatch_claims.rs
@@ -1,0 +1,371 @@
+use std::collections::HashMap;
+
+use tempfile::{TempDir, tempdir};
+
+use crate::daemon::db::{AsyncDaemonDb, ClaimedTaskBoardDispatch, TaskBoardDispatchClaimAction};
+use crate::daemon::task_board_managed_agents::managed_worker_id;
+use crate::task_board::{TaskBoardItem, TaskBoardStatus, build_dispatch_plans_with_policy};
+
+use super::admission_dispatch::{
+    admission_policy, configure_policy, ledger_kind_state, preparing_intent, test_db,
+};
+
+#[tokio::test]
+async fn worker_claim_renewal_prevents_reclaim() {
+    let (_dir, db, claim) = claimed_dispatch("task-worker-claim-renewal").await;
+    age_claim(&db, &claim.intent_id).await;
+
+    db.renew_task_board_dispatch_claim(&claim.intent_id, &claim.claim_token)
+        .await
+        .expect("renew worker claim");
+
+    assert!(
+        db.claim_next_task_board_dispatch()
+            .await
+            .expect("check renewed worker claim")
+            .is_none(),
+        "a live worker heartbeat must prevent concurrent reclamation",
+    );
+}
+
+#[tokio::test]
+async fn stale_worker_claim_cannot_mutate_reclaimed_claim() {
+    let (_dir, db, first) = claimed_dispatch("task-worker-claim-stale").await;
+    age_claim(&db, &first.intent_id).await;
+    let reclaimed = db
+        .claim_next_task_board_dispatch()
+        .await
+        .expect("reclaim worker dispatch")
+        .expect("expired worker claim");
+    assert_ne!(reclaimed.claim_token, first.claim_token);
+
+    db.renew_task_board_dispatch_claim(&first.intent_id, &first.claim_token)
+        .await
+        .expect_err("stale token must not renew the reclaimed worker claim");
+    db.complete_task_board_dispatch(&first.intent_id, &first.claim_token, "codex-stale-worker")
+        .await
+        .expect_err("stale token must not complete the reclaimed worker claim");
+
+    let (status, claim_token): (String, Option<String>) = sqlx::query_as(
+        "SELECT status, claim_token FROM task_board_dispatch_intents WHERE intent_id = ?1",
+    )
+    .bind(&first.intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load reclaimed worker claim");
+    assert_eq!(status, "starting");
+    assert_eq!(claim_token.as_deref(), Some(reclaimed.claim_token.as_str()));
+}
+
+#[tokio::test]
+async fn reclaimed_worker_restores_expired_frozen_admission_before_commit() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(2)).await;
+    let first_intent = prepare_admitted_dispatch(&db, "reclaimed-worker-first").await;
+    let first = db
+        .claim_task_board_dispatch("reclaimed-worker-first")
+        .await
+        .expect("claim first dispatch")
+        .expect("pending first dispatch");
+    assert!(matches!(first.action, TaskBoardDispatchClaimAction::Start));
+    let _second_intent = prepare_admitted_dispatch(&db, "reclaimed-worker-second").await;
+    configure_policy(&db, admission_policy(1)).await;
+    db.update_task_board_item("reclaimed-worker-first", |item| {
+        item.title = "Edited after uncertain start".to_owned();
+        Ok(true)
+    })
+    .await
+    .expect("edit non-frozen item metadata");
+    age_claim_and_release_admission(&db, &first.intent_id).await;
+
+    let reclaimed = db
+        .claim_task_board_dispatch("reclaimed-worker-first")
+        .await
+        .expect("reclaim uncertain dispatch")
+        .expect("expired dispatch claim");
+
+    assert_eq!(reclaimed.intent_id, first_intent);
+    assert!(matches!(
+        reclaimed.action,
+        TaskBoardDispatchClaimAction::Recover
+    ));
+    let worker_id = managed_worker_id(&reclaimed.applied, &reclaimed.intent_id);
+    db.renew_task_board_dispatch_claim(&reclaimed.intent_id, &reclaimed.claim_token)
+        .await
+        .expect("restore the deterministic worker's frozen admission");
+    db.complete_task_board_dispatch(&reclaimed.intent_id, &reclaimed.claim_token, &worker_id)
+        .await
+        .expect("commit deterministic worker evidence under frozen admission");
+    assert_eq!(
+        ledger_kind_state(&db, &reclaimed.intent_id, "concurrency").await,
+        "committed"
+    );
+    assert_eq!(
+        ledger_kind_state(&db, &reclaimed.intent_id, "rate").await,
+        "committed"
+    );
+}
+
+#[tokio::test]
+async fn first_worker_claim_still_revalidates_after_preparation_attempts() {
+    let db = test_db().await;
+    configure_policy(&db, admission_policy(2)).await;
+    let first_intent = prepare_admitted_dispatch(&db, "first-worker-revalidation").await;
+    let _second_intent = prepare_admitted_dispatch(&db, "first-worker-competitor").await;
+    configure_policy(&db, admission_policy(1)).await;
+
+    let error = db
+        .claim_task_board_dispatch("first-worker-revalidation")
+        .await
+        .expect_err("a normal first worker claim must revalidate current policy");
+
+    assert!(error.to_string().contains("admission deferred"));
+    assert_eq!(
+        ledger_kind_state(&db, &first_intent, "concurrency").await,
+        "released"
+    );
+}
+
+#[tokio::test]
+async fn completed_lookup_requires_the_exact_workflow_execution() {
+    let (_dir, db, claim) = claimed_dispatch("task-worker-completed-identity").await;
+    db.complete_task_board_dispatch(&claim.intent_id, &claim.claim_token, "codex-completed")
+        .await
+        .expect("complete worker dispatch");
+
+    assert!(
+        db.task_board_dispatch_is_completed(&claim.applied)
+            .await
+            .expect("check completed dispatch")
+    );
+    let mut different_execution = claim.applied;
+    different_execution.item.workflow.execution_id = Some("workflow-different".to_string());
+    assert!(
+        !db.task_board_dispatch_is_completed(&different_execution)
+            .await
+            .expect("check mismatched workflow execution")
+    );
+}
+
+#[tokio::test]
+async fn crash_reclaims_compensation_without_restarting_or_completing_worker() {
+    let (_dir, db, first) = claimed_dispatch("task-worker-compensation-reclaim").await;
+    db.begin_task_board_dispatch_compensation(
+        &first.intent_id,
+        &first.claim_token,
+        "codex-compensation-reclaim",
+        "worker started but dispatch completion failed",
+    )
+    .await
+    .expect("persist compensation before worker stop");
+    db.complete_task_board_dispatch(&first.intent_id, &first.claim_token, "codex-invalid")
+        .await
+        .expect_err("compensating dispatch must never complete");
+    age_claim(&db, &first.intent_id).await;
+
+    let reclaimed = db
+        .claim_next_task_board_dispatch()
+        .await
+        .expect("reclaim compensation")
+        .expect("compensation remains recoverable");
+    assert_ne!(reclaimed.claim_token, first.claim_token);
+    assert!(matches!(
+        &reclaimed.action,
+        TaskBoardDispatchClaimAction::Compensate { reason }
+            if reason == "worker started but dispatch completion failed"
+    ));
+    db.finalize_task_board_dispatch_compensation(
+        &first.intent_id,
+        &first.claim_token,
+        first.consumed_approval_grant_id.as_deref(),
+        "codex-compensation-reclaim",
+        "worker started but dispatch completion failed",
+    )
+    .await
+    .expect_err("stale worker claim cannot finalize compensation");
+    db.finalize_task_board_dispatch_compensation(
+        &reclaimed.intent_id,
+        &reclaimed.claim_token,
+        reclaimed.consumed_approval_grant_id.as_deref(),
+        "codex-compensation-reclaim",
+        "worker started but dispatch completion failed",
+    )
+    .await
+    .expect("current worker claim finalizes compensation");
+
+    let (status, marker, claim_token): (String, bool, Option<String>) = sqlx::query_as(
+        "SELECT status, compensation_pending, claim_token
+         FROM task_board_dispatch_intents WHERE intent_id = ?1",
+    )
+    .bind(&reclaimed.intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load finalized compensation");
+    assert_eq!(status, "failed");
+    assert!(!marker);
+    assert!(claim_token.is_none());
+    let item = db
+        .task_board_item("task-worker-compensation-reclaim")
+        .await
+        .expect("load compensated item");
+    assert_eq!(item.status, TaskBoardStatus::Todo);
+    assert!(item.session_id.is_none());
+}
+
+#[tokio::test]
+async fn compensation_renewal_ignores_broken_start_admission_evidence() {
+    let (_dir, db, claim) = claimed_dispatch("task-worker-compensation-admission").await;
+    db.begin_task_board_dispatch_compensation(
+        &claim.intent_id,
+        &claim.claim_token,
+        "codex-compensation-admission",
+        "worker stop required",
+    )
+    .await
+    .expect("persist compensation marker");
+    insert_unowned_admission_reservation(&db, &claim).await;
+
+    db.renew_task_board_dispatch_claim(&claim.intent_id, &claim.claim_token)
+        .await
+        .expect("compensation renewal must not re-enter start admission");
+}
+
+async fn claimed_dispatch(item_id: &str) -> (TempDir, AsyncDaemonDb, ClaimedTaskBoardDispatch) {
+    let dir = tempdir().expect("tempdir");
+    let db = AsyncDaemonDb::connect(&dir.path().join("harness.db"))
+        .await
+        .expect("open db");
+    db.create_task_board_item(TaskBoardItem::new(
+        item_id.to_owned(),
+        "Worker claim".to_owned(),
+        "Body".to_owned(),
+        "2026-07-17T10:00:00Z".to_owned(),
+    ))
+    .await
+    .expect("create item");
+    let item = db.task_board_item(item_id).await.expect("load item");
+    let lifecycle = build_dispatch_plans_with_policy(
+        &[item],
+        None,
+        None,
+        crate::task_board::SpawnGateSwitches::default(),
+        &HashMap::new(),
+    )
+    .remove(0)
+    .applied_lifecycle();
+    db.link_and_enqueue_task_board_dispatch(item_id, "session-1", "work-1", &lifecycle)
+        .await
+        .expect("enqueue worker dispatch");
+    let claim = db
+        .claim_task_board_dispatch(item_id)
+        .await
+        .expect("claim worker dispatch")
+        .expect("pending worker dispatch");
+    (dir, db, claim)
+}
+
+async fn prepare_admitted_dispatch(db: &AsyncDaemonDb, item_id: &str) -> String {
+    db.create_task_board_item(TaskBoardItem::new(
+        item_id.to_owned(),
+        "Admitted worker claim".to_owned(),
+        "Body".to_owned(),
+        "2026-07-17T10:00:00Z".to_owned(),
+    ))
+    .await
+    .expect("create admitted item");
+    let item = db
+        .task_board_item(item_id)
+        .await
+        .expect("load admitted item");
+    let plan = build_dispatch_plans_with_policy(
+        &[item],
+        None,
+        None,
+        crate::task_board::SpawnGateSwitches::default(),
+        &HashMap::new(),
+    )
+    .remove(0);
+    let intent = preparing_intent(
+        db.reserve_task_board_dispatch(&plan, "control-plane", Some("/tmp/project"), false)
+            .await
+            .expect("reserve admitted dispatch"),
+    );
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent)
+        .await
+        .expect("claim admitted preparation")
+        .expect("pending admitted preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("complete admitted preparation");
+    intent
+}
+
+async fn age_claim(db: &AsyncDaemonDb, intent_id: &str) {
+    sqlx::query(
+        "UPDATE task_board_dispatch_intents SET claimed_at = '1970-01-01T00:00:00Z'
+         WHERE intent_id = ?1",
+    )
+    .bind(intent_id)
+    .execute(db.pool())
+    .await
+    .expect("age worker claim");
+}
+
+async fn age_claim_and_release_admission(db: &AsyncDaemonDb, intent_id: &str) {
+    age_claim(db, intent_id).await;
+    sqlx::query(
+        "UPDATE task_board_dispatch_admission_ledger
+         SET state = 'released', expires_at = NULL,
+             released_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+         WHERE intent_id = ?1 AND state = 'reserved'",
+    )
+    .bind(intent_id)
+    .execute(db.pool())
+    .await
+    .expect("release admission beyond its reservation horizon");
+}
+
+async fn insert_unowned_admission_reservation(
+    db: &AsyncDaemonDb,
+    claim: &ClaimedTaskBoardDispatch,
+) {
+    let now = "2026-07-17T10:00:00Z";
+    let expires = "2099-07-17T10:15:00Z";
+    sqlx::query(
+        "INSERT INTO task_board_dispatch_admission_decisions (
+             decision_id, intent_id, generation, item_id, item_revision,
+             settings_revision, decision, policy_json, context_json,
+             requirements_json, blockers_json, launch_profile, evaluated_at,
+             next_available_at, is_current, superseded_at, created_at
+         ) VALUES (
+             'orphaned-compensation-decision', ?1, 99, ?2, 1, 1, 'allowed',
+             '{}', '{}', '[]', '[]', 'workspace_write', ?3, NULL, 0, ?3, ?3
+         )",
+    )
+    .bind(&claim.intent_id)
+    .bind(&claim.applied.board_item_id)
+    .bind(now)
+    .execute(db.pool())
+    .await
+    .expect("insert non-current admission decision");
+    sqlx::query(
+        "INSERT INTO task_board_dispatch_admission_ledger (
+             ledger_id, decision_id, decision, intent_id, generation, item_id,
+             canonical_key, kind, scope, amount, limit_value,
+             window_started_at, window_ends_at, state, managed_worker_id,
+             expires_at, reserved_at, committed_at, released_at
+         ) VALUES (
+             'orphaned-compensation-ledger', 'orphaned-compensation-decision',
+             'allowed', ?1, 99, ?2, 'concurrency:global', 'concurrency',
+             'global', 1, 1, NULL, NULL, 'reserved', NULL, ?3, ?4, NULL, NULL
+         )",
+    )
+    .bind(&claim.intent_id)
+    .bind(&claim.applied.board_item_id)
+    .bind(expires)
+    .bind(now)
+    .execute(db.pool())
+    .await
+    .expect("insert unowned admission reservation");
+}

--- a/src/daemon/db/tests/task_board/terminal_dispatch_lifecycle.rs
+++ b/src/daemon/db/tests/task_board/terminal_dispatch_lifecycle.rs
@@ -1,0 +1,412 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use tempfile::{TempDir, tempdir};
+
+use crate::daemon::db::policy::consume_approval_grant_in_tx;
+use crate::daemon::db::{AsyncDaemonDb, DaemonDb, NewApprovalGrant, ReservedTaskBoardDispatch};
+use crate::task_board::{
+    AgentMode, PolicyAction, PolicyReasonCode, SpawnGateSwitches, TaskBoardAutomationPolicy,
+    TaskBoardItem, TaskBoardPolicyLimit, TaskBoardPolicyScope, TaskBoardStatus,
+    build_dispatch_plans_with_policy,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IntentPhase {
+    Held,
+    Pending,
+    Starting,
+}
+
+impl IntentPhase {
+    const ALL: [Self; 3] = [Self::Held, Self::Pending, Self::Starting];
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Held => "held",
+            Self::Pending => "pending",
+            Self::Starting => "starting",
+        }
+    }
+
+    const fn is_claimed(self) -> bool {
+        matches!(self, Self::Starting)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TerminalAction {
+    Complete,
+    Delete,
+}
+
+impl TerminalAction {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Delete => "delete",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct IntentSnapshot {
+    status: String,
+    claim_token: Option<String>,
+    claimed_at: Option<String>,
+    grant_id: Option<String>,
+    last_error: Option<String>,
+    completed_at: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct GrantSnapshot {
+    state: String,
+    consumed_at: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct LedgerSnapshot {
+    state: String,
+    expires_at: Option<String>,
+    released_at: Option<String>,
+}
+
+struct Fixture {
+    db: AsyncDaemonDb,
+    _directory: TempDir,
+    item_id: String,
+    intent_id: String,
+    grant_id: String,
+    item_before: TaskBoardItem,
+    intent_before: IntentSnapshot,
+    grant_before: GrantSnapshot,
+    ledger_before: Vec<LedgerSnapshot>,
+}
+
+#[tokio::test]
+async fn terminal_transition_cancels_unclaimed_dispatches_and_fences_starting() {
+    exercise_terminal_action(TerminalAction::Complete).await;
+}
+
+#[tokio::test]
+async fn delete_cancels_unclaimed_dispatches_and_fences_starting() {
+    exercise_terminal_action(TerminalAction::Delete).await;
+}
+
+async fn exercise_terminal_action(action: TerminalAction) {
+    for phase in IntentPhase::ALL {
+        let fixture = fixture(phase, action).await;
+        let result = apply_action(&fixture.db, &fixture.item_id, action).await;
+        if phase.is_claimed() {
+            let error = result.expect_err("claimed starting dispatch must fence terminal mutation");
+            assert!(
+                error.to_string().contains("dispatch is claimed"),
+                "unexpected {phase:?} {action:?} error: {error}"
+            );
+            assert_fenced_state(&fixture).await;
+        } else {
+            result.expect("unclaimed pre-start dispatch must cancel atomically");
+            assert_cancelled_state(&fixture, action).await;
+        }
+    }
+}
+
+async fn apply_action(
+    db: &AsyncDaemonDb,
+    item_id: &str,
+    action: TerminalAction,
+) -> Result<(), crate::errors::CliError> {
+    match action {
+        TerminalAction::Complete => db
+            .update_task_board_item(item_id, |item| {
+                item.status = TaskBoardStatus::Done;
+                Ok(true)
+            })
+            .await
+            .map(|_| ()),
+        TerminalAction::Delete => db.delete_task_board_item(item_id).await.map(|_| ()),
+    }
+}
+
+async fn assert_cancelled_state(fixture: &Fixture, action: TerminalAction) {
+    let item = fixture
+        .db
+        .task_board_item(&fixture.item_id)
+        .await
+        .expect("load cancelled item");
+    match action {
+        TerminalAction::Complete => assert_eq!(item.status, TaskBoardStatus::Done),
+        TerminalAction::Delete => assert!(item.is_deleted()),
+    }
+    let intent = intent_snapshot(&fixture.db, &fixture.intent_id).await;
+    assert_eq!(intent.status, "failed");
+    assert!(intent.claim_token.is_none());
+    assert!(intent.claimed_at.is_none());
+    assert_eq!(intent.grant_id.as_deref(), Some(fixture.grant_id.as_str()));
+    assert!(intent.completed_at.is_some());
+    assert_eq!(
+        grant_snapshot(&fixture.db, &fixture.grant_id).await,
+        GrantSnapshot {
+            state: "approved".to_string(),
+            consumed_at: None,
+        }
+    );
+    let ledger = ledger_snapshot(&fixture.db, &fixture.intent_id).await;
+    assert!(!ledger.is_empty());
+    assert!(ledger.iter().all(|row| {
+        row.state == "released" && row.expires_at.is_none() && row.released_at.is_some()
+    }));
+}
+
+async fn assert_fenced_state(fixture: &Fixture) {
+    assert_eq!(
+        fixture
+            .db
+            .task_board_item(&fixture.item_id)
+            .await
+            .expect("load fenced item"),
+        fixture.item_before
+    );
+    assert_eq!(
+        intent_snapshot(&fixture.db, &fixture.intent_id).await,
+        fixture.intent_before
+    );
+    assert_eq!(
+        grant_snapshot(&fixture.db, &fixture.grant_id).await,
+        fixture.grant_before
+    );
+    assert_eq!(
+        ledger_snapshot(&fixture.db, &fixture.intent_id).await,
+        fixture.ledger_before
+    );
+}
+
+async fn fixture(phase: IntentPhase, action: TerminalAction) -> Fixture {
+    let TestDb { db, directory } = test_db().await;
+    configure_policy(&db).await;
+    let item_id = format!("terminal-{}-{}", phase.name(), action.name());
+    let mut item = TaskBoardItem::new(
+        item_id.clone(),
+        "Terminal dispatch lifecycle".to_string(),
+        "Body".to_string(),
+        "2026-07-17T10:00:00Z".to_string(),
+    );
+    item.agent_mode = AgentMode::Headless;
+    db.create_task_board_item(item).await.expect("create item");
+    let grant_id = approved_grant(&db, &item_id).await;
+    let mut plan = build_dispatch_plans_with_policy(
+        &[db.task_board_item(&item_id).await.expect("load item")],
+        None,
+        None,
+        SpawnGateSwitches::default(),
+        &HashMap::new(),
+    )
+    .remove(0);
+    plan.consumed_approval_grant_id = Some(grant_id.clone());
+    let intent_id = preparing_intent(
+        db.reserve_task_board_dispatch(
+            &plan,
+            "control-plane",
+            Some("/tmp/project"),
+            phase == IntentPhase::Held,
+        )
+        .await
+        .expect("reserve dispatch"),
+    );
+    let preparation = db
+        .claim_task_board_dispatch_preparation(&intent_id)
+        .await
+        .expect("claim preparation")
+        .expect("pending preparation");
+    db.complete_task_board_dispatch_preparation(&preparation, "branch", "/tmp/worktree")
+        .await
+        .expect("publish dispatch");
+    if phase == IntentPhase::Held {
+        attach_consumed_grant_to_held_intent(&db, &intent_id, &grant_id).await;
+    } else if phase == IntentPhase::Starting {
+        db.claim_task_board_dispatch(&item_id)
+            .await
+            .expect("claim worker dispatch")
+            .expect("pending worker dispatch");
+    }
+    let item_before = db
+        .task_board_item(&item_id)
+        .await
+        .expect("load fixture item");
+    let intent_before = intent_snapshot(&db, &intent_id).await;
+    assert_eq!(intent_before.status, phase.name());
+    let grant_before = grant_snapshot(&db, &grant_id).await;
+    assert_eq!(grant_before.state, "approved");
+    assert!(grant_before.consumed_at.is_some());
+    let ledger_before = ledger_snapshot(&db, &intent_id).await;
+    assert!(!ledger_before.is_empty());
+    assert!(
+        ledger_before.iter().any(|row| row.state == "reserved"),
+        "fixture has no active admission reservation: {ledger_before:?}"
+    );
+    Fixture {
+        db,
+        _directory: directory,
+        item_id,
+        intent_id,
+        grant_id,
+        item_before,
+        intent_before,
+        grant_before,
+        ledger_before,
+    }
+}
+
+async fn approved_grant(db: &AsyncDaemonDb, item_id: &str) -> String {
+    let grant = db
+        .ensure_pending_approval_grant(&NewApprovalGrant {
+            board_item_id: item_id.to_string(),
+            action: PolicyAction::SpawnAgent,
+            canvas_id: None,
+            canvas_revision: 1,
+            node_id: "approve-spawn".to_string(),
+            reason_code: PolicyReasonCode::ApprovalRequired,
+            expiry_seconds: None,
+        })
+        .await
+        .expect("create approval grant");
+    db.resolve_approval_grant(&grant.id, true, "operator")
+        .await
+        .expect("approve grant");
+    grant.id
+}
+
+async fn attach_consumed_grant_to_held_intent(db: &AsyncDaemonDb, intent_id: &str, grant_id: &str) {
+    let mut transaction = db.pool().begin().await.expect("begin grant transaction");
+    assert!(
+        consume_approval_grant_in_tx(&mut *transaction, grant_id)
+            .await
+            .expect("consume held grant")
+    );
+    sqlx::query(
+        "UPDATE task_board_dispatch_intents SET consumed_approval_grant_id = ?2
+         WHERE intent_id = ?1 AND status = 'held'",
+    )
+    .bind(intent_id)
+    .bind(grant_id)
+    .execute(&mut *transaction)
+    .await
+    .expect("attach held grant");
+    transaction.commit().await.expect("commit held grant");
+}
+
+fn preparing_intent(outcome: ReservedTaskBoardDispatch) -> String {
+    match outcome {
+        ReservedTaskBoardDispatch::Preparing { intent_id, .. } => intent_id,
+        ReservedTaskBoardDispatch::Applied(_) => panic!("new reservation already applied"),
+        ReservedTaskBoardDispatch::Blocked(_) => panic!("admission blocked fixture"),
+    }
+}
+
+async fn configure_policy(db: &AsyncDaemonDb) {
+    let mut settings = db
+        .task_board_orchestrator_settings()
+        .await
+        .expect("load settings");
+    settings.admission_policy = TaskBoardAutomationPolicy {
+        limits: vec![TaskBoardPolicyLimit::Concurrency {
+            scope: TaskBoardPolicyScope::Global,
+            limit: 10,
+            reservation: 1,
+        }],
+        windows: Vec::new(),
+    };
+    db.replace_task_board_orchestrator_settings(&settings)
+        .await
+        .expect("save settings");
+}
+
+struct TestDb {
+    db: AsyncDaemonDb,
+    directory: TempDir,
+}
+
+async fn test_db() -> TestDb {
+    let directory = tempdir().expect("tempdir");
+    let path = directory.path().join("harness.db");
+    let sync_db = DaemonDb::open(&path).expect("open sync db");
+    let project = super::super::sample_project();
+    sync_db.sync_project(&project).expect("sync project");
+    let session = super::super::sample_session_state();
+    sync_db
+        .sync_session(&project.project_id, &session)
+        .expect("sync session");
+    drop(sync_db);
+    TestDb {
+        db: AsyncDaemonDb::connect(&path).await.expect("open db"),
+        directory,
+    }
+}
+
+impl Deref for TestDb {
+    type Target = AsyncDaemonDb;
+
+    fn deref(&self) -> &Self::Target {
+        &self.db
+    }
+}
+
+async fn intent_snapshot(db: &AsyncDaemonDb, intent_id: &str) -> IntentSnapshot {
+    let row = sqlx::query_as::<
+        _,
+        (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ),
+    >(
+        "SELECT status, claim_token, claimed_at, consumed_approval_grant_id,
+                last_error, completed_at
+         FROM task_board_dispatch_intents WHERE intent_id = ?1",
+    )
+    .bind(intent_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("load intent snapshot");
+    IntentSnapshot {
+        status: row.0,
+        claim_token: row.1,
+        claimed_at: row.2,
+        grant_id: row.3,
+        last_error: row.4,
+        completed_at: row.5,
+    }
+}
+
+async fn grant_snapshot(db: &AsyncDaemonDb, grant_id: &str) -> GrantSnapshot {
+    let (state, consumed_at) =
+        sqlx::query_as("SELECT state, consumed_at FROM policy_approval_grants WHERE id = ?1")
+            .bind(grant_id)
+            .fetch_one(db.pool())
+            .await
+            .expect("load grant snapshot");
+    GrantSnapshot { state, consumed_at }
+}
+
+async fn ledger_snapshot(db: &AsyncDaemonDb, intent_id: &str) -> Vec<LedgerSnapshot> {
+    sqlx::query_as::<_, (String, Option<String>, Option<String>)>(
+        "SELECT state, expires_at, released_at
+         FROM task_board_dispatch_admission_ledger
+         WHERE intent_id = ?1 ORDER BY canonical_key",
+    )
+    .bind(intent_id)
+    .fetch_all(db.pool())
+    .await
+    .expect("load ledger snapshot")
+    .into_iter()
+    .map(|(state, expires_at, released_at)| LedgerSnapshot {
+        state,
+        expires_at,
+        released_at,
+    })
+    .collect()
+}

--- a/src/daemon/http/task_board_route_executor.rs
+++ b/src/daemon/http/task_board_route_executor.rs
@@ -1,7 +1,4 @@
-use tokio::task::spawn_blocking;
-use tracing::warn;
-
-use crate::daemon::db::{AsyncDaemonDb, ClaimedTaskBoardDispatch};
+use crate::daemon::db::AsyncDaemonDb;
 #[cfg(test)]
 use crate::daemon::protocol::ManagedAgentSnapshot;
 use crate::daemon::protocol::{
@@ -11,15 +8,15 @@ use crate::daemon::protocol::{
     TaskBoardOrchestratorRunOnceResponse,
 };
 use crate::daemon::service;
-use crate::daemon::task_board_managed_agents::{
-    rendered_worker_prompt, start_worker_for_applied_task,
-};
+use crate::daemon::task_board_managed_agents::rendered_worker_prompt;
 use crate::errors::{CliError, CliErrorKind};
 use crate::feature_flags::task_board_automation_v2_enabled_from_env;
+#[cfg(test)]
+use crate::task_board::DispatchFailureKind;
 use crate::task_board::{
-    DispatchAppliedTask, DispatchExecutionSummary, DispatchFailure, DispatchFailureKind,
-    TaskBoardAutomationRunTrigger,
+    DispatchAppliedTask, DispatchExecutionSummary, DispatchFailure, TaskBoardAutomationRunTrigger,
 };
+use tokio::task::spawn_blocking;
 
 use super::{DaemonHttpState, require_async_db};
 
@@ -27,6 +24,7 @@ mod automation_run;
 mod item_ops;
 mod orchestrator_ops;
 mod policy_ops;
+mod worker_start;
 
 pub(crate) use item_ops::*;
 pub(crate) use orchestrator_ops::*;
@@ -70,29 +68,13 @@ pub(crate) async fn deliver(
     }
     let mut claim = db.claim_held_task_board_dispatch(&request.item_id).await?;
     let prompt = rendered_worker_prompt(&claim.applied, &claim.intent_id);
-    match start_worker_for_applied_task(state, &claim.applied, &claim.intent_id).await {
-        Ok(agent) => {
-            claim.applied.item = db
-                .complete_task_board_dispatch(&claim.intent_id, &claim.claim_token)
-                .await?;
-            Ok(TaskBoardDispatchDeliverResponse {
-                intent_id: claim.intent_id,
-                applied: claim.applied,
-                rendered_prompt: prompt,
-                started_agent: Some(agent),
-            })
-        }
-        Err(error) => {
-            db.fail_task_board_dispatch(
-                &claim.intent_id,
-                &claim.claim_token,
-                claim.consumed_approval_grant_id.as_deref(),
-                &error.to_string(),
-            )
-            .await?;
-            Err(error)
-        }
-    }
+    let agent = worker_start::start_and_complete_delivered_worker(state, db, &mut claim).await?;
+    Ok(TaskBoardDispatchDeliverResponse {
+        intent_id: claim.intent_id,
+        applied: claim.applied,
+        rendered_prompt: prompt,
+        started_agent: Some(agent),
+    })
 }
 
 pub(crate) async fn pick(
@@ -149,7 +131,8 @@ async fn handle_dispatch_result(
 ) -> Result<TaskBoardDispatchResponse, CliError> {
     let mut response = result?;
     if !response.applied.is_empty() {
-        let (applied, failures) = start_claimed_workers(state, &response.applied, async_db).await;
+        let (applied, failures) =
+            worker_start::start_claimed_workers(state, &response.applied, async_db).await;
         response.applied = applied;
         response.failures.extend(failures);
         broadcast_sessions_updated(state, Some(async_db)).await;
@@ -170,7 +153,7 @@ async fn handle_run_once_result(
             .and_then(|run| run.dispatch.as_ref())
             .map(|dispatch| dispatch.applied.clone())
             .unwrap_or_default();
-        let (kept, failures) = start_claimed_workers(state, &applied, async_db).await;
+        let (kept, failures) = worker_start::start_claimed_workers(state, &applied, async_db).await;
         if let Some(dispatch) = status
             .last_run
             .as_mut()
@@ -195,74 +178,6 @@ fn amend_dispatch_for_worker_outcomes(
 ) {
     dispatch.applied = kept;
     dispatch.failures.extend(failures);
-}
-
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "worker startup must keep successful claims while routing each failure through durable rollback"
-)]
-async fn start_claimed_workers(
-    state: &DaemonHttpState,
-    applied: &[DispatchAppliedTask],
-    async_db: &AsyncDaemonDb,
-) -> (Vec<DispatchAppliedTask>, Vec<DispatchFailure>) {
-    let mut kept = Vec::new();
-    let mut failures = Vec::new();
-    for task in applied {
-        let mut claim = match async_db
-            .claim_task_board_dispatch(&task.board_item_id)
-            .await
-        {
-            Ok(Some(claim)) => claim,
-            Ok(None) => {
-                kept.push(task.clone());
-                continue;
-            }
-            Err(error) => {
-                warn!(board_item_id = %task.board_item_id, %error, "deferred task board worker claim to recovery loop");
-                kept.push(task.clone());
-                continue;
-            }
-        };
-        match start_worker_for_applied_task(state, &claim.applied, &claim.intent_id).await {
-            Ok(_) => {
-                match async_db
-                    .complete_task_board_dispatch(&claim.intent_id, &claim.claim_token)
-                    .await
-                {
-                    Ok(item) => claim.applied.item = item,
-                    Err(error) => {
-                        warn!(board_item_id = %task.board_item_id, %error, "task board worker started but intent completion failed");
-                    }
-                }
-                kept.push(claim.applied);
-            }
-            Err(error) => record_worker_failure(async_db, claim, error, &mut failures).await,
-        }
-    }
-    (kept, failures)
-}
-
-async fn record_worker_failure(
-    db: &AsyncDaemonDb,
-    claim: ClaimedTaskBoardDispatch,
-    error: CliError,
-    failures: &mut Vec<DispatchFailure>,
-) {
-    let rollback = db
-        .fail_task_board_dispatch(
-            &claim.intent_id,
-            &claim.claim_token,
-            claim.consumed_approval_grant_id.as_deref(),
-            &error.to_string(),
-        )
-        .await;
-    log_rollback_outcome(&claim.applied.board_item_id, rollback.err());
-    failures.push(DispatchFailure {
-        board_item_id: claim.applied.board_item_id,
-        kind: DispatchFailureKind::WorkerSpawnFailed,
-        message: error.to_string(),
-    });
 }
 
 /// Shared classifier for worker spawn outcomes. Runs `on_failure` for each
@@ -290,20 +205,6 @@ fn classify_worker_outcomes(
         }
     }
     (kept, failures)
-}
-
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "tracing macro expansion inflates the score; tokio-rs/tracing#553"
-)]
-fn log_rollback_outcome(board_item_id: &str, undo_error: Option<CliError>) {
-    if let Some(error) = undo_error {
-        warn!(
-            board_item_id,
-            error = %error,
-            "failed to roll back dispatched task-board item after worker spawn failure",
-        );
-    }
 }
 
 async fn broadcast_sessions_updated(state: &DaemonHttpState, async_db: Option<&AsyncDaemonDb>) {

--- a/src/daemon/http/task_board_route_executor/orchestrator_ops.rs
+++ b/src/daemon/http/task_board_route_executor/orchestrator_ops.rs
@@ -89,6 +89,9 @@ pub(crate) async fn update_orchestrator_settings(
     state: &DaemonHttpState,
     request: &TaskBoardOrchestratorSettingsUpdateRequest,
 ) -> Result<TaskBoardOrchestratorSettingsResponse, CliError> {
+    request.validate_admission_policy().map_err(|error| {
+        CliErrorKind::workflow_parse(format!("invalid task-board admission policy: {error}"))
+    })?;
     service::update_task_board_orchestrator_settings_db(
         require_async_db(state, "task board orchestrator settings update")?,
         request,

--- a/src/daemon/http/task_board_route_executor/worker_start.rs
+++ b/src/daemon/http/task_board_route_executor/worker_start.rs
@@ -1,0 +1,298 @@
+use tracing::warn;
+
+use crate::daemon::db::{AsyncDaemonDb, ClaimedTaskBoardDispatch, TaskBoardDispatchClaimAction};
+use crate::daemon::protocol::ManagedAgentSnapshot;
+use crate::daemon::task_board_managed_agents::{
+    TaskBoardWorkerStartError, begin_worker_compensation, maintain_task_board_dispatch_claim,
+    managed_worker_id, resume_worker_compensation, start_worker_for_applied_task,
+};
+use crate::errors::{CliError, CliErrorKind};
+use crate::task_board::{DispatchAppliedTask, DispatchFailure, DispatchFailureKind};
+
+use super::DaemonHttpState;
+
+pub(super) async fn start_and_complete_delivered_worker(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    claim: &mut ClaimedTaskBoardDispatch,
+) -> Result<ManagedAgentSnapshot, CliError> {
+    let _heartbeat =
+        maintain_task_board_dispatch_claim(db.clone(), &claim.intent_id, &claim.claim_token);
+    let agent = match start_worker_for_applied_task(
+        state,
+        &claim.applied,
+        &claim.intent_id,
+        &claim.claim_token,
+    )
+    .await
+    {
+        Ok(agent) => agent,
+        Err(start_error) => {
+            let may_rollback = start_error.may_rollback();
+            let error = start_error.into_cli_error();
+            if may_rollback {
+                db.fail_task_board_dispatch(
+                    &claim.intent_id,
+                    &claim.claim_token,
+                    claim.consumed_approval_grant_id.as_deref(),
+                    &error.to_string(),
+                )
+                .await?;
+            }
+            return Err(error);
+        }
+    };
+    if let Err(error) = ensure_started_claim_current(db, claim).await {
+        return match compensate_started_worker(state, db, claim, &error).await {
+            Ok(()) => Err(error),
+            Err(compensation_error) => Err(compensation_error),
+        };
+    }
+    match complete_started_worker(db, claim).await {
+        Ok(()) => Ok(agent),
+        Err(error) => match compensate_started_worker(state, db, claim, &error).await {
+            Ok(()) => Err(error),
+            Err(compensation_error) => Err(compensation_error),
+        },
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "worker startup must keep successful claims while routing each failure through durable rollback"
+)]
+pub(super) async fn start_claimed_workers(
+    state: &DaemonHttpState,
+    applied: &[DispatchAppliedTask],
+    db: &AsyncDaemonDb,
+) -> (Vec<DispatchAppliedTask>, Vec<DispatchFailure>) {
+    let mut kept = Vec::new();
+    let mut failures = Vec::new();
+    for task in applied {
+        let mut claim = match db.claim_task_board_dispatch(&task.board_item_id).await {
+            Ok(Some(claim)) => claim,
+            Ok(None) => {
+                record_unclaimed_outcome(
+                    db,
+                    task,
+                    CliErrorKind::workflow_io(
+                        "task-board worker start is not durably completed; recovery may own it",
+                    )
+                    .into(),
+                    &mut kept,
+                    &mut failures,
+                )
+                .await;
+                continue;
+            }
+            Err(error) => {
+                warn!(board_item_id = %task.board_item_id, %error, "deferred task board worker claim to recovery loop");
+                record_unclaimed_outcome(db, task, error, &mut kept, &mut failures).await;
+                continue;
+            }
+        };
+        let _heartbeat =
+            maintain_task_board_dispatch_claim(db.clone(), &claim.intent_id, &claim.claim_token);
+        if let TaskBoardDispatchClaimAction::Compensate { reason } = &claim.action {
+            let error = resume_compensating_claim(state, db, &claim, reason).await;
+            failures.push(worker_failure(&claim.applied, &error));
+            continue;
+        }
+        match start_worker_for_applied_task(
+            state,
+            &claim.applied,
+            &claim.intent_id,
+            &claim.claim_token,
+        )
+        .await
+        {
+            Ok(_) => {
+                if let Err(error) = ensure_started_claim_current(db, &claim).await {
+                    let message = compensate_started_worker(state, db, &claim, &error)
+                        .await
+                        .err()
+                        .unwrap_or(error);
+                    failures.push(worker_failure(&claim.applied, &message));
+                    continue;
+                }
+                if let Err(error) = complete_started_worker(db, &mut claim).await {
+                    let message = compensate_started_worker(state, db, &claim, &error)
+                        .await
+                        .err()
+                        .unwrap_or(error);
+                    failures.push(worker_failure(&claim.applied, &message));
+                    continue;
+                }
+                kept.push(claim.applied);
+            }
+            Err(error) => record_worker_failure(db, claim, error, &mut failures).await,
+        }
+    }
+    (kept, failures)
+}
+
+async fn record_unclaimed_outcome(
+    db: &AsyncDaemonDb,
+    applied: &DispatchAppliedTask,
+    error: CliError,
+    kept: &mut Vec<DispatchAppliedTask>,
+    failures: &mut Vec<DispatchFailure>,
+) {
+    match db.task_board_dispatch_is_held(applied).await {
+        Ok(true) => {
+            kept.push(applied.clone());
+            return;
+        }
+        Ok(false) => {}
+        Err(status_error) => {
+            failures.push(worker_failure(applied, &status_error));
+            return;
+        }
+    }
+    match db.task_board_dispatch_is_completed(applied).await {
+        Ok(true) => kept.push(applied.clone()),
+        Ok(false) => failures.push(worker_failure(applied, &error)),
+        Err(status_error) => failures.push(worker_failure(applied, &status_error)),
+    }
+}
+
+async fn complete_started_worker(
+    db: &AsyncDaemonDb,
+    claim: &mut ClaimedTaskBoardDispatch,
+) -> Result<(), CliError> {
+    claim.applied.item = db
+        .complete_task_board_dispatch(
+            &claim.intent_id,
+            &claim.claim_token,
+            &managed_worker_id(&claim.applied, &claim.intent_id),
+        )
+        .await?;
+    Ok(())
+}
+
+async fn compensate_started_worker(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    claim: &ClaimedTaskBoardDispatch,
+    completion_error: &CliError,
+) -> Result<(), CliError> {
+    begin_worker_compensation(
+        state,
+        db,
+        &claim.applied,
+        &claim.intent_id,
+        &claim.claim_token,
+        &completion_error.to_string(),
+    )
+        .await
+        .map_err(|stop_error| {
+            CliErrorKind::workflow_io(format!(
+                "task-board worker intent completion failed ({completion_error}); compensation failed ({stop_error}); the claim remains for recovery"
+            ))
+        })?;
+    db.finalize_task_board_dispatch_compensation(
+        &claim.intent_id,
+        &claim.claim_token,
+        claim.consumed_approval_grant_id.as_deref(),
+        &managed_worker_id(&claim.applied, &claim.intent_id),
+        &completion_error.to_string(),
+    )
+    .await
+    .map_err(|rollback_error| {
+        CliErrorKind::workflow_io(format!(
+            "task-board worker stopped after intent completion failed ({completion_error}), but rollback failed ({rollback_error})"
+        ))
+        .into()
+    })
+}
+
+async fn resume_compensating_claim(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    claim: &ClaimedTaskBoardDispatch,
+    reason: &str,
+) -> CliError {
+    let result = resume_worker_compensation(
+        state,
+        db,
+        &claim.applied,
+        &claim.intent_id,
+        &claim.claim_token,
+    )
+    .await;
+    if let Err(error) = result {
+        return error;
+    }
+    match db
+        .finalize_task_board_dispatch_compensation(
+            &claim.intent_id,
+            &claim.claim_token,
+            claim.consumed_approval_grant_id.as_deref(),
+            &managed_worker_id(&claim.applied, &claim.intent_id),
+            reason,
+        )
+        .await
+    {
+        Ok(()) => CliErrorKind::workflow_io(reason.to_string()).into(),
+        Err(error) => error,
+    }
+}
+
+async fn ensure_started_claim_current(
+    db: &AsyncDaemonDb,
+    claim: &ClaimedTaskBoardDispatch,
+) -> Result<(), CliError> {
+    db.renew_task_board_dispatch_claim(&claim.intent_id, &claim.claim_token)
+        .await
+        .map_err(|error| {
+            CliErrorKind::workflow_io(format!(
+                "task-board worker started, but dispatch claim '{}' is no longer current: {error}; leaving the worker and claim for recovery",
+                claim.intent_id
+            ))
+            .into()
+        })
+}
+
+async fn record_worker_failure(
+    db: &AsyncDaemonDb,
+    claim: ClaimedTaskBoardDispatch,
+    start_error: TaskBoardWorkerStartError,
+    failures: &mut Vec<DispatchFailure>,
+) {
+    let may_rollback = start_error.may_rollback();
+    let error = start_error.into_cli_error();
+    if may_rollback {
+        let rollback = db
+            .fail_task_board_dispatch(
+                &claim.intent_id,
+                &claim.claim_token,
+                claim.consumed_approval_grant_id.as_deref(),
+                &error.to_string(),
+            )
+            .await;
+        log_rollback_outcome(&claim.applied.board_item_id, rollback.err());
+    }
+    failures.push(worker_failure(&claim.applied, &error));
+}
+
+fn worker_failure(applied: &DispatchAppliedTask, error: &CliError) -> DispatchFailure {
+    DispatchFailure {
+        board_item_id: applied.board_item_id.clone(),
+        kind: DispatchFailureKind::WorkerSpawnFailed,
+        message: error.to_string(),
+    }
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "tracing macro expansion inflates the score; tokio-rs/tracing#553"
+)]
+fn log_rollback_outcome(board_item_id: &str, undo_error: Option<CliError>) {
+    if let Some(error) = undo_error {
+        warn!(
+            board_item_id,
+            error = %error,
+            "failed to roll back dispatched task-board item after worker spawn failure",
+        );
+    }
+}

--- a/src/daemon/http/tests/task_board_crud.rs
+++ b/src/daemon/http/tests/task_board_crud.rs
@@ -107,6 +107,14 @@ async fn run_flow() {
             .as_bool(),
         Some(true)
     );
+    let admission_policy = json!({
+        "limits": [{
+            "kind": "concurrency",
+            "scope": { "kind": "global" },
+            "limit": 2,
+            "reservation": 1
+        }]
+    });
     let settings = put_json(
         &client,
         &base_url,
@@ -114,12 +122,37 @@ async fn run_flow() {
         json!({
             "dry_run_default": false,
             "dispatch_status_filter": "todo",
-            "step_mode": true
+            "step_mode": true,
+            "admission_policy": admission_policy
         }),
     )
     .await;
     assert_eq!(settings["dry_run_default"].as_bool(), Some(false));
     assert_eq!(settings["step_mode"].as_bool(), Some(true));
+    assert_eq!(settings["admission_policy"], admission_policy);
+    let (invalid_status, invalid_error) = put_json_with_status(
+        &client,
+        &base_url,
+        http_paths::TASK_BOARD_ORCHESTRATOR_SETTINGS,
+        json!({
+            "dry_run_default": true,
+            "admission_policy": {
+                "limits": [{
+                    "kind": "concurrency",
+                    "scope": { "kind": "global" },
+                    "limit": 0,
+                    "reservation": 1
+                }]
+            }
+        }),
+    )
+    .await;
+    assert_eq!(invalid_status, StatusCode::BAD_REQUEST);
+    assert!(
+        invalid_error["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("invalid task-board admission policy"))
+    );
     let loaded_settings = get_json(
         &client,
         &base_url,
@@ -128,6 +161,7 @@ async fn run_flow() {
     .await;
     assert_eq!(loaded_settings["dry_run_default"].as_bool(), Some(false));
     assert_eq!(loaded_settings["step_mode"].as_bool(), Some(true));
+    assert_eq!(loaded_settings["admission_policy"], admission_policy);
     let status = get_json(
         &client,
         &base_url,
@@ -270,6 +304,15 @@ async fn post_json_with_status(
 
 async fn put_json(client: &reqwest::Client, base_url: &str, path: &str, body: Value) -> Value {
     json_request(client.put(format!("{base_url}{path}")).json(&body), path).await
+}
+
+async fn put_json_with_status(
+    client: &reqwest::Client,
+    base_url: &str,
+    path: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    json_request_with_status(client.put(format!("{base_url}{path}")).json(&body)).await
 }
 
 async fn get_json(client: &reqwest::Client, base_url: &str, path: &str) -> Value {

--- a/src/daemon/protocol/mod.rs
+++ b/src/daemon/protocol/mod.rs
@@ -10,6 +10,7 @@ mod session_requests;
 mod summaries;
 mod task_board;
 mod task_board_automation;
+mod task_board_item_requests;
 mod task_board_spawn_gate;
 mod task_board_steps;
 #[cfg(test)]
@@ -32,6 +33,7 @@ pub use session_requests::*;
 pub use summaries::*;
 pub use task_board::*;
 pub use task_board_automation::*;
+pub use task_board_item_requests::*;
 pub use task_board_spawn_gate::*;
 pub use task_board_steps::*;
 pub use voice::*;

--- a/src/daemon/protocol/task_board.rs
+++ b/src/daemon/protocol/task_board.rs
@@ -9,14 +9,13 @@ pub struct TaskBoardUpdatedPayload {
 }
 
 use crate::task_board::{
-    AgentMode, DispatchExecutionSummary, ExternalProvider, ExternalRef, ExternalSyncConflictPolicy,
-    ExternalSyncDirection, Machine, PlanningState, PolicyGraphMode, PolicyInput,
-    PolicyPipelineAuditSummary, PolicyPipelineDocument, PolicyPipelineGoLiveDiff,
-    PolicyPipelineReplayResult, PolicyPipelineSaveResponse, PolicyPipelineSimulationResult,
-    PolicyScenario, TaskBoardAuditSummary, TaskBoardAutomationSnapshot, TaskBoardEvaluationSummary,
-    TaskBoardGitIdentityDefaults, TaskBoardItem, TaskBoardMachineSummary, TaskBoardPriority,
-    TaskBoardProjectSummary, TaskBoardStatus, TaskBoardSyncSummary, TaskBoardWorkflowKind,
-    planning::PlanningTransition, types::TaskBoardWorkflowState,
+    DispatchExecutionSummary, ExternalProvider, ExternalSyncConflictPolicy, ExternalSyncDirection,
+    Machine, PolicyGraphMode, PolicyInput, PolicyPipelineAuditSummary, PolicyPipelineDocument,
+    PolicyPipelineGoLiveDiff, PolicyPipelineReplayResult, PolicyPipelineSaveResponse,
+    PolicyPipelineSimulationResult, PolicyScenario, TaskBoardAuditSummary,
+    TaskBoardAutomationSnapshot, TaskBoardEvaluationSummary, TaskBoardGitIdentityDefaults,
+    TaskBoardItem, TaskBoardMachineSummary, TaskBoardProjectSummary, TaskBoardStatus,
+    TaskBoardSyncSummary, planning::PlanningTransition,
 };
 
 pub use crate::task_board::{
@@ -30,117 +29,6 @@ pub use crate::task_board::{
     TaskBoardTodoistTokenSyncRequest,
     TaskBoardTodoistTokenSyncResponse as TaskBoardTodoistTokenSyncOutcome,
 };
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaskBoardCreateItemRequest {
-    pub title: String,
-    #[serde(default)]
-    pub body: String,
-    #[serde(default)]
-    pub priority: TaskBoardPriority,
-    #[serde(default)]
-    pub agent_mode: AgentMode,
-    #[serde(default)]
-    pub workflow_kind: TaskBoardWorkflowKind,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub execution_repository: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tags: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub project_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub target_project_types: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub external_refs: Vec<ExternalRef>,
-    #[serde(default)]
-    pub planning: PlanningState,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workflow: Option<TaskBoardWorkflowState>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub work_item_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct TaskBoardListItemsRequest {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub status: Option<TaskBoardStatus>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaskBoardGetItemRequest {
-    pub id: String,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct TaskBoardUpdateItemRequest {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub status: Option<TaskBoardStatus>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub priority: Option<TaskBoardPriority>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent_mode: Option<AgentMode>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workflow_kind: Option<TaskBoardWorkflowKind>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub execution_repository: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tags: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub project_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub target_project_types: Option<Vec<String>>,
-    #[serde(default, flatten)]
-    pub clear_identity: TaskBoardUpdateIdentityClears,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub external_refs: Option<Vec<ExternalRef>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub planning: Option<PlanningState>,
-    #[serde(default, flatten)]
-    pub clear_state: TaskBoardUpdateStateClears,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workflow: Option<TaskBoardWorkflowState>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub work_item_id: Option<String>,
-}
-
-#[expect(
-    clippy::struct_excessive_bools,
-    reason = "wire contract exposes independent identity-clear switches"
-)]
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct TaskBoardUpdateIdentityClears {
-    #[serde(default)]
-    pub clear_project_id: bool,
-    #[serde(default)]
-    pub clear_execution_repository: bool,
-    #[serde(default)]
-    pub clear_session_id: bool,
-    #[serde(default)]
-    pub clear_work_item_id: bool,
-}
-
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct TaskBoardUpdateStateClears {
-    #[serde(default)]
-    pub clear_planning: bool,
-    #[serde(default)]
-    pub clear_workflow: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaskBoardDeleteItemRequest {
-    pub id: String,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskBoardPlanBeginRequest {

--- a/src/daemon/protocol/task_board_item_requests.rs
+++ b/src/daemon/protocol/task_board_item_requests.rs
@@ -1,0 +1,135 @@
+use serde::{Deserialize, Serialize};
+
+use crate::task_board::{
+    AgentMode, ExternalRef, PlanningState, TaskBoardPriority, TaskBoardStatus,
+    TaskBoardWorkflowKind, types::TaskBoardWorkflowState,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskBoardCreateItemRequest {
+    pub title: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub priority: TaskBoardPriority,
+    #[serde(default)]
+    pub agent_mode: AgentMode,
+    #[serde(default)]
+    pub workflow_kind: TaskBoardWorkflowKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_repository: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_cost_microusd: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub target_project_types: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_refs: Vec<ExternalRef>,
+    #[serde(default)]
+    pub planning: PlanningState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<TaskBoardWorkflowState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TaskBoardListItemsRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<TaskBoardStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskBoardGetItemRequest {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TaskBoardUpdateItemRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<TaskBoardStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<TaskBoardPriority>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_mode: Option<AgentMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_kind: Option<TaskBoardWorkflowKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_repository: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_cost_microusd: Option<u64>,
+    #[serde(default, flatten)]
+    pub clear_estimates: TaskBoardUpdateEstimateClears,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_project_types: Option<Vec<String>>,
+    #[serde(default, flatten)]
+    pub clear_identity: TaskBoardUpdateIdentityClears,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_refs: Option<Vec<ExternalRef>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub planning: Option<PlanningState>,
+    #[serde(default, flatten)]
+    pub clear_state: TaskBoardUpdateStateClears,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<TaskBoardWorkflowState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+}
+
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "wire contract exposes independent identity-clear switches"
+)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct TaskBoardUpdateIdentityClears {
+    #[serde(default)]
+    pub clear_project_id: bool,
+    #[serde(default)]
+    pub clear_execution_repository: bool,
+    #[serde(default)]
+    pub clear_session_id: bool,
+    #[serde(default)]
+    pub clear_work_item_id: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct TaskBoardUpdateEstimateClears {
+    #[serde(default)]
+    pub clear_estimated_tokens: bool,
+    #[serde(default)]
+    pub clear_estimated_cost_microusd: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct TaskBoardUpdateStateClears {
+    #[serde(default)]
+    pub clear_planning: bool,
+    #[serde(default)]
+    pub clear_workflow: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskBoardDeleteItemRequest {
+    pub id: String,
+}

--- a/src/daemon/service/serve/mod.rs
+++ b/src/daemon/service/serve/mod.rs
@@ -104,6 +104,9 @@ pub async fn serve(config: DaemonServeConfig) -> Result<(), CliError> {
         async_db.clone(),
         config.sandboxed,
     );
+    codex_controller
+        .reconcile_task_board_admission_workers_after_restart()
+        .await?;
     let agent_tui_manager = AgentTuiManagerHandle::new_with_async_db(
         sender.clone(),
         db.clone(),

--- a/src/daemon/service/serve/remote.rs
+++ b/src/daemon/service/serve/remote.rs
@@ -91,6 +91,9 @@ pub async fn serve_remote_https(
         async_db.clone(),
         config.sandboxed,
     );
+    codex_controller
+        .reconcile_task_board_admission_workers_after_restart()
+        .await?;
     let agent_tui_manager = AgentTuiManagerHandle::new_with_async_db(
         sender.clone(),
         db.clone(),

--- a/src/daemon/service/serve/task_board_dispatch_loop.rs
+++ b/src/daemon/service/serve/task_board_dispatch_loop.rs
@@ -5,10 +5,13 @@ use tokio::task::JoinHandle;
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::warn;
 
-use crate::daemon::db::{AsyncDaemonDb, ClaimedTaskBoardDispatch};
+use crate::daemon::db::{AsyncDaemonDb, ClaimedTaskBoardDispatch, TaskBoardDispatchClaimAction};
 use crate::daemon::http::DaemonHttpState;
 use crate::daemon::service::task_board::prepare_claimed_task_board_dispatch;
-use crate::daemon::task_board_managed_agents::start_worker_for_applied_task;
+use crate::daemon::task_board_managed_agents::{
+    begin_worker_compensation, maintain_task_board_dispatch_claim, managed_worker_id,
+    resume_worker_compensation, start_worker_for_applied_task,
+};
 
 const RECOVERY_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_RECOVERIES_PER_TICK: usize = 16;
@@ -85,28 +88,169 @@ async fn finish_claim(
     db: &AsyncDaemonDb,
     claim: ClaimedTaskBoardDispatch,
 ) {
-    let result = start_worker_for_applied_task(state, &claim.applied, &claim.intent_id).await;
+    let _heartbeat =
+        maintain_task_board_dispatch_claim(db.clone(), &claim.intent_id, &claim.claim_token);
+    if let Some(reason) = compensation_reason(&claim.action) {
+        finish_compensating_claim(state, db, &claim, reason).await;
+        return;
+    }
+    let result =
+        start_worker_for_applied_task(state, &claim.applied, &claim.intent_id, &claim.claim_token)
+            .await;
     match result {
         Ok(_) => {
             if let Err(error) = db
-                .complete_task_board_dispatch(&claim.intent_id, &claim.claim_token)
+                .renew_task_board_dispatch_claim(&claim.intent_id, &claim.claim_token)
                 .await
             {
-                warn!(board_item_id = %claim.applied.board_item_id, %error, "task board dispatch recovery completion failed");
+                compensate_failed_completion(state, db, &claim, &error).await;
+                return;
             }
-        }
-        Err(error) => {
-            if let Err(rollback_error) = db
-                .fail_task_board_dispatch(
+            if let Err(error) = db
+                .complete_task_board_dispatch(
                     &claim.intent_id,
                     &claim.claim_token,
-                    claim.consumed_approval_grant_id.as_deref(),
-                    &error.to_string(),
+                    &managed_worker_id(&claim.applied, &claim.intent_id),
                 )
                 .await
             {
-                warn!(board_item_id = %claim.applied.board_item_id, %rollback_error, "task board dispatch recovery rollback failed");
+                compensate_failed_completion(state, db, &claim, &error).await;
             }
         }
+        Err(start_error) => {
+            let may_rollback = start_error.may_rollback();
+            let error = start_error.into_cli_error();
+            if may_rollback {
+                if let Err(rollback_error) = db
+                    .fail_task_board_dispatch(
+                        &claim.intent_id,
+                        &claim.claim_token,
+                        claim.consumed_approval_grant_id.as_deref(),
+                        &error.to_string(),
+                    )
+                    .await
+                {
+                    warn!(board_item_id = %claim.applied.board_item_id, %rollback_error, "task board dispatch recovery rollback failed");
+                }
+            } else {
+                warn!(
+                    board_item_id = %claim.applied.board_item_id,
+                    %error,
+                    "task board worker start outcome is uncertain; leaving the claim fenced for recovery"
+                );
+            }
+        }
+    }
+}
+
+fn compensation_reason(action: &TaskBoardDispatchClaimAction) -> Option<&str> {
+    match action {
+        TaskBoardDispatchClaimAction::Start | TaskBoardDispatchClaimAction::Recover => None,
+        TaskBoardDispatchClaimAction::Compensate { reason } => Some(reason.as_str()),
+    }
+}
+
+async fn compensate_failed_completion(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    claim: &ClaimedTaskBoardDispatch,
+    completion_error: &crate::errors::CliError,
+) {
+    if let Err(stop_error) = begin_worker_compensation(
+        state,
+        db,
+        &claim.applied,
+        &claim.intent_id,
+        &claim.claim_token,
+        &completion_error.to_string(),
+    )
+    .await
+    {
+        warn!(
+            board_item_id = %claim.applied.board_item_id,
+            %completion_error,
+            %stop_error,
+            "task board dispatch recovery completion and compensation failed; leaving claim fenced"
+        );
+        return;
+    }
+    if let Err(rollback_error) = db
+        .finalize_task_board_dispatch_compensation(
+            &claim.intent_id,
+            &claim.claim_token,
+            claim.consumed_approval_grant_id.as_deref(),
+            &managed_worker_id(&claim.applied, &claim.intent_id),
+            &completion_error.to_string(),
+        )
+        .await
+    {
+        warn!(
+            board_item_id = %claim.applied.board_item_id,
+            %completion_error,
+            %rollback_error,
+            "task board dispatch recovery stopped its worker but rollback failed"
+        );
+    }
+}
+
+async fn finish_compensating_claim(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    claim: &ClaimedTaskBoardDispatch,
+    reason: &str,
+) {
+    if let Err(error) = resume_worker_compensation(
+        state,
+        db,
+        &claim.applied,
+        &claim.intent_id,
+        &claim.claim_token,
+    )
+    .await
+    {
+        warn!(
+            board_item_id = %claim.applied.board_item_id,
+            %error,
+            "task board worker compensation retry failed; leaving durable compensation pending"
+        );
+        return;
+    }
+    if let Err(error) = db
+        .finalize_task_board_dispatch_compensation(
+            &claim.intent_id,
+            &claim.claim_token,
+            claim.consumed_approval_grant_id.as_deref(),
+            &managed_worker_id(&claim.applied, &claim.intent_id),
+            reason,
+        )
+        .await
+    {
+        warn!(
+            board_item_id = %claim.applied.board_item_id,
+            %error,
+            "task board worker compensation rollback failed; leaving durable compensation pending"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TaskBoardDispatchClaimAction, compensation_reason};
+
+    #[test]
+    fn recovered_compensation_routes_around_worker_start() {
+        let action = TaskBoardDispatchClaimAction::Compensate {
+            reason: "worker stop required".to_string(),
+        };
+
+        assert_eq!(compensation_reason(&action), Some("worker stop required"));
+        assert_eq!(
+            compensation_reason(&TaskBoardDispatchClaimAction::Start),
+            None
+        );
+        assert_eq!(
+            compensation_reason(&TaskBoardDispatchClaimAction::Recover),
+            None
+        );
     }
 }

--- a/src/daemon/service/task_board.rs
+++ b/src/daemon/service/task_board.rs
@@ -339,6 +339,14 @@ fn patch_from_request(request: &TaskBoardUpdateItemRequest) -> TaskBoardItemPatc
             request.execution_repository.as_ref(),
             request.clear_identity.clear_execution_repository,
         ),
+        estimated_tokens: optional_copy_patch(
+            request.estimated_tokens,
+            request.clear_estimates.clear_estimated_tokens,
+        ),
+        estimated_cost_microusd: optional_copy_patch(
+            request.estimated_cost_microusd,
+            request.clear_estimates.clear_estimated_cost_microusd,
+        ),
         external_refs: request.external_refs.clone(),
         planning: request.planning.clone(),
         clear_planning: request.clear_state.clear_planning,
@@ -364,6 +372,15 @@ fn optional_string_patch(value: Option<&String>, clear: bool) -> OptionalFieldPa
     value
         .cloned()
         .map_or(OptionalFieldPatch::Unchanged, OptionalFieldPatch::Set)
+}
+
+#[cfg(test)]
+fn optional_copy_patch<T: Copy>(value: Option<T>, clear: bool) -> OptionalFieldPatch<T> {
+    if clear {
+        OptionalFieldPatch::Clear
+    } else {
+        value.map_or(OptionalFieldPatch::Unchanged, OptionalFieldPatch::Set)
+    }
 }
 
 #[cfg(test)]

--- a/src/daemon/service/task_board/dispatch_preparation.rs
+++ b/src/daemon/service/task_board/dispatch_preparation.rs
@@ -37,6 +37,14 @@ pub(super) async fn reserve_and_prepare_task_board_dispatch(
         .map_err(|error| (DispatchFailureKind::LinkItem, error))?;
     let (intent_id, _) = match reserved {
         ReservedTaskBoardDispatch::Applied(applied) => return Ok(applied),
+        ReservedTaskBoardDispatch::Blocked(admission) => {
+            return Err((
+                DispatchFailureKind::LinkItem,
+                CliError::from(CliErrorKind::invalid_transition(
+                    admission.refusal_message(),
+                )),
+            ));
+        }
         ReservedTaskBoardDispatch::Preparing {
             intent_id,
             preparation,

--- a/src/daemon/service/task_board_db.rs
+++ b/src/daemon/service/task_board_db.rs
@@ -28,6 +28,7 @@ pub(crate) use crate::task_board::external::{
     TaskBoardSyncCoordinatorFence, TaskBoardSyncCoordinatorFenceDecision,
 };
 
+mod estimate_validation;
 #[cfg(test)]
 mod external_ref_tests;
 mod provider_sync_context_store;
@@ -37,6 +38,7 @@ mod reviews_sync;
 mod sync_audit;
 mod sync_run_context;
 
+use estimate_validation::{validate_estimate, validate_update_estimates};
 pub(crate) use reviews_sync::reconcile_shared_review_items_db;
 use reviews_sync::shared_review_request_clients;
 use sync_audit::SyncExecutionMetrics;
@@ -50,6 +52,8 @@ pub(crate) async fn create_task_board_item_db(
     db: &AsyncDaemonDb,
     request: &TaskBoardCreateItemRequest,
 ) -> Result<TaskBoardItem, CliError> {
+    validate_estimate("estimated_tokens", request.estimated_tokens)?;
+    validate_estimate("estimated_cost_microusd", request.estimated_cost_microusd)?;
     let mut item = TaskBoardItem::new(
         request
             .id
@@ -64,6 +68,8 @@ pub(crate) async fn create_task_board_item_db(
     item.workflow_kind = request.workflow_kind;
     item.execution_repository
         .clone_from(&request.execution_repository);
+    item.estimated_tokens = request.estimated_tokens;
+    item.estimated_cost_microusd = request.estimated_cost_microusd;
     item.tags.clone_from(&request.tags);
     item.project_id.clone_from(&request.project_id);
     item.target_project_types
@@ -99,10 +105,11 @@ pub(crate) async fn update_task_board_item_db(
     id: &str,
     request: &TaskBoardUpdateItemRequest,
 ) -> Result<TaskBoardItem, CliError> {
+    validate_update_estimates(request)?;
     super::task_board_completion::validate_linked_task_completion(db, id, request.status).await?;
     let mutation = db
         .update_task_board_item(id, |item| {
-            apply_update_request(item, request);
+            apply_update_request(item, request)?;
             Ok(true)
         })
         .await?
@@ -340,7 +347,11 @@ async fn apply_planning_transition_db(
     })
 }
 
-fn apply_update_request(item: &mut TaskBoardItem, request: &TaskBoardUpdateItemRequest) {
+fn apply_update_request(
+    item: &mut TaskBoardItem,
+    request: &TaskBoardUpdateItemRequest,
+) -> Result<(), CliError> {
+    validate_update_estimates(request)?;
     assign_if_some(&mut item.title, request.title.as_ref());
     assign_if_some(&mut item.body, request.body.as_ref());
     assign_copy_if_some(&mut item.status, request.status);
@@ -365,6 +376,16 @@ fn apply_update_request(item: &mut TaskBoardItem, request: &TaskBoardUpdateItemR
         request.execution_repository.as_ref(),
         request.clear_identity.clear_execution_repository,
     );
+    apply_optional_copy(
+        &mut item.estimated_tokens,
+        request.estimated_tokens,
+        request.clear_estimates.clear_estimated_tokens,
+    );
+    apply_optional_copy(
+        &mut item.estimated_cost_microusd,
+        request.estimated_cost_microusd,
+        request.clear_estimates.clear_estimated_cost_microusd,
+    );
     apply_optional_string(
         &mut item.session_id,
         request.session_id.as_ref(),
@@ -376,6 +397,7 @@ fn apply_update_request(item: &mut TaskBoardItem, request: &TaskBoardUpdateItemR
         request.clear_identity.clear_work_item_id,
     );
     apply_update_state(item, request);
+    Ok(())
 }
 
 fn replacement_external_refs(
@@ -426,6 +448,14 @@ fn assign_if_some<T: Clone>(target: &mut T, value: Option<&T>) {
 fn assign_copy_if_some<T: Copy>(target: &mut T, value: Option<T>) {
     if let Some(value) = value {
         *target = value;
+    }
+}
+
+fn apply_optional_copy<T: Copy>(target: &mut Option<T>, value: Option<T>, clear: bool) {
+    if clear {
+        *target = None;
+    } else if let Some(value) = value {
+        *target = Some(value);
     }
 }
 

--- a/src/daemon/service/task_board_db/estimate_validation.rs
+++ b/src/daemon/service/task_board_db/estimate_validation.rs
@@ -1,0 +1,66 @@
+use crate::daemon::db::db_error;
+use crate::daemon::protocol::TaskBoardUpdateItemRequest;
+use crate::errors::CliError;
+use crate::task_board::types::MAX_TASK_BOARD_ESTIMATE;
+
+pub(super) fn validate_update_estimates(
+    request: &TaskBoardUpdateItemRequest,
+) -> Result<(), CliError> {
+    validate_estimate_patch(
+        "estimated_tokens",
+        request.estimated_tokens,
+        request.clear_estimates.clear_estimated_tokens,
+    )?;
+    validate_estimate_patch(
+        "estimated_cost_microusd",
+        request.estimated_cost_microusd,
+        request.clear_estimates.clear_estimated_cost_microusd,
+    )
+}
+
+fn validate_estimate_patch(name: &str, value: Option<u64>, clear: bool) -> Result<(), CliError> {
+    if value.is_some() && clear {
+        return Err(db_error(format!(
+            "task-board {name} cannot be set and cleared together"
+        )));
+    }
+    validate_estimate(name, value)
+}
+
+pub(super) fn validate_estimate(name: &str, value: Option<u64>) -> Result<(), CliError> {
+    if value.is_none_or(|value| (1..=MAX_TASK_BOARD_ESTIMATE).contains(&value)) {
+        return Ok(());
+    }
+    Err(db_error(format!(
+        "task-board {name} must be between 1 and {MAX_TASK_BOARD_ESTIMATE}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::protocol::{TaskBoardUpdateEstimateClears, TaskBoardUpdateItemRequest};
+
+    #[test]
+    fn estimates_accept_absence_and_the_persisted_range() {
+        assert!(validate_estimate("estimate", None).is_ok());
+        assert!(validate_estimate("estimate", Some(1)).is_ok());
+        assert!(validate_estimate("estimate", Some(MAX_TASK_BOARD_ESTIMATE)).is_ok());
+    }
+
+    #[test]
+    fn estimates_reject_zero_overflow_and_set_clear_conflicts() {
+        assert!(validate_estimate("estimate", Some(0)).is_err());
+        assert!(validate_estimate("estimate", Some(MAX_TASK_BOARD_ESTIMATE + 1)).is_err());
+        let request = TaskBoardUpdateItemRequest {
+            estimated_tokens: Some(1),
+            clear_estimates: TaskBoardUpdateEstimateClears {
+                clear_estimated_tokens: true,
+                ..TaskBoardUpdateEstimateClears::default()
+            },
+            ..TaskBoardUpdateItemRequest::default()
+        };
+
+        assert!(validate_update_estimates(&request).is_err());
+    }
+}

--- a/src/daemon/service/task_board_db/external_ref_tests.rs
+++ b/src/daemon/service/task_board_db/external_ref_tests.rs
@@ -33,7 +33,7 @@ fn external_ref_replacement_preserves_matching_daemon_sync_state() {
         ..TaskBoardUpdateItemRequest::default()
     };
 
-    apply_update_request(&mut item, &request);
+    apply_update_request(&mut item, &request).expect("apply update");
 
     assert_eq!(item.external_refs.len(), 2);
     assert_eq!(item.external_refs[0].sync_state, None);
@@ -63,7 +63,7 @@ fn external_ref_replacement_rejects_stale_explicit_sync_state() {
         ..TaskBoardUpdateItemRequest::default()
     };
 
-    apply_update_request(&mut item, &request);
+    apply_update_request(&mut item, &request).expect("apply update");
 
     assert_eq!(item.external_refs[0].sync_state, Some(current));
 }
@@ -80,7 +80,7 @@ fn external_ref_replacement_rejects_sync_state_for_new_reference() {
         ..TaskBoardUpdateItemRequest::default()
     };
 
-    apply_update_request(&mut item, &request);
+    apply_update_request(&mut item, &request).expect("apply update");
 
     assert_eq!(item.external_refs[0].sync_state, None);
 }
@@ -98,6 +98,8 @@ async fn external_ref_creation_rejects_client_sync_state() {
         agent_mode: Default::default(),
         workflow_kind: Default::default(),
         execution_repository: None,
+        estimated_tokens: None,
+        estimated_cost_microusd: None,
         tags: Vec::new(),
         project_id: None,
         target_project_types: Vec::new(),
@@ -133,7 +135,7 @@ fn empty_external_ref_replacement_clears_every_reference() {
         ..TaskBoardUpdateItemRequest::default()
     };
 
-    apply_update_request(&mut item, &request);
+    apply_update_request(&mut item, &request).expect("apply update");
 
     assert!(item.external_refs.is_empty());
 }

--- a/src/daemon/service/task_board_orchestrator_control.rs
+++ b/src/daemon/service/task_board_orchestrator_control.rs
@@ -311,6 +311,9 @@ mod tests {
         let db = AsyncDaemonDb::connect(&temp.path().join("harness.db"))
             .await
             .expect("open database");
+        db.replace_task_board_orchestrator_state(&TaskBoardOrchestratorState::default())
+            .await
+            .expect("advance unrelated change revision");
         db.start_task_board_automation(TaskBoardAutomationDesiredMode::Continuous, Utc::now())
             .await
             .expect("start durable automation");
@@ -330,6 +333,13 @@ mod tests {
         assert_eq!(wakes.len(), 1);
         assert_eq!(wakes[0].entity_id.as_deref(), Some("automation-settings"));
         assert_eq!(wakes[0].entity_revision, u64::try_from(revision).ok());
+        let change_revision = query_scalar::<_, i64>(
+            "SELECT change_seq FROM change_tracking WHERE scope = 'task_board:orchestrator'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .expect("read orchestrator change revision");
+        assert!(change_revision > revision);
         assert!(matches!(
             wakes[0].payload,
             TaskBoardAutomationWakePayload::LedgerChanged(ref payload)

--- a/src/daemon/service/task_board_orchestrator_settings.rs
+++ b/src/daemon/service/task_board_orchestrator_settings.rs
@@ -71,6 +71,9 @@ fn apply_automation_fields(
     if let Some(execution_hosts) = &update.execution_hosts {
         settings.execution_hosts.clone_from(execution_hosts);
     }
+    if let Some(admission_policy) = &update.admission_policy {
+        settings.admission_policy.clone_from(admission_policy);
+    }
 }
 
 pub(super) fn normalize_github_inbox(

--- a/src/daemon/service/tests/task_board_dispatch_db.rs
+++ b/src/daemon/service/tests/task_board_dispatch_db.rs
@@ -53,6 +53,9 @@ fn prepared_dispatch_resumes_without_duplicate_session_or_task() {
                     preparation,
                 } => (intent_id, preparation),
                 ReservedTaskBoardDispatch::Applied(_) => panic!("new dispatch already applied"),
+                ReservedTaskBoardDispatch::Blocked(_) => {
+                    panic!("default admission blocked dispatch")
+                }
             };
             let first_claim = db
                 .claim_task_board_dispatch_preparation(&intent_id)

--- a/src/daemon/task_board_managed_agents.rs
+++ b/src/daemon/task_board_managed_agents.rs
@@ -1,4 +1,10 @@
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
+
 use crate::daemon::agent_tui::AgentTuiStartRequest;
+use crate::daemon::db::AsyncDaemonDb;
 use crate::daemon::http::{
     DaemonHttpState, require_async_db, run_codex_agent_blocking, run_terminal_agent_blocking,
 };
@@ -6,22 +12,293 @@ use crate::daemon::protocol::{CodexRunMode, CodexRunRequest, ManagedAgentSnapsho
 use crate::errors::{CliError, CliErrorKind};
 use crate::session::types::{CONTROL_PLANE_ACTOR_ID, SessionRole};
 use crate::task_board::{
-    AgentMode, DispatchAppliedTask, TaskBoardItem, WorkerPromptContext, render_worker_prompt,
+    AgentMode, DispatchAppliedTask, TaskBoardItem, TaskBoardLaunchCapability, WorkerPromptContext,
+    render_worker_prompt,
 };
 
 const DEFAULT_INTERACTIVE_RUNTIME: &str = "codex";
+const DISPATCH_CLAIM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
+pub(crate) struct TaskBoardDispatchClaimHeartbeat {
+    task: JoinHandle<()>,
+}
+
+#[derive(Debug)]
+pub(crate) struct TaskBoardWorkerStartError {
+    error: CliError,
+    may_rollback: bool,
+}
+
+impl TaskBoardWorkerStartError {
+    fn uncertain(error: CliError) -> Self {
+        Self {
+            error,
+            may_rollback: false,
+        }
+    }
+
+    fn uncertain_after_start(start_error: &CliError, probe_error: &CliError) -> Self {
+        Self::uncertain(
+            CliErrorKind::workflow_io(format!(
+                "managed worker start failed ({start_error}); deterministic recovery probe was uncertain ({probe_error})"
+            ))
+            .into(),
+        )
+    }
+
+    #[must_use]
+    pub(crate) const fn may_rollback(&self) -> bool {
+        self.may_rollback
+    }
+
+    #[must_use]
+    pub(crate) fn into_cli_error(self) -> CliError {
+        self.error
+    }
+}
+
+impl From<CliError> for TaskBoardWorkerStartError {
+    fn from(error: CliError) -> Self {
+        Self {
+            error,
+            may_rollback: true,
+        }
+    }
+}
+
+impl Drop for TaskBoardDispatchClaimHeartbeat {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub(crate) fn maintain_task_board_dispatch_claim(
+    db: AsyncDaemonDb,
+    intent_id: &str,
+    claim_token: &str,
+) -> TaskBoardDispatchClaimHeartbeat {
+    let intent_id = intent_id.to_string();
+    let claim_token = claim_token.to_string();
+    let task = tokio::spawn(async move {
+        loop {
+            sleep(DISPATCH_CLAIM_HEARTBEAT_INTERVAL).await;
+            if let Err(error) = db
+                .renew_task_board_dispatch_claim(&intent_id, &claim_token)
+                .await
+            {
+                tracing::warn!(%intent_id, %error, "task board worker claim heartbeat stopped");
+                break;
+            }
+        }
+    });
+    TaskBoardDispatchClaimHeartbeat { task }
+}
 
 pub(crate) async fn start_worker_for_applied_task(
     state: &DaemonHttpState,
     applied: &DispatchAppliedTask,
     dispatch_intent_id: &str,
-) -> Result<ManagedAgentSnapshot, CliError> {
+    claim_token: &str,
+) -> Result<ManagedAgentSnapshot, TaskBoardWorkerStartError> {
+    let session_id = applied.session_id.clone();
+    let worker_id = managed_worker_id(applied, dispatch_intent_id);
+    let _guard = state
+        .managed_agent_mutation_locks
+        .lock(&session_id, &worker_id)
+        .await;
+    // Keep this deterministic probe ahead of every mutable preflight. A claim
+    // reclaimed after an uncertain start may already own this exact worker;
+    // current item or admission drift cannot safely reject it first.
+    let existing = probe_existing_worker(state, applied, &worker_id)
+        .await
+        .map_err(TaskBoardWorkerStartError::uncertain)?;
+    if let Some(snapshot) = existing {
+        return recover_same_session_worker(snapshot, &session_id)
+            .map_err(TaskBoardWorkerStartError::uncertain);
+    }
     // Fail-closed recheck at the shared worker-start seam: this guards the
     // claim+start path used by both the route executor and the recovery loop, so
     // an already-prepared intent cannot start while the kill switch is engaged.
     // Transport-agnostic because it runs before stdio/bridge selection.
     ensure_spawn_kill_switch_clear(state, &applied.board_item_id).await?;
-    start_worker_by_mode(state, applied, dispatch_intent_id).await
+    require_async_db(state, "task-board worker admission check")?
+        .validate_task_board_dispatch_admission_start(
+            dispatch_intent_id,
+            claim_token,
+            launch_capability(applied.item.agent_mode),
+        )
+        .await?;
+    start_or_recover_worker(state, applied, dispatch_intent_id, &worker_id, &session_id).await
+}
+
+async fn start_or_recover_worker(
+    state: &DaemonHttpState,
+    applied: &DispatchAppliedTask,
+    dispatch_intent_id: &str,
+    worker_id: &str,
+    session_id: &str,
+) -> Result<ManagedAgentSnapshot, TaskBoardWorkerStartError> {
+    let start_error = match start_worker_by_mode(state, applied, dispatch_intent_id).await {
+        Ok(snapshot) => return Ok(snapshot),
+        Err(error) => error,
+    };
+    let probe = probe_existing_worker(state, applied, worker_id).await;
+    resolve_start_failure(start_error, probe, session_id)
+}
+
+fn resolve_start_failure(
+    start_error: CliError,
+    probe: Result<Option<ManagedAgentSnapshot>, CliError>,
+    session_id: &str,
+) -> Result<ManagedAgentSnapshot, TaskBoardWorkerStartError> {
+    match probe {
+        Ok(Some(snapshot)) => recover_same_session_worker(snapshot, session_id)
+            .map_err(TaskBoardWorkerStartError::uncertain),
+        Ok(None) => Err(TaskBoardWorkerStartError::from(start_error)),
+        Err(probe_error) => Err(TaskBoardWorkerStartError::uncertain_after_start(
+            &start_error,
+            &probe_error,
+        )),
+    }
+}
+
+pub(crate) async fn begin_worker_compensation(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    applied: &DispatchAppliedTask,
+    dispatch_intent_id: &str,
+    claim_token: &str,
+    reason: &str,
+) -> Result<(), CliError> {
+    compensate_worker_for_applied_task(
+        state,
+        db,
+        applied,
+        dispatch_intent_id,
+        claim_token,
+        Some(reason),
+    )
+    .await
+}
+
+pub(crate) async fn resume_worker_compensation(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    applied: &DispatchAppliedTask,
+    dispatch_intent_id: &str,
+    claim_token: &str,
+) -> Result<(), CliError> {
+    compensate_worker_for_applied_task(state, db, applied, dispatch_intent_id, claim_token, None)
+        .await
+}
+
+async fn compensate_worker_for_applied_task(
+    state: &DaemonHttpState,
+    db: &AsyncDaemonDb,
+    applied: &DispatchAppliedTask,
+    dispatch_intent_id: &str,
+    claim_token: &str,
+    reason: Option<&str>,
+) -> Result<(), CliError> {
+    let session_id = applied.session_id.clone();
+    let managed_worker_id = managed_worker_id(applied, dispatch_intent_id);
+    let _guard = state
+        .managed_agent_mutation_locks
+        .lock(&session_id, &managed_worker_id)
+        .await;
+    if let Some(reason) = reason {
+        db.begin_task_board_dispatch_compensation(
+            dispatch_intent_id,
+            claim_token,
+            &managed_worker_id,
+            reason,
+        )
+        .await?;
+    } else {
+        db.renew_task_board_dispatch_claim(dispatch_intent_id, claim_token)
+            .await?;
+    }
+    stop_worker_in_lane(state, applied, managed_worker_id).await
+}
+
+async fn stop_worker_in_lane(
+    state: &DaemonHttpState,
+    applied: &DispatchAppliedTask,
+    managed_worker_id: String,
+) -> Result<(), CliError> {
+    let worker_id = managed_worker_id.clone();
+    let result = if applied.item.agent_mode == AgentMode::Interactive {
+        run_terminal_agent_blocking(state, "task-board worker compensation", move |manager| {
+            manager.stop(&managed_worker_id)
+        })
+        .await
+        .map(|_| ())
+    } else {
+        run_codex_agent_blocking(state, "task-board worker compensation", move |controller| {
+            controller.stop(&managed_worker_id)
+        })
+        .await
+        .map(|_| ())
+    };
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if exact_worker_not_found(&error, applied.item.agent_mode, &worker_id) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+async fn probe_existing_worker(
+    state: &DaemonHttpState,
+    applied: &DispatchAppliedTask,
+    worker_id: &str,
+) -> Result<Option<ManagedAgentSnapshot>, CliError> {
+    let result = if applied.item.agent_mode == AgentMode::Interactive {
+        let worker_id = worker_id.to_string();
+        run_terminal_agent_blocking(state, "task-board worker lookup", move |manager| {
+            manager.get(&worker_id).map(ManagedAgentSnapshot::Terminal)
+        })
+        .await
+    } else {
+        let worker_id = worker_id.to_string();
+        run_codex_agent_blocking(state, "task-board worker lookup", move |controller| {
+            controller.run(&worker_id).map(ManagedAgentSnapshot::Codex)
+        })
+        .await
+    };
+    match result {
+        Ok(snapshot) => Ok(Some(snapshot)),
+        Err(error) if exact_worker_not_found(&error, applied.item.agent_mode, worker_id) => {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn exact_worker_not_found(error: &CliError, mode: AgentMode, worker_id: &str) -> bool {
+    if error.code() != "KSRCLI090" {
+        return false;
+    }
+    let expected = if mode == AgentMode::Interactive {
+        format!("session not active: terminal agent '{worker_id}' not found")
+    } else {
+        format!("session not active: codex run '{worker_id}' not found")
+    };
+    error.message() == expected
+}
+
+fn recover_same_session_worker(
+    snapshot: ManagedAgentSnapshot,
+    expected_session_id: &str,
+) -> Result<ManagedAgentSnapshot, CliError> {
+    if snapshot.session_id() == expected_session_id {
+        return Ok(snapshot);
+    }
+    Err(CliErrorKind::session_agent_conflict(format!(
+        "managed worker '{}' belongs to session '{}', not reclaimed session '{expected_session_id}'",
+        snapshot.agent_id(),
+        snapshot.session_id(),
+    ))
+    .into())
 }
 
 async fn start_worker_by_mode(
@@ -78,10 +355,6 @@ async fn start_codex_worker(
     let session_id = applied.session_id.clone();
     let run_id = codex_worker_id(dispatch_intent_id);
     let request = codex_worker_request(applied, &run_id);
-    let _guard = state
-        .managed_agent_mutation_locks
-        .lock(&session_id, "task-board:codex-worker")
-        .await;
     run_codex_agent_blocking(state, "task-board worker start", move |controller| {
         controller
             .start_run_with_id(&session_id, &request, run_id)
@@ -98,10 +371,6 @@ async fn start_interactive_worker(
     let session_id = applied.session_id.clone();
     let tui_id = terminal_worker_id(dispatch_intent_id);
     let request = terminal_worker_request(applied, &tui_id);
-    let _guard = state
-        .managed_agent_mutation_locks
-        .lock(&session_id, "task-board:terminal-worker")
-        .await;
     run_terminal_agent_blocking(state, "task-board worker start", move |manager| {
         manager
             .start_with_id(&session_id, &request, tui_id)
@@ -112,10 +381,8 @@ async fn start_interactive_worker(
 
 fn codex_worker_request(applied: &DispatchAppliedTask, managed_run_id: &str) -> CodexRunRequest {
     let mode = match applied.item.agent_mode {
-        AgentMode::Evaluate => CodexRunMode::Report,
-        AgentMode::Headless | AgentMode::Planning | AgentMode::Interactive => {
-            CodexRunMode::WorkspaceWrite
-        }
+        AgentMode::Planning | AgentMode::Evaluate => CodexRunMode::Report,
+        AgentMode::Headless | AgentMode::Interactive => CodexRunMode::WorkspaceWrite,
     };
     CodexRunRequest {
         actor: Some(CONTROL_PLANE_ACTOR_ID.to_string()),
@@ -136,6 +403,16 @@ fn codex_worker_request(applied: &DispatchAppliedTask, managed_run_id: &str) -> 
         model: None,
         effort: None,
         allow_custom_model: false,
+    }
+}
+
+const fn launch_capability(mode: AgentMode) -> Option<TaskBoardLaunchCapability> {
+    match mode {
+        AgentMode::Planning | AgentMode::Evaluate => {
+            Some(TaskBoardLaunchCapability::ReportReadOnly)
+        }
+        AgentMode::Headless => Some(TaskBoardLaunchCapability::WorkspaceWrite),
+        AgentMode::Interactive => None,
     }
 }
 
@@ -176,6 +453,14 @@ fn terminal_worker_id(dispatch_intent_id: &str) -> String {
     format!("agent-tui-{dispatch_intent_id}")
 }
 
+pub(crate) fn managed_worker_id(applied: &DispatchAppliedTask, dispatch_intent_id: &str) -> String {
+    if applied.item.agent_mode == AgentMode::Interactive {
+        terminal_worker_id(dispatch_intent_id)
+    } else {
+        codex_worker_id(dispatch_intent_id)
+    }
+}
+
 fn worker_capabilities(item: &TaskBoardItem) -> Vec<String> {
     let mut capabilities = vec![
         "task-board".to_string(),
@@ -203,251 +488,14 @@ pub(crate) fn rendered_worker_prompt(
     applied: &DispatchAppliedTask,
     dispatch_intent_id: &str,
 ) -> String {
-    let managed_run_id = if applied.item.agent_mode == AgentMode::Interactive {
-        terminal_worker_id(dispatch_intent_id)
-    } else {
-        codex_worker_id(dispatch_intent_id)
-    };
+    let managed_run_id = managed_worker_id(applied, dispatch_intent_id);
     worker_prompt(applied, &managed_run_id)
 }
 
 #[cfg(test)]
-mod tests {
-    use std::env::temp_dir;
-    use std::sync::{Arc, Mutex, OnceLock};
-    use std::time::Duration;
+#[path = "task_board_managed_agents_test_support.rs"]
+mod test_support;
 
-    use serde_json::json;
-    use tokio::sync::broadcast;
-    use tokio::time::timeout;
-    use uuid::Uuid;
-
-    use crate::daemon::agent_acp::AcpAgentManagerHandle;
-    use crate::daemon::agent_tui::AgentTuiManagerHandle;
-    use crate::daemon::codex_controller::CodexControllerHandle;
-    use crate::daemon::db::DaemonDb;
-    use crate::daemon::http::{
-        AsyncDaemonDbSlot, DaemonHttpState, ManagedAgentMutationLocks, connect_async_db_for_tests,
-    };
-    use crate::daemon::state::{DaemonManifest, HostBridgeManifest};
-    use crate::daemon::websocket::ReplayBuffer;
-    use crate::session::types::SessionRole;
-    use crate::task_board::dispatch::DispatchLifecycle;
-    use crate::task_board::{
-        AgentMode, DispatchAppliedTask, TaskBoardItem, TaskBoardPriority, TaskBoardStatus,
-        TaskBoardWorkflowState,
-    };
-    use crate::workspace::utc_now;
-
-    use super::{
-        codex_worker_id, codex_worker_request, start_interactive_worker, terminal_worker_id,
-        terminal_worker_request,
-    };
-
-    #[test]
-    fn codex_worker_request_carries_task_board_identity() {
-        let applied = applied_task(AgentMode::Headless);
-
-        let request = codex_worker_request(&applied, "codex-dispatch-intent-1");
-
-        assert_eq!(request.task_id.as_deref(), Some("task-1"));
-        assert_eq!(request.board_item_id.as_deref(), Some("board-1"));
-        assert_eq!(request.workflow_execution_id.as_deref(), Some("workflow-1"));
-        assert_eq!(request.role, SessionRole::Leader);
-        assert_eq!(request.fallback_role, Some(SessionRole::Worker));
-        assert!(
-            request
-                .capabilities
-                .contains(&"task-board:item:board-1".to_string())
-        );
-        assert!(request.prompt.contains("Session task: task-1"));
-        assert!(request.prompt.contains("Session id:\nsession-1"));
-        assert!(request.prompt.contains("Tags:\nbackend"));
-        assert!(request.prompt.contains("Worktree:\n/tmp/task-worktree"));
-        assert!(request.prompt.contains("External refs:\ngithub:123"));
-        assert!(
-            request
-                .prompt
-                .contains("Managed run id:\ncodex-dispatch-intent-1")
-        );
-        assert!(
-            request
-                .prompt
-                .contains("harness session task list session-1 --json")
-        );
-        assert!(
-            request
-                .prompt
-                .contains("harness session task submit-for-review session-1 task-1")
-        );
-        assert!(request.prompt.contains("authoritative safety net"));
-    }
-
-    #[test]
-    fn interactive_worker_request_uses_terminal_runtime() {
-        let applied = applied_task(AgentMode::Interactive);
-
-        let request = terminal_worker_request(&applied, "agent-tui-dispatch-intent-1");
-
-        assert_eq!(request.runtime, "codex");
-        assert_eq!(request.task_id.as_deref(), Some("task-1"));
-        assert_eq!(request.board_item_id.as_deref(), Some("board-1"));
-        assert_eq!(request.role, SessionRole::Leader);
-        assert_eq!(request.fallback_role, Some(SessionRole::Worker));
-        assert_eq!(request.rows, 24);
-        assert_eq!(request.cols, 80);
-    }
-
-    #[test]
-    fn worker_identity_is_stable_for_reclaimed_dispatch_claims() {
-        assert_eq!(
-            codex_worker_id("dispatch-intent-1"),
-            codex_worker_id("dispatch-intent-1")
-        );
-        assert_eq!(
-            terminal_worker_id("dispatch-intent-1"),
-            terminal_worker_id("dispatch-intent-1")
-        );
-        assert_ne!(
-            codex_worker_id("dispatch-intent-1"),
-            codex_worker_id("dispatch-intent-2")
-        );
-    }
-
-    #[tokio::test]
-    async fn start_interactive_worker_waits_for_terminal_lane_guard() {
-        let state = test_http_state();
-        let applied = applied_task(AgentMode::Interactive);
-        let outer_guard = state
-            .managed_agent_mutation_locks
-            .lock(&applied.session_id, "task-board:terminal-worker")
-            .await;
-
-        let future = start_interactive_worker(&state, &applied, "dispatch-intent-test");
-        tokio::pin!(future);
-
-        assert!(
-            timeout(Duration::from_millis(50), future.as_mut())
-                .await
-                .is_err(),
-            "interactive worker spawn must wait for the terminal-worker lane",
-        );
-
-        drop(outer_guard);
-
-        let result = timeout(Duration::from_secs(2), future)
-            .await
-            .expect("interactive worker spawn resumes once the lane is free");
-        // Spawning the real TUI fails in the test environment because no
-        // session is registered; the lock contract is what we care about.
-        assert!(
-            result.is_err(),
-            "test daemon has no session for the TUI spawn, expected error",
-        );
-    }
-
-    fn test_http_state() -> DaemonHttpState {
-        let (sender, _) = broadcast::channel(8);
-        let db_slot = Arc::new(OnceLock::new());
-        let async_db = Arc::new(OnceLock::new());
-        let db_path = temp_dir().join(format!("harness-tb-managed-{}.db", Uuid::new_v4()));
-        db_slot
-            .set(Arc::new(Mutex::new(
-                DaemonDb::open(&db_path).expect("open file db"),
-            )))
-            .expect("install db");
-        async_db
-            .set(connect_async_db_for_tests(&db_path))
-            .expect("install async db");
-        let manifest: DaemonManifest = serde_json::from_value(json!({
-            "version": "20.6.0",
-            "pid": 1,
-            "endpoint": "http://127.0.0.1:0",
-            "started_at": "2026-05-15T00:00:00Z",
-            "token_path": "/tmp/token",
-            "sandboxed": false,
-            "host_bridge": HostBridgeManifest::default(),
-            "revision": 0,
-            "updated_at": "",
-        }))
-        .expect("deserialize daemon manifest");
-        DaemonHttpState {
-            token: "token".into(),
-            auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
-            remote_domain: None,
-            remote_request_limits: None,
-            remote_pairing_limiter: crate::daemon::http::default_remote_pairing_limiter(),
-            remote_pairing_status_limiter:
-                crate::daemon::http::default_remote_pairing_status_limiter(),
-            sender: sender.clone(),
-            prepared_sender: broadcast::channel(8).0,
-            manifest,
-            daemon_epoch: "epoch".into(),
-            replay_buffer: Arc::new(Mutex::new(ReplayBuffer::new(8))),
-            db: db_slot.clone(),
-            async_db: AsyncDaemonDbSlot::from_inner(async_db.clone()),
-            db_path: Some(db_path),
-            codex_controller: CodexControllerHandle::new_with_async_db(
-                sender.clone(),
-                db_slot.clone(),
-                async_db.clone(),
-                false,
-            ),
-            acp_agent_manager: AcpAgentManagerHandle::new_with_async_db(
-                sender.clone(),
-                db_slot.clone(),
-                async_db.clone(),
-            ),
-            agent_tui_manager: AgentTuiManagerHandle::new_with_async_db(
-                sender.clone(),
-                db_slot,
-                async_db,
-                false,
-            ),
-            managed_agent_mutation_locks: ManagedAgentMutationLocks::default(),
-            recovery_snapshot: Default::default(),
-        }
-    }
-
-    fn applied_task(mode: AgentMode) -> DispatchAppliedTask {
-        let mut item = TaskBoardItem::new(
-            "board-1".into(),
-            "Ship managed worker launch".into(),
-            "Start a real worker.".into(),
-            utc_now(),
-        );
-        item.agent_mode = mode;
-        item.status = TaskBoardStatus::InProgress;
-        item.priority = TaskBoardPriority::High;
-        item.tags = vec!["backend".into()];
-        item.external_refs = vec![crate::task_board::ExternalRef {
-            provider: crate::task_board::ExternalRefProvider::GitHub,
-            external_id: "123".into(),
-            url: Some("https://github.example/issues/123".into()),
-            sync_state: None,
-        }];
-        item.workflow = TaskBoardWorkflowState {
-            execution_id: Some("workflow-1".into()),
-            worktree: Some("/tmp/task-worktree".into()),
-            ..TaskBoardWorkflowState::default()
-        };
-        DispatchAppliedTask {
-            board_item_id: item.id.clone(),
-            session_id: "session-1".into(),
-            work_item_id: "task-1".into(),
-            lifecycle: DispatchLifecycle::planned(
-                &crate::task_board::WorkerIntent { mode },
-                &crate::task_board::ReviewerIntent {
-                    phase: crate::task_board::FollowUpPhase::AfterWorkerReview,
-                    suggested_persona: "code-reviewer".into(),
-                    required_consensus: 2,
-                },
-                &crate::task_board::EvaluatorIntent {
-                    phase: crate::task_board::FollowUpPhase::AfterWorkerReview,
-                    mode: AgentMode::Evaluate,
-                },
-            ),
-            item,
-        }
-    }
-}
+#[cfg(test)]
+#[path = "task_board_managed_agents/tests.rs"]
+mod tests;

--- a/src/daemon/task_board_managed_agents/tests.rs
+++ b/src/daemon/task_board_managed_agents/tests.rs
@@ -1,0 +1,303 @@
+use std::time::Duration;
+
+use tokio::time::timeout;
+
+use crate::daemon::agent_tui::AgentTuiStatus;
+use crate::daemon::protocol::{CodexRunStatus, ManagedAgentSnapshot};
+use crate::errors::{CliError, CliErrorKind};
+use crate::session::types::SessionRole;
+use crate::task_board::AgentMode;
+
+use super::test_support::{applied_task, codex_snapshot, terminal_snapshot, test_http_state};
+use super::{
+    begin_worker_compensation, codex_worker_id, codex_worker_request, exact_worker_not_found,
+    managed_worker_id, recover_same_session_worker, resolve_start_failure,
+    start_worker_for_applied_task, stop_worker_in_lane, terminal_worker_id,
+    terminal_worker_request,
+};
+
+#[test]
+fn codex_worker_request_carries_task_board_identity() {
+    let applied = applied_task(AgentMode::Headless);
+
+    let request = codex_worker_request(&applied, "codex-dispatch-intent-1");
+
+    assert_eq!(request.task_id.as_deref(), Some("task-1"));
+    assert_eq!(request.board_item_id.as_deref(), Some("board-1"));
+    assert_eq!(request.workflow_execution_id.as_deref(), Some("workflow-1"));
+    assert_eq!(request.role, SessionRole::Leader);
+    assert_eq!(request.fallback_role, Some(SessionRole::Worker));
+    assert!(
+        request
+            .capabilities
+            .contains(&"task-board:item:board-1".to_string())
+    );
+    assert!(request.prompt.contains("Session task: task-1"));
+    assert!(request.prompt.contains("Session id:\nsession-1"));
+    assert!(request.prompt.contains("Tags:\nbackend"));
+    assert!(request.prompt.contains("Worktree:\n/tmp/task-worktree"));
+    assert!(request.prompt.contains("External refs:\ngithub:123"));
+    assert!(
+        request
+            .prompt
+            .contains("Managed run id:\ncodex-dispatch-intent-1")
+    );
+    assert!(
+        request
+            .prompt
+            .contains("harness session task list session-1 --json")
+    );
+    assert!(
+        request
+            .prompt
+            .contains("harness session task submit-for-review session-1 task-1")
+    );
+    assert!(request.prompt.contains("authoritative safety net"));
+}
+
+#[test]
+fn planning_and_evaluate_workers_are_report_only() {
+    for mode in [AgentMode::Planning, AgentMode::Evaluate] {
+        let applied = applied_task(mode);
+        let request = codex_worker_request(&applied, "codex-read-only");
+
+        assert_eq!(request.mode, crate::daemon::protocol::CodexRunMode::Report);
+    }
+}
+
+#[test]
+fn interactive_worker_request_uses_terminal_runtime() {
+    let applied = applied_task(AgentMode::Interactive);
+
+    let request = terminal_worker_request(&applied, "agent-tui-dispatch-intent-1");
+
+    assert_eq!(request.runtime, "codex");
+    assert_eq!(request.task_id.as_deref(), Some("task-1"));
+    assert_eq!(request.board_item_id.as_deref(), Some("board-1"));
+    assert_eq!(request.role, SessionRole::Leader);
+    assert_eq!(request.fallback_role, Some(SessionRole::Worker));
+    assert_eq!(request.rows, 24);
+    assert_eq!(request.cols, 80);
+}
+
+#[test]
+fn worker_identity_is_stable_for_reclaimed_dispatch_claims() {
+    assert_eq!(
+        codex_worker_id("dispatch-intent-1"),
+        codex_worker_id("dispatch-intent-1")
+    );
+    assert_eq!(
+        terminal_worker_id("dispatch-intent-1"),
+        terminal_worker_id("dispatch-intent-1")
+    );
+    assert_ne!(
+        codex_worker_id("dispatch-intent-1"),
+        codex_worker_id("dispatch-intent-2")
+    );
+}
+
+#[test]
+fn terminal_and_failed_same_session_workers_are_recovered() {
+    let snapshots = [
+        ManagedAgentSnapshot::Terminal(terminal_snapshot(AgentTuiStatus::Stopped, "session-1")),
+        ManagedAgentSnapshot::Codex(codex_snapshot(CodexRunStatus::Failed, "session-1")),
+    ];
+
+    for snapshot in snapshots {
+        let expected_id = snapshot.agent_id().to_string();
+        let recovered = resolve_start_failure(start_failure(), Ok(Some(snapshot)), "session-1")
+            .expect("same-session durable worker evidence");
+        assert_eq!(recovered.agent_id(), expected_id);
+    }
+}
+
+#[test]
+fn deterministic_worker_from_another_session_fails_closed() {
+    let snapshot =
+        ManagedAgentSnapshot::Codex(codex_snapshot(CodexRunStatus::Running, "different-session"));
+
+    let error = recover_same_session_worker(snapshot, "session-1")
+        .expect_err("cross-session deterministic identity must conflict");
+
+    assert_eq!(error.code(), "KSRCLI092");
+}
+
+#[test]
+fn only_exact_deterministic_lookup_miss_allows_start() {
+    let worker_id = codex_worker_id("dispatch-intent-1");
+    let exact: CliError =
+        CliErrorKind::session_not_active(format!("codex run '{worker_id}' not found")).into();
+    let uncertain: CliError =
+        CliErrorKind::session_not_active("codex controller not active").into();
+
+    assert!(exact_worker_not_found(
+        &exact,
+        AgentMode::Headless,
+        &worker_id
+    ));
+    assert!(!exact_worker_not_found(
+        &uncertain,
+        AgentMode::Headless,
+        &worker_id
+    ));
+}
+
+#[test]
+fn uncertain_probe_errors_are_not_rollback_safe() {
+    let probe_error = CliErrorKind::workflow_io("managed worker lookup failed").into();
+    let error = resolve_start_failure(start_failure(), Err(probe_error), "session-1")
+        .expect_err("uncertain second probe must retain recovery ownership");
+
+    assert!(!error.may_rollback());
+    assert_eq!(error.into_cli_error().code(), "WORKFLOW_IO");
+}
+
+#[test]
+fn exact_post_start_miss_is_rollback_safe() {
+    let error = resolve_start_failure(start_failure(), Ok(None), "session-1")
+        .expect_err("exact second miss preserves the start failure");
+
+    assert!(error.may_rollback());
+    assert_eq!(error.into_cli_error().code(), "WORKFLOW_IO");
+}
+
+fn start_failure() -> CliError {
+    CliErrorKind::workflow_io("managed worker start failed before persistence").into()
+}
+
+#[tokio::test]
+async fn worker_start_waits_for_lane_before_preflight() {
+    let state = test_http_state();
+    let applied = applied_task(AgentMode::Interactive);
+    let intent_id = "dispatch-intent-test";
+    let outer_guard = state
+        .managed_agent_mutation_locks
+        .lock(&applied.session_id, &managed_worker_id(&applied, intent_id))
+        .await;
+    let future = start_worker_for_applied_task(&state, &applied, intent_id, "stale-claim");
+    tokio::pin!(future);
+
+    assert!(
+        timeout(Duration::from_millis(50), future.as_mut())
+            .await
+            .is_err(),
+        "worker probe and preflight must wait for the deterministic worker lane",
+    );
+
+    drop(outer_guard);
+    let error = timeout(Duration::from_secs(2), future)
+        .await
+        .expect("worker start resumes once the lane is free")
+        .expect_err("test has no dispatch claim");
+    assert!(error.may_rollback());
+}
+
+#[tokio::test]
+async fn deterministic_worker_evidence_precedes_claim_preflight() {
+    let state = test_http_state();
+    let db = state.async_db.get().cloned().expect("test async db");
+    let applied = applied_task(AgentMode::Headless);
+    let intent_id = "dispatch-intent-reclaimed";
+    let worker_id = managed_worker_id(&applied, intent_id);
+    seed_session(&db, &applied.session_id).await;
+    let mut snapshot = codex_snapshot(CodexRunStatus::Running, &applied.session_id);
+    snapshot.run_id.clone_from(&worker_id);
+    snapshot.board_item_id = Some(applied.board_item_id.clone());
+    snapshot.task_id = Some(applied.work_item_id.clone());
+    snapshot.workflow_execution_id = applied.item.workflow.execution_id.clone();
+    snapshot.session_agent_id = None;
+    db.save_codex_run(&snapshot)
+        .await
+        .expect("persist deterministic worker evidence");
+
+    let recovered = start_worker_for_applied_task(&state, &applied, intent_id, "stale-claim")
+        .await
+        .expect("existing worker must be recovered before claim validation");
+
+    assert_eq!(recovered.agent_id(), worker_id);
+}
+
+async fn seed_session(db: &crate::daemon::db::AsyncDaemonDb, session_id: &str) {
+    let now = "2026-07-17T10:00:00Z";
+    let state_json = serde_json::json!({
+        "schema_version": crate::session::types::CURRENT_VERSION,
+        "session_id": session_id,
+        "context": "managed-agent recovery",
+        "status": "active",
+        "created_at": now,
+        "updated_at": now,
+    })
+    .to_string();
+    sqlx::query(
+        "INSERT INTO projects (
+             project_id, name, checkout_id, checkout_name, context_root,
+             is_worktree, discovered_at, updated_at
+         ) VALUES ('project-1', 'harness', 'checkout-1', 'main',
+                   '/tmp/harness-managed-agent-test', 0, ?1, ?1)",
+    )
+    .bind(now)
+    .execute(db.pool())
+    .await
+    .expect("seed managed-agent project");
+    sqlx::query(
+        "INSERT INTO sessions (
+             session_id, project_id, schema_version, context, status,
+             created_at, updated_at, state_json
+         ) VALUES (?1, 'project-1', 3, 'managed-agent recovery', 'active',
+                   ?2, ?2, ?3)",
+    )
+    .bind(session_id)
+    .bind(now)
+    .bind(state_json)
+    .execute(db.pool())
+    .await
+    .expect("seed managed-agent session");
+}
+
+#[tokio::test]
+async fn compensation_renews_claim_inside_worker_lane_before_stop() {
+    let state = test_http_state();
+    let db = state.async_db.get().cloned().expect("test async db");
+    let applied = applied_task(AgentMode::Interactive);
+    let intent_id = "dispatch-intent-compensation";
+    let worker_id = managed_worker_id(&applied, intent_id);
+    let outer_guard = state
+        .managed_agent_mutation_locks
+        .lock(&applied.session_id, &worker_id)
+        .await;
+    let future = begin_worker_compensation(
+        &state,
+        &db,
+        &applied,
+        intent_id,
+        "stale-claim",
+        "completion failed",
+    );
+    tokio::pin!(future);
+
+    assert!(
+        timeout(Duration::from_millis(50), future.as_mut())
+            .await
+            .is_err(),
+        "compensation must wait for the deterministic worker lane",
+    );
+
+    drop(outer_guard);
+    let error = timeout(Duration::from_secs(2), future)
+        .await
+        .expect("compensation resumes once the lane is free")
+        .expect_err("stale owner must fail before stop");
+    assert!(error.to_string().contains("lost its claim"));
+    assert!(!error.to_string().contains("terminal agent"));
+}
+
+#[tokio::test]
+async fn compensation_resume_accepts_a_worker_already_stopped_before_crash() {
+    let state = test_http_state();
+    let applied = applied_task(AgentMode::Interactive);
+    let worker_id = managed_worker_id(&applied, "dispatch-intent-crash-resume");
+
+    stop_worker_in_lane(&state, &applied, worker_id)
+        .await
+        .expect("missing deterministic worker proves the prior stop already completed");
+}

--- a/src/daemon/task_board_managed_agents_test_support.rs
+++ b/src/daemon/task_board_managed_agents_test_support.rs
@@ -1,0 +1,183 @@
+use std::env::temp_dir;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use serde_json::json;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use crate::daemon::agent_acp::AcpAgentManagerHandle;
+use crate::daemon::agent_tui::{
+    AgentTuiManagerHandle, AgentTuiSize, AgentTuiSnapshot, AgentTuiStatus, TerminalScreenSnapshot,
+};
+use crate::daemon::codex_controller::CodexControllerHandle;
+use crate::daemon::db::DaemonDb;
+use crate::daemon::http::{
+    AsyncDaemonDbSlot, DaemonHttpState, ManagedAgentMutationLocks, connect_async_db_for_tests,
+};
+use crate::daemon::protocol::{CodexRunMode, CodexRunSnapshot, CodexRunStatus};
+use crate::daemon::state::{DaemonManifest, HostBridgeManifest};
+use crate::daemon::websocket::ReplayBuffer;
+use crate::task_board::dispatch::DispatchLifecycle;
+use crate::task_board::{
+    AgentMode, DispatchAppliedTask, TaskBoardItem, TaskBoardPriority, TaskBoardStatus,
+    TaskBoardWorkflowState,
+};
+use crate::workspace::utc_now;
+
+pub(super) fn test_http_state() -> DaemonHttpState {
+    let (sender, _) = broadcast::channel(8);
+    let db_slot = Arc::new(OnceLock::new());
+    let async_db = Arc::new(OnceLock::new());
+    let db_path = temp_dir().join(format!("harness-tb-managed-{}.db", Uuid::new_v4()));
+    db_slot
+        .set(Arc::new(Mutex::new(
+            DaemonDb::open(&db_path).expect("open file db"),
+        )))
+        .expect("install db");
+    async_db
+        .set(connect_async_db_for_tests(&db_path))
+        .expect("install async db");
+    let manifest: DaemonManifest = serde_json::from_value(json!({
+        "version": "20.6.0",
+        "pid": 1,
+        "endpoint": "http://127.0.0.1:0",
+        "started_at": "2026-05-15T00:00:00Z",
+        "token_path": "/tmp/token",
+        "sandboxed": false,
+        "host_bridge": HostBridgeManifest::default(),
+        "revision": 0,
+        "updated_at": "",
+    }))
+    .expect("deserialize daemon manifest");
+    DaemonHttpState {
+        token: "token".into(),
+        auth_mode: crate::daemon::http::DaemonHttpAuthMode::Local,
+        remote_domain: None,
+        remote_request_limits: None,
+        remote_pairing_limiter: crate::daemon::http::default_remote_pairing_limiter(),
+        remote_pairing_status_limiter: crate::daemon::http::default_remote_pairing_status_limiter(),
+        sender: sender.clone(),
+        prepared_sender: broadcast::channel(8).0,
+        manifest,
+        daemon_epoch: "epoch".into(),
+        replay_buffer: Arc::new(Mutex::new(ReplayBuffer::new(8))),
+        db: db_slot.clone(),
+        async_db: AsyncDaemonDbSlot::from_inner(async_db.clone()),
+        db_path: Some(db_path),
+        codex_controller: CodexControllerHandle::new_with_async_db(
+            sender.clone(),
+            db_slot.clone(),
+            async_db.clone(),
+            false,
+        ),
+        acp_agent_manager: AcpAgentManagerHandle::new_with_async_db(
+            sender.clone(),
+            db_slot.clone(),
+            async_db.clone(),
+        ),
+        agent_tui_manager: AgentTuiManagerHandle::new_with_async_db(
+            sender.clone(),
+            db_slot,
+            async_db,
+            false,
+        ),
+        managed_agent_mutation_locks: ManagedAgentMutationLocks::default(),
+        recovery_snapshot: Default::default(),
+    }
+}
+
+pub(super) fn applied_task(mode: AgentMode) -> DispatchAppliedTask {
+    let mut item = TaskBoardItem::new(
+        "board-1".into(),
+        "Ship managed worker launch".into(),
+        "Start a real worker.".into(),
+        utc_now(),
+    );
+    item.agent_mode = mode;
+    item.status = TaskBoardStatus::InProgress;
+    item.priority = TaskBoardPriority::High;
+    item.tags = vec!["backend".into()];
+    item.external_refs = vec![crate::task_board::ExternalRef {
+        provider: crate::task_board::ExternalRefProvider::GitHub,
+        external_id: "123".into(),
+        url: Some("https://github.example/issues/123".into()),
+        sync_state: None,
+    }];
+    item.workflow = TaskBoardWorkflowState {
+        execution_id: Some("workflow-1".into()),
+        worktree: Some("/tmp/task-worktree".into()),
+        ..TaskBoardWorkflowState::default()
+    };
+    DispatchAppliedTask {
+        board_item_id: item.id.clone(),
+        session_id: "session-1".into(),
+        work_item_id: "task-1".into(),
+        lifecycle: DispatchLifecycle::planned(
+            &crate::task_board::WorkerIntent { mode },
+            &crate::task_board::ReviewerIntent {
+                phase: crate::task_board::FollowUpPhase::AfterWorkerReview,
+                suggested_persona: "code-reviewer".into(),
+                required_consensus: 2,
+            },
+            &crate::task_board::EvaluatorIntent {
+                phase: crate::task_board::FollowUpPhase::AfterWorkerReview,
+                mode: AgentMode::Evaluate,
+            },
+        ),
+        item,
+    }
+}
+
+pub(super) fn terminal_snapshot(status: AgentTuiStatus, session_id: &str) -> AgentTuiSnapshot {
+    AgentTuiSnapshot {
+        tui_id: "agent-tui-dispatch-intent-existing".into(),
+        session_id: session_id.into(),
+        agent_id: "worker-terminal".into(),
+        runtime: "codex".into(),
+        status,
+        argv: Vec::new(),
+        project_dir: "/tmp/project".into(),
+        size: AgentTuiSize { rows: 24, cols: 80 },
+        screen: TerminalScreenSnapshot {
+            rows: 24,
+            cols: 80,
+            cursor_row: 0,
+            cursor_col: 0,
+            text: String::new(),
+        },
+        transcript_path: "/tmp/transcript".into(),
+        exit_code: None,
+        signal: None,
+        error: None,
+        created_at: "2026-07-17T00:00:00Z".into(),
+        updated_at: "2026-07-17T00:00:01Z".into(),
+    }
+}
+
+pub(super) fn codex_snapshot(status: CodexRunStatus, session_id: &str) -> CodexRunSnapshot {
+    CodexRunSnapshot {
+        run_id: "codex-dispatch-intent-existing".into(),
+        session_id: session_id.into(),
+        task_id: Some("task-1".into()),
+        board_item_id: Some("board-1".into()),
+        workflow_execution_id: Some("workflow-1".into()),
+        session_agent_id: Some("worker-codex".into()),
+        display_name: Some("Codex".into()),
+        project_dir: "/tmp/project".into(),
+        thread_id: Some("thread-1".into()),
+        turn_id: None,
+        mode: CodexRunMode::WorkspaceWrite,
+        status,
+        prompt: "work".into(),
+        latest_summary: None,
+        final_message: None,
+        error: None,
+        pending_approvals: Vec::new(),
+        resolved_approvals: Vec::new(),
+        events: Vec::new(),
+        created_at: "2026-07-17T00:00:00Z".into(),
+        updated_at: "2026-07-17T00:00:01Z".into(),
+        model: None,
+        effort: None,
+    }
+}

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -269,12 +269,12 @@ async fn run_remote_serve_lifecycle_async(
         RemoteInitialAcmeControl::ShutdownAfterIssuance => return Ok(0),
     }
     let plan = build_remote_serve_execution_plan_from_config(args, db, remote_config)?;
-    service::serve_remote_https(
+    Box::pin(service::serve_remote_https(
         plan.service_config,
         plan.acme_plan,
         shutdown_tx,
         shutdown_rx,
-    )
+    ))
     .await?;
     Ok(0)
 }

--- a/src/daemon/transport/remote_serve.rs
+++ b/src/daemon/transport/remote_serve.rs
@@ -269,6 +269,7 @@ async fn run_remote_serve_lifecycle_async(
         RemoteInitialAcmeControl::ShutdownAfterIssuance => return Ok(0),
     }
     let plan = build_remote_serve_execution_plan_from_config(args, db, remote_config)?;
+    // Boxing keeps the long-lived HTTPS future below the denied large-futures threshold.
     Box::pin(service::serve_remote_https(
         plan.service_config,
         plan.acme_plan,

--- a/src/daemon/websocket/task_board/orchestrator.rs
+++ b/src/daemon/websocket/task_board/orchestrator.rs
@@ -200,6 +200,7 @@ pub(super) async fn dispatch_task_board_orchestrator_settings_update(
             "has_github_project": body.github_project.is_some(),
             "has_github_inbox": body.github_inbox.is_some(),
             "has_todoist_inbox": body.todoist_inbox.is_some(),
+            "has_admission_policy": body.admission_policy.is_some(),
             "has_policy_version": body.policy_version.is_some(),
         }),
         &result,

--- a/src/mcp/tools/task_board/items.rs
+++ b/src/mcp/tools/task_board/items.rs
@@ -78,6 +78,12 @@ fn create_schema() -> Value {
             "body": { "type": "string" },
             "priority": { "type": "string" },
             "agent_mode": { "type": "string" },
+            "estimated_tokens": {
+                "type": "integer", "minimum": 1, "maximum": 9_223_372_036_854_775_807_u64
+            },
+            "estimated_cost_microusd": {
+                "type": "integer", "minimum": 1, "maximum": 9_223_372_036_854_775_807_u64
+            },
             "tags": string_array_schema(),
             "project_id": { "type": "string" },
             "target_project_types": string_array_schema(),
@@ -157,6 +163,14 @@ fn update_schema() -> Value {
             "status": { "type": "string" },
             "priority": { "type": "string" },
             "agent_mode": { "type": "string" },
+            "estimated_tokens": {
+                "type": "integer", "minimum": 1, "maximum": 9_223_372_036_854_775_807_u64
+            },
+            "estimated_cost_microusd": {
+                "type": "integer", "minimum": 1, "maximum": 9_223_372_036_854_775_807_u64
+            },
+            "clear_estimated_tokens": { "type": "boolean" },
+            "clear_estimated_cost_microusd": { "type": "boolean" },
             "tags": string_array_schema(),
             "project_id": { "type": "string" },
             "target_project_types": string_array_schema(),
@@ -172,6 +186,24 @@ fn update_schema() -> Value {
             "work_item_id": { "type": "string" }
         },
         "required": ["id"],
+        "allOf": [
+            {
+                "not": {
+                    "properties": { "clear_estimated_tokens": { "const": true } },
+                    "required": ["estimated_tokens", "clear_estimated_tokens"]
+                }
+            },
+            {
+                "not": {
+                    "properties": {
+                        "clear_estimated_cost_microusd": { "const": true }
+                    },
+                    "required": [
+                        "estimated_cost_microusd", "clear_estimated_cost_microusd"
+                    ]
+                }
+            }
+        ],
         "additionalProperties": false
     })
 }
@@ -199,4 +231,37 @@ fn plan_approve_schema() -> Value {
         "required": ["id", "approved_by"],
         "additionalProperties": false
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{create_schema, update_schema};
+
+    #[test]
+    fn estimate_schemas_advertise_the_storage_bounds() {
+        for schema in [create_schema(), update_schema()] {
+            let properties = &schema["properties"];
+            for field in ["estimated_tokens", "estimated_cost_microusd"] {
+                assert_eq!(properties[field]["minimum"], json!(1));
+                assert_eq!(properties[field]["maximum"], json!(i64::MAX));
+            }
+        }
+    }
+
+    #[test]
+    fn update_schema_rejects_set_and_clear_combinations() {
+        let schema = update_schema();
+
+        assert_eq!(schema["allOf"].as_array().map(Vec::len), Some(2));
+        assert_eq!(
+            schema["allOf"][0]["not"]["required"],
+            json!(["estimated_tokens", "clear_estimated_tokens"])
+        );
+        assert_eq!(
+            schema["allOf"][1]["not"]["required"],
+            json!(["estimated_cost_microusd", "clear_estimated_cost_microusd"])
+        );
+    }
 }

--- a/src/mcp/tools/task_board/orchestrator.rs
+++ b/src/mcp/tools/task_board/orchestrator.rs
@@ -142,9 +142,88 @@ fn settings_update_schema() -> Value {
             "clear_dispatch_status_filter": { "type": "boolean" },
             "project_dir": { "type": "string" },
             "clear_project_dir": { "type": "boolean" },
+            "admission_policy": admission_policy_schema(),
             "policy_version": { "type": "string" }
         },
-        "additionalProperties": true
+        "additionalProperties": false
+    })
+}
+
+fn admission_policy_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "limits": {
+                "type": "array",
+                "items": admission_limit_schema()
+            },
+            "windows": {
+                "type": "array",
+                "items": admission_window_schema()
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+fn admission_limit_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": ["concurrency", "rate", "token_budget", "monetary_budget"]
+            },
+            "scope": admission_scope_schema(),
+            "limit": { "type": "integer", "minimum": 1 },
+            "limit_microusd": { "type": "integer", "minimum": 1 },
+            "window_seconds": { "type": "integer", "minimum": 1 },
+            "reservation": { "type": "integer", "minimum": 1 }
+        },
+        "required": ["kind", "scope"],
+        "additionalProperties": false
+    })
+}
+
+fn admission_scope_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": ["global", "workflow", "repository"]
+            },
+            "value": { "type": "string" }
+        },
+        "required": ["kind"],
+        "additionalProperties": false
+    })
+}
+
+fn admission_window_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "scope": admission_scope_schema(),
+            "timezone": { "type": "string" },
+            "weekdays": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "monday", "tuesday", "wednesday", "thursday", "friday",
+                        "saturday", "sunday"
+                    ]
+                }
+            },
+            "start_time": { "type": "string" },
+            "end_time": { "type": "string" },
+            "outside_action": { "type": "string", "enum": ["defer", "deny"] }
+        },
+        "required": [
+            "scope", "timezone", "weekdays", "start_time", "end_time", "outside_action"
+        ],
+        "additionalProperties": false
     })
 }
 

--- a/src/mcp/tools/task_board/orchestrator.rs
+++ b/src/mcp/tools/task_board/orchestrator.rs
@@ -220,6 +220,18 @@ fn admission_limit_schema() -> Value {
             }
         },
         "required": ["kind", "scope"],
+        "allOf": [
+            tagged_kind_requires_fields("concurrency", &["limit", "reservation"]),
+            tagged_kind_requires_fields(
+                "rate",
+                &["limit", "window_seconds", "reservation"]
+            ),
+            tagged_kind_requires_fields("token_budget", &["limit", "window_seconds"]),
+            tagged_kind_requires_fields(
+                "monetary_budget",
+                &["limit_microusd", "window_seconds"]
+            )
+        ],
         "additionalProperties": false
     })
 }
@@ -236,14 +248,14 @@ fn admission_scope_schema() -> Value {
         },
         "required": ["kind"],
         "allOf": [
-            scope_value_required_for("workflow"),
-            scope_value_required_for("repository")
+            tagged_kind_requires_fields("workflow", &["value"]),
+            tagged_kind_requires_fields("repository", &["value"])
         ],
         "additionalProperties": false
     })
 }
 
-fn scope_value_required_for(kind: &str) -> Value {
+fn tagged_kind_requires_fields(kind: &str, fields: &[&str]) -> Value {
     json!({
         "not": {
             "allOf": [
@@ -251,7 +263,7 @@ fn scope_value_required_for(kind: &str) -> Value {
                     "properties": { "kind": { "const": kind } },
                     "required": ["kind"]
                 },
-                { "not": { "required": ["value"] } }
+                { "not": { "required": fields } }
             ]
         }
     })

--- a/src/mcp/tools/task_board/orchestrator.rs
+++ b/src/mcp/tools/task_board/orchestrator.rs
@@ -137,15 +137,46 @@ fn settings_update_schema() -> Value {
     json!({
         "type": "object",
         "properties": {
+            "step_mode": { "type": "boolean" },
+            "enabled_workflows": workflow_list_schema(),
             "dry_run_default": { "type": "boolean" },
             "dispatch_status_filter": { "type": "string" },
             "clear_dispatch_status_filter": { "type": "boolean" },
             "project_dir": { "type": "string" },
             "clear_project_dir": { "type": "boolean" },
+            "github_project": open_object_schema(),
+            "github_inbox": open_object_schema(),
+            "todoist_inbox": open_object_schema(),
+            "scheduling": open_object_schema(),
+            "retry": open_object_schema(),
+            "reviewers": open_object_schema(),
+            "repositories": object_list_schema(),
+            "execution_hosts": object_list_schema(),
             "admission_policy": admission_policy_schema(),
             "policy_version": { "type": "string" }
         },
         "additionalProperties": false
+    })
+}
+
+fn workflow_list_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": {
+            "type": "string",
+            "enum": ["default_task", "pr_fix", "pr_review", "review"]
+        }
+    })
+}
+
+fn open_object_schema() -> Value {
+    json!({ "type": "object" })
+}
+
+fn object_list_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": open_object_schema()
     })
 }
 

--- a/src/mcp/tools/task_board/orchestrator.rs
+++ b/src/mcp/tools/task_board/orchestrator.rs
@@ -206,10 +206,18 @@ fn admission_limit_schema() -> Value {
                 "enum": ["concurrency", "rate", "token_budget", "monetary_budget"]
             },
             "scope": admission_scope_schema(),
-            "limit": { "type": "integer", "minimum": 1 },
-            "limit_microusd": { "type": "integer", "minimum": 1 },
-            "window_seconds": { "type": "integer", "minimum": 1 },
-            "reservation": { "type": "integer", "minimum": 1 }
+            "limit": {
+                "type": "integer", "minimum": 1, "maximum": 9_223_372_036_854_775_807_u64
+            },
+            "limit_microusd": {
+                "type": "integer", "minimum": 1, "maximum": 9_223_372_036_854_775_807_u64
+            },
+            "window_seconds": {
+                "type": "integer", "minimum": 1, "maximum": 9_223_372_036_854_775_807_u64
+            },
+            "reservation": {
+                "type": "integer", "minimum": 1, "maximum": 9_223_372_036_854_775_807_u64
+            }
         },
         "required": ["kind", "scope"],
         "additionalProperties": false
@@ -227,7 +235,25 @@ fn admission_scope_schema() -> Value {
             "value": { "type": "string" }
         },
         "required": ["kind"],
+        "allOf": [
+            scope_value_required_for("workflow"),
+            scope_value_required_for("repository")
+        ],
         "additionalProperties": false
+    })
+}
+
+fn scope_value_required_for(kind: &str) -> Value {
+    json!({
+        "not": {
+            "allOf": [
+                {
+                    "properties": { "kind": { "const": kind } },
+                    "required": ["kind"]
+                },
+                { "not": { "required": ["value"] } }
+            ]
+        }
     })
 }
 

--- a/src/mcp/tools/task_board/support.rs
+++ b/src/mcp/tools/task_board/support.rs
@@ -72,6 +72,25 @@ fn validate_params(params: Value, schema: &Value) -> Result<Value, ToolError> {
 }
 
 fn validate_value(path: &str, value: &Value, schema: &Value) -> Result<(), ToolError> {
+    if let Some(constraints) = schema.get("allOf").and_then(Value::as_array) {
+        for constraint in constraints {
+            validate_value(path, value, constraint)?;
+        }
+    }
+    if let Some(excluded) = schema.get("not")
+        && validate_value(path, value, excluded).is_ok()
+    {
+        return Err(ToolError::invalid(format!(
+            "{path} matches a disallowed field combination"
+        )));
+    }
+    if let Some(expected) = schema.get("const")
+        && expected != value
+    {
+        return Err(ToolError::invalid(format!(
+            "{path} must match the advertised constant"
+        )));
+    }
     if let Some(expected) = schema.get("type").and_then(Value::as_str)
         && !matches_schema_type(value, expected)
     {
@@ -155,7 +174,24 @@ fn validate_number(
             "{path} must be at least {minimum}"
         )));
     }
+    if let Some(maximum) = schema.get("maximum")
+        && number_exceeds_maximum(number, maximum)
+    {
+        return Err(ToolError::invalid(format!(
+            "{path} must be at most {maximum}"
+        )));
+    }
     Ok(())
+}
+
+fn number_exceeds_maximum(number: &serde_json::Number, maximum: &Value) -> bool {
+    if let (Some(number), Some(maximum)) = (number.as_u64(), maximum.as_u64()) {
+        return number > maximum;
+    }
+    number
+        .as_f64()
+        .zip(maximum.as_f64())
+        .is_some_and(|(number, maximum)| number > maximum)
 }
 
 fn matches_schema_type(value: &Value, expected: &str) -> bool {
@@ -382,6 +418,38 @@ mod validation_tests {
 
         assert!(validate_params(json!({ "tags": ["mcp", "cli"] }), &schema).is_ok());
         assert!(validate_params(json!({ "tags": ["mcp", 1] }), &schema).is_err());
+    }
+
+    #[test]
+    fn maximum_and_disallowed_field_combinations_are_enforced() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 9_223_372_036_854_775_807_u64
+                },
+                "clear": { "type": "boolean" }
+            },
+            "allOf": [{
+                "not": {
+                    "properties": { "clear": { "const": true } },
+                    "required": ["value", "clear"]
+                }
+            }],
+            "additionalProperties": false
+        });
+
+        assert!(validate_params(json!({ "value": 1 }), &schema).is_ok());
+        assert!(
+            validate_params(json!({ "value": 9_223_372_036_854_775_807_u64 }), &schema).is_ok()
+        );
+        assert!(
+            validate_params(json!({ "value": 9_223_372_036_854_775_808_u64 }), &schema).is_err()
+        );
+        assert!(validate_params(json!({ "value": 1, "clear": false }), &schema).is_ok());
+        assert!(validate_params(json!({ "value": 1, "clear": true }), &schema).is_err());
     }
 
     #[test]

--- a/src/mcp/tools/tests/task_board_tests.rs
+++ b/src/mcp/tools/tests/task_board_tests.rs
@@ -22,6 +22,8 @@ use crate::mcp::tool::ToolRegistry;
 
 use super::{register_all, socket_path};
 
+mod orchestrator_settings_tests;
+
 static DAEMON_TEST_MUTEX: OnceLock<AsyncMutex<()>> = OnceLock::new();
 
 fn daemon_test_mutex() -> &'static AsyncMutex<()> {
@@ -248,26 +250,6 @@ async fn dispatch_tool_proxies_to_running_daemon() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn orchestrator_settings_update_tool_proxies_to_running_daemon() {
-    let arguments = json!({
-        "dry_run_default": true,
-    });
-    let (result, captured) = call_task_board_tool(
-        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE,
-        arguments.clone(),
-        json!({ "saved": true }),
-    )
-    .await;
-
-    assert_eq!(text_result_json(&result), json!({ "saved": true }));
-    assert_eq!(
-        captured.request.method,
-        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE
-    );
-    assert_eq!(captured.request.params, arguments);
-}
-
-#[tokio::test(flavor = "current_thread")]
 async fn policy_save_draft_tool_proxies_to_running_daemon() {
     let arguments = json!({
         "document": {},
@@ -413,29 +395,6 @@ fn update_schema_uses_strict_additional_properties() {
         &schema,
         ws_methods::TASK_BOARD_UPDATE,
         TASK_BOARD_UPDATE_FIELDS,
-    );
-}
-
-#[test]
-fn orchestrator_settings_schema_advertises_strict_admission_policy() {
-    let schema = task_board_tool_schema(ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE);
-    assert_schema_covers_fields(
-        &schema,
-        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE,
-        &["admission_policy"],
-    );
-    let policy = &schema["properties"]["admission_policy"];
-    assert_eq!(policy["type"], "object");
-    assert_eq!(policy["additionalProperties"], false);
-    assert_eq!(policy["properties"]["limits"]["type"], "array");
-    assert_eq!(
-        policy["properties"]["limits"]["items"]["additionalProperties"],
-        false
-    );
-    assert_eq!(policy["properties"]["windows"]["type"], "array");
-    assert_eq!(
-        policy["properties"]["windows"]["items"]["additionalProperties"],
-        false
     );
 }
 

--- a/src/mcp/tools/tests/task_board_tests.rs
+++ b/src/mcp/tools/tests/task_board_tests.rs
@@ -417,6 +417,29 @@ fn update_schema_uses_strict_additional_properties() {
 }
 
 #[test]
+fn orchestrator_settings_schema_advertises_strict_admission_policy() {
+    let schema = task_board_tool_schema(ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE);
+    assert_schema_covers_fields(
+        &schema,
+        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE,
+        &["admission_policy"],
+    );
+    let policy = &schema["properties"]["admission_policy"];
+    assert_eq!(policy["type"], "object");
+    assert_eq!(policy["additionalProperties"], false);
+    assert_eq!(policy["properties"]["limits"]["type"], "array");
+    assert_eq!(
+        policy["properties"]["limits"]["items"]["additionalProperties"],
+        false
+    );
+    assert_eq!(policy["properties"]["windows"]["type"], "array");
+    assert_eq!(
+        policy["properties"]["windows"]["items"]["additionalProperties"],
+        false
+    );
+}
+
+#[test]
 fn policy_schemas_advertise_protocol_fields() {
     for tool_name in [
         ws_methods::POLICY_PIPELINE_GET,

--- a/src/mcp/tools/tests/task_board_tests/orchestrator_settings_tests.rs
+++ b/src/mcp/tools/tests/task_board_tests/orchestrator_settings_tests.rs
@@ -54,12 +54,33 @@ async fn update_tool_proxies_every_public_field_to_running_daemon() {
         "repositories": [],
         "execution_hosts": [],
         "admission_policy": {
-            "limits": [{
-                "kind": "concurrency",
-                "scope": { "kind": "global" },
-                "limit": 1,
-                "reservation": 1,
-            }],
+            "limits": [
+                {
+                    "kind": "concurrency",
+                    "scope": { "kind": "global" },
+                    "limit": 1,
+                    "reservation": 1,
+                },
+                {
+                    "kind": "rate",
+                    "scope": { "kind": "workflow", "value": "default_task" },
+                    "limit": 10,
+                    "window_seconds": 60,
+                    "reservation": 1,
+                },
+                {
+                    "kind": "token_budget",
+                    "scope": { "kind": "repository", "value": "example/repo" },
+                    "limit": 1_000,
+                    "window_seconds": 3_600,
+                },
+                {
+                    "kind": "monetary_budget",
+                    "scope": { "kind": "global" },
+                    "limit_microusd": 10_000,
+                    "window_seconds": 3_600,
+                },
+            ],
             "windows": [{
                 "scope": { "kind": "repository", "value": "example/repo" },
                 "timezone": "UTC",
@@ -115,6 +136,12 @@ fn schema_advertises_every_field_and_strict_admission_policy() {
             "{field} must match the persisted integer bound"
         );
     }
+    assert_eq!(
+        policy["properties"]["limits"]["items"]["allOf"]
+            .as_array()
+            .map(Vec::len),
+        Some(4)
+    );
     let scope = &policy["properties"]["limits"]["items"]["properties"]["scope"];
     assert_eq!(scope["allOf"].as_array().map(Vec::len), Some(2));
 }
@@ -144,6 +171,35 @@ async fn schema_rejects_overflow_and_missing_non_global_scope_values() {
                 "scope": { "kind": "repository" },
                 "limit": 1,
                 "reservation": 1,
+            }],
+        }),
+        json!({
+            "limits": [{
+                "kind": "concurrency",
+                "scope": { "kind": "global" },
+                "limit": 1,
+            }],
+        }),
+        json!({
+            "limits": [{
+                "kind": "rate",
+                "scope": { "kind": "global" },
+                "limit": 1,
+                "reservation": 1,
+            }],
+        }),
+        json!({
+            "limits": [{
+                "kind": "token_budget",
+                "scope": { "kind": "global" },
+                "window_seconds": 60,
+            }],
+        }),
+        json!({
+            "limits": [{
+                "kind": "monetary_budget",
+                "scope": { "kind": "global" },
+                "window_seconds": 60,
             }],
         }),
     ];

--- a/src/mcp/tools/tests/task_board_tests/orchestrator_settings_tests.rs
+++ b/src/mcp/tools/tests/task_board_tests/orchestrator_settings_tests.rs
@@ -53,7 +53,22 @@ async fn update_tool_proxies_every_public_field_to_running_daemon() {
         },
         "repositories": [],
         "execution_hosts": [],
-        "admission_policy": { "limits": [], "windows": [] },
+        "admission_policy": {
+            "limits": [{
+                "kind": "concurrency",
+                "scope": { "kind": "global" },
+                "limit": 1,
+                "reservation": 1,
+            }],
+            "windows": [{
+                "scope": { "kind": "repository", "value": "example/repo" },
+                "timezone": "UTC",
+                "weekdays": ["monday"],
+                "start_time": "09:00",
+                "end_time": "17:00",
+                "outside_action": "defer",
+            }],
+        },
         "policy_version": "1",
     });
     let (result, captured) = call_task_board_tool(
@@ -92,4 +107,59 @@ fn schema_advertises_every_field_and_strict_admission_policy() {
         policy["properties"]["windows"]["items"]["additionalProperties"],
         false
     );
+    let limit = &policy["properties"]["limits"]["items"]["properties"];
+    for field in ["limit", "limit_microusd", "window_seconds", "reservation"] {
+        assert_eq!(
+            limit[field]["maximum"],
+            json!(9_223_372_036_854_775_807_u64),
+            "{field} must match the persisted integer bound"
+        );
+    }
+    let scope = &policy["properties"]["limits"]["items"]["properties"]["scope"];
+    assert_eq!(scope["allOf"].as_array().map(Vec::len), Some(2));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn schema_rejects_overflow_and_missing_non_global_scope_values() {
+    let invalid_policies = [
+        json!({
+            "limits": [{
+                "kind": "concurrency",
+                "scope": { "kind": "global" },
+                "limit": 9_223_372_036_854_775_808_u64,
+                "reservation": 1,
+            }],
+        }),
+        json!({
+            "limits": [{
+                "kind": "concurrency",
+                "scope": { "kind": "workflow" },
+                "limit": 1,
+                "reservation": 1,
+            }],
+        }),
+        json!({
+            "limits": [{
+                "kind": "concurrency",
+                "scope": { "kind": "repository" },
+                "limit": 1,
+                "reservation": 1,
+            }],
+        }),
+    ];
+
+    for admission_policy in invalid_policies {
+        let registry = task_board_registry();
+        let tool = registry
+            .get(ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE)
+            .expect("settings update tool registered");
+        let error = tool
+            .call(json!({ "admission_policy": admission_policy }))
+            .await
+            .expect_err("invalid admission policy must fail before daemon I/O");
+        assert!(
+            matches!(error, crate::mcp::tool::ToolError::InvalidParams(_)),
+            "unexpected validation error: {error:?}"
+        );
+    }
 }

--- a/src/mcp/tools/tests/task_board_tests/orchestrator_settings_tests.rs
+++ b/src/mcp/tools/tests/task_board_tests/orchestrator_settings_tests.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+const UPDATE_FIELDS: &[&str] = &[
+    "step_mode",
+    "enabled_workflows",
+    "dry_run_default",
+    "dispatch_status_filter",
+    "clear_dispatch_status_filter",
+    "project_dir",
+    "clear_project_dir",
+    "github_project",
+    "github_inbox",
+    "todoist_inbox",
+    "scheduling",
+    "retry",
+    "reviewers",
+    "repositories",
+    "execution_hosts",
+    "admission_policy",
+    "policy_version",
+];
+
+#[tokio::test(flavor = "current_thread")]
+async fn update_tool_proxies_every_public_field_to_running_daemon() {
+    let arguments = json!({
+        "step_mode": true,
+        "enabled_workflows": ["default_task", "pr_review"],
+        "dry_run_default": true,
+        "dispatch_status_filter": "backlog",
+        "clear_dispatch_status_filter": false,
+        "project_dir": "/tmp/project",
+        "clear_project_dir": false,
+        "github_project": {},
+        "github_inbox": {},
+        "todoist_inbox": {},
+        "scheduling": {
+            "max_dispatches_per_run": 1,
+            "max_concurrent_workflows": 1,
+            "reconcile_interval_seconds": 60,
+        },
+        "retry": {
+            "max_attempts": 3,
+            "base_delay_seconds": 30,
+            "multiplier": 4,
+            "max_delay_seconds": 600,
+            "deterministic_jitter_percent": 10,
+        },
+        "reviewers": {
+            "reviewer_count": 1,
+            "required_approvals": 1,
+            "max_revision_cycles": 3,
+            "profiles": [],
+        },
+        "repositories": [],
+        "execution_hosts": [],
+        "admission_policy": { "limits": [], "windows": [] },
+        "policy_version": "1",
+    });
+    let (result, captured) = call_task_board_tool(
+        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE,
+        arguments.clone(),
+        json!({ "saved": true }),
+    )
+    .await;
+
+    assert_eq!(text_result_json(&result), json!({ "saved": true }));
+    assert_eq!(
+        captured.request.method,
+        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE
+    );
+    assert_eq!(captured.request.params, arguments);
+}
+
+#[test]
+fn schema_advertises_every_field_and_strict_admission_policy() {
+    let schema = task_board_tool_schema(ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE);
+    assert_schema_covers_fields(
+        &schema,
+        ws_methods::TASK_BOARD_ORCHESTRATOR_SETTINGS_UPDATE,
+        UPDATE_FIELDS,
+    );
+    let policy = &schema["properties"]["admission_policy"];
+    assert_eq!(policy["type"], "object");
+    assert_eq!(policy["additionalProperties"], false);
+    assert_eq!(policy["properties"]["limits"]["type"], "array");
+    assert_eq!(
+        policy["properties"]["limits"]["items"]["additionalProperties"],
+        false
+    );
+    assert_eq!(policy["properties"]["windows"]["type"], "array");
+    assert_eq!(
+        policy["properties"]["windows"]["items"]["additionalProperties"],
+        false
+    );
+}

--- a/src/task_board/automation.rs
+++ b/src/task_board/automation.rs
@@ -1,16 +1,30 @@
 //! Shared contracts for durable Task Board automation.
 
+mod admission;
 mod interfaces;
+mod launch_capability;
+mod policy_compiler;
+mod policy_compiler_windows;
 mod remote;
 mod settings;
 mod status;
 mod wake;
 mod workflow;
 
+pub use admission::*;
 pub use interfaces::*;
+pub use launch_capability::*;
+pub use policy_compiler::*;
 pub use remote::*;
 pub use settings::*;
 pub use status::*;
 pub use workflow::*;
 
 pub(crate) use wake::*;
+
+#[cfg(test)]
+mod admission_tests;
+#[cfg(test)]
+mod launch_capability_tests;
+#[cfg(test)]
+mod policy_compiler_tests;

--- a/src/task_board/automation/admission.rs
+++ b/src/task_board/automation/admission.rs
@@ -1,0 +1,519 @@
+use std::cmp::Ordering;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::task_board::{TaskBoardAdmissionRequirement, TaskBoardAdmissionRequirementKind};
+
+/// Authoritative consumption for one admission scope at a frozen instant.
+/// Monetary values use integer USD millionths.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBoardAdmissionUsage {
+    pub kind: TaskBoardAdmissionRequirementKind,
+    pub scope: String,
+    pub consumed: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_at: Option<String>,
+}
+
+/// Canonical identity for one independently-accounted admission scope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBoardAdmissionRequirementKey {
+    pub kind: TaskBoardAdmissionRequirementKind,
+    pub scope: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_starts_at: Option<String>,
+}
+
+impl TaskBoardAdmissionRequirementKey {
+    /// Collision-free, versioned representation suitable for durable keys.
+    #[must_use]
+    pub fn stable_id(&self) -> String {
+        let seconds = self
+            .window_seconds
+            .map_or_else(|| "-".to_owned(), |value| value.to_string());
+        let starts_at = self.window_starts_at.as_deref().map_or_else(
+            || "-".to_owned(),
+            |value| format!("{}:{value}", value.len()),
+        );
+        format!(
+            "admission:v1:{}:{}:{}:{seconds}:{starts_at}",
+            kind_name(self.kind),
+            self.scope.len(),
+            self.scope
+        )
+    }
+}
+
+impl PartialOrd for TaskBoardAdmissionRequirementKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TaskBoardAdmissionRequirementKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        key_tuple(self).cmp(&key_tuple(other))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskBoardAdmissionDecision {
+    Allowed,
+    Deferred,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskBoardAdmissionBlockReason {
+    MissingUsage,
+    LimitReached,
+    WindowNotStarted,
+    WindowClosed,
+    MissingResetTime,
+    ArithmeticOverflow,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBoardAdmissionBlocker {
+    pub requirement: TaskBoardAdmissionRequirement,
+    pub reason: TaskBoardAdmissionBlockReason,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBoardAdmissionEvaluation {
+    pub decision: TaskBoardAdmissionDecision,
+    pub evaluated_at: String,
+    /// Canonical frozen inputs, not proof that durable reservations exist.
+    pub requirements: Vec<TaskBoardAdmissionRequirement>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<TaskBoardAdmissionBlocker>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_available_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TaskBoardAdmissionError {
+    #[error("admission scope is empty")]
+    EmptyScope,
+    #[error("admission requirement for '{scope}' has a zero limit")]
+    ZeroLimit { scope: String },
+    #[error("admission requirement for '{scope}' has a zero reservation")]
+    ZeroReservation { scope: String },
+    #[error("admission requirement for '{scope}' has an invalid window")]
+    InvalidWindow { scope: String },
+    #[error("admission requirement for '{scope}' has invalid timestamp '{value}'")]
+    InvalidTimestamp { scope: String, value: String },
+    #[error("admission requirements conflict at canonical key '{key}'")]
+    ConflictingRequirement { key: String },
+    #[error("admission usage conflicts at canonical key '{key}'")]
+    ConflictingUsage { key: String },
+    #[error("time-window admission usage is invalid for '{scope}'")]
+    InvalidUsageKind { scope: String },
+    #[error("admission usage for '{scope}' has an invalid window")]
+    InvalidUsageWindow { scope: String },
+    #[error("admission evaluation timestamp '{value}' is invalid")]
+    InvalidEvaluationTime { value: String },
+}
+
+/// Normalize and validate one requirement before deriving its durable key.
+///
+/// # Errors
+/// Returns an error when any requirement field is invalid.
+pub fn canonical_admission_requirement_key(
+    requirement: &TaskBoardAdmissionRequirement,
+) -> Result<TaskBoardAdmissionRequirementKey, TaskBoardAdmissionError> {
+    normalize_requirement(requirement.clone()).map(|value| requirement_key(&value))
+}
+
+/// Normalize, sort, and deduplicate exact requirements. Non-identical values
+/// sharing one canonical key are rejected independent of source order.
+///
+/// # Errors
+/// Returns an error for an invalid requirement or canonical-key conflict.
+pub fn collect_admission_requirements(
+    requirements: impl IntoIterator<Item = TaskBoardAdmissionRequirement>,
+) -> Result<Vec<TaskBoardAdmissionRequirement>, TaskBoardAdmissionError> {
+    let mut collected = requirements
+        .into_iter()
+        .map(normalize_requirement)
+        .collect::<Result<Vec<_>, _>>()?;
+    collected.sort_by(compare_requirements);
+    for pair in collected.windows(2) {
+        let left_key = requirement_key(&pair[0]);
+        if left_key == requirement_key(&pair[1]) && pair[0] != pair[1] {
+            return Err(TaskBoardAdmissionError::ConflictingRequirement {
+                key: left_key.stable_id(),
+            });
+        }
+    }
+    collected.dedup();
+    Ok(collected)
+}
+
+/// Evaluate canonical requirements against a caller-frozen authoritative usage
+/// snapshot and clock. Only the later transactional layer may reserve capacity.
+///
+/// # Errors
+/// Returns an error for invalid, conflicting, or non-canonical input snapshots.
+pub fn evaluate_admission_requirements(
+    requirements: impl IntoIterator<Item = TaskBoardAdmissionRequirement>,
+    usage: impl IntoIterator<Item = TaskBoardAdmissionUsage>,
+    evaluated_at: &str,
+) -> Result<TaskBoardAdmissionEvaluation, TaskBoardAdmissionError> {
+    let evaluated_at = parse_evaluation_time(evaluated_at)?;
+    let requirements = collect_admission_requirements(requirements)?;
+    let usage = collect_usage(usage)?;
+    let mut blockers = Vec::new();
+    for requirement in &requirements {
+        if requirement.kind == TaskBoardAdmissionRequirementKind::TimeWindow {
+            evaluate_time_window(requirement, evaluated_at, &mut blockers);
+        } else {
+            evaluate_consumption(requirement, &usage, &mut blockers);
+        }
+    }
+    Ok(TaskBoardAdmissionEvaluation {
+        decision: admission_decision(&blockers),
+        evaluated_at: canonical_time(evaluated_at),
+        requirements,
+        next_available_at: latest_available_at(&blockers),
+        blockers,
+    })
+}
+
+fn normalize_requirement(
+    mut requirement: TaskBoardAdmissionRequirement,
+) -> Result<TaskBoardAdmissionRequirement, TaskBoardAdmissionError> {
+    requirement.scope = normalized_scope(&requirement.scope)?;
+    if requirement.limit == 0 {
+        return Err(TaskBoardAdmissionError::ZeroLimit {
+            scope: requirement.scope,
+        });
+    }
+    if requirement.reservation == Some(0) {
+        return Err(TaskBoardAdmissionError::ZeroReservation {
+            scope: requirement.scope,
+        });
+    }
+    requirement.reservation.get_or_insert(1);
+    normalize_requirement_window(&mut requirement)?;
+    Ok(requirement)
+}
+
+fn normalize_requirement_window(
+    requirement: &mut TaskBoardAdmissionRequirement,
+) -> Result<(), TaskBoardAdmissionError> {
+    match requirement.kind {
+        TaskBoardAdmissionRequirementKind::Concurrency => {
+            if requirement.window_seconds.is_some() || requirement.available_at.is_some() {
+                return invalid_window(requirement);
+            }
+        }
+        TaskBoardAdmissionRequirementKind::Rate
+        | TaskBoardAdmissionRequirementKind::TokenBudget
+        | TaskBoardAdmissionRequirementKind::MonetaryBudget => {
+            if requirement
+                .window_seconds
+                .is_none_or(|seconds| seconds == 0)
+                || requirement.available_at.is_some()
+            {
+                return invalid_window(requirement);
+            }
+        }
+        TaskBoardAdmissionRequirementKind::TimeWindow => {
+            if requirement
+                .window_seconds
+                .is_none_or(|seconds| seconds == 0)
+            {
+                return invalid_window(requirement);
+            }
+            let value = requirement.available_at.as_deref().ok_or_else(|| {
+                TaskBoardAdmissionError::InvalidWindow {
+                    scope: requirement.scope.clone(),
+                }
+            })?;
+            let parsed =
+                parse_time(value).ok_or_else(|| TaskBoardAdmissionError::InvalidTimestamp {
+                    scope: requirement.scope.clone(),
+                    value: value.to_owned(),
+                })?;
+            requirement.available_at = Some(canonical_time(parsed));
+        }
+    }
+    Ok(())
+}
+
+fn invalid_window<T>(
+    requirement: &TaskBoardAdmissionRequirement,
+) -> Result<T, TaskBoardAdmissionError> {
+    Err(TaskBoardAdmissionError::InvalidWindow {
+        scope: requirement.scope.clone(),
+    })
+}
+
+fn collect_usage(
+    usage: impl IntoIterator<Item = TaskBoardAdmissionUsage>,
+) -> Result<Vec<TaskBoardAdmissionUsage>, TaskBoardAdmissionError> {
+    let mut usage = usage
+        .into_iter()
+        .map(normalize_usage)
+        .collect::<Result<Vec<_>, _>>()?;
+    usage.sort_by(compare_usage);
+    for pair in usage.windows(2) {
+        let key = usage_key(&pair[0]);
+        if key == usage_key(&pair[1]) && pair[0] != pair[1] {
+            return Err(TaskBoardAdmissionError::ConflictingUsage {
+                key: key.stable_id(),
+            });
+        }
+    }
+    usage.dedup();
+    Ok(usage)
+}
+
+fn normalize_usage(
+    mut usage: TaskBoardAdmissionUsage,
+) -> Result<TaskBoardAdmissionUsage, TaskBoardAdmissionError> {
+    usage.scope = normalized_scope(&usage.scope)?;
+    match usage.kind {
+        TaskBoardAdmissionRequirementKind::Concurrency if usage.window_seconds.is_none() => {}
+        TaskBoardAdmissionRequirementKind::Rate
+        | TaskBoardAdmissionRequirementKind::TokenBudget
+        | TaskBoardAdmissionRequirementKind::MonetaryBudget
+            if usage.window_seconds.is_some_and(|seconds| seconds > 0) => {}
+        TaskBoardAdmissionRequirementKind::TimeWindow => {
+            return Err(TaskBoardAdmissionError::InvalidUsageKind { scope: usage.scope });
+        }
+        _ => {
+            return Err(TaskBoardAdmissionError::InvalidUsageWindow { scope: usage.scope });
+        }
+    }
+    if let Some(value) = usage.available_at.as_deref() {
+        let parsed =
+            parse_time(value).ok_or_else(|| TaskBoardAdmissionError::InvalidTimestamp {
+                scope: usage.scope.clone(),
+                value: value.to_owned(),
+            })?;
+        usage.available_at = Some(canonical_time(parsed));
+    }
+    Ok(usage)
+}
+
+fn evaluate_time_window(
+    requirement: &TaskBoardAdmissionRequirement,
+    evaluated_at: DateTime<Utc>,
+    blockers: &mut Vec<TaskBoardAdmissionBlocker>,
+) {
+    let starts_at = requirement
+        .available_at
+        .as_deref()
+        .and_then(parse_time)
+        .expect("normalized time-window start");
+    let duration = requirement
+        .window_seconds
+        .and_then(|seconds| i64::try_from(seconds).ok())
+        .and_then(chrono::Duration::try_seconds);
+    let Some(ends_at) = duration.and_then(|value| starts_at.checked_add_signed(value)) else {
+        blockers.push(blocker(
+            requirement,
+            TaskBoardAdmissionBlockReason::ArithmeticOverflow,
+            None,
+        ));
+        return;
+    };
+    if evaluated_at < starts_at {
+        blockers.push(blocker(
+            requirement,
+            TaskBoardAdmissionBlockReason::WindowNotStarted,
+            requirement.available_at.clone(),
+        ));
+    } else if evaluated_at >= ends_at {
+        blockers.push(blocker(
+            requirement,
+            TaskBoardAdmissionBlockReason::WindowClosed,
+            None,
+        ));
+    }
+}
+
+fn evaluate_consumption(
+    requirement: &TaskBoardAdmissionRequirement,
+    usage: &[TaskBoardAdmissionUsage],
+    blockers: &mut Vec<TaskBoardAdmissionBlocker>,
+) {
+    let key = requirement_key(requirement);
+    let Some(observation) = usage.iter().find(|value| usage_key(value) == key) else {
+        blockers.push(blocker(
+            requirement,
+            TaskBoardAdmissionBlockReason::MissingUsage,
+            None,
+        ));
+        return;
+    };
+    let Some(projected) = observation
+        .consumed
+        .checked_add(requirement.reservation.expect("normalized reservation"))
+    else {
+        blockers.push(blocker(
+            requirement,
+            TaskBoardAdmissionBlockReason::ArithmeticOverflow,
+            None,
+        ));
+        return;
+    };
+    if projected <= requirement.limit {
+        return;
+    }
+    let missing_reset = requirement.kind != TaskBoardAdmissionRequirementKind::Concurrency
+        && observation.available_at.is_none();
+    let reason = if missing_reset {
+        TaskBoardAdmissionBlockReason::MissingResetTime
+    } else {
+        TaskBoardAdmissionBlockReason::LimitReached
+    };
+    blockers.push(blocker(
+        requirement,
+        reason,
+        observation.available_at.clone(),
+    ));
+}
+
+fn blocker(
+    requirement: &TaskBoardAdmissionRequirement,
+    reason: TaskBoardAdmissionBlockReason,
+    available_at: Option<String>,
+) -> TaskBoardAdmissionBlocker {
+    TaskBoardAdmissionBlocker {
+        requirement: requirement.clone(),
+        reason,
+        available_at,
+    }
+}
+
+fn admission_decision(blockers: &[TaskBoardAdmissionBlocker]) -> TaskBoardAdmissionDecision {
+    if blockers.iter().any(|blocker| {
+        matches!(
+            blocker.reason,
+            TaskBoardAdmissionBlockReason::MissingUsage
+                | TaskBoardAdmissionBlockReason::WindowClosed
+                | TaskBoardAdmissionBlockReason::MissingResetTime
+                | TaskBoardAdmissionBlockReason::ArithmeticOverflow
+        )
+    }) {
+        TaskBoardAdmissionDecision::Rejected
+    } else if blockers.is_empty() {
+        TaskBoardAdmissionDecision::Allowed
+    } else {
+        TaskBoardAdmissionDecision::Deferred
+    }
+}
+
+fn latest_available_at(blockers: &[TaskBoardAdmissionBlocker]) -> Option<String> {
+    blockers
+        .iter()
+        .filter_map(|blocker| blocker.available_at.as_deref())
+        .filter_map(parse_time)
+        .max()
+        .map(canonical_time)
+}
+
+fn compare_requirements(
+    left: &TaskBoardAdmissionRequirement,
+    right: &TaskBoardAdmissionRequirement,
+) -> Ordering {
+    requirement_key(left)
+        .cmp(&requirement_key(right))
+        .then_with(|| left.limit.cmp(&right.limit))
+        .then_with(|| left.reservation.cmp(&right.reservation))
+}
+
+fn compare_usage(left: &TaskBoardAdmissionUsage, right: &TaskBoardAdmissionUsage) -> Ordering {
+    usage_key(left)
+        .cmp(&usage_key(right))
+        .then_with(|| left.consumed.cmp(&right.consumed))
+        .then_with(|| left.available_at.cmp(&right.available_at))
+}
+
+fn requirement_key(
+    requirement: &TaskBoardAdmissionRequirement,
+) -> TaskBoardAdmissionRequirementKey {
+    TaskBoardAdmissionRequirementKey {
+        kind: requirement.kind,
+        scope: requirement.scope.clone(),
+        window_seconds: requirement.window_seconds,
+        window_starts_at: (requirement.kind == TaskBoardAdmissionRequirementKind::TimeWindow)
+            .then(|| requirement.available_at.clone())
+            .flatten(),
+    }
+}
+
+fn usage_key(usage: &TaskBoardAdmissionUsage) -> TaskBoardAdmissionRequirementKey {
+    TaskBoardAdmissionRequirementKey {
+        kind: usage.kind,
+        scope: usage.scope.clone(),
+        window_seconds: usage.window_seconds,
+        window_starts_at: None,
+    }
+}
+
+fn key_tuple(key: &TaskBoardAdmissionRequirementKey) -> (u8, &str, Option<u64>, Option<&str>) {
+    (
+        kind_rank(key.kind),
+        key.scope.as_str(),
+        key.window_seconds,
+        key.window_starts_at.as_deref(),
+    )
+}
+
+fn normalized_scope(scope: &str) -> Result<String, TaskBoardAdmissionError> {
+    let scope = scope.trim();
+    if scope.is_empty() {
+        Err(TaskBoardAdmissionError::EmptyScope)
+    } else {
+        Ok(scope.to_owned())
+    }
+}
+
+const fn kind_rank(kind: TaskBoardAdmissionRequirementKind) -> u8 {
+    match kind {
+        TaskBoardAdmissionRequirementKind::Concurrency => 0,
+        TaskBoardAdmissionRequirementKind::Rate => 1,
+        TaskBoardAdmissionRequirementKind::TimeWindow => 2,
+        TaskBoardAdmissionRequirementKind::TokenBudget => 3,
+        TaskBoardAdmissionRequirementKind::MonetaryBudget => 4,
+    }
+}
+
+const fn kind_name(kind: TaskBoardAdmissionRequirementKind) -> &'static str {
+    match kind {
+        TaskBoardAdmissionRequirementKind::Concurrency => "concurrency",
+        TaskBoardAdmissionRequirementKind::Rate => "rate",
+        TaskBoardAdmissionRequirementKind::TimeWindow => "time_window",
+        TaskBoardAdmissionRequirementKind::TokenBudget => "token_budget",
+        TaskBoardAdmissionRequirementKind::MonetaryBudget => "monetary_budget",
+    }
+}
+
+fn parse_evaluation_time(value: &str) -> Result<DateTime<Utc>, TaskBoardAdmissionError> {
+    parse_time(value.trim()).ok_or_else(|| TaskBoardAdmissionError::InvalidEvaluationTime {
+        value: value.to_owned(),
+    })
+}
+
+fn parse_time(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|parsed| parsed.with_timezone(&Utc))
+}
+
+fn canonical_time(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::AutoSi, true)
+}

--- a/src/task_board/automation/admission_tests.rs
+++ b/src/task_board/automation/admission_tests.rs
@@ -1,0 +1,286 @@
+use super::*;
+
+fn requirement(
+    kind: TaskBoardAdmissionRequirementKind,
+    scope: &str,
+    limit: u64,
+    window_seconds: Option<u64>,
+    reservation: u64,
+) -> TaskBoardAdmissionRequirement {
+    TaskBoardAdmissionRequirement {
+        kind,
+        scope: scope.to_owned(),
+        limit,
+        window_seconds,
+        reservation: Some(reservation),
+        available_at: None,
+    }
+}
+
+fn usage(
+    kind: TaskBoardAdmissionRequirementKind,
+    scope: &str,
+    consumed: u64,
+    window_seconds: Option<u64>,
+    available_at: Option<&str>,
+) -> TaskBoardAdmissionUsage {
+    TaskBoardAdmissionUsage {
+        kind,
+        scope: scope.to_owned(),
+        consumed,
+        window_seconds,
+        available_at: available_at.map(str::to_owned),
+    }
+}
+
+#[test]
+fn collection_is_stable_and_exposes_a_canonical_key() {
+    let concurrency = requirement(
+        TaskBoardAdmissionRequirementKind::Concurrency,
+        " repository:sample/widgets ",
+        2,
+        None,
+        1,
+    );
+    let tokens = requirement(
+        TaskBoardAdmissionRequirementKind::TokenBudget,
+        "workflow:default_task",
+        10_000,
+        Some(3_600),
+        500,
+    );
+
+    let forward = collect_admission_requirements([tokens.clone(), concurrency.clone()])
+        .expect("collect forward");
+    let reverse = collect_admission_requirements([concurrency, tokens]).expect("collect reverse");
+
+    assert_eq!(forward, reverse);
+    assert_eq!(forward[0].scope, "repository:sample/widgets");
+    let key = canonical_admission_requirement_key(&forward[0]).expect("canonical key");
+    assert_eq!(key.kind, TaskBoardAdmissionRequirementKind::Concurrency);
+    assert_eq!(key.scope, "repository:sample/widgets");
+    assert_eq!(key.window_seconds, None);
+    assert_eq!(key.window_starts_at, None);
+    assert_eq!(
+        key.stable_id(),
+        "admission:v1:concurrency:25:repository:sample/widgets:-:-"
+    );
+}
+
+#[test]
+fn identical_requirements_deduplicate_but_key_conflicts_are_rejected() {
+    let first = requirement(
+        TaskBoardAdmissionRequirementKind::Rate,
+        "global",
+        5,
+        Some(60),
+        1,
+    );
+    let duplicate = first.clone();
+    let mut conflict = first.clone();
+    conflict.limit = 6;
+
+    assert_eq!(
+        collect_admission_requirements([first.clone(), duplicate])
+            .expect("deduplicate exact requirement"),
+        vec![first.clone()]
+    );
+    let forward = collect_admission_requirements([first.clone(), conflict.clone()]);
+    let reverse = collect_admission_requirements([conflict, first]);
+    assert_eq!(forward, reverse);
+    assert!(matches!(
+        forward,
+        Err(TaskBoardAdmissionError::ConflictingRequirement { .. })
+    ));
+}
+
+#[test]
+fn all_five_requirement_kinds_allow_with_capacity() {
+    let mut time_window = requirement(
+        TaskBoardAdmissionRequirementKind::TimeWindow,
+        "workflow:maintenance",
+        1,
+        Some(7_200),
+        1,
+    );
+    time_window.available_at = Some("2026-07-15T08:00:00+02:00".into());
+    let requirements = vec![
+        requirement(
+            TaskBoardAdmissionRequirementKind::Concurrency,
+            "repository:sample/widgets",
+            2,
+            None,
+            1,
+        ),
+        requirement(
+            TaskBoardAdmissionRequirementKind::Rate,
+            "global",
+            10,
+            Some(60),
+            1,
+        ),
+        time_window,
+        requirement(
+            TaskBoardAdmissionRequirementKind::TokenBudget,
+            "workflow:default_task",
+            10_000,
+            Some(3_600),
+            500,
+        ),
+        requirement(
+            TaskBoardAdmissionRequirementKind::MonetaryBudget,
+            "global",
+            2_000_000,
+            Some(86_400),
+            125_000,
+        ),
+    ];
+    let usage = vec![
+        usage(
+            TaskBoardAdmissionRequirementKind::Concurrency,
+            "repository:sample/widgets",
+            1,
+            None,
+            None,
+        ),
+        usage(
+            TaskBoardAdmissionRequirementKind::Rate,
+            "global",
+            4,
+            Some(60),
+            Some("2026-07-15T06:31:00Z"),
+        ),
+        usage(
+            TaskBoardAdmissionRequirementKind::TokenBudget,
+            "workflow:default_task",
+            4_000,
+            Some(3_600),
+            Some("2026-07-15T07:00:00Z"),
+        ),
+        usage(
+            TaskBoardAdmissionRequirementKind::MonetaryBudget,
+            "global",
+            500_000,
+            Some(86_400),
+            Some("2026-07-16T06:00:00Z"),
+        ),
+    ];
+
+    let result = evaluate_admission_requirements(requirements, usage, "2026-07-15T06:30:00Z")
+        .expect("evaluate admission");
+
+    assert_eq!(result.decision, TaskBoardAdmissionDecision::Allowed);
+    assert_eq!(result.requirements.len(), 5);
+    assert!(result.blockers.is_empty());
+}
+
+#[test]
+fn capacity_uses_checked_arithmetic_and_exact_deferral_boundaries() {
+    let rate = requirement(
+        TaskBoardAdmissionRequirementKind::Rate,
+        "global",
+        u64::MAX,
+        Some(60),
+        1,
+    );
+    let overflow = evaluate_admission_requirements(
+        [rate],
+        [usage(
+            TaskBoardAdmissionRequirementKind::Rate,
+            "global",
+            u64::MAX,
+            Some(60),
+            Some("2026-07-15T06:01:00Z"),
+        )],
+        "2026-07-15T06:00:00Z",
+    )
+    .expect("overflow is a deterministic decision");
+    assert_eq!(overflow.decision, TaskBoardAdmissionDecision::Rejected);
+    assert_eq!(
+        overflow.blockers[0].reason,
+        TaskBoardAdmissionBlockReason::ArithmeticOverflow
+    );
+
+    let concurrency = requirement(
+        TaskBoardAdmissionRequirementKind::Concurrency,
+        "global",
+        1,
+        None,
+        1,
+    );
+    let deferred = evaluate_admission_requirements(
+        [concurrency],
+        [usage(
+            TaskBoardAdmissionRequirementKind::Concurrency,
+            "global",
+            1,
+            None,
+            Some("2026-07-15T06:02:00Z"),
+        )],
+        "2026-07-15T06:00:00Z",
+    )
+    .expect("capacity deferral");
+    assert_eq!(deferred.decision, TaskBoardAdmissionDecision::Deferred);
+    assert_eq!(
+        deferred.next_available_at.as_deref(),
+        Some("2026-07-15T06:02:00Z")
+    );
+}
+
+#[test]
+fn time_windows_are_half_open() {
+    let mut window = requirement(
+        TaskBoardAdmissionRequirementKind::TimeWindow,
+        "global",
+        1,
+        Some(3_600),
+        1,
+    );
+    window.available_at = Some("2026-07-15T06:00:00Z".into());
+
+    let at_start =
+        evaluate_admission_requirements([window.clone()], Vec::new(), "2026-07-15T06:00:00Z")
+            .expect("start is included");
+    let at_end = evaluate_admission_requirements([window], Vec::new(), "2026-07-15T07:00:00Z")
+        .expect("end is excluded");
+
+    assert_eq!(at_start.decision, TaskBoardAdmissionDecision::Allowed);
+    assert_eq!(at_end.decision, TaskBoardAdmissionDecision::Rejected);
+    assert_eq!(
+        at_end.blockers[0].reason,
+        TaskBoardAdmissionBlockReason::WindowClosed
+    );
+}
+
+#[test]
+fn missing_or_conflicting_usage_fails_closed() {
+    let tokens = requirement(
+        TaskBoardAdmissionRequirementKind::TokenBudget,
+        "global",
+        1_000,
+        Some(3_600),
+        100,
+    );
+    let missing =
+        evaluate_admission_requirements([tokens.clone()], Vec::new(), "2026-07-15T06:00:00Z")
+            .expect("missing usage is a decision");
+    assert_eq!(missing.decision, TaskBoardAdmissionDecision::Rejected);
+    assert_eq!(
+        missing.blockers[0].reason,
+        TaskBoardAdmissionBlockReason::MissingUsage
+    );
+
+    let first = usage(
+        TaskBoardAdmissionRequirementKind::TokenBudget,
+        "global",
+        0,
+        Some(3_600),
+        Some("2026-07-15T07:00:00Z"),
+    );
+    let mut second = first.clone();
+    second.consumed = 1;
+    assert!(matches!(
+        evaluate_admission_requirements([tokens], [first, second], "2026-07-15T06:00:00Z"),
+        Err(TaskBoardAdmissionError::ConflictingUsage { .. })
+    ));
+}

--- a/src/task_board/automation/launch_capability.rs
+++ b/src/task_board/automation/launch_capability.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+use crate::task_board::AgentMode;
+
+/// Runtime capability required by the frozen Task Board launch decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskBoardLaunchCapability {
+    ReportReadOnly,
+    WorkspaceWrite,
+}
+
+impl TaskBoardLaunchCapability {
+    #[must_use]
+    pub const fn is_read_only(self) -> bool {
+        matches!(self, Self::ReportReadOnly)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TaskBoardLaunchCapabilityError {
+    #[error("interactive Task Board launches cannot enforce an admission capability")]
+    InteractiveNotEnforceable,
+    #[error("agent mode '{mode:?}' requires '{expected:?}', not '{actual:?}'")]
+    CapabilityMismatch {
+        mode: AgentMode,
+        expected: TaskBoardLaunchCapability,
+        actual: TaskBoardLaunchCapability,
+    },
+}
+
+/// Resolve the capability the runtime request must enforce.
+///
+/// # Errors
+/// Returns an error because interactive launches cannot enforce this contract.
+pub const fn launch_capability_for_agent_mode(
+    mode: AgentMode,
+) -> Result<TaskBoardLaunchCapability, TaskBoardLaunchCapabilityError> {
+    match mode {
+        AgentMode::Planning | AgentMode::Evaluate => Ok(TaskBoardLaunchCapability::ReportReadOnly),
+        AgentMode::Headless => Ok(TaskBoardLaunchCapability::WorkspaceWrite),
+        AgentMode::Interactive => Err(TaskBoardLaunchCapabilityError::InteractiveNotEnforceable),
+    }
+}
+
+/// Fail closed if the constructed runtime request does not match the frozen
+/// capability decision.
+///
+/// # Errors
+/// Returns an error for interactive mode or a capability mismatch.
+pub fn validate_launch_capability(
+    mode: AgentMode,
+    actual: TaskBoardLaunchCapability,
+) -> Result<(), TaskBoardLaunchCapabilityError> {
+    let expected = launch_capability_for_agent_mode(mode)?;
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(TaskBoardLaunchCapabilityError::CapabilityMismatch {
+            mode,
+            expected,
+            actual,
+        })
+    }
+}

--- a/src/task_board/automation/launch_capability_tests.rs
+++ b/src/task_board/automation/launch_capability_tests.rs
@@ -1,0 +1,53 @@
+use super::*;
+use crate::task_board::AgentMode;
+
+#[test]
+fn planning_and_evaluate_map_to_report_read_only() {
+    for mode in [AgentMode::Planning, AgentMode::Evaluate] {
+        assert_eq!(
+            launch_capability_for_agent_mode(mode),
+            Ok(TaskBoardLaunchCapability::ReportReadOnly)
+        );
+        assert!(
+            launch_capability_for_agent_mode(mode)
+                .expect("read-only capability")
+                .is_read_only()
+        );
+    }
+}
+
+#[test]
+fn headless_maps_to_workspace_write() {
+    assert_eq!(
+        launch_capability_for_agent_mode(AgentMode::Headless),
+        Ok(TaskBoardLaunchCapability::WorkspaceWrite)
+    );
+    assert!(
+        !launch_capability_for_agent_mode(AgentMode::Headless)
+            .expect("write capability")
+            .is_read_only()
+    );
+}
+
+#[test]
+fn interactive_fails_closed() {
+    assert_eq!(
+        launch_capability_for_agent_mode(AgentMode::Interactive),
+        Err(TaskBoardLaunchCapabilityError::InteractiveNotEnforceable)
+    );
+}
+
+#[test]
+fn mismatched_constructed_capability_is_rejected() {
+    assert_eq!(
+        validate_launch_capability(
+            AgentMode::Planning,
+            TaskBoardLaunchCapability::WorkspaceWrite,
+        ),
+        Err(TaskBoardLaunchCapabilityError::CapabilityMismatch {
+            mode: AgentMode::Planning,
+            expected: TaskBoardLaunchCapability::ReportReadOnly,
+            actual: TaskBoardLaunchCapability::WorkspaceWrite,
+        })
+    );
+}

--- a/src/task_board/automation/policy_compiler.rs
+++ b/src/task_board/automation/policy_compiler.rs
@@ -8,6 +8,9 @@ use crate::task_board::{
     collect_admission_requirements, evaluate_admission_requirements, normalize_repository_slug,
 };
 
+mod validation;
+use validation::validate_limit;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum TaskBoardPolicyScope {
@@ -385,36 +388,6 @@ fn policy_rule_for_limit(
             reservation,
         },
     })
-}
-
-fn validate_limit(
-    limit: &TaskBoardPolicyLimit,
-    scope: &ResolvedScope,
-) -> Result<(), TaskBoardPolicyCompilationError> {
-    let valid = match limit {
-        TaskBoardPolicyLimit::Concurrency {
-            limit, reservation, ..
-        } => *limit > 0 && *reservation > 0,
-        TaskBoardPolicyLimit::Rate {
-            limit,
-            window_seconds,
-            reservation,
-            ..
-        } => *limit > 0 && *window_seconds > 0 && *reservation > 0,
-        TaskBoardPolicyLimit::TokenBudget {
-            limit,
-            window_seconds,
-            ..
-        } => *limit > 0 && *window_seconds > 0,
-        TaskBoardPolicyLimit::MonetaryBudget {
-            limit_microusd,
-            window_seconds,
-            ..
-        } => *limit_microusd > 0 && *window_seconds > 0,
-    };
-    valid
-        .then_some(())
-        .ok_or_else(|| TaskBoardPolicyCompilationError::InvalidLimit { scope: scope.key() })
 }
 
 fn compile_limit(

--- a/src/task_board/automation/policy_compiler.rs
+++ b/src/task_board/automation/policy_compiler.rs
@@ -1,0 +1,519 @@
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::policy_compiler_windows::{compile_policy_window, policy_window_rule};
+use crate::task_board::{
+    TaskBoardAdmissionError, TaskBoardAdmissionEvaluation, TaskBoardAdmissionRequirement,
+    TaskBoardAdmissionRequirementKind, TaskBoardAdmissionUsage, TaskBoardWorkflowKind,
+    collect_admission_requirements, evaluate_admission_requirements, normalize_repository_slug,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum TaskBoardPolicyScope {
+    Global,
+    Workflow(TaskBoardWorkflowKind),
+    Repository(String),
+}
+
+/// Quantitative policy limits compile into durable admission requirements.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TaskBoardPolicyLimit {
+    Concurrency {
+        scope: TaskBoardPolicyScope,
+        limit: u64,
+        reservation: u64,
+    },
+    Rate {
+        scope: TaskBoardPolicyScope,
+        limit: u64,
+        window_seconds: u64,
+        reservation: u64,
+    },
+    TokenBudget {
+        scope: TaskBoardPolicyScope,
+        limit: u64,
+        window_seconds: u64,
+    },
+    MonetaryBudget {
+        scope: TaskBoardPolicyScope,
+        limit_microusd: u64,
+        window_seconds: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskBoardPolicyWeekday {
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+    Sunday,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskBoardOutsideWindowAction {
+    Defer,
+    Deny,
+}
+
+/// Recurring local-time window using 24-hour `HH:MM` and an IANA timezone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBoardPolicyWindow {
+    pub scope: TaskBoardPolicyScope,
+    pub timezone: String,
+    pub weekdays: Vec<TaskBoardPolicyWeekday>,
+    pub start_time: String,
+    pub end_time: String,
+    pub outside_action: TaskBoardOutsideWindowAction,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBoardAutomationPolicy {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub limits: Vec<TaskBoardPolicyLimit>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub windows: Vec<TaskBoardPolicyWindow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBoardPolicyCompilationContext {
+    pub workflow_kind: TaskBoardWorkflowKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    pub evaluated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_cost_microusd: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBoardCompiledPolicy {
+    pub evaluated_at: String,
+    pub requirements: Vec<TaskBoardAdmissionRequirement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TaskBoardPolicyCompilationError {
+    #[error("unknown workflow cannot compile an automation policy")]
+    UnknownWorkflow,
+    #[error("policy repository '{repository}' is invalid, expected owner/repo")]
+    InvalidRepository { repository: String },
+    #[error("policy scope '{scope}' has an invalid positive limit, window, or reservation")]
+    InvalidLimit { scope: String },
+    #[error("policy scope '{scope}' requires token estimate evidence")]
+    MissingTokenEvidence { scope: String },
+    #[error("policy scope '{scope}' requires a positive token estimate")]
+    InvalidTokenEvidence { scope: String },
+    #[error("policy scope '{scope}' requires monetary cost evidence")]
+    MissingCostEvidence { scope: String },
+    #[error("policy scope '{scope}' requires a positive microusd cost estimate")]
+    InvalidCostEvidence { scope: String },
+    #[error("policy rules conflict at canonical key '{key}'")]
+    ConflictingRule { key: String },
+    #[error("policy scope '{scope}' has invalid IANA timezone '{timezone}'")]
+    InvalidTimezone { scope: String, timezone: String },
+    #[error("policy scope '{scope}' has no weekdays")]
+    EmptyWeekdays { scope: String },
+    #[error("policy scope '{scope}' has invalid local window time '{value}'")]
+    InvalidLocalTime { scope: String, value: String },
+    #[error("policy scope '{scope}' has a zero-length local window")]
+    ZeroLengthWindow { scope: String },
+    #[error("policy scope '{scope}' has no resolvable local window occurrence")]
+    UnresolvableWindow { scope: String },
+    #[error("policy evaluation timestamp '{value}' is invalid")]
+    InvalidEvaluationTime { value: String },
+    #[error(transparent)]
+    Admission(#[from] TaskBoardAdmissionError),
+}
+
+/// Validate every rule, including rules that do not match a later compilation
+/// context, and reject conflicting canonical rules independent of input order.
+///
+/// # Errors
+/// Returns an error for any invalid rule or canonical-key conflict.
+pub fn validate_task_board_policy(
+    policy: &TaskBoardAutomationPolicy,
+) -> Result<(), TaskBoardPolicyCompilationError> {
+    let mut rules = Vec::with_capacity(policy.limits.len() + policy.windows.len());
+    for limit in &policy.limits {
+        rules.push(policy_rule_for_limit(limit)?);
+    }
+    for window in &policy.windows {
+        let scope = ResolvedScope::new(&window.scope)?;
+        rules.push(policy_window_rule(window, scope)?);
+    }
+    rules.sort_by(|left, right| left.key.cmp(&right.key));
+    for pair in rules.windows(2) {
+        if pair[0].key == pair[1].key && pair[0].value != pair[1].value {
+            return Err(TaskBoardPolicyCompilationError::ConflictingRule {
+                key: pair[0].key.stable_id(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Compile every matching rule against one frozen clock and evidence snapshot.
+///
+/// # Errors
+/// Returns an error for invalid policy, context, evidence, or window data.
+pub fn compile_task_board_policy(
+    policy: &TaskBoardAutomationPolicy,
+    context: &TaskBoardPolicyCompilationContext,
+) -> Result<TaskBoardCompiledPolicy, TaskBoardPolicyCompilationError> {
+    validate_task_board_policy(policy)?;
+    let context = ResolvedContext::new(context)?;
+    let mut requirements = Vec::new();
+    for limit in &policy.limits {
+        let scope = ResolvedScope::new(limit.scope())?;
+        if scope.matches(&context) {
+            requirements.push(compile_limit(limit, &scope, &context)?);
+        }
+    }
+    for window in &policy.windows {
+        let scope = ResolvedScope::new(&window.scope)?;
+        let evaluated_at = scope.matches(&context).then_some(context.evaluated_at);
+        if let Some(requirement) = compile_policy_window(window, scope, evaluated_at)? {
+            requirements.push(requirement);
+        }
+    }
+    Ok(TaskBoardCompiledPolicy {
+        evaluated_at: canonical_time(context.evaluated_at),
+        requirements: collect_admission_requirements(requirements)?,
+    })
+}
+
+/// Compile then evaluate without introducing clocks or mutable storage.
+///
+/// # Errors
+/// Returns an error when policy compilation or admission evaluation fails.
+pub fn evaluate_task_board_policy(
+    policy: &TaskBoardAutomationPolicy,
+    context: &TaskBoardPolicyCompilationContext,
+    usage: impl IntoIterator<Item = TaskBoardAdmissionUsage>,
+) -> Result<TaskBoardAdmissionEvaluation, TaskBoardPolicyCompilationError> {
+    let compiled = compile_task_board_policy(policy, context)?;
+    evaluate_admission_requirements(compiled.requirements, usage, &compiled.evaluated_at)
+        .map_err(Into::into)
+}
+
+impl TaskBoardPolicyLimit {
+    const fn scope(&self) -> &TaskBoardPolicyScope {
+        match self {
+            Self::Concurrency { scope, .. }
+            | Self::Rate { scope, .. }
+            | Self::TokenBudget { scope, .. }
+            | Self::MonetaryBudget { scope, .. } => scope,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ResolvedScope {
+    Global,
+    Workflow(TaskBoardWorkflowKind),
+    Repository(String),
+}
+
+impl ResolvedScope {
+    fn new(scope: &TaskBoardPolicyScope) -> Result<Self, TaskBoardPolicyCompilationError> {
+        match scope {
+            TaskBoardPolicyScope::Global => Ok(Self::Global),
+            TaskBoardPolicyScope::Workflow(TaskBoardWorkflowKind::Unknown) => {
+                Err(TaskBoardPolicyCompilationError::UnknownWorkflow)
+            }
+            TaskBoardPolicyScope::Workflow(workflow) => Ok(Self::Workflow(*workflow)),
+            TaskBoardPolicyScope::Repository(repository) => {
+                normalize_repository_slug(Some(repository))
+                    .map(Self::Repository)
+                    .ok_or_else(|| TaskBoardPolicyCompilationError::InvalidRepository {
+                        repository: repository.clone(),
+                    })
+            }
+        }
+    }
+
+    fn matches(&self, context: &ResolvedContext) -> bool {
+        match self {
+            Self::Global => true,
+            Self::Workflow(workflow) => *workflow == context.workflow_kind,
+            Self::Repository(repository) => context.repository.as_ref() == Some(repository),
+        }
+    }
+
+    pub(super) fn key(&self) -> String {
+        match self {
+            Self::Global => "global".into(),
+            Self::Workflow(workflow) => format!("workflow:{}", workflow_name(*workflow)),
+            Self::Repository(repository) => format!("repository:{repository}"),
+        }
+    }
+}
+
+struct ResolvedContext {
+    workflow_kind: TaskBoardWorkflowKind,
+    repository: Option<String>,
+    evaluated_at: DateTime<Utc>,
+    estimated_tokens: Option<u64>,
+    estimated_cost_microusd: Option<u64>,
+}
+
+impl ResolvedContext {
+    fn new(
+        context: &TaskBoardPolicyCompilationContext,
+    ) -> Result<Self, TaskBoardPolicyCompilationError> {
+        if context.workflow_kind == TaskBoardWorkflowKind::Unknown {
+            return Err(TaskBoardPolicyCompilationError::UnknownWorkflow);
+        }
+        let repository = context
+            .repository
+            .as_deref()
+            .map(|repository| {
+                normalize_repository_slug(Some(repository)).ok_or_else(|| {
+                    TaskBoardPolicyCompilationError::InvalidRepository {
+                        repository: repository.to_owned(),
+                    }
+                })
+            })
+            .transpose()?;
+        let evaluated_at = DateTime::parse_from_rfc3339(context.evaluated_at.trim())
+            .map(|value| value.with_timezone(&Utc))
+            .map_err(|_| TaskBoardPolicyCompilationError::InvalidEvaluationTime {
+                value: context.evaluated_at.clone(),
+            })?;
+        Ok(Self {
+            workflow_kind: context.workflow_kind,
+            repository,
+            evaluated_at,
+            estimated_tokens: context.estimated_tokens,
+            estimated_cost_microusd: context.estimated_cost_microusd,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum PolicyRuleKey {
+    Limit {
+        kind: u8,
+        scope: String,
+        window_seconds: Option<u64>,
+    },
+    Window {
+        scope: String,
+        signature: String,
+    },
+}
+
+impl PolicyRuleKey {
+    fn stable_id(&self) -> String {
+        match self {
+            Self::Limit {
+                kind,
+                scope,
+                window_seconds,
+            } => format!(
+                "policy:v1:limit:{kind}:{}:{scope}:{}",
+                scope.len(),
+                window_seconds.map_or_else(|| "-".into(), |value| value.to_string())
+            ),
+            Self::Window { scope, signature } => format!(
+                "policy:v1:window:{}:{scope}:{}:{signature}",
+                scope.len(),
+                signature.len()
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PolicyRuleValue {
+    Limit {
+        limit: u64,
+        reservation: Option<u64>,
+    },
+    Window {
+        outside_action: TaskBoardOutsideWindowAction,
+    },
+}
+
+pub(super) struct PolicyRule {
+    pub(super) key: PolicyRuleKey,
+    pub(super) value: PolicyRuleValue,
+}
+
+fn policy_rule_for_limit(
+    limit: &TaskBoardPolicyLimit,
+) -> Result<PolicyRule, TaskBoardPolicyCompilationError> {
+    let scope = ResolvedScope::new(limit.scope())?;
+    validate_limit(limit, &scope)?;
+    let (kind, amount, window_seconds, reservation) = match limit {
+        TaskBoardPolicyLimit::Concurrency {
+            limit, reservation, ..
+        } => (0, *limit, None, Some(*reservation)),
+        TaskBoardPolicyLimit::Rate {
+            limit,
+            window_seconds,
+            reservation,
+            ..
+        } => (1, *limit, Some(*window_seconds), Some(*reservation)),
+        TaskBoardPolicyLimit::TokenBudget {
+            limit,
+            window_seconds,
+            ..
+        } => (3, *limit, Some(*window_seconds), None),
+        TaskBoardPolicyLimit::MonetaryBudget {
+            limit_microusd,
+            window_seconds,
+            ..
+        } => (4, *limit_microusd, Some(*window_seconds), None),
+    };
+    Ok(PolicyRule {
+        key: PolicyRuleKey::Limit {
+            kind,
+            scope: scope.key(),
+            window_seconds,
+        },
+        value: PolicyRuleValue::Limit {
+            limit: amount,
+            reservation,
+        },
+    })
+}
+
+fn validate_limit(
+    limit: &TaskBoardPolicyLimit,
+    scope: &ResolvedScope,
+) -> Result<(), TaskBoardPolicyCompilationError> {
+    let valid = match limit {
+        TaskBoardPolicyLimit::Concurrency {
+            limit, reservation, ..
+        } => *limit > 0 && *reservation > 0,
+        TaskBoardPolicyLimit::Rate {
+            limit,
+            window_seconds,
+            reservation,
+            ..
+        } => *limit > 0 && *window_seconds > 0 && *reservation > 0,
+        TaskBoardPolicyLimit::TokenBudget {
+            limit,
+            window_seconds,
+            ..
+        } => *limit > 0 && *window_seconds > 0,
+        TaskBoardPolicyLimit::MonetaryBudget {
+            limit_microusd,
+            window_seconds,
+            ..
+        } => *limit_microusd > 0 && *window_seconds > 0,
+    };
+    valid
+        .then_some(())
+        .ok_or_else(|| TaskBoardPolicyCompilationError::InvalidLimit { scope: scope.key() })
+}
+
+fn compile_limit(
+    limit: &TaskBoardPolicyLimit,
+    scope: &ResolvedScope,
+    context: &ResolvedContext,
+) -> Result<TaskBoardAdmissionRequirement, TaskBoardPolicyCompilationError> {
+    let scope_key = scope.key();
+    let (kind, limit, window_seconds, reservation) = match limit {
+        TaskBoardPolicyLimit::Concurrency {
+            limit, reservation, ..
+        } => (
+            TaskBoardAdmissionRequirementKind::Concurrency,
+            *limit,
+            None,
+            *reservation,
+        ),
+        TaskBoardPolicyLimit::Rate {
+            limit,
+            window_seconds,
+            reservation,
+            ..
+        } => (
+            TaskBoardAdmissionRequirementKind::Rate,
+            *limit,
+            Some(*window_seconds),
+            *reservation,
+        ),
+        TaskBoardPolicyLimit::TokenBudget {
+            limit,
+            window_seconds,
+            ..
+        } => (
+            TaskBoardAdmissionRequirementKind::TokenBudget,
+            *limit,
+            Some(*window_seconds),
+            positive_token_evidence(context.estimated_tokens, &scope_key)?,
+        ),
+        TaskBoardPolicyLimit::MonetaryBudget {
+            limit_microusd,
+            window_seconds,
+            ..
+        } => (
+            TaskBoardAdmissionRequirementKind::MonetaryBudget,
+            *limit_microusd,
+            Some(*window_seconds),
+            positive_cost_evidence(context.estimated_cost_microusd, &scope_key)?,
+        ),
+    };
+    Ok(TaskBoardAdmissionRequirement {
+        kind,
+        scope: scope_key,
+        limit,
+        window_seconds,
+        reservation: Some(reservation),
+        available_at: None,
+    })
+}
+
+fn positive_token_evidence(
+    evidence: Option<u64>,
+    scope: &str,
+) -> Result<u64, TaskBoardPolicyCompilationError> {
+    match evidence {
+        Some(value) if value > 0 => Ok(value),
+        Some(_) => Err(TaskBoardPolicyCompilationError::InvalidTokenEvidence {
+            scope: scope.to_owned(),
+        }),
+        None => Err(TaskBoardPolicyCompilationError::MissingTokenEvidence {
+            scope: scope.to_owned(),
+        }),
+    }
+}
+
+fn positive_cost_evidence(
+    evidence: Option<u64>,
+    scope: &str,
+) -> Result<u64, TaskBoardPolicyCompilationError> {
+    match evidence {
+        Some(value) if value > 0 => Ok(value),
+        Some(_) => Err(TaskBoardPolicyCompilationError::InvalidCostEvidence {
+            scope: scope.to_owned(),
+        }),
+        None => Err(TaskBoardPolicyCompilationError::MissingCostEvidence {
+            scope: scope.to_owned(),
+        }),
+    }
+}
+
+const fn workflow_name(workflow: TaskBoardWorkflowKind) -> &'static str {
+    match workflow {
+        TaskBoardWorkflowKind::Unknown => "unknown",
+        TaskBoardWorkflowKind::DefaultTask => "default_task",
+        TaskBoardWorkflowKind::PrFix => "pr_fix",
+        TaskBoardWorkflowKind::PrReview => "pr_review",
+        TaskBoardWorkflowKind::Review => "review",
+    }
+}
+
+fn canonical_time(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::AutoSi, true)
+}

--- a/src/task_board/automation/policy_compiler/validation.rs
+++ b/src/task_board/automation/policy_compiler/validation.rs
@@ -1,0 +1,41 @@
+use super::{ResolvedScope, TaskBoardPolicyCompilationError, TaskBoardPolicyLimit};
+
+const MAX_PERSISTED_ADMISSION_VALUE: u64 = i64::MAX as u64;
+
+pub(super) fn validate_limit(
+    limit: &TaskBoardPolicyLimit,
+    scope: &ResolvedScope,
+) -> Result<(), TaskBoardPolicyCompilationError> {
+    let valid = match limit {
+        TaskBoardPolicyLimit::Concurrency {
+            limit, reservation, ..
+        } => persisted_positive(*limit) && persisted_positive(*reservation),
+        TaskBoardPolicyLimit::Rate {
+            limit,
+            window_seconds,
+            reservation,
+            ..
+        } => {
+            persisted_positive(*limit)
+                && persisted_positive(*window_seconds)
+                && persisted_positive(*reservation)
+        }
+        TaskBoardPolicyLimit::TokenBudget {
+            limit,
+            window_seconds,
+            ..
+        } => persisted_positive(*limit) && persisted_positive(*window_seconds),
+        TaskBoardPolicyLimit::MonetaryBudget {
+            limit_microusd,
+            window_seconds,
+            ..
+        } => persisted_positive(*limit_microusd) && persisted_positive(*window_seconds),
+    };
+    valid
+        .then_some(())
+        .ok_or_else(|| TaskBoardPolicyCompilationError::InvalidLimit { scope: scope.key() })
+}
+
+const fn persisted_positive(value: u64) -> bool {
+    value > 0 && value <= MAX_PERSISTED_ADMISSION_VALUE
+}

--- a/src/task_board/automation/policy_compiler_tests.rs
+++ b/src/task_board/automation/policy_compiler_tests.rs
@@ -142,6 +142,19 @@ fn whole_policy_validation_rejects_invalid_unmatched_rules() {
         Err(TaskBoardPolicyCompilationError::InvalidLimit { .. })
     ));
 
+    let unpersistable_limit = TaskBoardAutomationPolicy {
+        limits: vec![TaskBoardPolicyLimit::Concurrency {
+            scope: TaskBoardPolicyScope::Global,
+            limit: u64::MAX,
+            reservation: 1,
+        }],
+        windows: Vec::new(),
+    };
+    assert!(matches!(
+        validate_task_board_policy(&unpersistable_limit),
+        Err(TaskBoardPolicyCompilationError::InvalidLimit { .. })
+    ));
+
     let invalid_window = TaskBoardAutomationPolicy {
         limits: Vec::new(),
         windows: vec![window(

--- a/src/task_board/automation/policy_compiler_tests.rs
+++ b/src/task_board/automation/policy_compiler_tests.rs
@@ -1,0 +1,344 @@
+use super::*;
+
+fn context(evaluated_at: &str) -> TaskBoardPolicyCompilationContext {
+    TaskBoardPolicyCompilationContext {
+        workflow_kind: TaskBoardWorkflowKind::DefaultTask,
+        repository: Some("Example/Compass".into()),
+        evaluated_at: evaluated_at.into(),
+        estimated_tokens: Some(400),
+        estimated_cost_microusd: Some(75_000),
+    }
+}
+
+fn window(
+    outside_action: TaskBoardOutsideWindowAction,
+    timezone: &str,
+    weekdays: Vec<TaskBoardPolicyWeekday>,
+    start_time: &str,
+    end_time: &str,
+) -> TaskBoardPolicyWindow {
+    TaskBoardPolicyWindow {
+        scope: TaskBoardPolicyScope::Repository("example/compass".into()),
+        timezone: timezone.into(),
+        weekdays,
+        start_time: start_time.into(),
+        end_time: end_time.into(),
+        outside_action,
+    }
+}
+
+fn limit_policy() -> TaskBoardAutomationPolicy {
+    TaskBoardAutomationPolicy {
+        limits: vec![
+            TaskBoardPolicyLimit::Concurrency {
+                scope: TaskBoardPolicyScope::Repository(" example/compass ".into()),
+                limit: 2,
+                reservation: 1,
+            },
+            TaskBoardPolicyLimit::Rate {
+                scope: TaskBoardPolicyScope::Workflow(TaskBoardWorkflowKind::DefaultTask),
+                limit: 5,
+                window_seconds: 60,
+                reservation: 1,
+            },
+            TaskBoardPolicyLimit::TokenBudget {
+                scope: TaskBoardPolicyScope::Global,
+                limit: 10_000,
+                window_seconds: 3_600,
+            },
+            TaskBoardPolicyLimit::MonetaryBudget {
+                scope: TaskBoardPolicyScope::Repository("example/compass".into()),
+                limit_microusd: 1_000_000,
+                window_seconds: 86_400,
+            },
+            TaskBoardPolicyLimit::Concurrency {
+                scope: TaskBoardPolicyScope::Repository("example/lantern".into()),
+                limit: 1,
+                reservation: 1,
+            },
+        ],
+        windows: Vec::new(),
+    }
+}
+
+#[test]
+fn compiler_combines_matching_scopes_and_positive_integer_evidence() {
+    let compiled = compile_task_board_policy(&limit_policy(), &context("2026-07-15T10:00:00Z"))
+        .expect("compile policy");
+
+    assert_eq!(compiled.requirements.len(), 4);
+    assert_eq!(compiled.requirements[0].scope, "repository:example/compass");
+    assert_eq!(compiled.requirements[1].scope, "workflow:default_task");
+    let tokens = compiled
+        .requirements
+        .iter()
+        .find(|requirement| requirement.kind == TaskBoardAdmissionRequirementKind::TokenBudget)
+        .expect("token requirement");
+    let money = compiled
+        .requirements
+        .iter()
+        .find(|requirement| requirement.kind == TaskBoardAdmissionRequirementKind::MonetaryBudget)
+        .expect("money requirement");
+    assert_eq!(tokens.reservation, Some(400));
+    assert_eq!(money.reservation, Some(75_000));
+}
+
+#[test]
+fn token_and_microusd_evidence_must_be_present_and_positive() {
+    let token_policy = TaskBoardAutomationPolicy {
+        limits: vec![TaskBoardPolicyLimit::TokenBudget {
+            scope: TaskBoardPolicyScope::Global,
+            limit: 10_000,
+            window_seconds: 3_600,
+        }],
+        windows: Vec::new(),
+    };
+    let mut token_context = context("2026-07-15T10:00:00Z");
+    token_context.estimated_tokens = None;
+    assert!(matches!(
+        compile_task_board_policy(&token_policy, &token_context),
+        Err(TaskBoardPolicyCompilationError::MissingTokenEvidence { .. })
+    ));
+    token_context.estimated_tokens = Some(0);
+    assert!(matches!(
+        compile_task_board_policy(&token_policy, &token_context),
+        Err(TaskBoardPolicyCompilationError::InvalidTokenEvidence { .. })
+    ));
+
+    let money_policy = TaskBoardAutomationPolicy {
+        limits: vec![TaskBoardPolicyLimit::MonetaryBudget {
+            scope: TaskBoardPolicyScope::Global,
+            limit_microusd: 1_000_000,
+            window_seconds: 86_400,
+        }],
+        windows: Vec::new(),
+    };
+    let mut money_context = context("2026-07-15T10:00:00Z");
+    money_context.estimated_cost_microusd = None;
+    assert!(matches!(
+        compile_task_board_policy(&money_policy, &money_context),
+        Err(TaskBoardPolicyCompilationError::MissingCostEvidence { .. })
+    ));
+    money_context.estimated_cost_microusd = Some(0);
+    assert!(matches!(
+        compile_task_board_policy(&money_policy, &money_context),
+        Err(TaskBoardPolicyCompilationError::InvalidCostEvidence { .. })
+    ));
+}
+
+#[test]
+fn whole_policy_validation_rejects_invalid_unmatched_rules() {
+    let invalid_limit = TaskBoardAutomationPolicy {
+        limits: vec![TaskBoardPolicyLimit::Rate {
+            scope: TaskBoardPolicyScope::Repository("example/lantern".into()),
+            limit: 5,
+            window_seconds: 0,
+            reservation: 1,
+        }],
+        windows: Vec::new(),
+    };
+    assert!(matches!(
+        validate_task_board_policy(&invalid_limit),
+        Err(TaskBoardPolicyCompilationError::InvalidLimit { .. })
+    ));
+
+    let invalid_window = TaskBoardAutomationPolicy {
+        limits: Vec::new(),
+        windows: vec![window(
+            TaskBoardOutsideWindowAction::Deny,
+            "Fictional/Clock",
+            vec![TaskBoardPolicyWeekday::Monday],
+            "09:00",
+            "17:00",
+        )],
+    };
+
+    assert!(matches!(
+        validate_task_board_policy(&invalid_window),
+        Err(TaskBoardPolicyCompilationError::InvalidTimezone { .. })
+    ));
+}
+
+#[test]
+fn whole_policy_rejects_conflicting_canonical_rules_independent_of_order() {
+    let first = TaskBoardPolicyLimit::Concurrency {
+        scope: TaskBoardPolicyScope::Repository(" Example/Compass ".into()),
+        limit: 2,
+        reservation: 1,
+    };
+    let second = TaskBoardPolicyLimit::Concurrency {
+        scope: TaskBoardPolicyScope::Repository("example/compass".into()),
+        limit: 3,
+        reservation: 1,
+    };
+    let forward = TaskBoardAutomationPolicy {
+        limits: vec![first.clone(), second.clone()],
+        windows: Vec::new(),
+    };
+    let reverse = TaskBoardAutomationPolicy {
+        limits: vec![second, first],
+        windows: Vec::new(),
+    };
+
+    let forward_error = validate_task_board_policy(&forward).expect_err("conflicting policy");
+    let reverse_error = validate_task_board_policy(&reverse).expect_err("conflicting policy");
+    assert_eq!(forward_error, reverse_error);
+    assert!(matches!(
+        forward_error,
+        TaskBoardPolicyCompilationError::ConflictingRule { .. }
+    ));
+}
+
+#[test]
+fn whole_policy_rejects_conflicting_window_actions() {
+    let first = window(
+        TaskBoardOutsideWindowAction::Defer,
+        "Europe/Warsaw",
+        vec![TaskBoardPolicyWeekday::Monday],
+        "09:00",
+        "17:00",
+    );
+    let mut conflict = first.clone();
+    conflict.outside_action = TaskBoardOutsideWindowAction::Deny;
+    let policy = TaskBoardAutomationPolicy {
+        limits: Vec::new(),
+        windows: vec![first, conflict],
+    };
+
+    assert!(matches!(
+        validate_task_board_policy(&policy),
+        Err(TaskBoardPolicyCompilationError::ConflictingRule { .. })
+    ));
+}
+
+#[test]
+fn exact_policy_duplicates_compile_once_with_stable_order() {
+    let first = TaskBoardPolicyLimit::Rate {
+        scope: TaskBoardPolicyScope::Global,
+        limit: 10,
+        window_seconds: 60,
+        reservation: 1,
+    };
+    let duplicate = first.clone();
+    let token = TaskBoardPolicyLimit::TokenBudget {
+        scope: TaskBoardPolicyScope::Global,
+        limit: 10_000,
+        window_seconds: 3_600,
+    };
+    let forward = TaskBoardAutomationPolicy {
+        limits: vec![token.clone(), first.clone(), duplicate],
+        windows: Vec::new(),
+    };
+    let reverse = TaskBoardAutomationPolicy {
+        limits: vec![first, token],
+        windows: Vec::new(),
+    };
+
+    validate_task_board_policy(&forward).expect("exact duplicate is valid");
+    let forward = compile_task_board_policy(&forward, &context("2026-07-15T10:00:00Z"))
+        .expect("compile forward");
+    let reverse = compile_task_board_policy(&reverse, &context("2026-07-15T10:00:00Z"))
+        .expect("compile reverse");
+    assert_eq!(forward, reverse);
+    assert_eq!(forward.requirements.len(), 2);
+}
+
+#[test]
+fn recurring_window_explicitly_defers_or_denies() {
+    let deferred = TaskBoardAutomationPolicy {
+        limits: Vec::new(),
+        windows: vec![window(
+            TaskBoardOutsideWindowAction::Defer,
+            "Europe/Warsaw",
+            vec![TaskBoardPolicyWeekday::Monday],
+            "09:00",
+            "17:00",
+        )],
+    };
+    let denied = TaskBoardAutomationPolicy {
+        windows: vec![window(
+            TaskBoardOutsideWindowAction::Deny,
+            "Europe/Warsaw",
+            vec![TaskBoardPolicyWeekday::Monday],
+            "09:00",
+            "17:00",
+        )],
+        ..TaskBoardAutomationPolicy::default()
+    };
+    let context = context("2026-07-14T10:00:00Z");
+
+    let deferred = evaluate_task_board_policy(&deferred, &context, Vec::new())
+        .expect("evaluate deferred window");
+    let denied =
+        evaluate_task_board_policy(&denied, &context, Vec::new()).expect("evaluate denied window");
+    assert_eq!(deferred.decision, TaskBoardAdmissionDecision::Deferred);
+    assert_eq!(
+        deferred.next_available_at.as_deref(),
+        Some("2026-07-20T07:00:00Z")
+    );
+    assert_eq!(denied.decision, TaskBoardAdmissionDecision::Rejected);
+    assert_eq!(
+        denied.blockers[0].reason,
+        TaskBoardAdmissionBlockReason::WindowClosed
+    );
+}
+
+#[test]
+fn ambiguous_fall_back_boundary_uses_the_later_fold() {
+    let policy = TaskBoardAutomationPolicy {
+        limits: Vec::new(),
+        windows: vec![window(
+            TaskBoardOutsideWindowAction::Deny,
+            "America/New_York",
+            vec![TaskBoardPolicyWeekday::Sunday],
+            "01:00",
+            "03:00",
+        )],
+    };
+    let compiled = compile_task_board_policy(&policy, &context("2026-11-01T06:30:00Z"))
+        .expect("compile fall-back window");
+    assert_eq!(
+        compiled.requirements[0].available_at.as_deref(),
+        Some("2026-11-01T06:00:00Z")
+    );
+    assert_eq!(compiled.requirements[0].window_seconds, Some(7_200));
+}
+
+#[test]
+fn nonexistent_spring_boundary_advances_to_first_valid_minute() {
+    let policy = TaskBoardAutomationPolicy {
+        limits: Vec::new(),
+        windows: vec![window(
+            TaskBoardOutsideWindowAction::Deny,
+            "America/New_York",
+            vec![TaskBoardPolicyWeekday::Sunday],
+            "02:30",
+            "04:00",
+        )],
+    };
+    let compiled = compile_task_board_policy(&policy, &context("2026-03-08T07:30:00Z"))
+        .expect("compile spring-forward window");
+    assert_eq!(
+        compiled.requirements[0].available_at.as_deref(),
+        Some("2026-03-08T07:00:00Z")
+    );
+    assert_eq!(compiled.requirements[0].window_seconds, Some(3_600));
+}
+
+#[test]
+fn overnight_window_uses_the_next_local_day() {
+    let policy = TaskBoardAutomationPolicy {
+        limits: Vec::new(),
+        windows: vec![window(
+            TaskBoardOutsideWindowAction::Deny,
+            "Europe/Warsaw",
+            vec![TaskBoardPolicyWeekday::Monday],
+            "22:00",
+            "02:00",
+        )],
+    };
+    let evaluation =
+        evaluate_task_board_policy(&policy, &context("2026-07-13T22:30:00Z"), Vec::new())
+            .expect("evaluate overnight window");
+    assert_eq!(evaluation.decision, TaskBoardAdmissionDecision::Allowed);
+}

--- a/src/task_board/automation/policy_compiler_windows.rs
+++ b/src/task_board/automation/policy_compiler_windows.rs
@@ -1,0 +1,299 @@
+use chrono::{
+    DateTime, Datelike, Days, Duration, LocalResult, NaiveDate, NaiveDateTime, NaiveTime,
+    SecondsFormat, TimeZone, Utc, Weekday,
+};
+use chrono_tz::Tz;
+
+use super::policy_compiler::{
+    PolicyRule, PolicyRuleKey, PolicyRuleValue, ResolvedScope, TaskBoardOutsideWindowAction,
+    TaskBoardPolicyCompilationError, TaskBoardPolicyWeekday, TaskBoardPolicyWindow,
+};
+use crate::task_board::{TaskBoardAdmissionRequirement, TaskBoardAdmissionRequirementKind};
+
+pub(super) fn policy_window_rule(
+    window: &TaskBoardPolicyWindow,
+    scope: ResolvedScope,
+) -> Result<PolicyRule, TaskBoardPolicyCompilationError> {
+    let resolved = ResolvedWindowPolicy::new(window, scope)?;
+    Ok(PolicyRule {
+        key: PolicyRuleKey::Window {
+            scope: resolved.scope.key(),
+            signature: resolved.signature(),
+        },
+        value: PolicyRuleValue::Window {
+            outside_action: resolved.outside_action,
+        },
+    })
+}
+
+pub(super) fn compile_policy_window(
+    window: &TaskBoardPolicyWindow,
+    scope: ResolvedScope,
+    evaluated_at: Option<DateTime<Utc>>,
+) -> Result<Option<TaskBoardAdmissionRequirement>, TaskBoardPolicyCompilationError> {
+    let resolved = ResolvedWindowPolicy::new(window, scope)?;
+    evaluated_at
+        .map(|value| resolved.compile_requirement(value))
+        .transpose()
+}
+
+struct ResolvedWindowPolicy {
+    scope: ResolvedScope,
+    timezone: Tz,
+    weekdays: Vec<TaskBoardPolicyWeekday>,
+    start_time: NaiveTime,
+    end_time: NaiveTime,
+    outside_action: TaskBoardOutsideWindowAction,
+}
+
+impl ResolvedWindowPolicy {
+    fn new(
+        window: &TaskBoardPolicyWindow,
+        scope: ResolvedScope,
+    ) -> Result<Self, TaskBoardPolicyCompilationError> {
+        let scope_key = scope.key();
+        let timezone = window.timezone.trim().parse::<Tz>().map_err(|_| {
+            TaskBoardPolicyCompilationError::InvalidTimezone {
+                scope: scope_key.clone(),
+                timezone: window.timezone.clone(),
+            }
+        })?;
+        let mut weekdays = window.weekdays.clone();
+        weekdays.sort_unstable();
+        weekdays.dedup();
+        if weekdays.is_empty() {
+            return Err(TaskBoardPolicyCompilationError::EmptyWeekdays { scope: scope_key });
+        }
+        let start_time = parse_local_time(&window.start_time, &scope)?;
+        let end_time = parse_local_time(&window.end_time, &scope)?;
+        if start_time == end_time {
+            return Err(TaskBoardPolicyCompilationError::ZeroLengthWindow { scope: scope.key() });
+        }
+        Ok(Self {
+            scope,
+            timezone,
+            weekdays,
+            start_time,
+            end_time,
+            outside_action: window.outside_action,
+        })
+    }
+
+    fn signature(&self) -> String {
+        let weekdays = self
+            .weekdays
+            .iter()
+            .map(|weekday| weekday_name(*weekday))
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(
+            "{}|{weekdays}|{}|{}",
+            self.timezone,
+            self.start_time.format("%H:%M"),
+            self.end_time.format("%H:%M")
+        )
+    }
+
+    fn compile_requirement(
+        &self,
+        evaluated_at: DateTime<Utc>,
+    ) -> Result<TaskBoardAdmissionRequirement, TaskBoardPolicyCompilationError> {
+        let occurrences = self.occurrences(evaluated_at)?;
+        let selected = occurrences
+            .iter()
+            .find(|window| window.start <= evaluated_at && evaluated_at < window.end)
+            .or_else(|| self.select_closed_occurrence(&occurrences, evaluated_at))
+            .ok_or_else(|| TaskBoardPolicyCompilationError::UnresolvableWindow {
+                scope: self.scope.key(),
+            })?;
+        let duration = selected
+            .end
+            .signed_duration_since(selected.start)
+            .num_seconds();
+        let window_seconds = u64::try_from(duration).map_err(|_| {
+            TaskBoardPolicyCompilationError::UnresolvableWindow {
+                scope: self.scope.key(),
+            }
+        })?;
+        Ok(TaskBoardAdmissionRequirement {
+            kind: TaskBoardAdmissionRequirementKind::TimeWindow,
+            scope: self.scope.key(),
+            limit: 1,
+            window_seconds: Some(window_seconds),
+            reservation: Some(1),
+            available_at: Some(canonical_time(selected.start)),
+        })
+    }
+
+    fn select_closed_occurrence<'a>(
+        &self,
+        occurrences: &'a [WindowOccurrence],
+        evaluated_at: DateTime<Utc>,
+    ) -> Option<&'a WindowOccurrence> {
+        match self.outside_action {
+            TaskBoardOutsideWindowAction::Defer => occurrences
+                .iter()
+                .filter(|window| window.start > evaluated_at)
+                .min_by_key(|window| window.start),
+            TaskBoardOutsideWindowAction::Deny => occurrences
+                .iter()
+                .filter(|window| window.end <= evaluated_at)
+                .max_by_key(|window| window.end),
+        }
+    }
+
+    fn occurrences(
+        &self,
+        evaluated_at: DateTime<Utc>,
+    ) -> Result<Vec<WindowOccurrence>, TaskBoardPolicyCompilationError> {
+        let local_date = evaluated_at.with_timezone(&self.timezone).date_naive();
+        let mut occurrences = Vec::new();
+        for offset in -8_i32..=8 {
+            let Some(date) = offset_date(local_date, offset) else {
+                continue;
+            };
+            if !self
+                .weekdays
+                .iter()
+                .any(|weekday| weekday.matches(date.weekday()))
+            {
+                continue;
+            }
+            occurrences.push(self.occurrence(date)?);
+        }
+        Ok(occurrences)
+    }
+
+    fn occurrence(
+        &self,
+        date: NaiveDate,
+    ) -> Result<WindowOccurrence, TaskBoardPolicyCompilationError> {
+        let end_date = if self.end_time <= self.start_time {
+            date.checked_add_days(Days::new(1))
+        } else {
+            Some(date)
+        }
+        .ok_or_else(|| TaskBoardPolicyCompilationError::UnresolvableWindow {
+            scope: self.scope.key(),
+        })?;
+        let start =
+            resolve_local_boundary(self.timezone, date.and_time(self.start_time), &self.scope)?;
+        let end =
+            resolve_local_boundary(self.timezone, end_date.and_time(self.end_time), &self.scope)?;
+        let (start, end) = fail_closed_interval(start, end).ok_or_else(|| {
+            TaskBoardPolicyCompilationError::UnresolvableWindow {
+                scope: self.scope.key(),
+            }
+        })?;
+        Ok(WindowOccurrence { start, end })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WindowOccurrence {
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResolvedBoundary {
+    earliest: DateTime<Utc>,
+    latest: DateTime<Utc>,
+}
+
+impl TaskBoardPolicyWeekday {
+    const fn matches(self, weekday: Weekday) -> bool {
+        matches!(
+            (self, weekday),
+            (Self::Monday, Weekday::Mon)
+                | (Self::Tuesday, Weekday::Tue)
+                | (Self::Wednesday, Weekday::Wed)
+                | (Self::Thursday, Weekday::Thu)
+                | (Self::Friday, Weekday::Fri)
+                | (Self::Saturday, Weekday::Sat)
+                | (Self::Sunday, Weekday::Sun)
+        )
+    }
+}
+
+fn parse_local_time(
+    value: &str,
+    scope: &ResolvedScope,
+) -> Result<NaiveTime, TaskBoardPolicyCompilationError> {
+    NaiveTime::parse_from_str(value.trim(), "%H:%M").map_err(|_| {
+        TaskBoardPolicyCompilationError::InvalidLocalTime {
+            scope: scope.key(),
+            value: value.to_owned(),
+        }
+    })
+}
+
+fn offset_date(date: NaiveDate, offset: i32) -> Option<NaiveDate> {
+    if offset.is_negative() {
+        date.checked_sub_days(Days::new(u64::from(offset.unsigned_abs())))
+    } else {
+        date.checked_add_days(Days::new(u64::from(offset.unsigned_abs())))
+    }
+}
+
+// A fold can map to disjoint UTC intervals. Choose the narrowest valid pair,
+// preferring the later start, so ambiguous local time fails closed.
+fn fail_closed_interval(
+    start: ResolvedBoundary,
+    end: ResolvedBoundary,
+) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    [
+        (start.latest, end.earliest),
+        (start.latest, end.latest),
+        (start.earliest, end.earliest),
+    ]
+    .into_iter()
+    .find(|(start, end)| end > start)
+}
+
+// A gap advances to the first valid local minute, bounded well past real DST
+// transitions while still failing closed for corrupt timezone data.
+fn resolve_local_boundary(
+    timezone: Tz,
+    local: NaiveDateTime,
+    scope: &ResolvedScope,
+) -> Result<ResolvedBoundary, TaskBoardPolicyCompilationError> {
+    for minute in 0_i64..=180 {
+        let Some(candidate) = local.checked_add_signed(Duration::minutes(minute)) else {
+            break;
+        };
+        match timezone.from_local_datetime(&candidate) {
+            LocalResult::Single(value) => {
+                let value = value.with_timezone(&Utc);
+                return Ok(ResolvedBoundary {
+                    earliest: value,
+                    latest: value,
+                });
+            }
+            LocalResult::Ambiguous(first, second) => {
+                return Ok(ResolvedBoundary {
+                    earliest: first.min(second).with_timezone(&Utc),
+                    latest: first.max(second).with_timezone(&Utc),
+                });
+            }
+            LocalResult::None => {}
+        }
+    }
+    Err(TaskBoardPolicyCompilationError::UnresolvableWindow { scope: scope.key() })
+}
+
+const fn weekday_name(weekday: TaskBoardPolicyWeekday) -> &'static str {
+    match weekday {
+        TaskBoardPolicyWeekday::Monday => "monday",
+        TaskBoardPolicyWeekday::Tuesday => "tuesday",
+        TaskBoardPolicyWeekday::Wednesday => "wednesday",
+        TaskBoardPolicyWeekday::Thursday => "thursday",
+        TaskBoardPolicyWeekday::Friday => "friday",
+        TaskBoardPolicyWeekday::Saturday => "saturday",
+        TaskBoardPolicyWeekday::Sunday => "sunday",
+    }
+}
+
+fn canonical_time(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::AutoSi, true)
+}

--- a/src/task_board/orchestrator.rs
+++ b/src/task_board/orchestrator.rs
@@ -81,6 +81,11 @@ impl TaskBoardOrchestrator {
         &self,
         update: &TaskBoardOrchestratorSettingsUpdateRequest,
     ) -> Result<TaskBoardOrchestratorSettings, CliError> {
+        update.validate_admission_policy().map_err(|error| {
+            crate::errors::CliErrorKind::workflow_parse(format!(
+                "invalid task-board admission policy: {error}"
+            ))
+        })?;
         let mut settings = self.settings()?;
         apply_settings_update(&mut settings, update);
         settings.github_inbox = normalize_github_inbox(&settings.github_inbox)?;

--- a/src/task_board/orchestrator/settings.rs
+++ b/src/task_board/orchestrator/settings.rs
@@ -159,6 +159,9 @@ pub(super) fn apply_settings_update(
     if let Some(execution_hosts) = &update.execution_hosts {
         settings.execution_hosts.clone_from(execution_hosts);
     }
+    if let Some(admission_policy) = &update.admission_policy {
+        settings.admission_policy.clone_from(admission_policy);
+    }
     if let Some(policy_version) = &update.policy_version {
         settings.policy_version.clone_from(policy_version);
     }

--- a/src/task_board/orchestrator/tests.rs
+++ b/src/task_board/orchestrator/tests.rs
@@ -4,8 +4,8 @@ use tempfile::tempdir;
 use super::*;
 use crate::task_board::{
     DispatchAppliedTask, ExternalProvider, ExternalSyncAction, ExternalSyncOperation,
-    TaskBoardEvaluationRecord, TaskBoardEvaluationSummary, TaskBoardItem, TaskBoardStatus,
-    TaskBoardWorkflowStatus, build_dispatch_plan,
+    TaskBoardAutomationPolicy, TaskBoardEvaluationRecord, TaskBoardEvaluationSummary,
+    TaskBoardItem, TaskBoardStatus, TaskBoardWorkflowStatus, build_dispatch_plan,
 };
 
 #[test]
@@ -239,6 +239,10 @@ fn partial_settings_json_populates_defaults() {
     assert_eq!(settings.enabled_workflows, defaults.enabled_workflows);
     assert_eq!(settings.dry_run_default, defaults.dry_run_default);
     assert_eq!(settings.policy_version, defaults.policy_version);
+    assert_eq!(
+        settings.admission_policy,
+        TaskBoardAutomationPolicy::default()
+    );
 }
 
 #[test]

--- a/src/task_board/orchestrator/types.rs
+++ b/src/task_board/orchestrator/types.rs
@@ -6,8 +6,10 @@ use super::super::policy::POLICY_VERSION;
 use super::super::summary::{TaskBoardAuditSummary, TaskBoardSyncSummary};
 use super::super::types::{TaskBoardStatus, TaskBoardWorkflowStatus};
 use super::super::{
-    TaskBoardAutomationRetrySettings, TaskBoardAutomationSchedulingSettings,
-    TaskBoardExecutionHostConfig, TaskBoardRepositoryAutomationConfig, TaskBoardReviewerSettings,
+    TaskBoardAutomationPolicy, TaskBoardAutomationRetrySettings,
+    TaskBoardAutomationSchedulingSettings, TaskBoardExecutionHostConfig,
+    TaskBoardPolicyCompilationError, TaskBoardRepositoryAutomationConfig,
+    TaskBoardReviewerSettings, validate_task_board_policy,
 };
 
 pub use crate::task_board::github::GitHubProjectConfig as TaskBoardGitHubProjectConfig;
@@ -56,6 +58,8 @@ pub struct TaskBoardOrchestratorSettings {
     pub repositories: Vec<TaskBoardRepositoryAutomationConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub execution_hosts: Vec<TaskBoardExecutionHostConfig>,
+    #[serde(default)]
+    pub admission_policy: TaskBoardAutomationPolicy,
     #[serde(default = "default_policy_version")]
     pub policy_version: String,
 }
@@ -92,6 +96,8 @@ pub struct TaskBoardOrchestratorSettingsUpdateRequest {
     pub repositories: Option<Vec<TaskBoardRepositoryAutomationConfig>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_hosts: Option<Vec<TaskBoardExecutionHostConfig>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission_policy: Option<TaskBoardAutomationPolicy>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_version: Option<String>,
 }
@@ -255,8 +261,21 @@ impl Default for TaskBoardOrchestratorSettings {
             reviewers: TaskBoardReviewerSettings::default(),
             repositories: Vec::new(),
             execution_hosts: Vec::new(),
+            admission_policy: TaskBoardAutomationPolicy::default(),
             policy_version: default_policy_version(),
         }
+    }
+}
+
+impl TaskBoardOrchestratorSettingsUpdateRequest {
+    /// Validate the complete replacement admission policy, when supplied.
+    ///
+    /// # Errors
+    /// Returns the first deterministic whole-policy validation error.
+    pub fn validate_admission_policy(&self) -> Result<(), TaskBoardPolicyCompilationError> {
+        self.admission_policy
+            .as_ref()
+            .map_or(Ok(()), validate_task_board_policy)
     }
 }
 

--- a/src/task_board/store.rs
+++ b/src/task_board/store.rs
@@ -1,7 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
-
 use crate::errors::{CliError, CliErrorKind};
 use crate::infra::io;
 #[cfg(test)]
@@ -10,10 +8,12 @@ use crate::workspace::harness_data_root;
 #[cfg(test)]
 use crate::workspace::utc_now;
 
+mod frontmatter;
 #[cfg(test)]
 mod loading;
 #[cfg(test)]
 mod parse_cache;
+use frontmatter::TaskBoardFrontmatter;
 #[cfg(test)]
 use parse_cache::BOARD_PARSE_CACHE;
 
@@ -21,8 +21,8 @@ use super::TaskBoardWorkflowKind;
 #[cfg(test)]
 use super::types::CURRENT_TASK_BOARD_ITEM_VERSION;
 use super::types::{
-    AgentMode, ExternalRef, ExternalRefProvider, PlanningState, TaskBoardItem, TaskBoardPriority,
-    TaskBoardStatus, TaskBoardWorkflowState,
+    AgentMode, ExternalRef, PlanningState, TaskBoardItem, TaskBoardPriority, TaskBoardStatus,
+    TaskBoardWorkflowState,
 };
 
 #[derive(Debug, Clone)]
@@ -43,6 +43,8 @@ pub struct TaskBoardItemPatch {
     pub agent_mode: Option<AgentMode>,
     pub workflow_kind: Option<TaskBoardWorkflowKind>,
     pub execution_repository: OptionalFieldPatch<String>,
+    pub estimated_tokens: OptionalFieldPatch<u64>,
+    pub estimated_cost_microusd: OptionalFieldPatch<u64>,
     pub external_refs: Option<Vec<ExternalRef>>,
     pub planning: Option<PlanningState>,
     pub clear_planning: bool,
@@ -62,101 +64,6 @@ pub enum OptionalFieldPatch<T> {
     Unchanged,
     Set(T),
     Clear,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct TaskBoardFrontmatter {
-    schema_version: u32,
-    id: String,
-    title: String,
-    status: TaskBoardStatus,
-    priority: TaskBoardPriority,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    tags: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    project_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    target_project_types: Vec<String>,
-    agent_mode: AgentMode,
-    #[serde(default)]
-    workflow_kind: TaskBoardWorkflowKind,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    execution_repository: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    external_refs: Vec<ExternalRef>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    imported_from_provider: Option<ExternalRefProvider>,
-    #[serde(default)]
-    planning: PlanningState,
-    #[serde(default, skip_serializing_if = "TaskBoardWorkflowState::is_default")]
-    workflow: TaskBoardWorkflowState,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    session_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    work_item_id: Option<String>,
-    #[serde(default)]
-    usage: super::types::TaskUsage,
-    created_at: String,
-    updated_at: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    deleted_at: Option<String>,
-}
-
-impl From<&TaskBoardItem> for TaskBoardFrontmatter {
-    fn from(item: &TaskBoardItem) -> Self {
-        Self {
-            schema_version: item.schema_version,
-            id: item.id.clone(),
-            title: item.title.clone(),
-            status: item.status,
-            priority: item.priority,
-            tags: item.tags.clone(),
-            project_id: item.project_id.clone(),
-            target_project_types: item.target_project_types.clone(),
-            agent_mode: item.agent_mode,
-            workflow_kind: item.workflow_kind,
-            execution_repository: item.execution_repository.clone(),
-            external_refs: item.external_refs.clone(),
-            imported_from_provider: item.imported_from_provider,
-            planning: item.planning.clone(),
-            workflow: item.workflow.clone(),
-            session_id: item.session_id.clone(),
-            work_item_id: item.work_item_id.clone(),
-            usage: item.usage.clone(),
-            created_at: item.created_at.clone(),
-            updated_at: item.updated_at.clone(),
-            deleted_at: item.deleted_at.clone(),
-        }
-    }
-}
-
-impl TaskBoardFrontmatter {
-    fn into_item(self, body: String) -> TaskBoardItem {
-        TaskBoardItem {
-            schema_version: self.schema_version,
-            id: self.id,
-            title: self.title,
-            body,
-            status: self.status,
-            priority: self.priority,
-            tags: self.tags,
-            project_id: self.project_id,
-            target_project_types: self.target_project_types,
-            agent_mode: self.agent_mode,
-            workflow_kind: self.workflow_kind,
-            execution_repository: self.execution_repository,
-            external_refs: self.external_refs,
-            imported_from_provider: self.imported_from_provider,
-            planning: self.planning,
-            workflow: self.workflow,
-            session_id: self.session_id,
-            work_item_id: self.work_item_id,
-            usage: self.usage,
-            created_at: self.created_at,
-            updated_at: self.updated_at,
-            deleted_at: self.deleted_at,
-        }
-    }
 }
 
 #[must_use]
@@ -430,6 +337,11 @@ fn apply_planning_patch(target: &mut PlanningState, patch: Option<&PlanningState
 fn apply_link_patch(item: &mut TaskBoardItem, patch: TaskBoardItemPatch) {
     apply_optional_patch(&mut item.project_id, patch.project_id);
     apply_optional_patch(&mut item.execution_repository, patch.execution_repository);
+    apply_optional_patch(&mut item.estimated_tokens, patch.estimated_tokens);
+    apply_optional_patch(
+        &mut item.estimated_cost_microusd,
+        patch.estimated_cost_microusd,
+    );
     apply_optional_patch(&mut item.session_id, patch.session_id);
     apply_optional_patch(&mut item.work_item_id, patch.work_item_id);
 }

--- a/src/task_board/store/frontmatter.rs
+++ b/src/task_board/store/frontmatter.rs
@@ -1,0 +1,110 @@
+use serde::{Deserialize, Serialize};
+
+use super::super::TaskBoardWorkflowKind;
+use super::super::types::{
+    AgentMode, ExternalRef, ExternalRefProvider, PlanningState, TaskBoardItem, TaskBoardPriority,
+    TaskBoardStatus, TaskBoardWorkflowState, TaskUsage,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct TaskBoardFrontmatter {
+    schema_version: u32,
+    id: String,
+    title: String,
+    status: TaskBoardStatus,
+    priority: TaskBoardPriority,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    target_project_types: Vec<String>,
+    agent_mode: AgentMode,
+    #[serde(default)]
+    workflow_kind: TaskBoardWorkflowKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    execution_repository: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    estimated_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    estimated_cost_microusd: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    external_refs: Vec<ExternalRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    imported_from_provider: Option<ExternalRefProvider>,
+    #[serde(default)]
+    planning: PlanningState,
+    #[serde(default, skip_serializing_if = "TaskBoardWorkflowState::is_default")]
+    workflow: TaskBoardWorkflowState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    work_item_id: Option<String>,
+    #[serde(default)]
+    usage: TaskUsage,
+    created_at: String,
+    updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    deleted_at: Option<String>,
+}
+
+impl From<&TaskBoardItem> for TaskBoardFrontmatter {
+    fn from(item: &TaskBoardItem) -> Self {
+        Self {
+            schema_version: item.schema_version,
+            id: item.id.clone(),
+            title: item.title.clone(),
+            status: item.status,
+            priority: item.priority,
+            tags: item.tags.clone(),
+            project_id: item.project_id.clone(),
+            target_project_types: item.target_project_types.clone(),
+            agent_mode: item.agent_mode,
+            workflow_kind: item.workflow_kind,
+            execution_repository: item.execution_repository.clone(),
+            estimated_tokens: item.estimated_tokens,
+            estimated_cost_microusd: item.estimated_cost_microusd,
+            external_refs: item.external_refs.clone(),
+            imported_from_provider: item.imported_from_provider,
+            planning: item.planning.clone(),
+            workflow: item.workflow.clone(),
+            session_id: item.session_id.clone(),
+            work_item_id: item.work_item_id.clone(),
+            usage: item.usage.clone(),
+            created_at: item.created_at.clone(),
+            updated_at: item.updated_at.clone(),
+            deleted_at: item.deleted_at.clone(),
+        }
+    }
+}
+
+impl TaskBoardFrontmatter {
+    pub(super) fn into_item(self, body: String) -> TaskBoardItem {
+        TaskBoardItem {
+            schema_version: self.schema_version,
+            id: self.id,
+            title: self.title,
+            body,
+            status: self.status,
+            priority: self.priority,
+            tags: self.tags,
+            project_id: self.project_id,
+            target_project_types: self.target_project_types,
+            agent_mode: self.agent_mode,
+            workflow_kind: self.workflow_kind,
+            execution_repository: self.execution_repository,
+            estimated_tokens: self.estimated_tokens,
+            estimated_cost_microusd: self.estimated_cost_microusd,
+            external_refs: self.external_refs,
+            imported_from_provider: self.imported_from_provider,
+            planning: self.planning,
+            workflow: self.workflow,
+            session_id: self.session_id,
+            work_item_id: self.work_item_id,
+            usage: self.usage,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            deleted_at: self.deleted_at,
+        }
+    }
+}

--- a/src/task_board/transport.rs
+++ b/src/task_board/transport.rs
@@ -154,6 +154,8 @@ pub struct TaskBoardUpdateArgs {
     #[command(flatten)]
     pub clear_links: TaskBoardUpdateClearLinkArgs,
     #[command(flatten)]
+    pub clear_estimates: TaskBoardUpdateClearEstimateArgs,
+    #[command(flatten)]
     pub clear_state: TaskBoardUpdateClearStateArgs,
 }
 
@@ -165,6 +167,14 @@ pub struct TaskBoardUpdateClearLinkArgs {
     pub clear_session: bool,
     #[arg(long)]
     pub clear_work_item: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct TaskBoardUpdateClearEstimateArgs {
+    #[arg(long, conflicts_with = "estimated_tokens")]
+    pub clear_estimated_tokens: bool,
+    #[arg(long, conflicts_with = "estimated_cost_microusd")]
+    pub clear_estimated_cost_microusd: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/task_board/transport/item_args.rs
+++ b/src/task_board/transport/item_args.rs
@@ -4,8 +4,8 @@ use clap::Args;
 
 use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::types::{
-    ExternalRef, ExternalRefProvider, PlanningState, TaskBoardWorkflowState,
-    TaskBoardWorkflowStatus,
+    ExternalRef, ExternalRefProvider, MAX_TASK_BOARD_ESTIMATE, PlanningState,
+    TaskBoardWorkflowState, TaskBoardWorkflowStatus,
 };
 use crate::workspace::utc_now;
 
@@ -43,9 +43,9 @@ pub struct TaskBoardItemFieldArgs {
     pub session_id: Option<String>,
     #[arg(long)]
     pub work_item_id: Option<String>,
-    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=i64::MAX as u64))]
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=MAX_TASK_BOARD_ESTIMATE))]
     pub estimated_tokens: Option<u64>,
-    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=i64::MAX as u64))]
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=MAX_TASK_BOARD_ESTIMATE))]
     pub estimated_cost_microusd: Option<u64>,
 }
 

--- a/src/task_board/transport/item_args.rs
+++ b/src/task_board/transport/item_args.rs
@@ -43,6 +43,10 @@ pub struct TaskBoardItemFieldArgs {
     pub session_id: Option<String>,
     #[arg(long)]
     pub work_item_id: Option<String>,
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=i64::MAX as u64))]
+    pub estimated_tokens: Option<u64>,
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=i64::MAX as u64))]
+    pub estimated_cost_microusd: Option<u64>,
 }
 
 impl TaskBoardItemFieldArgs {

--- a/src/task_board/transport/item_commands.rs
+++ b/src/task_board/transport/item_commands.rs
@@ -1,7 +1,8 @@
 use crate::app::command_context::{AppContext, Execute};
 use crate::daemon::protocol::{
     TaskBoardAuditRequest, TaskBoardCreateItemRequest, TaskBoardListItemsRequest,
-    TaskBoardUpdateIdentityClears, TaskBoardUpdateItemRequest, TaskBoardUpdateStateClears,
+    TaskBoardUpdateEstimateClears, TaskBoardUpdateIdentityClears, TaskBoardUpdateItemRequest,
+    TaskBoardUpdateStateClears,
 };
 use crate::errors::CliError;
 use crate::task_board::TaskBoardWorkflowKind;
@@ -21,6 +22,8 @@ impl Execute for TaskBoardCreateArgs {
             agent_mode: self.agent_mode,
             workflow_kind: TaskBoardWorkflowKind::default(),
             execution_repository: None,
+            estimated_tokens: self.fields.estimated_tokens,
+            estimated_cost_microusd: self.fields.estimated_cost_microusd,
             tags: self.tag.clone(),
             project_id: self.project_id.clone(),
             target_project_types: self.target_project_type.clone(),
@@ -93,6 +96,12 @@ impl TaskBoardUpdateArgs {
             agent_mode: self.agent_mode,
             workflow_kind: None,
             execution_repository: None,
+            estimated_tokens: self.fields.estimated_tokens,
+            estimated_cost_microusd: self.fields.estimated_cost_microusd,
+            clear_estimates: TaskBoardUpdateEstimateClears {
+                clear_estimated_tokens: self.clear_estimates.clear_estimated_tokens,
+                clear_estimated_cost_microusd: self.clear_estimates.clear_estimated_cost_microusd,
+            },
             tags: (!self.tag.is_empty()).then(|| self.tag.clone()),
             project_id: self.project_id.clone(),
             target_project_types: (!self.target_project_type.is_empty())

--- a/src/task_board/transport/orchestrator.rs
+++ b/src/task_board/transport/orchestrator.rs
@@ -9,9 +9,9 @@ use crate::daemon::protocol::{
 use crate::errors::{CliError, CliErrorKind};
 use crate::task_board::types::TaskBoardStatus;
 use crate::task_board::{
-    TaskBoardGitRepositoryOverride, TaskBoardGitRuntimeConfig, TaskBoardGitRuntimeProfile,
-    TaskBoardGitSigningConfig, TaskBoardGitSigningMode, TaskBoardOrchestratorStatus,
-    normalize_repository_slug,
+    TaskBoardAutomationPolicy, TaskBoardGitRepositoryOverride, TaskBoardGitRuntimeConfig,
+    TaskBoardGitRuntimeProfile, TaskBoardGitSigningConfig, TaskBoardGitSigningMode,
+    TaskBoardOrchestratorStatus, normalize_repository_slug, validate_task_board_policy,
 };
 
 use super::orchestrator_tokens::{
@@ -80,6 +80,9 @@ pub struct TaskBoardOrchestratorSettingsArgs {
     pub project_dir: Option<String>,
     #[arg(long)]
     pub clear_project_dir: bool,
+    /// Complete admission policy as a JSON object.
+    #[arg(long, value_name = "JSON", value_parser = parse_admission_policy)]
+    pub admission_policy: Option<TaskBoardAutomationPolicy>,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -220,6 +223,7 @@ impl TaskBoardOrchestratorSettingsArgs {
             || self.clear_dispatch_status_filter
             || self.project_dir.is_some()
             || self.clear_project_dir
+            || self.admission_policy.is_some()
     }
 
     fn update_request(&self) -> TaskBoardOrchestratorSettingsUpdateRequest {
@@ -230,9 +234,18 @@ impl TaskBoardOrchestratorSettingsArgs {
             clear_dispatch_status_filter: self.clear_dispatch_status_filter,
             project_dir: self.project_dir.clone(),
             clear_project_dir: self.clear_project_dir,
+            admission_policy: self.admission_policy.clone(),
             ..TaskBoardOrchestratorSettingsUpdateRequest::default()
         }
     }
+}
+
+fn parse_admission_policy(value: &str) -> Result<TaskBoardAutomationPolicy, String> {
+    let policy = serde_json::from_str(value)
+        .map_err(|error| format!("invalid task-board admission policy JSON: {error}"))?;
+    validate_task_board_policy(&policy)
+        .map_err(|error| format!("invalid task-board admission policy: {error}"))?;
+    Ok(policy)
 }
 
 impl Execute for TaskBoardOrchestratorRuntimeConfigArgs {

--- a/src/task_board/types.rs
+++ b/src/task_board/types.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::automation::TaskBoardWorkflowKind;
 
 pub const CURRENT_TASK_BOARD_ITEM_VERSION: u32 = 1;
+pub const MAX_TASK_BOARD_ESTIMATE: u64 = i64::MAX as u64;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskBoardItem {
@@ -28,6 +29,10 @@ pub struct TaskBoardItem {
     pub workflow_kind: TaskBoardWorkflowKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_repository: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_cost_microusd: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub external_refs: Vec<ExternalRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -64,6 +69,8 @@ impl TaskBoardItem {
             agent_mode: AgentMode::Headless,
             workflow_kind: TaskBoardWorkflowKind::DefaultTask,
             execution_repository: None,
+            estimated_tokens: None,
+            estimated_cost_microusd: None,
             external_refs: Vec::new(),
             imported_from_provider: None,
             planning: PlanningState::default(),

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-testkit"
-version = "48.4.0"
+version = "48.5.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false


### PR DESCRIPTION
## Motivation
Task-board automation had no durable admission boundary before creating sessions, worktrees, grants, or workers. Concurrent and retried dispatches could therefore exceed configured concurrency, rate, time-window, token, or cost limits or launch from stale policy evidence.

## Implementation
- Add a validated default-empty admission policy and positive integer token and cost estimates across HTTP, CLI, MCP, and generated contracts.
- Compile concurrency, rate, DST-aware time-window, token, and microusd requirements deterministically while rejecting conflicting canonical requirements and arithmetic overflow.
- Persist immutable schema-v39 decisions and intent-scoped all-or-none reservations, then atomically revalidate stale held, claimed, and starting dispatches.
- Commit finite usage exactly once after a proven worker start, release concurrency across failure, terminal, deletion, and recovery paths, and enforce read-only Planning/Evaluate versus write-capable Headless launches while rejecting unsupported Interactive launches.
- Cover migration and repair, races, crashes, stale revisions, recovery, transport parity, codegen, Monitor build, unit and integration suites, and synchronize the approved release set to 48.5.0.