### PR TITLE
fix(test): isolate socket, helper, and daemon test state

### DIFF
--- a/src/daemon/client/test_support.rs
+++ b/src/daemon/client/test_support.rs
@@ -101,6 +101,7 @@ pub(crate) fn fake_running_xdg_daemon(
 }
 
 pub(crate) fn read_http_request(stream: &mut TcpStream) -> String {
+    stream.set_nonblocking(false).expect("blocking stream");
     stream
         .set_read_timeout(Some(std::time::Duration::from_secs(1)))
         .expect("read timeout");

--- a/src/daemon/http/tests/reviews_policy_writes.rs
+++ b/src/daemon/http/tests/reviews_policy_writes.rs
@@ -13,10 +13,12 @@ async fn review_write_http_routes_fail_closed_without_enforced_policy() {
     let xdg_root = xdg_root.to_str().expect("utf8 xdg").to_owned();
     temp_env::async_with_vars(
         [
+            ("HARNESS_DAEMON_DATA_HOME", Some(xdg_root.as_str())),
             ("XDG_DATA_HOME", Some(xdg_root.as_str())),
             ("CLAUDE_SESSION_ID", Some("http-review-policy-writes")),
         ],
         async {
+            crate::daemon::state::ensure_daemon_dirs().expect("daemon dirs");
             let (base_url, server) = serve_http(test_http_state_with_db()).await;
             let client = reqwest::Client::new();
 

--- a/src/daemon/websocket/reviews_tests.rs
+++ b/src/daemon/websocket/reviews_tests.rs
@@ -12,10 +12,12 @@ async fn review_write_websocket_routes_fail_closed_without_enforced_policy() {
     let xdg_root = xdg_root.to_str().expect("utf8 xdg").to_owned();
     temp_env::async_with_vars(
         [
+            ("HARNESS_DAEMON_DATA_HOME", Some(xdg_root.as_str())),
             ("XDG_DATA_HOME", Some(xdg_root.as_str())),
             ("CLAUDE_SESSION_ID", Some("ws-review-policy-writes")),
         ],
         async {
+            crate::daemon::state::ensure_daemon_dirs().expect("daemon dirs");
             let state = test_http_state_with_db();
 
             for case in review_websocket_write_cases() {

--- a/src/mcp/automation/accessibility.rs
+++ b/src/mcp/automation/accessibility.rs
@@ -9,8 +9,6 @@ use tokio::time::{Duration, timeout};
 
 use crate::mcp::registry::{ElementKind, GetElementResult, ListElementsResult};
 
-#[cfg(test)]
-use super::backend::INPUT_OVERRIDE_ENV;
 use super::backend::{Backend, detect_backend};
 
 // Keep helper fallback queries bounded so a wedged AX tree degrades to a fast
@@ -112,9 +110,18 @@ pub async fn perform_action(
     action: AccessibilityAction,
 ) -> Result<(), AccessibilityActionError> {
     let program = helper_program_for_action().await?;
-    match run_action_request(&program, identifier, window_id, action).await {
+    perform_action_with_program(&program, identifier, window_id, action).await
+}
+
+pub(crate) async fn perform_action_with_program(
+    program: &Path,
+    identifier: &str,
+    window_id: Option<i64>,
+    action: AccessibilityAction,
+) -> Result<(), AccessibilityActionError> {
+    match run_action_request(program, identifier, window_id, action).await {
         Err(AccessibilityActionError::NotFound) if window_id.is_some() => {
-            run_action_request(&program, identifier, None, action).await
+            run_action_request(program, identifier, None, action).await
         }
         result => result,
     }
@@ -365,14 +372,9 @@ esac
             log_path = log_path.to_string_lossy()
         );
         write_helper_script(&helper, &script);
-        let helper_path = helper.to_string_lossy().into_owned();
-
-        temp_env::async_with_vars([(INPUT_OVERRIDE_ENV, Some(helper_path.as_str()))], async {
-            perform_action("button.send", Some(7), AccessibilityAction::Press)
-                .await
-                .expect("unscoped retry succeeds");
-        })
-        .await;
+        perform_action_with_program(&helper, "button.send", Some(7), AccessibilityAction::Press)
+            .await
+            .expect("unscoped retry succeeds");
 
         assert_eq!(
             fs::read_to_string(log_path).expect("read retry log"),

--- a/src/mcp/automation/backend.rs
+++ b/src/mcp/automation/backend.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::env;
 use std::fs::Metadata;
 use std::fs::read_dir;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -38,12 +39,23 @@ impl Backend {
 /// Order: `$HARNESS_MONITOR_INPUT_BIN` > bundled helper under the registry
 /// package > `cliclick` on PATH > None.
 pub async fn detect_backend() -> Backend {
+    let mut probe = |path: PathBuf| async move { viable_helper_candidate(&path).await };
+    detect_backend_with_probe(&mut probe).await
+}
+
+pub(crate) async fn detect_backend_with_probe<P, F>(probe: &mut P) -> Backend
+where
+    P: FnMut(PathBuf) -> F,
+    F: Future<Output = Option<(SystemTime, PathBuf)>>,
+{
     if let Some(path) = env_override()
-        && viable_helper_candidate(&path).await.is_some()
+        && probe(path.clone()).await.is_some()
     {
         return Backend::HarnessInput(path);
     }
-    if let Some(candidate) = default_helper_candidate().await {
+    if let Some(candidate) =
+        default_helper_candidate_from_roots_with_probe(&helper_search_roots(), probe).await
+    {
         return Backend::HarnessInput(candidate);
     }
     if on_path("cliclick").await {
@@ -60,29 +72,21 @@ fn env_override() -> Option<PathBuf> {
     Some(PathBuf::from(value))
 }
 
-pub(crate) async fn default_helper_candidate() -> Option<PathBuf> {
-    default_helper_candidate_from_roots(&helper_search_roots()).await
-}
-
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "exercised by automation tests to lock helper ranking"
-    )
-)]
-pub(crate) async fn default_helper_candidate_in(repo_root: &Path) -> Option<PathBuf> {
-    best_helper_candidate(helper_candidates_from(repo_root)).await
-}
-
-pub(crate) async fn default_helper_candidate_from_roots(roots: &[PathBuf]) -> Option<PathBuf> {
+pub(crate) async fn default_helper_candidate_from_roots_with_probe<P, F>(
+    roots: &[PathBuf],
+    probe: &mut P,
+) -> Option<PathBuf>
+where
+    P: FnMut(PathBuf) -> F,
+    F: Future<Output = Option<(SystemTime, PathBuf)>>,
+{
     let mut seen = HashSet::new();
     let candidates: Vec<PathBuf> = roots
         .iter()
         .flat_map(|root| helper_candidates_from(root))
         .filter(|candidate| seen.insert(candidate.clone()))
         .collect();
-    best_helper_candidate(candidates).await
+    best_helper_candidate_with_probe(candidates, probe).await
 }
 
 fn helper_candidates_from(repo_root: &Path) -> Vec<PathBuf> {
@@ -130,13 +134,15 @@ fn prefers_candidate(candidate: &Path, incumbent: &Path) -> bool {
             .any(|component| component.as_os_str() == "debug")
 }
 
-async fn best_helper_candidate<I>(candidates: I) -> Option<PathBuf>
+async fn best_helper_candidate_with_probe<I, P, F>(candidates: I, probe: &mut P) -> Option<PathBuf>
 where
     I: IntoIterator<Item = PathBuf>,
+    P: FnMut(PathBuf) -> F,
+    F: Future<Output = Option<(SystemTime, PathBuf)>>,
 {
     let mut best: Option<(SystemTime, PathBuf)> = None;
     for candidate in candidates {
-        let Some((modified, candidate)) = viable_helper_candidate(&candidate).await else {
+        let Some((modified, candidate)) = probe(candidate).await else {
             continue;
         };
         if best.as_ref().is_none_or(|(best_modified, best_path)| {
@@ -150,11 +156,23 @@ where
 }
 
 async fn viable_helper_candidate(path: &Path) -> Option<(SystemTime, PathBuf)> {
+    let mut launch_check = |path: PathBuf| async move { helper_launches(&path).await };
+    viable_helper_candidate_with_launch_check(path, &mut launch_check).await
+}
+
+pub(crate) async fn viable_helper_candidate_with_launch_check<L, F>(
+    path: &Path,
+    launch_check: &mut L,
+) -> Option<(SystemTime, PathBuf)>
+where
+    L: FnMut(PathBuf) -> F,
+    F: Future<Output = bool>,
+{
     let metadata = fs::metadata(path).await.ok()?;
     if !metadata.is_file() || !is_executable(&metadata) {
         return None;
     }
-    if !helper_launches(path).await {
+    if !launch_check(path.to_path_buf()).await {
         return None;
     }
     Some((

--- a/src/mcp/automation/mod.rs
+++ b/src/mcp/automation/mod.rs
@@ -14,6 +14,8 @@ mod screenshot;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+pub(crate) use accessibility::perform_action_with_program as perform_accessibility_action_with_program;
 pub use accessibility::{
     AccessibilityAction, AccessibilityActionError, AccessibilityQueryError,
     get_element as get_accessibility_element, get_element_args as accessibility_get_element_args,

--- a/src/mcp/automation/tests.rs
+++ b/src/mcp/automation/tests.rs
@@ -1,17 +1,21 @@
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::fs;
+use std::future::{Ready, ready};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use std::os::unix::fs::PermissionsExt;
+use tokio::sync::Barrier;
 
 use crate::mcp::automation::AccessibilityAction;
 use crate::mcp::registry::ElementKind;
 
 use super::accessibility::{get_element_args, list_elements_args, perform_action_args};
 use super::backend::{
-    Backend, INPUT_OVERRIDE_ENV, default_helper_candidate_from_roots, default_helper_candidate_in,
-    detect_backend, helper_search_roots_from,
+    Backend, INPUT_OVERRIDE_ENV, default_helper_candidate_from_roots_with_probe,
+    detect_backend_with_probe, helper_search_roots_from, viable_helper_candidate_with_launch_check,
 };
 use super::input::{MouseButton, click_args, move_mouse_args, type_text_args};
 use super::screenshot::{ScreenshotOptions, ScreenshotTarget, screenshot_args};
@@ -49,6 +53,20 @@ fn valid_helper_script() -> &'static str {
 
 fn failing_helper_script() -> &'static str {
     "#!/bin/sh\nexit 1\n"
+}
+
+fn probe_fixture_candidate(
+    viable: &HashSet<PathBuf>,
+    path: PathBuf,
+) -> Ready<Option<(SystemTime, PathBuf)>> {
+    let candidate = viable.contains(&path).then(|| {
+        let modified = fs::metadata(&path)
+            .expect("candidate metadata")
+            .modified()
+            .expect("candidate timestamp");
+        (modified, path)
+    });
+    ready(candidate)
 }
 
 #[test]
@@ -265,12 +283,53 @@ async fn detect_backend_honours_env_override_when_file_exists() {
     let expected_path = temp.path().join("harness-monitor-input");
     write_helper_script(&expected_path, valid_helper_script());
     let path_value = expected_path.to_string_lossy().into_owned();
-    let backend = temp_env::async_with_vars(
-        [(INPUT_OVERRIDE_ENV, Some(path_value.as_str()))],
-        async move { detect_backend().await },
-    )
-    .await;
+    let expected_for_probe = expected_path.clone();
+    let backend =
+        temp_env::async_with_vars([(INPUT_OVERRIDE_ENV, Some(path_value.as_str()))], async {
+            let mut probe = move |path: PathBuf| {
+                ready((path == expected_for_probe).then_some((SystemTime::UNIX_EPOCH, path)))
+            };
+            detect_backend_with_probe(&mut probe).await
+        })
+        .await;
     assert_eq!(backend, Backend::HarnessInput(expected_path));
+}
+
+#[tokio::test]
+async fn helper_candidate_requires_executable_metadata_and_a_successful_launch() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let missing = temp.path().join("missing-helper");
+    let mut successful_launch = |_| ready(true);
+    assert!(
+        viable_helper_candidate_with_launch_check(&missing, &mut successful_launch)
+            .await
+            .is_none()
+    );
+
+    let helper = temp.path().join("harness-monitor-input");
+    write_helper_script(&helper, valid_helper_script());
+    let mut failed_launch = |_| ready(false);
+    assert!(
+        viable_helper_candidate_with_launch_check(&helper, &mut failed_launch)
+            .await
+            .is_none()
+    );
+
+    let mut successful_launch = |_| ready(true);
+    let viable = viable_helper_candidate_with_launch_check(&helper, &mut successful_launch).await;
+    assert_eq!(viable.map(|(_, path)| path), Some(helper.clone()));
+
+    let mut permissions = fs::metadata(&helper)
+        .expect("helper metadata")
+        .permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&helper, permissions).expect("remove executable bit");
+    let mut successful_launch = |_| ready(true);
+    assert!(
+        viable_helper_candidate_with_launch_check(&helper, &mut successful_launch)
+            .await
+            .is_none()
+    );
 }
 
 #[tokio::test]
@@ -286,7 +345,11 @@ async fn default_helper_candidate_prefers_newest_platform_build() {
     set_helper_modified(&release, 1);
     set_helper_modified(&debug, 2);
 
-    let candidate = default_helper_candidate_in(temp.path()).await;
+    let viable = HashSet::from([release.clone(), debug.clone()]);
+    let mut probe = |path| probe_fixture_candidate(&viable, path);
+    let candidate =
+        default_helper_candidate_from_roots_with_probe(&[temp.path().to_path_buf()], &mut probe)
+            .await;
     assert_eq!(candidate, Some(debug));
 }
 
@@ -303,7 +366,11 @@ async fn default_helper_candidate_skips_newer_non_viable_platform_build() {
     set_helper_modified(&release, 1);
     set_helper_modified(&debug, 2);
 
-    let candidate = default_helper_candidate_in(temp.path()).await;
+    let viable = HashSet::from([release.clone()]);
+    let mut probe = |path| probe_fixture_candidate(&viable, path);
+    let candidate =
+        default_helper_candidate_from_roots_with_probe(&[temp.path().to_path_buf()], &mut probe)
+            .await;
     assert_eq!(candidate, Some(release));
 }
 
@@ -322,12 +389,57 @@ async fn default_helper_candidate_prefers_newest_viable_candidate_across_search_
     set_helper_modified(&older, 1);
     set_helper_modified(&newer, 2);
 
-    let candidate = default_helper_candidate_from_roots(&[
-        first_root.path().to_path_buf(),
-        second_root.path().to_path_buf(),
-    ])
+    let viable = HashSet::from([older.clone(), newer.clone()]);
+    let mut probe = |path| probe_fixture_candidate(&viable, path);
+    let candidate = default_helper_candidate_from_roots_with_probe(
+        &[
+            first_root.path().to_path_buf(),
+            second_root.path().to_path_buf(),
+        ],
+        &mut probe,
+    )
     .await;
     assert_eq!(candidate, Some(newer));
+}
+
+#[tokio::test]
+async fn concurrent_helper_discovery_keeps_injected_probe_results_isolated() {
+    let first_root = tempfile::tempdir().expect("first root");
+    let second_root = tempfile::tempdir().expect("second root");
+    let first = first_root
+        .path()
+        .join("mcp-servers/harness-monitor-registry/.build/arm64-apple-macosx/release/harness-monitor-input");
+    let second = second_root
+        .path()
+        .join("mcp-servers/harness-monitor-registry/.build/arm64-apple-macosx/release/harness-monitor-input");
+    write_helper_script(&first, valid_helper_script());
+    write_helper_script(&second, valid_helper_script());
+    let barrier = Arc::new(Barrier::new(2));
+
+    let discover = |root: PathBuf, expected: PathBuf, barrier: Arc<Barrier>| async move {
+        let viable = HashSet::from([expected]);
+        let mut probe = move |path| {
+            let candidate = probe_fixture_candidate(&viable, path);
+            let barrier = Arc::clone(&barrier);
+            async move {
+                barrier.wait().await;
+                candidate.await
+            }
+        };
+        default_helper_candidate_from_roots_with_probe(&[root], &mut probe).await
+    };
+
+    let (first_result, second_result) = tokio::join!(
+        discover(
+            first_root.path().to_path_buf(),
+            first.clone(),
+            Arc::clone(&barrier),
+        ),
+        discover(second_root.path().to_path_buf(), second.clone(), barrier,),
+    );
+
+    assert_eq!(first_result, Some(first));
+    assert_eq!(second_result, Some(second));
 }
 
 #[test]

--- a/src/mcp/tools/drag_drop.rs
+++ b/src/mcp/tools/drag_drop.rs
@@ -1,10 +1,11 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use crate::mcp::automation::drag_drop;
+use crate::mcp::automation::{AutomationError, drag_drop};
 use crate::mcp::protocol::ToolResult;
 use crate::mcp::registry::{GetElementResult, Rect, RegistryClient};
 use crate::mcp::tool::{Tool, ToolError};
@@ -40,6 +41,62 @@ impl DragDropTool {
     async fn fetch_element(&self, identifier: &str) -> Result<GetElementResult, ToolError> {
         resolve_get_element(&self.client, identifier).await
     }
+
+    pub(crate) async fn call_with_dependencies<R, RFut, D, DFut>(
+        &self,
+        params: Value,
+        mut resolve_element: R,
+        perform_drag_drop: D,
+    ) -> Result<ToolResult, ToolError>
+    where
+        R: FnMut(String) -> RFut,
+        RFut: Future<Output = Result<GetElementResult, ToolError>>,
+        D: FnOnce(f64, f64, f64, f64, u64) -> DFut,
+        DFut: Future<Output = Result<(), AutomationError>>,
+    {
+        let parsed: Params = decode_params(params)?;
+        if parsed.source_identifier.is_empty() {
+            return Err(ToolError::invalid("sourceIdentifier cannot be empty"));
+        }
+        if parsed.destination_identifier.is_empty() {
+            return Err(ToolError::invalid("destinationIdentifier cannot be empty"));
+        }
+        if parsed.duration_ms > MAX_DURATION_MS {
+            return Err(ToolError::invalid(format!(
+                "durationMs must be <= {MAX_DURATION_MS}"
+            )));
+        }
+
+        let source = resolve_element(parsed.source_identifier.clone()).await?;
+        let destination = resolve_element(parsed.destination_identifier.clone()).await?;
+        if !source.element.enabled {
+            return Err(ToolError::invalid(format!(
+                "sourceIdentifier '{}' resolves to a disabled target",
+                parsed.source_identifier
+            )));
+        }
+        if !destination.element.enabled {
+            return Err(ToolError::invalid(format!(
+                "destinationIdentifier '{}' resolves to a disabled target",
+                parsed.destination_identifier
+            )));
+        }
+        let (start_x, start_y) = center(&source.element.frame);
+        let (end_x, end_y) = center(&destination.element.frame);
+        perform_drag_drop(start_x, start_y, end_x, end_y, parsed.duration_ms)
+            .await
+            .map_err(|error| ToolError::internal(error.to_string()))?;
+        let payload = json!({
+            "dragged": {
+                "sourceIdentifier": parsed.source_identifier,
+                "destinationIdentifier": parsed.destination_identifier,
+                "start": {"x": start_x, "y": start_y},
+                "end": {"x": end_x, "y": end_y},
+                "durationMs": parsed.duration_ms,
+            }
+        });
+        Ok(ToolResult::text(payload.to_string()))
+    }
 }
 
 #[async_trait]
@@ -67,48 +124,14 @@ impl Tool for DragDropTool {
     }
 
     async fn call(&self, params: Value) -> Result<ToolResult, ToolError> {
-        let parsed: Params = decode_params(params)?;
-        if parsed.source_identifier.is_empty() {
-            return Err(ToolError::invalid("sourceIdentifier cannot be empty"));
-        }
-        if parsed.destination_identifier.is_empty() {
-            return Err(ToolError::invalid("destinationIdentifier cannot be empty"));
-        }
-        if parsed.duration_ms > MAX_DURATION_MS {
-            return Err(ToolError::invalid(format!(
-                "durationMs must be <= {MAX_DURATION_MS}"
-            )));
-        }
-
-        let source = self.fetch_element(&parsed.source_identifier).await?;
-        let destination = self.fetch_element(&parsed.destination_identifier).await?;
-        if !source.element.enabled {
-            return Err(ToolError::invalid(format!(
-                "sourceIdentifier '{}' resolves to a disabled target",
-                parsed.source_identifier
-            )));
-        }
-        if !destination.element.enabled {
-            return Err(ToolError::invalid(format!(
-                "destinationIdentifier '{}' resolves to a disabled target",
-                parsed.destination_identifier
-            )));
-        }
-        let (start_x, start_y) = center(&source.element.frame);
-        let (end_x, end_y) = center(&destination.element.frame);
-        drag_drop(start_x, start_y, end_x, end_y, parsed.duration_ms)
-            .await
-            .map_err(|error| ToolError::internal(error.to_string()))?;
-        let payload = json!({
-            "dragged": {
-                "sourceIdentifier": parsed.source_identifier,
-                "destinationIdentifier": parsed.destination_identifier,
-                "start": {"x": start_x, "y": start_y},
-                "end": {"x": end_x, "y": end_y},
-                "durationMs": parsed.duration_ms,
-            }
-        });
-        Ok(ToolResult::text(payload.to_string()))
+        self.call_with_dependencies(
+            params,
+            |identifier| async move { self.fetch_element(&identifier).await },
+            |start_x, start_y, end_x, end_y, duration_ms| async move {
+                drag_drop(start_x, start_y, end_x, end_y, duration_ms).await
+            },
+        )
+        .await
     }
 }
 

--- a/src/mcp/tools/press_element.rs
+++ b/src/mcp/tools/press_element.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -64,31 +65,16 @@ impl PressElementTool {
             Err(error) => Err(ToolError::internal(error.to_string())),
         }
     }
-}
 
-#[async_trait]
-impl Tool for PressElementTool {
-    fn name(&self) -> &'static str {
-        "press_element"
-    }
-
-    fn description(&self) -> &'static str {
-        "Invoke an element's semantic accessibility activation without moving \
-         the mouse or requiring the app to be frontmost."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "identifier": {"type": "string"},
-            },
-            "required": ["identifier"],
-            "additionalProperties": false,
-        })
-    }
-
-    async fn call(&self, params: Value) -> Result<ToolResult, ToolError> {
+    pub(crate) async fn call_with_accessibility_action<F, Fut>(
+        &self,
+        params: Value,
+        fallback_action: F,
+    ) -> Result<ToolResult, ToolError>
+    where
+        F: FnOnce(String, Option<i64>, AccessibilityAction) -> Fut,
+        Fut: Future<Output = Result<(), AccessibilityActionError>>,
+    {
         let parsed: Params = decode_params(params)?;
         if parsed.identifier.is_empty() {
             return Err(ToolError::invalid("identifier cannot be empty"));
@@ -132,8 +118,8 @@ impl Tool for PressElementTool {
             }
         }
 
-        match perform_accessibility_action(
-            &parsed.identifier,
+        match fallback_action(
+            parsed.identifier.clone(),
             element.element.window_id,
             AccessibilityAction::Press,
         )
@@ -156,6 +142,36 @@ impl Tool for PressElementTool {
             ))),
             Err(error) => Err(ToolError::internal(error.to_string())),
         }
+    }
+}
+
+#[async_trait]
+impl Tool for PressElementTool {
+    fn name(&self) -> &'static str {
+        "press_element"
+    }
+
+    fn description(&self) -> &'static str {
+        "Invoke an element's semantic accessibility activation without moving \
+         the mouse or requiring the app to be frontmost."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "identifier": {"type": "string"},
+            },
+            "required": ["identifier"],
+            "additionalProperties": false,
+        })
+    }
+
+    async fn call(&self, params: Value) -> Result<ToolResult, ToolError> {
+        self.call_with_accessibility_action(params, |identifier, window_id, action| async move {
+            perform_accessibility_action(&identifier, window_id, action).await
+        })
+        .await
     }
 }
 

--- a/src/mcp/tools/scroll.rs
+++ b/src/mcp/tools/scroll.rs
@@ -1,10 +1,11 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use crate::mcp::automation::scroll;
+use crate::mcp::automation::{AutomationError, scroll};
 use crate::mcp::protocol::ToolResult;
 use crate::mcp::registry::{GetElementResult, Rect, RegistryClient};
 use crate::mcp::tool::{Tool, ToolError};
@@ -33,6 +34,45 @@ impl ScrollTool {
     async fn fetch_element(&self, identifier: &str) -> Result<GetElementResult, ToolError> {
         resolve_get_element(&self.client, identifier).await
     }
+
+    pub(crate) async fn call_with_dependencies<R, RFut, S, SFut>(
+        &self,
+        params: Value,
+        resolve_element: R,
+        perform_scroll: S,
+    ) -> Result<ToolResult, ToolError>
+    where
+        R: FnOnce(String) -> RFut,
+        RFut: Future<Output = Result<GetElementResult, ToolError>>,
+        S: FnOnce(f64, f64, f64, f64) -> SFut,
+        SFut: Future<Output = Result<(), AutomationError>>,
+    {
+        let parsed: Params = decode_params(params)?;
+        if parsed.identifier.is_empty() {
+            return Err(ToolError::invalid("identifier cannot be empty"));
+        }
+        let element = resolve_element(parsed.identifier.clone()).await?;
+        if !element.element.enabled {
+            return Err(ToolError::invalid(format!(
+                "identifier '{}' resolves to a disabled target",
+                parsed.identifier
+            )));
+        }
+        let (cx, cy) = center(&element.element.frame);
+        perform_scroll(cx, cy, parsed.delta_x, parsed.delta_y)
+            .await
+            .map_err(|error| ToolError::internal(error.to_string()))?;
+        let payload = json!({
+            "scrolled": {
+                "identifier": parsed.identifier,
+                "x": cx,
+                "y": cy,
+                "deltaX": parsed.delta_x,
+                "deltaY": parsed.delta_y,
+            }
+        });
+        Ok(ToolResult::text(payload.to_string()))
+    }
 }
 
 #[async_trait]
@@ -60,31 +100,12 @@ impl Tool for ScrollTool {
     }
 
     async fn call(&self, params: Value) -> Result<ToolResult, ToolError> {
-        let parsed: Params = decode_params(params)?;
-        if parsed.identifier.is_empty() {
-            return Err(ToolError::invalid("identifier cannot be empty"));
-        }
-        let element = self.fetch_element(&parsed.identifier).await?;
-        if !element.element.enabled {
-            return Err(ToolError::invalid(format!(
-                "identifier '{}' resolves to a disabled target",
-                parsed.identifier
-            )));
-        }
-        let (cx, cy) = center(&element.element.frame);
-        scroll(cx, cy, parsed.delta_x, parsed.delta_y)
-            .await
-            .map_err(|error| ToolError::internal(error.to_string()))?;
-        let payload = json!({
-            "scrolled": {
-                "identifier": parsed.identifier,
-                "x": cx,
-                "y": cy,
-                "deltaX": parsed.delta_x,
-                "deltaY": parsed.delta_y,
-            }
-        });
-        Ok(ToolResult::text(payload.to_string()))
+        self.call_with_dependencies(
+            params,
+            |identifier| async move { self.fetch_element(&identifier).await },
+            |x, y, delta_x, delta_y| async move { scroll(x, y, delta_x, delta_y).await },
+        )
+        .await
     }
 }
 

--- a/src/mcp/tools/tests.rs
+++ b/src/mcp/tools/tests.rs
@@ -16,7 +16,10 @@ use super::{
     ClickElementTool, DragDropTool, GetElementTool, ListElementsTool, ListWindowsTool,
     PressElementTool, ScrollTool, register_all,
 };
-use crate::mcp::automation::{AccessibilityQueryError, INPUT_OVERRIDE_ENV};
+use crate::mcp::automation::{
+    AccessibilityAction, AccessibilityActionError, AccessibilityQueryError,
+    perform_accessibility_action_with_program,
+};
 use crate::mcp::protocol::ContentBlock;
 use crate::mcp::registry::RegistryClient;
 use crate::mcp::registry::{
@@ -197,48 +200,6 @@ fn write_helper_script(path: &Path, body: &str) {
     let mut permissions = fs::metadata(path).expect("helper metadata").permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(path, permissions).expect("set helper executable");
-}
-
-fn write_fake_harness_input(path: &Path) {
-    let script = r#"#!/bin/sh
-case "$1" in
-  --help|check)
-    exit 0
-    ;;
-  get-element)
-    identifier="$2"
-    case "$identifier" in
-      "task.source")
-        x=10
-        y=20
-        width=50
-        height=40
-        ;;
-      "agent.destination")
-        x=210
-        y=120
-        width=60
-        height=60
-        ;;
-      *)
-        x=10
-        y=20
-        width=30
-        height=40
-        ;;
-    esac
-    printf '{"element":{"identifier":"%s","label":"%s","value":null,"hint":null,"kind":"button","frame":{"x":%s,"y":%s,"width":%s,"height":%s},"windowID":7,"enabled":true,"selected":false,"focused":true}}\n' \
-      "$identifier" "$identifier" "$x" "$y" "$width" "$height"
-    ;;
-  scroll|drag|perform-action)
-    exit 0
-    ;;
-  *)
-    exit 64
-    ;;
-esac
-"#;
-    write_helper_script(path, script);
 }
 
 fn write_press_action_helper(path: &Path, log_path: &Path) {

--- a/src/mcp/tools/tests/interaction_tests.rs
+++ b/src/mcp/tools/tests/interaction_tests.rs
@@ -4,7 +4,6 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::daemon::protocol::{task_board_mcp_methods, ws_methods};
-use crate::mcp::automation::INPUT_OVERRIDE_ENV;
 use crate::mcp::registry::RegistryClient;
 use crate::mcp::tool::{Tool, ToolRegistry};
 
@@ -39,25 +38,32 @@ async fn scroll_tool_rejects_disabled_targets() {
 async fn scroll_tool_uses_helper_fallback_when_registry_reports_not_found() {
     let dir = TempDir::new().unwrap();
     let path = socket_path(&dir);
-    let helper = dir.path().join("fake-harness-monitor-input");
-    write_fake_harness_input(&helper);
-    let helper_value = helper.to_string_lossy().into_owned();
     let server = spawn_single_response(&path, not_found_response(1));
     let client = Arc::new(RegistryClient::with_socket_path(path));
+    let resolve_client = Arc::clone(&client);
     let tool = ScrollTool::new(client);
 
-    let result = temp_env::async_with_vars(
-        [(INPUT_OVERRIDE_ENV, Some(helper_value.as_str()))],
-        async move {
-            tool.call(json!({
+    let result = tool
+        .call_with_dependencies(
+            json!({
                 "identifier": "harness.session.cockpit.scroll",
                 "deltaY": 180,
-            }))
-            .await
-        },
-    )
-    .await
-    .expect("helper fallback should let scroll succeed");
+            }),
+            move |identifier| {
+                let client = Arc::clone(&resolve_client);
+                async move {
+                    resolve_get_element_with(&client, &identifier, |identifier| async move {
+                        Ok(GetElementResult {
+                            element: fallback_element(&identifier, 7, ElementKind::Button),
+                        })
+                    })
+                    .await
+                }
+            },
+            |_x, _y, _delta_x, _delta_y| async { Ok(()) },
+        )
+        .await
+        .expect("helper fallback should let scroll succeed");
 
     let request_line = server.await.unwrap();
     assert!(request_line.contains("\"identifier\":\"harness.session.cockpit.scroll\""));
@@ -126,25 +132,32 @@ async fn drag_drop_tool_rejects_disabled_destination() {
 async fn drag_drop_tool_uses_helper_fallback_when_registry_reports_not_found() {
     let dir = TempDir::new().unwrap();
     let path = socket_path(&dir);
-    let helper = dir.path().join("fake-harness-monitor-input");
-    write_fake_harness_input(&helper);
-    let helper_value = helper.to_string_lossy().into_owned();
     let server = spawn_response_sequence(&path, vec![not_found_response(1), not_found_response(2)]);
     let client = Arc::new(RegistryClient::with_socket_path(path));
+    let resolve_client = Arc::clone(&client);
     let tool = DragDropTool::new(client);
 
-    let result = temp_env::async_with_vars(
-        [(INPUT_OVERRIDE_ENV, Some(helper_value.as_str()))],
-        async move {
-            tool.call(json!({
+    let result = tool
+        .call_with_dependencies(
+            json!({
                 "sourceIdentifier": "task.source",
                 "destinationIdentifier": "agent.destination",
-            }))
-            .await
-        },
-    )
-    .await
-    .expect("helper fallback should let drag succeed");
+            }),
+            move |identifier| {
+                let client = Arc::clone(&resolve_client);
+                async move {
+                    resolve_get_element_with(&client, &identifier, |identifier| async move {
+                        Ok(GetElementResult {
+                            element: fallback_element(&identifier, 7, ElementKind::Button),
+                        })
+                    })
+                    .await
+                }
+            },
+            |_start_x, _start_y, _end_x, _end_y, _duration_ms| async { Ok(()) },
+        )
+        .await
+        .expect("helper fallback should let drag succeed");
 
     let requests = server.await.unwrap();
     assert_eq!(requests.len(), 2);

--- a/src/mcp/tools/tests/registry_tool_tests.rs
+++ b/src/mcp/tools/tests/registry_tool_tests.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+async fn unexpected_accessibility_fallback(
+    _identifier: String,
+    _window_id: Option<i64>,
+    _action: AccessibilityAction,
+) -> Result<(), AccessibilityActionError> {
+    panic!("registry path unexpectedly used the accessibility fallback");
+}
+
 #[tokio::test]
 async fn list_windows_tool_returns_json_text_result() {
     let dir = TempDir::new().unwrap();
@@ -124,16 +132,19 @@ async fn press_element_invokes_helper_semantic_action() {
     let helper = dir.path().join("harness-monitor-input");
     let log_path = dir.path().join("press-action.log");
     write_press_action_helper(&helper, &log_path);
-    let helper_path = helper.to_string_lossy().into_owned();
     let client = Arc::new(RegistryClient::with_socket_path(path));
     let tool = PressElementTool::new(client);
 
-    let result = temp_env::async_with_vars(
-        [(INPUT_OVERRIDE_ENV, Some(helper_path.as_str()))],
-        async move { tool.call(json!({"identifier": "button.send"})).await },
-    )
-    .await
-    .expect("semantic action succeeds");
+    let result = tool
+        .call_with_accessibility_action(
+            json!({"identifier": "button.send"}),
+            move |identifier, window_id, action| async move {
+                perform_accessibility_action_with_program(&helper, &identifier, window_id, action)
+                    .await
+            },
+        )
+        .await
+        .expect("semantic action succeeds");
     let request_line = server.await.unwrap();
 
     assert!(!result.is_error);
@@ -157,16 +168,19 @@ async fn press_element_surfaces_missing_semantic_action_as_tool_error_result() {
         4,
         "error: no supported accessibility action for identifier: button.send",
     );
-    let helper_path = helper.to_string_lossy().into_owned();
     let client = Arc::new(RegistryClient::with_socket_path(path));
     let tool = PressElementTool::new(client);
 
-    let result = temp_env::async_with_vars(
-        [(INPUT_OVERRIDE_ENV, Some(helper_path.as_str()))],
-        async move { tool.call(json!({"identifier": "button.send"})).await },
-    )
-    .await
-    .expect("tool-level error result");
+    let result = tool
+        .call_with_accessibility_action(
+            json!({"identifier": "button.send"}),
+            move |identifier, window_id, action| async move {
+                perform_accessibility_action_with_program(&helper, &identifier, window_id, action)
+                    .await
+            },
+        )
+        .await
+        .expect("tool-level error result");
     let request_line = server.await.unwrap();
 
     assert!(request_line.contains("\"op\":\"getElement\""));
@@ -195,25 +209,16 @@ async fn press_element_uses_registry_semantic_action_when_advertised() {
             .to_string(),
         ],
     );
-    let helper = dir.path().join("harness-monitor-input");
-    let helper_log = dir.path().join("helper.log");
-    write_helper_script(
-        &helper,
-        &format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 0\n",
-            helper_log.to_string_lossy()
-        ),
-    );
-    let helper_path = helper.to_string_lossy().into_owned();
     let client = Arc::new(RegistryClient::with_socket_path(path));
     let tool = PressElementTool::new(client);
 
-    let result = temp_env::async_with_vars(
-        [(INPUT_OVERRIDE_ENV, Some(helper_path.as_str()))],
-        async move { tool.call(json!({"identifier": "button.send"})).await },
-    )
-    .await
-    .expect("registry semantic action succeeds");
+    let result = tool
+        .call_with_accessibility_action(
+            json!({"identifier": "button.send"}),
+            unexpected_accessibility_fallback,
+        )
+        .await
+        .expect("registry semantic action succeeds");
     let request_lines = server.await.unwrap();
 
     assert!(!result.is_error);
@@ -221,11 +226,6 @@ async fn press_element_uses_registry_semantic_action_when_advertised() {
     assert!(request_lines[0].contains("\"op\":\"getElement\""));
     assert!(request_lines[1].contains("\"op\":\"performAction\""));
     assert!(request_lines[1].contains("\"action\":\"press\""));
-    assert!(
-        !helper_log.exists(),
-        "registry-first path should not consult helper: {}",
-        fs::read_to_string(&helper_log).unwrap_or_default()
-    );
 }
 
 #[tokio::test]
@@ -250,16 +250,19 @@ async fn press_element_falls_back_to_helper_when_registry_press_transport_is_uns
     let helper = dir.path().join("harness-monitor-input");
     let log_path = dir.path().join("press-action.log");
     write_press_action_helper(&helper, &log_path);
-    let helper_path = helper.to_string_lossy().into_owned();
     let client = Arc::new(RegistryClient::with_socket_path(path));
     let tool = PressElementTool::new(client);
 
-    let result = temp_env::async_with_vars(
-        [(INPUT_OVERRIDE_ENV, Some(helper_path.as_str()))],
-        async move { tool.call(json!({"identifier": "button.send"})).await },
-    )
-    .await
-    .expect("helper fallback succeeds");
+    let result = tool
+        .call_with_accessibility_action(
+            json!({"identifier": "button.send"}),
+            move |identifier, window_id, action| async move {
+                perform_accessibility_action_with_program(&helper, &identifier, window_id, action)
+                    .await
+            },
+        )
+        .await
+        .expect("helper fallback succeeds");
     let request_lines = server.await.unwrap();
 
     assert!(!result.is_error);
@@ -291,25 +294,16 @@ async fn press_element_surfaces_registry_action_unavailable_without_helper_fallb
             .to_string(),
         ],
     );
-    let helper = dir.path().join("harness-monitor-input");
-    let helper_log = dir.path().join("helper.log");
-    write_helper_script(
-        &helper,
-        &format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 0\n",
-            helper_log.to_string_lossy()
-        ),
-    );
-    let helper_path = helper.to_string_lossy().into_owned();
     let client = Arc::new(RegistryClient::with_socket_path(path));
     let tool = PressElementTool::new(client);
 
-    let result = temp_env::async_with_vars(
-        [(INPUT_OVERRIDE_ENV, Some(helper_path.as_str()))],
-        async move { tool.call(json!({"identifier": "button.send"})).await },
-    )
-    .await
-    .expect("tool-level error result");
+    let result = tool
+        .call_with_accessibility_action(
+            json!({"identifier": "button.send"}),
+            unexpected_accessibility_fallback,
+        )
+        .await
+        .expect("tool-level error result");
     let request_lines = server.await.unwrap();
 
     assert!(result.is_error);
@@ -320,11 +314,6 @@ async fn press_element_surfaces_registry_action_unavailable_without_helper_fallb
         vec![ContentBlock::text(
             "identifier 'button.send' resolves to a live element without a supported semantic press action"
         )]
-    );
-    assert!(
-        !helper_log.exists(),
-        "action-unavailable should not drop to helper: {}",
-        fs::read_to_string(&helper_log).unwrap_or_default()
     );
 }
 

--- a/src/task_board/external/github/test_support.rs
+++ b/src/task_board/external/github/test_support.rs
@@ -68,10 +68,19 @@ pub(super) fn spawn_sequence_mock(
 }
 
 fn accept_before_deadline(listener: &TcpListener) -> TcpStream {
+    accept_before_deadline_with_stream_setup(listener, |_| {})
+}
+
+fn accept_before_deadline_with_stream_setup<F>(listener: &TcpListener, stream_setup: F) -> TcpStream
+where
+    F: FnOnce(&TcpStream),
+{
     let deadline = Instant::now() + Duration::from_secs(10);
+    let mut stream_setup = Some(stream_setup);
     loop {
         match listener.accept() {
             Ok((stream, _)) => {
+                stream_setup.take().expect("stream setup")(&stream);
                 prepare_accepted_stream(&stream);
                 return stream;
             }
@@ -177,18 +186,36 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         listener.set_nonblocking(true).expect("nonblocking");
         let address = listener.local_addr().expect("listener address");
+        let (write_request, wait_to_write) = std::sync::mpsc::channel();
         let client = thread::spawn(move || {
             let mut stream = TcpStream::connect(address).expect("connect");
-            thread::sleep(Duration::from_millis(50));
+            if wait_to_write.recv().is_err() {
+                return;
+            }
             stream
                 .write_all(b"GET /delayed HTTP/1.1\r\nHost: localhost\r\n\r\n")
                 .expect("write delayed request");
         });
-        let mut stream = accept_before_deadline(&listener);
+        let mut stream = accept_before_deadline_with_stream_setup(&listener, |stream| {
+            stream
+                .set_nonblocking(true)
+                .expect("simulate inherited nonblocking mode");
+        });
+        #[cfg(all(unix, feature = "bridge-runtime"))]
+        assert!(!stream_is_nonblocking(&stream));
+        write_request.send(()).expect("release request writer");
 
         let request = read_http_request(&mut stream);
 
         client.join().expect("client");
         assert!(request.starts_with("GET /delayed HTTP/1.1\r\n"));
+    }
+
+    #[cfg(all(unix, feature = "bridge-runtime"))]
+    fn stream_is_nonblocking(stream: &TcpStream) -> bool {
+        use nix::fcntl::{FcntlArg, OFlag, fcntl};
+
+        let flags = fcntl(stream, FcntlArg::F_GETFL).expect("read stream flags");
+        OFlag::from_bits_truncate(flags).contains(OFlag::O_NONBLOCK)
     }
 }

--- a/src/task_board/external/github/test_support.rs
+++ b/src/task_board/external/github/test_support.rs
@@ -71,7 +71,10 @@ fn accept_before_deadline(listener: &TcpListener) -> TcpStream {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         match listener.accept() {
-            Ok((stream, _)) => return stream,
+            Ok((stream, _)) => {
+                prepare_accepted_stream(&stream);
+                return stream;
+            }
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 assert!(Instant::now() < deadline, "timed out waiting for request");
                 thread::sleep(Duration::from_millis(5));
@@ -79,6 +82,10 @@ fn accept_before_deadline(listener: &TcpListener) -> TcpStream {
             Err(error) => panic!("accept request: {error}"),
         }
     }
+}
+
+fn prepare_accepted_stream(stream: &TcpStream) {
+    stream.set_nonblocking(false).expect("blocking stream");
 }
 
 fn read_http_request(stream: &mut TcpStream) -> String {
@@ -159,4 +166,29 @@ fn write_response(stream: &mut TcpStream, response: MockResponse) {
     );
     stream.write_all(raw.as_bytes()).expect("write response");
     stream.flush().expect("flush response");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepted_stream_waits_for_delayed_request_bytes() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        listener.set_nonblocking(true).expect("nonblocking");
+        let address = listener.local_addr().expect("listener address");
+        let client = thread::spawn(move || {
+            let mut stream = TcpStream::connect(address).expect("connect");
+            thread::sleep(Duration::from_millis(50));
+            stream
+                .write_all(b"GET /delayed HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                .expect("write delayed request");
+        });
+        let mut stream = accept_before_deadline(&listener);
+
+        let request = read_http_request(&mut stream);
+
+        client.join().expect("client");
+        assert!(request.starts_with("GET /delayed HTTP/1.1\r\n"));
+    }
 }

--- a/src/task_board/external/todoist/todoist_tests.rs
+++ b/src/task_board/external/todoist/todoist_tests.rs
@@ -405,6 +405,7 @@ fn capture_request(request: &str) -> CapturedRequest {
 }
 
 fn read_http_request(stream: &mut TcpStream) -> String {
+    stream.set_nonblocking(false).expect("blocking stream");
     stream
         .set_read_timeout(Some(std::time::Duration::from_secs(1)))
         .expect("read timeout");


### PR DESCRIPTION
## Motivation
Concurrent unit runs could read from accepted nonblocking sockets before request bytes arrived, while MCP tests coupled helper selection to process timing and review-policy tests could reach the live daemon database. These isolation leaks caused pristine-main test failures despite isolated reruns passing.

## Implementation
- Reset accepted TCP mock streams to blocking mode before synchronous reads and cover delayed request bytes deterministically.
- Inject deterministic helper probes and action dependencies into MCP tests while preserving production discovery and action behavior.
- Give review-policy route tests explicit temporary daemon data roots so policy lookup cannot escape to the app group.
- Validated focused socket and policy tests, repeated mcp:test and test:unit passes, harness:check, and check.